### PR TITLE
fix(release): bump version to 0.4.3 and update pypi-publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI with attestations
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.9.0
+        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc  # v1.12.2
         with:
           attestations: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-04-21
+
+### Added
+- Sigstore-signed release workflow with PyPI trusted publishing and PEP 740 attestations
+- CodeQL SAST workflow
+- OpenSSF Best Practices (Passing) badge
+- CONTRIBUTING.md
+
+### Changed
+- Scorecard workflow pinned to peeled commit SHAs, with `workflow_dispatch` trigger added
+- SECURITY.md restructured for OpenSSF Scorecard Security-Policy check
+
 ## [0.4.2] - 2026-04-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.4.2"
+version = "0.4.3"
 description = "Adaptive AI Agent Execution Layer — risk scoring, audit trails, regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
The v0.4.3 tag failed because:
1. pyproject.toml had version 0.4.2 hardcoded, so the built wheel was vaara-0.4.2, which collides with the version already on PyPI.
2. pypa/gh-action-pypi-publish v1.9.0 uses an old twine that cannot parse Metadata-Version 2.4 emitted by modern hatchling/setuptools, so it failed the pre-upload metadata check with a misleading 'Name, Version missing' error.

Bumps:
- pyproject.toml version 0.4.2 -> 0.4.3
- CHANGELOG.md new 0.4.3 entry
- pypa/gh-action-pypi-publish v1.9.0 -> v1.12.2 (peeled commit SHA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 0.4.3

* **New Features**
  * Sigstore-signed releases with PyPI trusted publishing and PEP 740 attestations support
  * CodeQL static analysis security testing workflow integration
  * OpenSSF Best Practices badge recognition

* **Documentation**
  * Added contributing guidelines
  * Security policy updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->