### PR TITLE
ci: bump pypa/gh-action-pypi-publish to v1.14.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI with attestations
-        uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc  # v1.12.2
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           attestations: true
 


### PR DESCRIPTION
v1.12.2 ships twine 6 which rejects wheels with Metadata-Version 2.4 (emitted by setuptools >= 69). v1.14.0 ships twine 7 and accepts 2.4, so uploads stop failing in pre-upload validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release infrastructure to enhance the publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->