### PR TITLE
ci: adversarial corpus eval workflow

### DIFF
--- a/.github/workflows/adversarial-eval.yml
+++ b/.github/workflows/adversarial-eval.yml
@@ -1,0 +1,67 @@
+name: Adversarial Corpus Eval
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Vaara
+        run: pip install -e ".[dev]"
+
+      - name: Run adversarial evaluator
+        id: eval
+        run: |
+          python scripts/eval_adversarial.py --corpus-dir tests/adversarial
+          LATEST=$(ls -t tests/adversarial/results_*.json 2>/dev/null | head -1)
+          if [ -z "$LATEST" ]; then
+            echo "No results file produced"
+            exit 1
+          fi
+          echo "results_file=$LATEST" >> "$GITHUB_OUTPUT"
+          cp "$LATEST" /tmp/adversarial_results.json
+
+      - name: Summary to job output
+        run: |
+          python - <<'PYEOF' >> "$GITHUB_STEP_SUMMARY"
+          import json, os
+          from pathlib import Path
+          d = json.loads(Path(os.environ["RESULTS_FILE"]).read_text())
+          s = d.get("summary", {})
+          print("## Adversarial Corpus Eval")
+          print()
+          print(f"Corpus: **{d['n_entries']}** entries across **{len(s)}** categories.")
+          print()
+          print("| Category | n | Deny | Esc | Allow | Allow-leakage | Mean risk |")
+          print("|---|---|---|---|---|---|---|")
+          for cat in sorted(s):
+              c = s[cat]
+              print(
+                  f"| `{cat}` | {c['n']} | {c['denied']} | {c['escalated']} "
+                  f"| {c['allowed']} | {c['allow_leakage_rate']*100:.1f}% "
+                  f"| {c['mean_risk']:.3f} |"
+              )
+          PYEOF
+        env:
+          RESULTS_FILE: ${{ steps.eval.outputs.results_file }}
+
+      - name: Upload results artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: adversarial-eval-results
+          path: /tmp/adversarial_results.json
+          if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
## Summary

Runs `scripts/eval_adversarial.py` on every push to main and every pull request. Publishes the per-category allow-leakage table to the GitHub Actions run summary, and uploads the results JSON as a 30-day artifact.

Implements the "continuous CI evaluation" deliverable committed in the 2026-04-22 LTFF proposal.

## What lands on a run

Every CI run of this workflow renders a Markdown table on the Actions run page, e.g.:

```
## Adversarial Corpus Eval

Corpus: 200 entries across 8 categories.

| Category              | n  | Deny | Esc | Allow | Allow-leakage | Mean risk |
|-----------------------|----|------|-----|-------|---------------|-----------|
| credential_exfil      | 25 | 0    | 6   | 19    | 76.0%         | 0.169     |
| data_exfil            | 25 | 0    | 11  | 14    | 56.0%         | 0.199     |
| destructive_actions   | 25 | 0    | 20  | 5     | 20.0%         | 0.222     |
| jailbreak             | 25 | 0    | 13  | 12    | 48.0%         | 0.203     |
| privilege_escalation  | 25 | 0    | 2   | 23    | 92.0%         | 0.173     |
| prompt_injection      | 25 | 0    | 11  | 14    | 56.0%         | 0.196     |
| ssrf_via_tools        | 25 | 0    | 0   | 25    | 100.0%        | 0.162     |
| tool_misuse           | 25 | 0    | 7   | 18    | 72.0%         | 0.185     |
```

The full JSON (including per-entry decisions and mean risks) is uploaded as the `adversarial-eval-results` artifact with 30-day retention.

## Not a fail-gate (yet)

This PR publishes evidence; it does not fail CI on regression. Current numbers are still finding their stable floor (PR #24 just moved allow-leakage down; PR #26 will move it further). A follow-up PR can add a threshold-based fail once a few main-branch commits establish a stable baseline.

## Action SHAs

All action SHAs match existing workflows in the repo (`actions/checkout@v6.0.2`, `actions/setup-python@v6.2.0`, `actions/upload-artifact@v7.0.1`). OpenSSF Scorecard pattern preserved.

## Test plan

- [ ] Workflow triggers on push to main and PRs
- [ ] Evaluator runs successfully on a fresh checkout
- [ ] Summary table renders on the Actions run page
- [ ] `adversarial-eval-results` artifact is downloadable after the run

## Follow-ups

- Add a threshold-based fail-gate (e.g., fail if `privilege_escalation` allow-leakage exceeds the main-branch baseline by more than 5pp).
- Post the table as a sticky PR comment once a trusted third-party action is pinned.
- Generate a README badge that tracks the overall allow-leakage trend over time.
