### PR TITLE
fix(langchain): preserve tool signature for config/run_manager kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-04-22
+
+### Fixed
+- `vaara_wrap_tool` signature preservation via `functools.wraps` so LangChain `BaseTool.run()` injects `config` and `run_manager` kwargs under langchain-core >= 0.3.
+
+### Added
+- `examples/langchain_agent.py` runnable end-to-end with minimal action taxonomy and pre-calibrated pipeline.
+
 ## [0.4.3] - 2026-04-21
 
 ### Added

--- a/examples/langchain_agent.py
+++ b/examples/langchain_agent.py
@@ -1,0 +1,126 @@
+"""LangChain + Vaara — intercept tool calls before they execute.
+
+Run:
+    pip install vaara langchain-core rich
+    python examples/langchain_agent.py
+
+Wires Vaara into LangChain's tool-dispatch path using the core
+`pipeline.intercept(...)` API. Works with any LangChain version and
+with any agent loop (create_react_agent, AgentExecutor, LangGraph).
+
+This example registers a minimal action taxonomy so you can see how
+different tool categories get differentiated scores. For higher-level
+integrations see VaaraCallbackHandler and vaara_wrap_tool in the README.
+"""
+from __future__ import annotations
+
+from langchain_core.tools import tool
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from vaara.pipeline import InterceptionPipeline
+from vaara.sandbox.trace_gen import TraceGenerator
+from vaara.taxonomy.actions import (
+    ActionCategory,
+    ActionType,
+    BlastRadius,
+    Reversibility,
+    UrgencyClass,
+)
+
+
+@tool
+def write_config(path: str, content: str) -> str:
+    """Write a config file."""
+    return f"wrote {len(content)} bytes to {path}"
+
+
+@tool
+def shell_exec(command: str) -> str:
+    """Execute a shell command."""
+    return f"[mock] {command}"
+
+
+@tool
+def fetch_url(url: str) -> str:
+    """HTTP GET a URL."""
+    return f"[mock] GET {url}"
+
+
+# --- Taxonomy -------------------------------------------------------------
+# Vaara's scorer reads action metadata (reversibility, blast radius, urgency)
+# from a registry. You define what each tool is. Below is a minimal taxonomy
+# for the three demo tools.
+pipeline = InterceptionPipeline()
+registry = pipeline.registry
+
+registry.register(ActionType(
+    name="config_write", category=ActionCategory.INFRASTRUCTURE,
+    reversibility=Reversibility.PARTIALLY, blast_radius=BlastRadius.SHARED,
+    urgency=UrgencyClass.DEFERRABLE, description="Writes a config file",
+))
+registry.register(ActionType(
+    name="shell_exec", category=ActionCategory.INFRASTRUCTURE,
+    reversibility=Reversibility.IRREVERSIBLE, blast_radius=BlastRadius.GLOBAL,
+    urgency=UrgencyClass.DEFERRABLE, description="Executes a shell command",
+))
+registry.register(ActionType(
+    name="http_fetch", category=ActionCategory.COMMUNICATION,
+    reversibility=Reversibility.FULLY, blast_radius=BlastRadius.LOCAL,
+    urgency=UrgencyClass.DEFERRABLE, description="HTTP GET",
+))
+registry.map_tool("write_config", "config_write")
+registry.map_tool("shell_exec", "shell_exec")
+registry.map_tool("fetch_url", "http_fetch")
+
+# Pre-calibrate so cold-start doesn't escalate everything.
+TraceGenerator().pre_calibrate(pipeline, TraceGenerator().generate(n_traces=200))
+
+# Scripted call sequence an agent might propose, some benign, some risky.
+demo_calls = [
+    (fetch_url, {"url": "https://example.com/"}),
+    (write_config, {"path": "/tmp/ok.yaml", "content": "safe"}),
+    (shell_exec, {"command": "ls /tmp"}),
+    (shell_exec, {"command": "rm -rf /"}),
+    (fetch_url, {"url": "http://169.254.169.254/latest/meta-data/"}),
+    (write_config, {"path": "/etc/sudoers", "content": "agent ALL=(ALL) NOPASSWD: ALL"}),
+]
+
+
+def governed_invoke(pipeline, lc_tool, args, *, agent_id="demo-agent"):
+    """Intercept, then (if allowed) invoke the tool and close the feedback loop.
+
+    Drop this pattern into your LangChain AgentExecutor / LangGraph node
+    right before the tool call actually fires. That is the Vaara hook.
+    """
+    result = pipeline.intercept(
+        agent_id=agent_id, tool_name=lc_tool.name,
+        parameters=args, agent_confidence=0.8,
+    )
+    if not result.allowed:
+        return result, None
+    output = lc_tool.invoke(args)
+    pipeline.report_outcome(result.action_id, outcome_severity=0.0)
+    return result, output
+
+
+console = Console()
+table = Table(title="LangChain → Vaara → tool", box=box.SIMPLE, pad_edge=False)
+table.add_column("tool", style="cyan", no_wrap=True)
+table.add_column("args", overflow="fold")
+table.add_column("risk", no_wrap=True)
+table.add_column("outcome")
+
+for lc_tool, args in demo_calls:
+    result, output = governed_invoke(pipeline, lc_tool, args)
+    risk = f"{result.risk_score:.2f} [{result.risk_interval[0]:.2f}-{result.risk_interval[1]:.2f}]"
+    if result.allowed:
+        verdict = f"[green]ALLOW[/] → {output}"
+    elif result.decision == "escalate":
+        verdict = f"[yellow]ESCALATE[/] → {result.reason.split(' (')[0]}"
+    else:
+        verdict = f"[red]BLOCK[/] → {result.reason.split(' (')[0]}"
+    table.add_row(lc_tool.name, str(args)[:60], risk, verdict)
+
+console.print(table)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.4.3"
+version = "0.4.4"
 description = "Adaptive AI Agent Execution Layer — risk scoring, audit trails, regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.4"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/integrations/langchain.py
+++ b/src/vaara/integrations/langchain.py
@@ -33,6 +33,7 @@ Requires: langchain-core >= 0.2 (not a hard dependency — imported at runtime)
 
 from __future__ import annotations
 
+import functools
 import logging
 import threading
 from collections import OrderedDict
@@ -415,6 +416,8 @@ def vaara_wrap_tool(
     # layers of interception that MWU-weight and outcome-report twice.
     # Stamping wrappers first guarantees any concurrent re-read of
     # tool._run sees an already-marked wrapper and short-circuits.
+    wrapped_run = functools.wraps(original_run)(wrapped_run) if original_run is not None else wrapped_run
+    wrapped_arun = functools.wraps(original_arun)(wrapped_arun) if original_arun is not None else wrapped_arun
     wrapped_run._vaara_wrapped = True  # type: ignore[attr-defined]
     wrapped_arun._vaara_wrapped = True  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Summary

- `vaara_wrap_tool` broke with `langchain-core >= 0.3` because the `*args/**kwargs` wrapper signature made LangChain's `BaseTool.run()` introspection skip injecting `config` and `run_manager` kwargs, then the original `_run` raised `missing 1 required keyword-only argument: 'config'`.
- Fix applies `functools.wraps(original_run)` so `inspect.signature` follows `__wrapped__` through to the real signature and LangChain resumes passing the kwargs our wrapper forwards.
- Adds `examples/langchain_agent.py` showing the core integration pattern with a minimal taxonomy and pre-calibrated pipeline (standalone runnable, no LLM API key required).

## Test plan

- [x] `pip install -e .` then invoke a `@tool`-decorated function wrapped via `vaara_wrap_tool` under `langchain-core==0.3.84`: succeeds (was `TypeError` on main).
- [x] `python examples/langchain_agent.py` runs end-to-end, shows 6 scripted calls with differentiated risk scores.
- [ ] CI adversarial-eval workflow passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable example demonstrating governance of LangChain agents with risk assessment and automated action control (allow, block, escalate).

* **Improvements**
  * Preserve tool wrapper metadata so LangChain tool integrations retain expected signatures and behavior.

* **Chores**
  * Updated package version and changelog for the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->