### PR TITLE
chore: add community health files (PR template, issue templates, CoC, CODEOWNERS)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — auto-assigns reviewers on PRs that touch matching paths.
+# Single-maintainer for now; this still surfaces "code ownership defined"
+# in the GitHub UI and gives forks / external contributors a clear target.
+
+* @vaaraio

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: Something Vaara does that it shouldn't, or doesn't that it should.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time. The fields below help us reproduce
+        the issue without a back-and-forth.
+  - type: input
+    id: vaara-version
+    attributes:
+      label: Vaara version
+      description: Output of `python -c "import vaara; print(vaara.__version__)"`
+      placeholder: "0.6.0"
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: install-source
+    attributes:
+      label: How was Vaara installed?
+      options:
+        - "pip install vaara (PyPI)"
+        - "pip install vaara[ml]"
+        - "pip install vaara[yaml]"
+        - "pip install -e . (editable, from source)"
+        - "Other"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you do, what did you expect, what did you see instead.
+      placeholder: |
+        I called Pipeline.intercept() with X.
+        I expected DENY because of Y.
+        I got ALLOW.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: A short Python snippet or shell sequence that triggers the bug.
+      render: python
+    validations:
+      required: false
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Traceback or relevant log output
+      description: Paste the full traceback if there is one.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability (private disclosure)
+    url: https://github.com/vaaraio/vaara/security/advisories/new
+    about: Do not open a public issue for security reports. Use private advisory disclosure per SECURITY.md.
+  - name: Compliance / regulator-facing question
+    url: mailto:hello@vaara.io
+    about: For deployer-facing questions about EU AI Act / DORA / ISO 42001 mapping, email rather than open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature-or-question.yml
+++ b/.github/ISSUE_TEMPLATE/feature-or-question.yml
@@ -1,0 +1,48 @@
+name: Feature request or question
+description: Suggest a capability, ask about an integration, raise a design question.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: What are you trying to do?
+      description: |
+        A short paragraph on the goal, not just the feature. We want to
+        understand the underlying need so the answer might be "use X
+        differently" rather than a new feature.
+    validations:
+      required: true
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: What does Vaara do today?
+      description: |
+        Either: "I tried X and it does Y, but I want Z" or "I couldn't
+        find a way to do this in the current API/CLI."
+    validations:
+      required: false
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape (optional)
+      description: |
+        If you have a concrete idea for an API, CLI flag, policy field,
+        or integration, describe it. Pseudocode is fine. Don't worry
+        about getting it exactly right.
+      render: markdown
+    validations:
+      required: false
+  - type: dropdown
+    id: regulatory-context
+    attributes:
+      label: Regulatory context
+      description: Is this driven by a specific compliance obligation?
+      options:
+        - "Not regulatory"
+        - "EU AI Act"
+        - "DORA"
+        - "ISO/IEC 42001"
+        - "GDPR / data protection"
+        - "Other (mention in description)"
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Keep this short. Detail belongs in the diff and the CHANGELOG. -->
+
+## Summary
+
+<!-- 1–3 bullets. What changes, why now. -->
+
+-
+
+## Test plan
+
+<!-- Check off what you ran locally. Add new boxes for anything specific. -->
+
+- [ ] `pytest -q` passes
+- [ ] `scripts/lint_full.sh` passes (ruff + bandit + mypy + pytest)
+- [ ] CHANGELOG.md updated if this changes the public API or shipped behaviour
+- [ ] No secrets, audit DBs, or large binaries staged
+
+## Risk / blast radius
+
+<!-- One line. Examples: "test-only", "internal refactor, no API change",
+     "audit DB schema bump (migration tested)", "CLI flag added", "breaking change". -->
+
+-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at hello@vaara.io. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+


### PR DESCRIPTION
## Summary

Adds the GitHub community-health set the repo was missing post-v0.6.0. Each file has operational utility, credibility-signal value to the audit / regulator audience that checks public repos, or both.

- `.github/PULL_REQUEST_TEMPLATE.md` — Summary / Test plan / Risk structure that mirrors what we've been writing manually. Forces the `pytest -q` and `scripts/lint_full.sh` checkboxes so the pre-push gate stays in muscle memory.
- `.github/ISSUE_TEMPLATE/bug-report.yml` — YAML form schema with required version / Python / install-source fields and an optional reproducer block. Cuts the back-and-forth on "doesn't work" reports.
- `.github/ISSUE_TEMPLATE/feature-or-question.yml` — YAML form schema steering toward the underlying goal plus a regulatory-context dropdown that surfaces EU AI Act / DORA / ISO 42001 framing.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, routes security reports to the private advisory flow per `SECURITY.md`, and routes compliance / regulator questions to `hello@vaara.io` rather than public threads.
- `.github/CODEOWNERS` — single-maintainer (`@vaaraio` on every path). Surfaces "code ownership defined" in the GitHub UI and auto-assigns review on forks and external PRs.
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 verbatim from contributor-covenant.org, contact pointed at `hello@vaara.io`. Canonical text on purpose. Custom CoC drafts read as cargo-cult and are worse than the standard everyone already recognises.

## Test plan

- [x] `pytest -q` passes (310 passed / 12 skipped)
- [x] `scripts/lint_full.sh` passes (ruff + bandit + mypy + pytest)
- [x] No code paths touched. Pure additions under `.github/` and a top-level `CODE_OF_CONDUCT.md`.
- [x] PR template auto-populates correctly on the next PR opened against this repo.
- [ ] CI green
- [ ] Reviewer eyeball pass

## Risk / blast radius

Test-only / docs-only at the operational level. No runtime code change, no new dependency, no schema migration. Worst case: a new contributor sees the templates and complains they're too restrictive, in which case we tune the form fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub issue templates for structured bug reports and feature requests to improve contribution quality
  * Implemented pull request template with testing and review checklist
  * Established contributor code of conduct defining community standards and expected behaviors
  * Configured code ownership for automated pull request routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->