### PR TITLE
chore: rephrase pyproject description for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "vaara"
 version = "0.6.0"
-description = "Adaptive AI Agent Execution Layer — risk scoring, audit trails, regulatory compliance"
+description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Replaced the em-dash in `pyproject.toml`'s description with a comma-separated phrasing. Cleaner PyPI tagline rendering, easier to read on the package page header.

## Heads-up

This only takes effect on PyPI when the next release publishes a fresh wheel. PyPI's current `v0.6.0` page keeps the old description until then.

## Test plan

- [x] `scripts/lint_full.sh` clean (ruff + bandit + mypy + 310 passed / 12 skipped pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)