### PR TITLE
docs: trim README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/vaara-wordmark-dark.png">
-    <img src="docs/vaara-wordmark-light.png" alt="Vaara, built to see over the noise" width="900">
+    <img src="docs/vaara-wordmark-light.png" alt="Vaara" width="900">
   </picture>
 </p>
 
@@ -14,30 +14,9 @@
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
 </p>
 
-Adaptive AI agent execution layer. Sits between agents and actions, scores risk in real time, and produces evidence artefacts that support EU AI Act Article 14 human-oversight and Article 12 logging obligations.
+Vaara intercepts agent tool calls, scores each one with a conformal risk interval, and writes a hash-chained audit record. Online learning across five expert signals via Multiplicative Weight Update. Distribution-free conformal coverage on the score.
 
-Article-by-article evidence mapping: [COMPLIANCE.md](COMPLIANCE.md).
-
-Position paper on the European Commission's AI Alliance platform: [Article 14 at runtime](https://futurium.ec.europa.eu/en/apply-ai-alliance/community-content/article-14-runtime-why-oversight-agentic-ai-has-be-evidenced-action-not-model).
-
-> Vaara is a tool that helps deployers assemble evidence for their own
-> conformity work. It does not itself conduct conformity assessments,
-> certify compliance, or constitute legal advice. Deployers remain
-> responsible for their obligations under the EU AI Act and other
-> applicable law.
-
-**Three questions for every agent action:**
-1. Should this happen? (adaptive risk scoring with conformal prediction)
-2. What is this? (action taxonomy with regulatory classification)
-3. What happened and why? (hash-chained audit trail)
-
-## Why Vaara
-
-AI governance tools audit **models**. Vaara governs **actions**.
-
-Models are scored once at deployment. Agents act continuously at runtime, calling tools and modifying infrastructure. Individual actions may be safe, but *sequences* can be catastrophic. `read_data` + `export_data` + `delete_data` is a data exfiltration pattern where each step alone is benign.
-
-Vaara catches this. It learns which risk signals predict bad outcomes, adapts its scoring online, and wraps every estimate in a distribution-free confidence interval. No retraining. No manual threshold tuning.
+For broader agent governance (zero-trust identity, capability-based access control, multi-language SDKs) see Microsoft's [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit). Vaara is narrower.
 
 ## Install
 
@@ -45,276 +24,38 @@ Vaara catches this. It learns which risk signals predict bad outcomes, adapts it
 pip install vaara
 ```
 
-Python 3.10+. Zero runtime dependencies for the default install.
+Python 3.10+. Zero runtime deps. Optional XGBoost classifier: `pip install vaara[ml]`.
 
-For the optional ML adversarial classifier (XGBoost-based, ships with a 295 KB pre-trained bundle):
-
-```bash
-pip install vaara[ml]
-```
-
-This pulls in `xgboost`, `scikit-learn`, `joblib`, and `numpy`. See the Adversarial Classifier section below.
-
-## Quick Start
+## Quick start
 
 ```python
 from vaara.pipeline import InterceptionPipeline
 
 pipeline = InterceptionPipeline()
-
-# Agent wants to execute a tool
 result = pipeline.intercept(
     agent_id="agent-007",
     tool_name="fs.write_file",
     parameters={"path": "/etc/service.yaml", "content": "..."},
     agent_confidence=0.8,
 )
-
 if result.allowed:
-    execute_tool("fs.write_file", {"path": "/etc/service.yaml", "content": "..."})
-    # Report outcome so the scorer learns
     pipeline.report_outcome(result.action_id, outcome_severity=0.0)
 else:
-    print(f"Blocked: {result.reason}")
-    # result.decision is "deny" or "escalate"
-    # result.risk_score and result.risk_interval available
+    print(result.reason)
 ```
 
-## Adversarial Classifier (optional)
+`report_outcome` closes the loop. MWU reweights signals based on which ones predicted the outcome.
 
-Vaara ships an opt-in XGBoost classifier trained on a 5,955-entry corpus (3,422 attack across 8 categories, 2,533 benign), spanning hand-curated seeds and LLM-generated variants. Install with `pip install vaara[ml]`.
+## Where things live
 
-```python
-from vaara.adversarial_classifier import AdversarialClassifier
+- [docs/formal_specification.md](docs/formal_specification.md): math. MWU regret bound O(sqrt(T log N)), conformal coverage guarantees, security properties.
+- [COMPLIANCE.md](COMPLIANCE.md): Article-level evidence mapping for EU AI Act (Articles 9, 11 to 15, 61) and DORA (Articles 10, 12, 13). Eval numbers, threshold sweeps, PAIR adversarial calibration.
+- `src/vaara/integrations/`: LangChain, OpenAI Agents SDK, CrewAI, MCP server.
+- `src/vaara/audit/`: hash-chain trail, SQLite backend, append-only WAL.
+- `src/vaara/sandbox/`: synthetic-trace cold-start calibration.
 
-clf = AdversarialClassifier()  # loads bundled model, threshold=0.55 default
-
-# Score a proposed tool call
-prob = clf.score(
-    tool_name="http_get",
-    parameters={"url": "http://169.254.169.254/latest/meta-data/"},
-    context={},
-)  # -> 0.99 for SSRF to cloud metadata
-
-if clf.is_malicious("http_get", {"url": "https://api.github.com/user"}, {}):
-    # threshold-based decision using the bundle's default_threshold
-    ...
-```
-
-### Numbers (v0.6, full Vaara stack)
-
-Distribution-shift split, threshold 0.55:
-
-| Source                                | Attack recall | Benign FPR |
-|---------------------------------------|--------------:|-----------:|
-| Hand-curated (held-out, 250)          |        97.1% |      70.0% |
-| LLM-generated (in-sample, 5,705)      |        95.2% |      87.5% |
-
-Held-out is the generalization signal; in-sample is fit. Most full-stack benign FPR comes from heuristic ESCALATEs (human review), not denials — by design.
-
-**PAIR adaptive-attacker calibration:** Qwen2.5-32B-Instruct as both attacker and judge, 25 hand-curated jailbreak seeds, 5-iteration budget — **ASR 0.0% (0/25)**. Not a claim of imperviousness against stronger attackers (70B+) or alternate strategies.
-
-Latency: 140 µs mean, 210 µs p99 (commodity CPU, no GPU at inference).
-
-Full per-source / per-class breakdown: [COMPLIANCE.md](COMPLIANCE.md). Reproducers: `scripts/eval_distribution_shift.py`, `scripts/eval_stack_ablation.py`, `scripts/eval_pair_attack.py`.
-
-### Operating notes
-
-- Classifier over-triggers on legitimate uses of powerful tools (`http_post`, `send_email`, `shell_exec`). At threshold 0.55, classifier-alone benign FPR is 21% (5-fold CV OOF). Full stack escalates rather than denies — see COMPLIANCE.md for per-source breakdown.
-- Recommended: ship with `decision="escalate"` (send to human-in-loop), not `decision="deny"`.
-- Threshold is configurable per call. `AdversarialClassifier(threshold=0.50)` is the higher-recall / higher-FPR operating point; `threshold=0.65` reduces FPR at the cost of recall. See CHANGELOG v0.5.3 sweep table.
-
-## How It Works
-
-### Risk Scoring (Adaptive)
-
-Five expert signals scored per action, combined via [Multiplicative Weight Update](https://theory.epfl.ch/osMDPs/papers/AroraHK12.pdf):
-
-| Signal | What it measures |
-|--------|-----------------|
-| **Taxonomy base** | Static risk from action metadata (reversibility, blast radius, urgency) |
-| **Agent history** | This agent's track record (denial rate, bad outcomes) |
-| **Sequence pattern** | Dangerous action sequences (data exfiltration, privilege escalation, unauthorized tool chaining) |
-| **Burst detection** | Unusual action frequency spikes |
-| **Confidence gap** | High confidence on high-risk actions = suspicious |
-
-MWU learns which signals actually predict bad outcomes and shifts weight toward them. It carries a theoretical regret bound of O(√(T log N)) against the best fixed expert in hindsight (Arora–Hazan–Kale 2012).
-
-### Conformal Prediction
-
-Every risk score is wrapped in a [conformal prediction interval](https://arxiv.org/abs/2107.07511):
-
-```
-P(true_risk in [lower, upper]) >= 1 - alpha
-```
-
-No distributional assumptions. No model retraining. The decision uses the **upper bound** -- conservative by construction. Under distribution shift, [FACI](https://arxiv.org/abs/2106.00170) adaptive alpha maintains long-run coverage.
-
-### Decisions
-
-```
-ALLOW     : upper bound < 0.3 (configurable)
-ESCALATE  : between 0.3 and 0.7, route to human
-DENY      : upper bound > 0.7
-```
-
-Cold start is maximally cautious: wide intervals route most actions through human review. As outcomes accumulate, intervals tighten and the system becomes autonomous.
-
-## Framework Integrations
-
-### LangChain
-
-```python
-from vaara.integrations.langchain import VaaraCallbackHandler
-
-pipeline = InterceptionPipeline()
-handler = VaaraCallbackHandler(pipeline, agent_id="my-agent")
-agent = create_react_agent(llm, tools)
-
-result = agent.invoke(
-    {"messages": [("user", "...")]},
-    config={"callbacks": [handler]},
-)
-```
-
-### OpenAI Agents SDK
-
-```python
-from vaara.integrations.openai_agents import VaaraToolGuardrail
-
-pipeline = InterceptionPipeline()
-guardrail = VaaraToolGuardrail(pipeline)
-agent = Agent(name="my-agent", tools=[...], output_guardrails=[guardrail])
-```
-
-### CrewAI
-
-```python
-from vaara.integrations.crewai import VaaraCrewGovernance
-
-pipeline = InterceptionPipeline()
-gov = VaaraCrewGovernance(pipeline)
-safe_crew = gov.governed_kickoff(crew)
-```
-
-### MCP Server (Claude Code, Cursor)
-
-```bash
-python -m vaara.integrations.mcp_server
-```
-
-Add to Claude Code settings:
-```json
-{
-  "mcpServers": {
-    "vaara": {
-      "command": "python",
-      "args": ["-m", "vaara.integrations.mcp_server"]
-    }
-  }
-}
-```
-
-## Compliance evidence
-
-Vaara collects and maps evidence artefacts to specific article references
-in the EU AI Act and DORA. The output is evidence, not a conformity
-verdict. The deployer, with a Notified Body where applicable, owns the
-conformity decision.
-
-```python
-report = pipeline.run_compliance_assessment(
-    system_name="My Agent System",
-    system_version="1.0.0",
-)
-
-# Article-by-article evidence mapping
-for article in report.articles:
-    print(f"{article.requirement.article}: {article.status.value}")
-    # Article 9(1): evidence_sufficient
-    # Article 12(1): evidence_sufficient
-    # ...
-```
-
-**Article references covered:**
-- EU AI Act: Articles 9, 11–15, 61 (risk management, documentation,
-  logging, transparency, human oversight, accuracy, post-market
-  monitoring)
-- DORA: Articles 10, 12, 13 (ICT risk management, incident detection,
-  incident response)
-
-Full article-by-article mapping, evidence types, CLI handoff flow, and
-what the deployer still owns: [COMPLIANCE.md](COMPLIANCE.md).
-
-The audit trail is hash-chained (SHA-256) and tamper-evident, which
-supports Article 12(1) record-keeping obligations when configured with
-the deployer's required log content.
-
-## Cold Start
-
-Generate synthetic traces to pre-calibrate the scorer:
-
-```python
-from vaara.sandbox.trace_gen import TraceGenerator
-
-gen = TraceGenerator()
-traces = gen.generate(n_traces=100)
-gen.pre_calibrate(pipeline, traces)
-# Calibration in minutes instead of hours
-```
-
-Three agent archetypes (benign, careless, adversarial) with realistic outcome distributions.
-
-## Architecture
-
-```
-Agent (LangChain / OpenAI / CrewAI / MCP)
-    |
-    v
-InterceptionPipeline.intercept()
-    |
-    +-- ActionRegistry     ->  classify tool_name to ActionType
-    +-- AdaptiveScorer     ->  MWU + conformal risk interval
-    +-- AuditTrail         ->  hash-chained immutable log
-    +-- ComplianceEngine   ->  EU AI Act + DORA evidence mapping
-    |
-    v
-InterceptionResult { allowed, risk_score, risk_interval, reason }
-    |
-    v
-Execute or Block
-    |
-    v
-report_outcome()  ->  closes feedback loop, MWU learns
-```
-
-## Persistence
-
-```python
-from vaara.audit.trail import AuditTrail
-from vaara.audit.sqlite_backend import SQLiteAuditBackend
-from vaara.pipeline import InterceptionPipeline
-
-backend = SQLiteAuditBackend("audit.db")
-trail = AuditTrail(on_record=backend.write_record)
-pipeline = InterceptionPipeline(trail=trail)
-```
-
-WAL-mode SQLite, append-only, hash chain verified on load.
-
-## Formal Specification
-
-See [docs/formal_specification.md](docs/formal_specification.md) for the mathematical foundations: MWU regret bounds, conformal coverage guarantees, convergence rates, and security properties.
-
-## Tests
-
-```bash
-pip install vaara[dev]
-pytest
-```
-
-200+ tests, runs in <1s.
+> Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.
 
 ## License
 
-See [LICENSE](LICENSE).
+[LICENSE](LICENSE)


### PR DESCRIPTION
61 lines instead of 320. Pointers to COMPLIANCE.md and docs/formal_specification.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * README refactored with refreshed headline description highlighting core capabilities
  * Quick Start guide simplified for easier onboarding
  * New reference section added directing users to key documentation and directories
  * Updated logo alt text and license link formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->