### PR TITLE
feat: per-category Mondrian conformal calibration

### DIFF
--- a/src/vaara/scorer/adaptive.py
+++ b/src/vaara/scorer/adaptive.py
@@ -297,60 +297,127 @@ class MWUExperts:
 class ConformalCalibrator:
     """Split conformal prediction for risk score intervals.
 
-    Maintains a calibration set of (predicted_risk, actual_outcome) pairs.
-    Produces prediction intervals that contain the true risk with
-    probability >= 1 - alpha, with no distributional assumptions.
+    Maintains calibration sets of (predicted_risk, actual_outcome) pairs and
+    produces prediction intervals that contain the true risk with probability
+    >= 1 - alpha, with no distributional assumptions.
 
-    Uses FACI-style adaptive alpha when enough data is available:
-    the effective alpha tracks coverage errors online, tightening when
-    the interval misses and loosening when it's too conservative.
+    FACI-style adaptive alpha runs once enough data is available: the
+    effective alpha tracks coverage errors online, tightening when the
+    interval misses and loosening when it stays conservative.
+
+    Mondrian (class-conditional) mode is opt-in via the ``category`` argument
+    on ``add_calibration_point`` and ``predict_interval``. Each distinct
+    category string gets its own residual deque, FACI alpha, and conformal
+    quantile, so a per-category coverage guarantee holds independently. Calls
+    without ``category`` all land in a single shared bucket and behaviour is
+    identical to marginal split conformal, so existing call sites do not need
+    to change.
 
     Reference:
     - Vovk, Gammerman & Shafer (2005), "Algorithmic Learning in a Random World"
     - Gibbs & Candes (2021), "Adaptive Conformal Inference Under Distribution Shift"
+    - Vovk (2012), "Conditional validity of inductive conformal predictors"
+      (Mondrian conformal prediction)
     """
+
+    _DEFAULT_BUCKET = "__default__"
 
     def __init__(
         self,
         alpha: float = 0.10,        # Target miscoverage rate (10%)
         min_calibration: int = 30,   # Min points before conformal kicks in
-        max_calibration: int = 2000, # Rolling window size
+        max_calibration: int = 2000, # Rolling window size per bucket
         gamma: float = 0.005,        # FACI step size for adaptive alpha
     ) -> None:
         self._alpha = alpha
-        self._alpha_t = alpha         # Adaptive alpha (FACI)
         self._min_calibration = min_calibration
         self._max_calibration = max_calibration
         self._gamma = gamma
-        # Calibration residuals: |predicted - actual|
-        self._residuals: deque[float] = deque(maxlen=max_calibration)
+        # Per-bucket residuals and adaptive alphas. Marginal-only callers
+        # (no category arg) all land in _DEFAULT_BUCKET, preserving the
+        # pre-Mondrian behaviour exactly. The dicts grow lazily as new
+        # categories appear, so an unused Mondrian mode pays only one dict
+        # lookup per call relative to the old single-deque implementation.
+        self._residuals: dict[str, deque[float]] = {}
+        self._alpha_t: dict[str, float] = {}
         # Lock guards _residuals and _alpha_t. AdaptiveScorer wraps all
         # calls with its own RLock, but ConformalCalibrator can be shared
         # or accessed directly (e.g. in free-threaded Python 3.13+).
         self._lock = threading.Lock()
 
+    @staticmethod
+    def _bucket_key(category: Optional[str]) -> str:
+        return category if category else ConformalCalibrator._DEFAULT_BUCKET
+
+    def _ensure_bucket_locked(self, key: str) -> deque[float]:
+        bucket = self._residuals.get(key)
+        if bucket is None:
+            bucket = deque(maxlen=self._max_calibration)
+            self._residuals[key] = bucket
+            self._alpha_t[key] = self._alpha
+        return bucket
+
     @property
     def calibration_size(self) -> int:
+        """Total residuals across all category buckets.
+
+        For per-category counts use ``calibration_size_for(category)``.
+        """
         with self._lock:
-            return len(self._residuals)
+            return sum(len(b) for b in self._residuals.values())
 
     @property
     def is_calibrated(self) -> bool:
-        with self._lock:
-            return len(self._residuals) >= self._min_calibration
+        """True when the default (marginal) bucket has reached min_calibration.
+
+        For per-category readiness use ``is_calibrated_for(category)``.
+        """
+        return self.calibration_size_for(None) >= self._min_calibration
 
     @property
     def effective_alpha(self) -> float:
-        with self._lock:
-            return self._alpha_t
+        """Effective FACI-adapted alpha for the default bucket.
 
-    def add_calibration_point(self, predicted: float, actual: float) -> None:
+        For per-category alpha use ``effective_alpha_for(category)``.
+        """
+        return self.effective_alpha_for(None)
+
+    def calibration_size_for(self, category: Optional[str]) -> int:
+        """Residual count in the named bucket (default bucket if None)."""
+        key = self._bucket_key(category)
+        with self._lock:
+            return len(self._residuals.get(key, ()))
+
+    def is_calibrated_for(self, category: Optional[str]) -> bool:
+        """True when the named bucket has reached min_calibration."""
+        return self.calibration_size_for(category) >= self._min_calibration
+
+    def effective_alpha_for(self, category: Optional[str]) -> float:
+        """Effective FACI-adapted alpha for the named bucket.
+
+        Returns the configured alpha when the bucket has not yet been touched.
+        """
+        key = self._bucket_key(category)
+        with self._lock:
+            return self._alpha_t.get(key, self._alpha)
+
+    def add_calibration_point(
+        self,
+        predicted: float,
+        actual: float,
+        category: Optional[str] = None,
+    ) -> None:
         """Add a (predicted, actual) pair to the calibration set.
 
         Called by the audit trail when action outcomes are known.
-        Non-finite inputs are dropped — one NaN in the residual deque
-        poisons every future quantile (sorted() of NaN is
-        implementation-defined and breaks coverage guarantees).
+        Non-finite inputs are dropped: one NaN in the residual deque poisons
+        every future quantile (``sorted()`` of NaN is implementation-defined
+        and breaks coverage guarantees).
+
+        When ``category`` is provided, the residual lands in a per-category
+        bucket maintained independently. When omitted, the residual goes to
+        the default bucket and behaviour matches pre-Mondrian split conformal
+        exactly.
         """
         try:
             predicted_f = float(predicted)
@@ -360,46 +427,61 @@ class ConformalCalibrator:
         if not (math.isfinite(predicted_f) and math.isfinite(actual_f)):
             return
         residual = abs(predicted_f - actual_f)
+        key = self._bucket_key(category)
         with self._lock:
-            self._residuals.append(residual)
-            # FACI adaptive alpha update
-            if len(self._residuals) >= self._min_calibration:
-                # err_t = 1 if actual was outside the interval we would have produced
-                quantile = self._get_quantile_locked()
+            bucket = self._ensure_bucket_locked(key)
+            bucket.append(residual)
+            if len(bucket) >= self._min_calibration:
+                # FACI adaptive alpha update, scoped to this bucket so the
+                # default bucket's alpha trajectory cannot be perturbed by
+                # outcomes routed to a per-category bucket (and vice versa).
+                quantile = self._get_quantile_locked(key)
                 covered = residual <= quantile
                 err_t = 0.0 if covered else 1.0
-                # alpha_t+1 = alpha_t + gamma * (alpha - err_t)
-                self._alpha_t = self._alpha_t + self._gamma * (self._alpha - err_t)
-                self._alpha_t = min(0.5, max(0.001, self._alpha_t))
+                alpha_t = self._alpha_t[key] + self._gamma * (self._alpha - err_t)
+                self._alpha_t[key] = min(0.5, max(0.001, alpha_t))
 
-    def _get_quantile_locked(self) -> float:
-        """Conformal quantile — caller must hold self._lock."""
-        if not self._residuals:
+    def _get_quantile_locked(self, key: str) -> float:
+        """Conformal quantile for the named bucket. Caller must hold ``self._lock``."""
+        bucket = self._residuals.get(key)
+        if not bucket:
             return 1.0
-        sorted_residuals = sorted(self._residuals)
+        sorted_residuals = sorted(bucket)
         n = len(sorted_residuals)
+        alpha_t = self._alpha_t.get(key, self._alpha)
         # Quantile level: ceil((1 - alpha)(n + 1)) / n
-        level = math.ceil((1 - self._alpha_t) * (n + 1)) / n
+        level = math.ceil((1 - alpha_t) * (n + 1)) / n
         level = min(1.0, level)
         idx = min(int(level * n), n - 1)
         return sorted_residuals[idx]
 
-    def _get_quantile(self) -> float:
-        """Conformal quantile from calibration residuals."""
+    def _get_quantile(self, category: Optional[str] = None) -> float:
+        """Conformal quantile from the named bucket's residuals."""
+        key = self._bucket_key(category)
         with self._lock:
-            return self._get_quantile_locked()
+            return self._get_quantile_locked(key)
 
-    def predict_interval(self, point_estimate: float) -> tuple[float, float]:
+    def predict_interval(
+        self,
+        point_estimate: float,
+        category: Optional[str] = None,
+    ) -> tuple[float, float]:
         """Produce a conformal prediction interval around the point estimate.
 
-        Returns (lower, upper) where true risk is in [lower, upper]
-        with probability >= 1 - alpha.
+        Returns ``(lower, upper)`` where the true risk is in ``[lower, upper]``
+        with probability >= 1 - alpha for the named category bucket.
+
+        When ``category`` is omitted the default bucket is used and behaviour
+        matches pre-Mondrian split conformal exactly. When the named bucket
+        has fewer than ``min_calibration`` residuals, returns the conservative
+        ``[point - 0.3, point + 0.3]`` fallback (clamped to [0, 1]).
         """
+        key = self._bucket_key(category)
         with self._lock:
-            if len(self._residuals) < self._min_calibration:
-                # Not enough data — return conservative interval
+            bucket = self._residuals.get(key)
+            if not bucket or len(bucket) < self._min_calibration:
                 return (max(0.0, point_estimate - 0.3), min(1.0, point_estimate + 0.3))
-            q = self._get_quantile_locked()
+            q = self._get_quantile_locked(key)
         lower = max(0.0, point_estimate - q)
         upper = min(1.0, point_estimate + q)
         return (lower, upper)

--- a/tests/test_mondrian_conformal.py
+++ b/tests/test_mondrian_conformal.py
@@ -1,0 +1,136 @@
+"""Tests for the Mondrian (class-conditional) extension to ConformalCalibrator.
+
+The marginal-mode behaviour is covered by tests/test_scorer.py against
+ConformalCalibrator's pre-existing surface. This file verifies the new
+opt-in per-category mode and that it leaves the marginal mode bit-for-bit
+unchanged.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from vaara.scorer.adaptive import ConformalCalibrator
+
+
+@pytest.fixture
+def calibrator():
+    # Small min_calibration keeps test runs fast while still exercising
+    # the FACI update path (which only triggers at min_calibration and beyond).
+    return ConformalCalibrator(
+        alpha=0.10, min_calibration=10, max_calibration=100, gamma=0.005,
+    )
+
+
+class TestBackwardsCompat:
+    def test_no_category_arg_lands_in_default_bucket(self, calibrator):
+        for _ in range(10):
+            calibrator.add_calibration_point(0.5, 0.5)
+        assert calibrator.calibration_size == 10
+        assert calibrator.calibration_size_for(None) == 10
+        assert calibrator.is_calibrated
+
+    def test_predict_interval_marginal_path_unchanged(self, calibrator):
+        # Below min_calibration → conservative ±0.3 fallback
+        assert calibrator.predict_interval(0.5) == (0.2, 0.8)
+        for _ in range(10):
+            calibrator.add_calibration_point(0.5, 0.5)
+        # All zero residuals → tight interval at the point estimate
+        assert calibrator.predict_interval(0.5) == (0.5, 0.5)
+
+    def test_effective_alpha_starts_at_configured(self, calibrator):
+        assert calibrator.effective_alpha == 0.10
+        assert calibrator.effective_alpha_for(None) == 0.10
+        assert calibrator.effective_alpha_for("never_seen") == 0.10
+
+
+class TestPerCategoryIsolation:
+    def test_residuals_isolated_by_category(self, calibrator):
+        for _ in range(10):
+            calibrator.add_calibration_point(0.0, 0.5, category="A")
+            calibrator.add_calibration_point(0.0, 0.0, category="B")
+        assert calibrator.calibration_size_for("A") == 10
+        assert calibrator.calibration_size_for("B") == 10
+        assert calibrator.calibration_size_for(None) == 0
+        assert calibrator.calibration_size == 20
+
+    def test_quantile_diverges_per_category(self, calibrator):
+        # A: residual = 0.5 every time. B: residual = 0.05 every time.
+        for _ in range(15):
+            calibrator.add_calibration_point(0.0, 0.5, category="A")
+            calibrator.add_calibration_point(0.05, 0.0, category="B")
+        lo_a, hi_a = calibrator.predict_interval(0.5, category="A")
+        lo_b, hi_b = calibrator.predict_interval(0.5, category="B")
+        assert (hi_a - lo_a) > (hi_b - lo_b)
+        assert (hi_b - lo_b) < 0.2
+
+    def test_default_bucket_unaffected_by_categorized_calls(self, calibrator):
+        for _ in range(20):
+            calibrator.add_calibration_point(0.0, 0.7, category="X")
+        assert not calibrator.is_calibrated
+        assert calibrator.predict_interval(0.5) == (0.2, 0.8)
+
+    def test_alpha_t_isolated_per_bucket(self, calibrator):
+        # 15 points with residual 1.0 → 5 FACI updates, alpha_t drifts
+        for _ in range(15):
+            calibrator.add_calibration_point(0.0, 1.0, category="A")
+        assert calibrator.effective_alpha_for("A") != 0.10
+        assert calibrator.effective_alpha_for(None) == 0.10
+        assert calibrator.effective_alpha == 0.10
+
+
+class TestReadiness:
+    def test_is_calibrated_for_per_bucket(self, calibrator):
+        for _ in range(10):
+            calibrator.add_calibration_point(0.5, 0.5, category="A")
+        for _ in range(5):
+            calibrator.add_calibration_point(0.5, 0.5, category="B")
+        assert calibrator.is_calibrated_for("A") is True
+        assert calibrator.is_calibrated_for("B") is False
+        assert calibrator.is_calibrated_for(None) is False
+
+    def test_unseen_category_returns_zero_size(self, calibrator):
+        assert calibrator.calibration_size_for("never_seen") == 0
+        assert not calibrator.is_calibrated_for("never_seen")
+
+
+class TestPredictIntervalPerCategory:
+    def test_underfilled_category_conservative_fallback(self, calibrator):
+        for _ in range(15):
+            calibrator.add_calibration_point(0.5, 0.5, category="A")
+        # Querying an underfilled bucket falls back regardless of A's state
+        assert calibrator.predict_interval(0.5, category="B") == (0.2, 0.8)
+
+    def test_categorized_predict_uses_bucket_quantile(self, calibrator):
+        for _ in range(15):
+            calibrator.add_calibration_point(0.5, 0.5, category="A")
+        assert calibrator.predict_interval(0.5, category="A") == (0.5, 0.5)
+
+    def test_clamping_preserved_per_category(self, calibrator):
+        for _ in range(15):
+            calibrator.add_calibration_point(0.0, 1.0, category="A")
+        lo, hi = calibrator.predict_interval(0.5, category="A")
+        assert lo == 0.0
+        assert hi == 1.0
+
+
+class TestRobustness:
+    def test_nan_input_dropped_per_bucket(self, calibrator):
+        calibrator.add_calibration_point(0.5, float("nan"), category="A")
+        calibrator.add_calibration_point(float("inf"), 0.5, category="A")
+        calibrator.add_calibration_point(0.5, math.nan, category="A")
+        assert calibrator.calibration_size_for("A") == 0
+
+    def test_non_numeric_input_dropped(self, calibrator):
+        calibrator.add_calibration_point("oops", 0.5, category="A")
+        calibrator.add_calibration_point(0.5, None, category="A")
+        assert calibrator.calibration_size_for("A") == 0
+
+    def test_empty_string_category_routes_to_default(self, calibrator):
+        # Empty string is falsy. Routing it to the default bucket avoids
+        # phantom "" buckets when callers accidentally pass an empty value.
+        calibrator.add_calibration_point(0.5, 0.5, category="")
+        assert calibrator.calibration_size_for(None) == 1
+        assert calibrator.calibration_size_for("") == 1
+        assert calibrator.calibration_size == 1


### PR DESCRIPTION
## Summary

`ConformalCalibrator` gains an opt-in `category` argument on `add_calibration_point` and `predict_interval`. Each distinct category string gets its own residual deque, FACI alpha trajectory, and conformal quantile, so a per-category coverage guarantee holds independently of the marginal one.

Without `category`, calls land in a single default bucket and behaviour matches pre-Mondrian split conformal exactly. `AdaptiveScorer` (and every other current call site) keeps working unchanged.

## New surface

- `calibration_size_for(category)`
- `is_calibrated_for(category)`
- `effective_alpha_for(category)`

The existing properties (`calibration_size`, `is_calibrated`, `effective_alpha`) keep their semantics. `calibration_size` now sums across all buckets, which equals the old single-deque length when only the default bucket is used.

## Why

The empirical coverage measurement landed in #59 surfaces marginal coverage only. A 90% headline that hides 60% on `credential_exfil` and 99% on `benign_control` is exactly the failure mode that Mondrian (class-conditional) conformal addresses. This PR is the calibrator-side groundwork. AdaptiveScorer integration (routing per-action category through to the calibrator) and a `--mondrian` flag on `scripts/eval_adversarial.py` ship as a follow-up so this PR stays focused and easy to review.

## Test plan

- [x] `pytest tests/test_mondrian_conformal.py -q` (15 passed: backwards compat, per-category isolation, FACI per bucket, conservative fallback per bucket, NaN safety, empty-string routing)
- [x] `pytest tests/test_scorer.py -q` (24 passed, all pre-Mondrian tests still green, confirms backwards compat)
- [x] `pytest tests/ -q` (361 passed, 12 skipped)
- [x] `ruff check src/vaara/scorer/adaptive.py tests/test_mondrian_conformal.py` clean
- [x] `mypy src/vaara/scorer/adaptive.py` clean

## Reference

Vovk (2012), "Conditional validity of inductive conformal predictors" (Mondrian conformal prediction).

Generated with [Claude Code](https://claude.com/claude-code)
