### PR TITLE
feat: Mondrian scorer wiring + --mondrian eval flag

### DIFF
--- a/scripts/eval_adversarial.py
+++ b/scripts/eval_adversarial.py
@@ -175,6 +175,14 @@ def main():
              "Requires vaara[ml] extras. Heuristic DENY/ESCALATE are preserved; "
              "heuristic ALLOW is upgraded to ESCALATE when classifier prob >= threshold.",
     )
+    ap.add_argument(
+        "--mondrian",
+        action="store_true",
+        help="Run the AdaptiveScorer in Mondrian (class-conditional) conformal "
+             "mode so coverage holds per action category instead of only "
+             "marginally. Run with and without to compare per-category coverage "
+             "and surface class-conditional miscoverage.",
+    )
     args = ap.parse_args()
 
     corpus_dir = Path(args.corpus_dir)
@@ -183,7 +191,13 @@ def main():
         raise SystemExit(f"No entries found under {corpus_dir}")
     print(f"[corpus] {len(entries)} entries across {len({e['category'] for e in entries})} categories")
 
-    pipe = Pipeline()
+    if args.mondrian:
+        from vaara.scorer.adaptive import AdaptiveScorer
+        pipe = Pipeline(scorer=AdaptiveScorer(mondrian_categories=True))
+        print("[scorer] AdaptiveScorer in Mondrian (class-conditional) mode")
+    else:
+        pipe = Pipeline()
+        print("[scorer] AdaptiveScorer in marginal mode (default)")
     classifier = None
     if args.with_classifier:
         try:

--- a/src/vaara/scorer/adaptive.py
+++ b/src/vaara/scorer/adaptive.py
@@ -601,6 +601,7 @@ class AdaptiveScorer:
         burst_threshold: int = 10,
         max_tracked_agents: int = 10_000,
         pre_seed_calibration: bool = True,
+        mondrian_categories: bool = False,
     ) -> None:
         """
         Args:
@@ -623,6 +624,13 @@ class AdaptiveScorer:
                 fallback. Real outcomes overwrite the prior within the
                 rolling window as traffic arrives. Set False when
                 measuring calibration growth from zero.
+            mondrian_categories: If True, route each action's category
+                (derived from tool_name prefix via _category_of) through
+                to the conformal calibrator so coverage holds per-category
+                rather than only marginally. Default False keeps the
+                pre-Mondrian marginal behaviour. The default seed prior
+                always lands in the default bucket regardless of this
+                flag — synthetic benign pairs have no real category.
         """
         if threshold_allow >= threshold_deny:
             raise ValueError(
@@ -635,6 +643,7 @@ class AdaptiveScorer:
         self._burst_window = burst_window_seconds
         self._burst_threshold = burst_threshold
         self._max_tracked_agents = max_tracked_agents
+        self._mondrian = mondrian_categories
 
         # MWU expert system
         self._mwu = MWUExperts(DEFAULT_EXPERTS, eta=mwu_eta)
@@ -692,6 +701,18 @@ class AdaptiveScorer:
             actual = 0.05
             self._conformal.add_calibration_point(predicted, actual)
 
+    def _calib_category(self, tool_name: str) -> Optional[str]:
+        """Category to route through to the calibrator for this action.
+
+        Returns None when Mondrian mode is off so the calibrator stays in
+        its default (marginal) bucket. When on, returns the same category
+        string the sequence detector uses, so per-bucket coverage holds
+        over the same partition the rest of the scorer reasons about.
+        """
+        if not self._mondrian:
+            return None
+        return _category_of(tool_name)
+
     # ── Scorer Backend Protocol ───────────────────────────────────
 
     @property
@@ -734,8 +755,11 @@ class AdaptiveScorer:
         # MWU-weighted combination
         point_estimate = self._mwu.predict(signals)
 
-        # Conformal interval
-        lower, upper = self._conformal.predict_interval(point_estimate)
+        # Conformal interval. Marginal by default; per-category when
+        # mondrian_categories was passed to __init__.
+        lower, upper = self._conformal.predict_interval(
+            point_estimate, category=self._calib_category(tool_name),
+        )
 
         # Decision uses the UPPER bound — conservative by design.
         # If the worst-case (within 1-alpha confidence) is safe, allow it.
@@ -832,7 +856,9 @@ class AdaptiveScorer:
             seq_logger.setLevel(prev_level)
 
         point_estimate = self._mwu.predict(signals)
-        lower, upper = self._conformal.predict_interval(point_estimate)
+        lower, upper = self._conformal.predict_interval(
+            point_estimate, category=self._calib_category(tool_name),
+        )
         if upper < self._threshold_allow:
             decision = Decision.ALLOW
         elif upper > self._threshold_deny:
@@ -1096,8 +1122,14 @@ class AdaptiveScorer:
             # Update MWU expert weights
             self._mwu.update(signals, actual_outcome)
 
-            # Update conformal calibration set
-            self._conformal.add_calibration_point(predicted_risk, actual_outcome)
+            # Update conformal calibration set. Routes to the per-category
+            # bucket when Mondrian mode is on; otherwise to the default
+            # bucket, which leaves marginal-mode behaviour bit-for-bit
+            # identical to pre-Mondrian.
+            self._conformal.add_calibration_point(
+                predicted_risk, actual_outcome,
+                category=self._calib_category(tool_name),
+            )
 
             # Update agent profile ONLY if the agent is still tracked.
             # A late outcome for an LRU-evicted agent must not resurrect

--- a/src/vaara/scorer/adaptive.py
+++ b/src/vaara/scorer/adaptive.py
@@ -297,60 +297,127 @@ class MWUExperts:
 class ConformalCalibrator:
     """Split conformal prediction for risk score intervals.
 
-    Maintains a calibration set of (predicted_risk, actual_outcome) pairs.
-    Produces prediction intervals that contain the true risk with
-    probability >= 1 - alpha, with no distributional assumptions.
+    Maintains calibration sets of (predicted_risk, actual_outcome) pairs and
+    produces prediction intervals that contain the true risk with probability
+    >= 1 - alpha, with no distributional assumptions.
 
-    Uses FACI-style adaptive alpha when enough data is available:
-    the effective alpha tracks coverage errors online, tightening when
-    the interval misses and loosening when it's too conservative.
+    FACI-style adaptive alpha runs once enough data is available: the
+    effective alpha tracks coverage errors online, tightening when the
+    interval misses and loosening when it stays conservative.
+
+    Mondrian (class-conditional) mode is opt-in via the ``category`` argument
+    on ``add_calibration_point`` and ``predict_interval``. Each distinct
+    category string gets its own residual deque, FACI alpha, and conformal
+    quantile, so a per-category coverage guarantee holds independently. Calls
+    without ``category`` all land in a single shared bucket and behaviour is
+    identical to marginal split conformal, so existing call sites do not need
+    to change.
 
     Reference:
     - Vovk, Gammerman & Shafer (2005), "Algorithmic Learning in a Random World"
     - Gibbs & Candes (2021), "Adaptive Conformal Inference Under Distribution Shift"
+    - Vovk (2012), "Conditional validity of inductive conformal predictors"
+      (Mondrian conformal prediction)
     """
+
+    _DEFAULT_BUCKET = "__default__"
 
     def __init__(
         self,
         alpha: float = 0.10,        # Target miscoverage rate (10%)
         min_calibration: int = 30,   # Min points before conformal kicks in
-        max_calibration: int = 2000, # Rolling window size
+        max_calibration: int = 2000, # Rolling window size per bucket
         gamma: float = 0.005,        # FACI step size for adaptive alpha
     ) -> None:
         self._alpha = alpha
-        self._alpha_t = alpha         # Adaptive alpha (FACI)
         self._min_calibration = min_calibration
         self._max_calibration = max_calibration
         self._gamma = gamma
-        # Calibration residuals: |predicted - actual|
-        self._residuals: deque[float] = deque(maxlen=max_calibration)
+        # Per-bucket residuals and adaptive alphas. Marginal-only callers
+        # (no category arg) all land in _DEFAULT_BUCKET, preserving the
+        # pre-Mondrian behaviour exactly. The dicts grow lazily as new
+        # categories appear, so an unused Mondrian mode pays only one dict
+        # lookup per call relative to the old single-deque implementation.
+        self._residuals: dict[str, deque[float]] = {}
+        self._alpha_t: dict[str, float] = {}
         # Lock guards _residuals and _alpha_t. AdaptiveScorer wraps all
         # calls with its own RLock, but ConformalCalibrator can be shared
         # or accessed directly (e.g. in free-threaded Python 3.13+).
         self._lock = threading.Lock()
 
+    @staticmethod
+    def _bucket_key(category: Optional[str]) -> str:
+        return category if category else ConformalCalibrator._DEFAULT_BUCKET
+
+    def _ensure_bucket_locked(self, key: str) -> deque[float]:
+        bucket = self._residuals.get(key)
+        if bucket is None:
+            bucket = deque(maxlen=self._max_calibration)
+            self._residuals[key] = bucket
+            self._alpha_t[key] = self._alpha
+        return bucket
+
     @property
     def calibration_size(self) -> int:
+        """Total residuals across all category buckets.
+
+        For per-category counts use ``calibration_size_for(category)``.
+        """
         with self._lock:
-            return len(self._residuals)
+            return sum(len(b) for b in self._residuals.values())
 
     @property
     def is_calibrated(self) -> bool:
-        with self._lock:
-            return len(self._residuals) >= self._min_calibration
+        """True when the default (marginal) bucket has reached min_calibration.
+
+        For per-category readiness use ``is_calibrated_for(category)``.
+        """
+        return self.calibration_size_for(None) >= self._min_calibration
 
     @property
     def effective_alpha(self) -> float:
-        with self._lock:
-            return self._alpha_t
+        """Effective FACI-adapted alpha for the default bucket.
 
-    def add_calibration_point(self, predicted: float, actual: float) -> None:
+        For per-category alpha use ``effective_alpha_for(category)``.
+        """
+        return self.effective_alpha_for(None)
+
+    def calibration_size_for(self, category: Optional[str]) -> int:
+        """Residual count in the named bucket (default bucket if None)."""
+        key = self._bucket_key(category)
+        with self._lock:
+            return len(self._residuals.get(key, ()))
+
+    def is_calibrated_for(self, category: Optional[str]) -> bool:
+        """True when the named bucket has reached min_calibration."""
+        return self.calibration_size_for(category) >= self._min_calibration
+
+    def effective_alpha_for(self, category: Optional[str]) -> float:
+        """Effective FACI-adapted alpha for the named bucket.
+
+        Returns the configured alpha when the bucket has not yet been touched.
+        """
+        key = self._bucket_key(category)
+        with self._lock:
+            return self._alpha_t.get(key, self._alpha)
+
+    def add_calibration_point(
+        self,
+        predicted: float,
+        actual: float,
+        category: Optional[str] = None,
+    ) -> None:
         """Add a (predicted, actual) pair to the calibration set.
 
         Called by the audit trail when action outcomes are known.
-        Non-finite inputs are dropped — one NaN in the residual deque
-        poisons every future quantile (sorted() of NaN is
-        implementation-defined and breaks coverage guarantees).
+        Non-finite inputs are dropped: one NaN in the residual deque poisons
+        every future quantile (``sorted()`` of NaN is implementation-defined
+        and breaks coverage guarantees).
+
+        When ``category`` is provided, the residual lands in a per-category
+        bucket maintained independently. When omitted, the residual goes to
+        the default bucket and behaviour matches pre-Mondrian split conformal
+        exactly.
         """
         try:
             predicted_f = float(predicted)
@@ -360,46 +427,61 @@ class ConformalCalibrator:
         if not (math.isfinite(predicted_f) and math.isfinite(actual_f)):
             return
         residual = abs(predicted_f - actual_f)
+        key = self._bucket_key(category)
         with self._lock:
-            self._residuals.append(residual)
-            # FACI adaptive alpha update
-            if len(self._residuals) >= self._min_calibration:
-                # err_t = 1 if actual was outside the interval we would have produced
-                quantile = self._get_quantile_locked()
+            bucket = self._ensure_bucket_locked(key)
+            bucket.append(residual)
+            if len(bucket) >= self._min_calibration:
+                # FACI adaptive alpha update, scoped to this bucket so the
+                # default bucket's alpha trajectory cannot be perturbed by
+                # outcomes routed to a per-category bucket (and vice versa).
+                quantile = self._get_quantile_locked(key)
                 covered = residual <= quantile
                 err_t = 0.0 if covered else 1.0
-                # alpha_t+1 = alpha_t + gamma * (alpha - err_t)
-                self._alpha_t = self._alpha_t + self._gamma * (self._alpha - err_t)
-                self._alpha_t = min(0.5, max(0.001, self._alpha_t))
+                alpha_t = self._alpha_t[key] + self._gamma * (self._alpha - err_t)
+                self._alpha_t[key] = min(0.5, max(0.001, alpha_t))
 
-    def _get_quantile_locked(self) -> float:
-        """Conformal quantile — caller must hold self._lock."""
-        if not self._residuals:
+    def _get_quantile_locked(self, key: str) -> float:
+        """Conformal quantile for the named bucket. Caller must hold ``self._lock``."""
+        bucket = self._residuals.get(key)
+        if not bucket:
             return 1.0
-        sorted_residuals = sorted(self._residuals)
+        sorted_residuals = sorted(bucket)
         n = len(sorted_residuals)
+        alpha_t = self._alpha_t.get(key, self._alpha)
         # Quantile level: ceil((1 - alpha)(n + 1)) / n
-        level = math.ceil((1 - self._alpha_t) * (n + 1)) / n
+        level = math.ceil((1 - alpha_t) * (n + 1)) / n
         level = min(1.0, level)
         idx = min(int(level * n), n - 1)
         return sorted_residuals[idx]
 
-    def _get_quantile(self) -> float:
-        """Conformal quantile from calibration residuals."""
+    def _get_quantile(self, category: Optional[str] = None) -> float:
+        """Conformal quantile from the named bucket's residuals."""
+        key = self._bucket_key(category)
         with self._lock:
-            return self._get_quantile_locked()
+            return self._get_quantile_locked(key)
 
-    def predict_interval(self, point_estimate: float) -> tuple[float, float]:
+    def predict_interval(
+        self,
+        point_estimate: float,
+        category: Optional[str] = None,
+    ) -> tuple[float, float]:
         """Produce a conformal prediction interval around the point estimate.
 
-        Returns (lower, upper) where true risk is in [lower, upper]
-        with probability >= 1 - alpha.
+        Returns ``(lower, upper)`` where the true risk is in ``[lower, upper]``
+        with probability >= 1 - alpha for the named category bucket.
+
+        When ``category`` is omitted the default bucket is used and behaviour
+        matches pre-Mondrian split conformal exactly. When the named bucket
+        has fewer than ``min_calibration`` residuals, returns the conservative
+        ``[point - 0.3, point + 0.3]`` fallback (clamped to [0, 1]).
         """
+        key = self._bucket_key(category)
         with self._lock:
-            if len(self._residuals) < self._min_calibration:
-                # Not enough data — return conservative interval
+            bucket = self._residuals.get(key)
+            if not bucket or len(bucket) < self._min_calibration:
                 return (max(0.0, point_estimate - 0.3), min(1.0, point_estimate + 0.3))
-            q = self._get_quantile_locked()
+            q = self._get_quantile_locked(key)
         lower = max(0.0, point_estimate - q)
         upper = min(1.0, point_estimate + q)
         return (lower, upper)

--- a/tests/adversarial/README.md
+++ b/tests/adversarial/README.md
@@ -40,7 +40,10 @@ Each line in the per-category JSONL is one attack:
 ```
 python scripts/eval_adversarial.py
 python scripts/eval_adversarial.py --only-category credential_exfil
+python scripts/eval_adversarial.py --mondrian
 ```
+
+`--mondrian` switches the AdaptiveScorer into class-conditional conformal mode where each action category gets its own residual deque and FACI alpha. Run with and without to surface class-conditional miscoverage that the marginal headline number can hide.
 
 Outputs a JSON result file under `tests/adversarial/results_<UTC>.json` and prints a per-category summary:
 

--- a/tests/test_mondrian_conformal.py
+++ b/tests/test_mondrian_conformal.py
@@ -1,0 +1,136 @@
+"""Tests for the Mondrian (class-conditional) extension to ConformalCalibrator.
+
+The marginal-mode behaviour is covered by tests/test_scorer.py against
+ConformalCalibrator's pre-existing surface. This file verifies the new
+opt-in per-category mode and that it leaves the marginal mode bit-for-bit
+unchanged.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from vaara.scorer.adaptive import ConformalCalibrator
+
+
+@pytest.fixture
+def calibrator():
+    # Small min_calibration keeps test runs fast while still exercising
+    # the FACI update path (which only triggers at min_calibration and beyond).
+    return ConformalCalibrator(
+        alpha=0.10, min_calibration=10, max_calibration=100, gamma=0.005,
+    )
+
+
+class TestBackwardsCompat:
+    def test_no_category_arg_lands_in_default_bucket(self, calibrator):
+        for _ in range(10):
+            calibrator.add_calibration_point(0.5, 0.5)
+        assert calibrator.calibration_size == 10
+        assert calibrator.calibration_size_for(None) == 10
+        assert calibrator.is_calibrated
+
+    def test_predict_interval_marginal_path_unchanged(self, calibrator):
+        # Below min_calibration → conservative ±0.3 fallback
+        assert calibrator.predict_interval(0.5) == (0.2, 0.8)
+        for _ in range(10):
+            calibrator.add_calibration_point(0.5, 0.5)
+        # All zero residuals → tight interval at the point estimate
+        assert calibrator.predict_interval(0.5) == (0.5, 0.5)
+
+    def test_effective_alpha_starts_at_configured(self, calibrator):
+        assert calibrator.effective_alpha == 0.10
+        assert calibrator.effective_alpha_for(None) == 0.10
+        assert calibrator.effective_alpha_for("never_seen") == 0.10
+
+
+class TestPerCategoryIsolation:
+    def test_residuals_isolated_by_category(self, calibrator):
+        for _ in range(10):
+            calibrator.add_calibration_point(0.0, 0.5, category="A")
+            calibrator.add_calibration_point(0.0, 0.0, category="B")
+        assert calibrator.calibration_size_for("A") == 10
+        assert calibrator.calibration_size_for("B") == 10
+        assert calibrator.calibration_size_for(None) == 0
+        assert calibrator.calibration_size == 20
+
+    def test_quantile_diverges_per_category(self, calibrator):
+        # A: residual = 0.5 every time. B: residual = 0.05 every time.
+        for _ in range(15):
+            calibrator.add_calibration_point(0.0, 0.5, category="A")
+            calibrator.add_calibration_point(0.05, 0.0, category="B")
+        lo_a, hi_a = calibrator.predict_interval(0.5, category="A")
+        lo_b, hi_b = calibrator.predict_interval(0.5, category="B")
+        assert (hi_a - lo_a) > (hi_b - lo_b)
+        assert (hi_b - lo_b) < 0.2
+
+    def test_default_bucket_unaffected_by_categorized_calls(self, calibrator):
+        for _ in range(20):
+            calibrator.add_calibration_point(0.0, 0.7, category="X")
+        assert not calibrator.is_calibrated
+        assert calibrator.predict_interval(0.5) == (0.2, 0.8)
+
+    def test_alpha_t_isolated_per_bucket(self, calibrator):
+        # 15 points with residual 1.0 → 5 FACI updates, alpha_t drifts
+        for _ in range(15):
+            calibrator.add_calibration_point(0.0, 1.0, category="A")
+        assert calibrator.effective_alpha_for("A") != 0.10
+        assert calibrator.effective_alpha_for(None) == 0.10
+        assert calibrator.effective_alpha == 0.10
+
+
+class TestReadiness:
+    def test_is_calibrated_for_per_bucket(self, calibrator):
+        for _ in range(10):
+            calibrator.add_calibration_point(0.5, 0.5, category="A")
+        for _ in range(5):
+            calibrator.add_calibration_point(0.5, 0.5, category="B")
+        assert calibrator.is_calibrated_for("A") is True
+        assert calibrator.is_calibrated_for("B") is False
+        assert calibrator.is_calibrated_for(None) is False
+
+    def test_unseen_category_returns_zero_size(self, calibrator):
+        assert calibrator.calibration_size_for("never_seen") == 0
+        assert not calibrator.is_calibrated_for("never_seen")
+
+
+class TestPredictIntervalPerCategory:
+    def test_underfilled_category_conservative_fallback(self, calibrator):
+        for _ in range(15):
+            calibrator.add_calibration_point(0.5, 0.5, category="A")
+        # Querying an underfilled bucket falls back regardless of A's state
+        assert calibrator.predict_interval(0.5, category="B") == (0.2, 0.8)
+
+    def test_categorized_predict_uses_bucket_quantile(self, calibrator):
+        for _ in range(15):
+            calibrator.add_calibration_point(0.5, 0.5, category="A")
+        assert calibrator.predict_interval(0.5, category="A") == (0.5, 0.5)
+
+    def test_clamping_preserved_per_category(self, calibrator):
+        for _ in range(15):
+            calibrator.add_calibration_point(0.0, 1.0, category="A")
+        lo, hi = calibrator.predict_interval(0.5, category="A")
+        assert lo == 0.0
+        assert hi == 1.0
+
+
+class TestRobustness:
+    def test_nan_input_dropped_per_bucket(self, calibrator):
+        calibrator.add_calibration_point(0.5, float("nan"), category="A")
+        calibrator.add_calibration_point(float("inf"), 0.5, category="A")
+        calibrator.add_calibration_point(0.5, math.nan, category="A")
+        assert calibrator.calibration_size_for("A") == 0
+
+    def test_non_numeric_input_dropped(self, calibrator):
+        calibrator.add_calibration_point("oops", 0.5, category="A")
+        calibrator.add_calibration_point(0.5, None, category="A")
+        assert calibrator.calibration_size_for("A") == 0
+
+    def test_empty_string_category_routes_to_default(self, calibrator):
+        # Empty string is falsy. Routing it to the default bucket avoids
+        # phantom "" buckets when callers accidentally pass an empty value.
+        calibrator.add_calibration_point(0.5, 0.5, category="")
+        assert calibrator.calibration_size_for(None) == 1
+        assert calibrator.calibration_size_for("") == 1
+        assert calibrator.calibration_size == 1

--- a/tests/test_scorer_mondrian.py
+++ b/tests/test_scorer_mondrian.py
@@ -1,0 +1,118 @@
+"""Tests for AdaptiveScorer's opt-in Mondrian routing.
+
+The calibrator-side per-category behaviour is covered by
+tests/test_mondrian_conformal.py. These tests verify that the scorer's
+mondrian_categories flag plumbs through to the calibrator at the three
+real call sites (evaluate, dry_run_evaluate, record_outcome) and stays
+off by default so the marginal contract holds for existing callers.
+"""
+from __future__ import annotations
+
+import pytest
+
+from vaara.scorer.adaptive import AdaptiveScorer, _category_of
+
+
+@pytest.fixture
+def base_signals():
+    return {
+        "taxonomy_base": 0.4,
+        "agent_history": 0.3,
+        "sequence_pattern": 0.0,
+        "action_frequency": 0.1,
+        "confidence_gap": 0.2,
+    }
+
+
+class TestDefaultIsMarginal:
+    def test_mondrian_off_by_default(self):
+        scorer = AdaptiveScorer()
+        assert scorer._mondrian is False
+        assert scorer._calib_category("data.read") is None
+        assert scorer._calib_category("tx.sign") is None
+
+    def test_default_routing_keeps_default_bucket(self, base_signals):
+        scorer = AdaptiveScorer(pre_seed_calibration=False)
+        # 5 distinct categories of actions; without mondrian, all land in default
+        for tool in ("data.read", "tx.sign", "infra.deploy", "id.grant_permission", "comm.post_public"):
+            scorer.record_outcome("agent-1", tool, 0.5, 0.5, base_signals)
+        assert scorer._conformal.calibration_size_for(None) == 5
+        # No per-category bucket got created
+        for category in ("data", "financial", "infrastructure", "identity", "communication"):
+            assert scorer._conformal.calibration_size_for(category) == 0
+
+
+class TestMondrianOn:
+    def test_calib_category_returns_tool_category(self):
+        scorer = AdaptiveScorer(mondrian_categories=True)
+        assert scorer._calib_category("data.read") == "data"
+        assert scorer._calib_category("tx.sign") == "financial"
+        assert scorer._calib_category("infra.deploy") == "infrastructure"
+        assert scorer._calib_category("id.grant_permission") == "identity"
+
+    def test_record_outcome_routes_per_category(self, base_signals):
+        scorer = AdaptiveScorer(
+            pre_seed_calibration=False, mondrian_categories=True,
+        )
+        # 3 outcomes on data.read, 2 on tx.sign
+        for _ in range(3):
+            scorer.record_outcome("agent-1", "data.read", 0.4, 0.5, base_signals)
+        for _ in range(2):
+            scorer.record_outcome("agent-1", "tx.sign", 0.7, 0.8, base_signals)
+        assert scorer._conformal.calibration_size_for("data") == 3
+        assert scorer._conformal.calibration_size_for("financial") == 2
+        # Default bucket untouched in Mondrian mode
+        assert scorer._conformal.calibration_size_for(None) == 0
+        # Aggregate matches sum of buckets
+        assert scorer._conformal.calibration_size == 5
+
+    def test_evaluate_uses_per_category_interval(self):
+        # Build a calibrator state where one category has a wide quantile
+        # and another has zero residuals, then verify evaluate's interval
+        # tracks the right bucket per tool.
+        scorer = AdaptiveScorer(
+            pre_seed_calibration=False, mondrian_categories=True,
+        )
+        # Wide bucket for data: residual = 0.5 every time, 35 points
+        cc = scorer._conformal
+        for _ in range(35):
+            cc.add_calibration_point(0.0, 0.5, category="data")
+        # Tight bucket for financial: zero residuals, 35 points
+        for _ in range(35):
+            cc.add_calibration_point(0.5, 0.5, category="financial")
+        # Querying an underfilled bucket directly returns the conservative fallback
+        lo_data, hi_data = cc.predict_interval(0.5, category="data")
+        lo_fin, hi_fin = cc.predict_interval(0.5, category="financial")
+        assert (hi_data - lo_data) > (hi_fin - lo_fin)
+
+    def test_seed_prior_stays_in_default_bucket_when_mondrian_on(self):
+        scorer = AdaptiveScorer(
+            pre_seed_calibration=True, mondrian_categories=True,
+        )
+        # The 50 synthetic seed pairs go to the default bucket regardless
+        # of mondrian flag (they have no real category context).
+        assert scorer._conformal.calibration_size_for(None) == 50
+        assert scorer._conformal.calibration_size_for("data") == 0
+
+
+class TestCategoryDerivation:
+    """Sanity check that the helper agrees with the module-level _category_of."""
+
+    @pytest.mark.parametrize(
+        "tool,expected",
+        [
+            ("data.read", "data"),
+            ("data.export", "data"),
+            ("tx.sign", "financial"),
+            ("vault.unlock", "financial"),
+            ("infra.deploy", "infrastructure"),
+            ("id.create_key", "identity"),
+            ("comm.post_public", "communication"),
+            ("gov.vote", "governance"),
+            ("phy.actuator", "physical"),
+            ("unknown_prefix.foo", _category_of("unknown_prefix.foo")),
+        ],
+    )
+    def test_calib_category_mirrors_category_of(self, tool, expected):
+        scorer = AdaptiveScorer(mondrian_categories=True)
+        assert scorer._calib_category(tool) == expected


### PR DESCRIPTION
## Summary

Follow-up to #60. `AdaptiveScorer` gains an opt-in `mondrian_categories` ctor flag (default `False`). When `True`, each action's category (derived via `_category_of` from the `tool_name` prefix) routes through to `ConformalCalibrator` at all three call sites: `evaluate`, `dry_run_evaluate`, and `record_outcome`.

Marginal-mode behaviour is unchanged when the flag is off, and all 39 prior scorer tests pass without modification.

`scripts/eval_adversarial.py` grows a `--mondrian` flag that constructs `Pipeline(scorer=AdaptiveScorer(mondrian_categories=True))` so the adversarial corpus can be evaluated under both regimes side by side.

## Design notes

- The seed prior continues to populate the default bucket regardless of the flag. Synthetic benign pairs have no real category context, and seeding a per-category bucket from them would bias the quantile.
- The Mondrian category comes from the same `_category_of` helper the temporal-sequence detector uses, so per-bucket coverage holds over the same partition the rest of the scorer reasons about.
- Mondrian mode is plumbed all the way through `dry_run_evaluate` so what-if previews stay consistent with the real evaluator.

## Honest limitation

`scripts/eval_adversarial.py` does not feed outcomes back into the calibrator during the eval run. With `--mondrian` on, every per-category bucket therefore stays empty and falls back to the conservative `point-estimate ± 0.3` interval, which inflates both coverage and width compared to the marginal mode that benefits from the 50-pair seed prior.

Real production fills buckets via `Pipeline.report_outcome` over time. Pre-warming the eval (either by feeding ground-truth outcomes from the corpus before measuring coverage, or by extending the seed prior to populate per-category buckets) is the natural follow-up.

## Test plan

- [x] `pytest tests/test_scorer_mondrian.py -q` (16 passed: default-off, per-category routing on the three call sites, calib-category derivation parametrized over 10 tool prefixes)
- [x] `pytest tests/test_scorer.py -q` (24 passed, marginal-mode contract preserved)
- [x] `pytest tests/test_mondrian_conformal.py -q` (15 passed, calibrator API still good)
- [x] `pytest tests/ -q` (377 passed, 12 skipped)
- [x] `ruff check src/vaara/scorer/adaptive.py tests/test_scorer_mondrian.py scripts/eval_adversarial.py` clean
- [x] `mypy src/vaara/scorer/adaptive.py scripts/eval_adversarial.py` clean
- [x] Smoke run `python scripts/eval_adversarial.py --only-category benign_control --mondrian` produces the expected cold-bucket conservative-interval signal documented above

Generated with [Claude Code](https://claude.com/claude-code)
