### PR TITLE
feat: PROV-DM export carries conformal calibration context

### DIFF
--- a/src/vaara/audit/prov_export.py
+++ b/src/vaara/audit/prov_export.py
@@ -77,6 +77,21 @@ def _entity_for(rec: AuditRecord, action_id: str) -> tuple[Optional[str], dict]:
             attrs["vaara:conformalInterval"] = [
                 data["conformal_lower"], data["conformal_upper"],
             ]
+        # Conformal calibration context. Surfacing these on the score Entity
+        # lets an external auditor distinguish a wide interval from a cold
+        # calibrator (low calibration_size) versus one from genuine high
+        # uncertainty (large effective_alpha after FACI drift), and tells
+        # them which Mondrian bucket produced the interval when in
+        # class-conditional mode.
+        cal_size = data.get("calibration_size")
+        if cal_size is not None:
+            attrs["vaara:calibrationSize"] = cal_size
+        eff_alpha = data.get("effective_alpha")
+        if eff_alpha is not None:
+            attrs["vaara:effectiveAlpha"] = eff_alpha
+        bucket = data.get("bucket_category")
+        if bucket:
+            attrs["vaara:bucketCategory"] = bucket
         return f"vaara:score/{action_id}", attrs
     if et in (EventType.DECISION_MADE, EventType.ACTION_BLOCKED):
         default_dec = "deny" if et == EventType.ACTION_BLOCKED else "allow"

--- a/src/vaara/pipeline.py
+++ b/src/vaara/pipeline.py
@@ -437,6 +437,21 @@ class InterceptionPipeline:
         if not isinstance(signals, dict):
             signals = {}
 
+        # Conformal context: effective alpha (FACI-adapted) and bucket
+        # category (Mondrian per-category bucket, None when marginal). Both
+        # are coerced defensively so a buggy backend cannot poison the audit
+        # trail with NaN/inf or non-string category labels.
+        eff_alpha_raw = raw.get("effective_alpha", 0.10)
+        try:
+            effective_alpha = float(eff_alpha_raw)
+        except (TypeError, ValueError):
+            effective_alpha = 0.10
+        if not _math.isfinite(effective_alpha):
+            effective_alpha = 0.10
+        effective_alpha = max(0.0, min(1.0, effective_alpha))
+        bucket_raw = raw.get("bucket_category")
+        bucket_category = bucket_raw if isinstance(bucket_raw, str) and bucket_raw else None
+
         # 5. Record risk scoring in audit
         self.trail.record_risk_scored(
             action_id=action_id,
@@ -448,6 +463,8 @@ class InterceptionPipeline:
                 "conformal_upper": interval[1],
                 "signals": signals,
                 "calibration_size": raw.get("calibration_size", 0),
+                "effective_alpha": effective_alpha,
+                "bucket_category": bucket_category,
             },
             regulatory_domains=action_type.regulatory_domains,
         )

--- a/src/vaara/scorer/adaptive.py
+++ b/src/vaara/scorer/adaptive.py
@@ -94,6 +94,8 @@ class RiskAssessment:
     threshold_deny: float          # Score above this → deny (between = escalate)
     sequence_risk: float           # Contribution from temporal patterns
     calibration_size: int          # How many calibration points we have
+    effective_alpha: float = 0.10  # FACI-adapted alpha for the bucket used
+    bucket_category: Optional[str] = None  # Mondrian bucket; None = marginal
     evaluation_ms: float = 0.0
     explanation: str = ""
 
@@ -138,6 +140,8 @@ class RiskAssessment:
                 "signals": self.signals,
                 "sequence_risk": self.sequence_risk,
                 "calibration_size": self.calibration_size,
+                "effective_alpha": self.effective_alpha,
+                "bucket_category": self.bucket_category,
             },
             "evaluation_ms": self.evaluation_ms,
             "error": None,
@@ -757,9 +761,11 @@ class AdaptiveScorer:
 
         # Conformal interval. Marginal by default; per-category when
         # mondrian_categories was passed to __init__.
+        bucket = self._calib_category(tool_name)
         lower, upper = self._conformal.predict_interval(
-            point_estimate, category=self._calib_category(tool_name),
+            point_estimate, category=bucket,
         )
+        eff_alpha = self._conformal.effective_alpha_for(bucket)
 
         # Decision uses the UPPER bound — conservative by design.
         # If the worst-case (within 1-alpha confidence) is safe, allow it.
@@ -805,6 +811,8 @@ class AdaptiveScorer:
             threshold_deny=self._threshold_deny,
             sequence_risk=signals.get("sequence_pattern", 0.0),
             calibration_size=self._conformal.calibration_size,
+            effective_alpha=eff_alpha,
+            bucket_category=bucket,
             evaluation_ms=elapsed_ms,
             explanation=explanation,
         )
@@ -856,8 +864,9 @@ class AdaptiveScorer:
             seq_logger.setLevel(prev_level)
 
         point_estimate = self._mwu.predict(signals)
+        bucket = self._calib_category(tool_name)
         lower, upper = self._conformal.predict_interval(
-            point_estimate, category=self._calib_category(tool_name),
+            point_estimate, category=bucket,
         )
         if upper < self._threshold_allow:
             decision = Decision.ALLOW
@@ -871,6 +880,9 @@ class AdaptiveScorer:
             "raw_result": {
                 "point_estimate": point_estimate,
                 "conformal_interval": [lower, upper],
+                "calibration_size": self._conformal.calibration_size,
+                "effective_alpha": self._conformal.effective_alpha_for(bucket),
+                "bucket_category": bucket,
             },
         }
 

--- a/tests/test_prov_export.py
+++ b/tests/test_prov_export.py
@@ -224,6 +224,60 @@ def test_iso_timestamp_format() -> None:
     )
 
 
+def _score_entity_with(extra_data: dict) -> dict:
+    """Run the exporter on a single RISK_SCORED record and return the score Entity."""
+    base = {"point_estimate": 0.62, "conformal_lower": 0.55, "conformal_upper": 0.69}
+    rec = _record(
+        EventType.RISK_SCORED, record_id="r1", timestamp=1700000000.0,
+        data={**base, **extra_data},
+    )
+    doc = audit_to_prov_json([rec])
+    return doc["bundle"]["vaara:action/act-1"]["entity"]["vaara:score/act-1"]
+
+
+def test_score_entity_carries_calibration_size() -> None:
+    ent = _score_entity_with({"calibration_size": 1234})
+    assert ent["vaara:calibrationSize"] == 1234
+
+
+def test_score_entity_carries_effective_alpha() -> None:
+    ent = _score_entity_with({"effective_alpha": 0.0875})
+    assert ent["vaara:effectiveAlpha"] == 0.0875
+
+
+def test_score_entity_carries_bucket_category_when_mondrian() -> None:
+    ent = _score_entity_with({"bucket_category": "financial"})
+    assert ent["vaara:bucketCategory"] == "financial"
+
+
+def test_score_entity_omits_bucket_category_when_marginal() -> None:
+    # bucket_category=None is the marginal-mode marker; should not surface
+    ent = _score_entity_with({"bucket_category": None})
+    assert "vaara:bucketCategory" not in ent
+
+
+def test_score_entity_omits_calibration_context_when_data_missing() -> None:
+    # Pre-enrichment audit records (or any record produced without the
+    # extended fields) must not surface synthetic attributes.
+    ent = _score_entity_with({})
+    assert "vaara:calibrationSize" not in ent
+    assert "vaara:effectiveAlpha" not in ent
+    assert "vaara:bucketCategory" not in ent
+
+
+def test_score_entity_full_enrichment_round_trip() -> None:
+    ent = _score_entity_with({
+        "calibration_size": 250,
+        "effective_alpha": 0.10,
+        "bucket_category": "data",
+    })
+    assert ent["vaara:riskScore"] == 0.62
+    assert ent["vaara:conformalInterval"] == [0.55, 0.69]
+    assert ent["vaara:calibrationSize"] == 250
+    assert ent["vaara:effectiveAlpha"] == 0.10
+    assert ent["vaara:bucketCategory"] == "data"
+
+
 def test_cli_rejects_malformed_jsonl(tmp_path: Path, capsys) -> None:
     """A bad line returns exit code 2 with line context, no traceback."""
     from vaara.cli import main


### PR DESCRIPTION
## Summary

W3C PROV-JSON score Entities now surface the full conformal context an external auditor needs to read an interval honestly:

- `vaara:calibrationSize` — residual count in the bucket that produced the interval. A wide interval at `calibration_size=5` means a cold calibrator; the same interval at 2000 means genuine high uncertainty.
- `vaara:effectiveAlpha` — FACI-adapted alpha actually used for this decision, not the configured default. Drift away from the configured alpha is itself an audit signal.
- `vaara:bucketCategory` — Mondrian bucket label when class-conditional mode is on. Omitted entirely in marginal mode so the PROV document stays clean for callers who never opt in.

## Data flow

| Layer | What changed |
|---|---|
| `RiskAssessment` (dataclass) | Two new fields: `effective_alpha: float = 0.10`, `bucket_category: Optional[str] = None`. |
| `AdaptiveScorer` (`evaluate`, `dry_run_evaluate`) | Captures both from the calibrator instance that just produced the interval. |
| `to_backend_decision` | Both included in `raw_result`. |
| `Pipeline.intercept` | Reads them with the same defensive coercion as `conformal_interval` (NaN/inf falls back to configured alpha; non-string category falls back to `None`). |
| `AuditTrail` | Stores in `record.data` alongside existing `conformal_lower` / `conformal_upper` / `calibration_size`. |
| `prov_export` | Surfaces each one. Omits any attribute whose source value is missing or `None`, so pre-enrichment audit records produce the same PROV output as before. |

## Why

#60 added Mondrian per-bucket calibration; #61 wired AdaptiveScorer to use it. Without this PR an auditor reading a PROV trail sees only `vaara:conformalInterval` and cannot tell whether a wide interval came from an empty bucket, a FACI alpha drift, or genuine uncertainty. With it, those three states are distinguishable from the document alone, without re-running Vaara.

## Test plan

- [x] `pytest tests/test_prov_export.py -q` (21 passed: 15 prior + 6 new — calibrationSize, effectiveAlpha, bucketCategory presence and bucketCategory omission in marginal mode and full omission when source data is missing, plus a full-enrichment round-trip)
- [x] `pytest tests/test_pipeline.py tests/test_scorer.py tests/test_scorer_mondrian.py tests/test_mondrian_conformal.py -q` (all green, no contracts broken)
- [x] `pytest tests/ -q` (383 passed, 12 skipped)
- [x] `ruff check src/vaara/scorer/adaptive.py src/vaara/pipeline.py src/vaara/audit/prov_export.py tests/test_prov_export.py` clean
- [x] `mypy src/vaara/scorer/adaptive.py src/vaara/pipeline.py src/vaara/audit/prov_export.py` clean
- [x] End-to-end smoke: `Pipeline(scorer=AdaptiveScorer(mondrian_categories=True)).intercept(... tool_name="data.read" ...)` produces a PROV document with `vaara:calibrationSize=50` (from the seed prior), `vaara:effectiveAlpha=0.1`, `vaara:bucketCategory="data"`

Generated with [Claude Code](https://claude.com/claude-code)
