### PR TITLE
chore: release v0.8.0 (Article 73 incident export + HIL review queue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-14
+
 **Theme: Article 73 serious-incident export (interim).** Adds the export
 surface a provider needs to satisfy EU AI Act Article 73 reporting
 obligations. The Commission template promised by Article 73 paragraph 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.7.0"
+version = "0.8.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## Summary

Cuts v0.8.0 bundling the two features that landed since v0.7.0:

- **#67** — Article 73 serious-incident export (INTERIM, pending Commission template promised by paragraph 7). Schema `vaara-incident/1.0`, reporting deadline derived from Article 3(49) sub-category.
- **#69** — Human-in-the-loop review queue (EU AI Act Article 14). SQLite-backed queue, pipeline wiring, `vaara review` CLI, `ESCALATION_RESOLVED` written to the audit hash chain on operator action.

Both are pure additions, no breaking changes. Semver MINOR bump 0.7.0 → 0.8.0.

## What this PR contains

- `pyproject.toml` 0.7.0 → 0.8.0
- `src/vaara/__init__.py` `__version__` 0.7.0 → 0.8.0
- `CHANGELOG.md` `[Unreleased]` block moved to `[0.8.0] - 2026-05-14`

## Audit pass per `feedback_release_readme_audit.md`

- [x] README — no version-string drift; numbers section is methodology-anchored (corpus size, recall, ASR, latency, MWU bound), unchanged 0.7.0 → 0.8.0
- [x] `src/vaara/__init__.py` library docstring — unchanged, still accurate
- [x] `examples/` — no version-pinned claims
- [x] `scripts/` — historical v0.5.x / v0.6 references are methodology anchors (e.g., "v0.5.0 baseline reproducer"), correct as-is
- [x] `COMPLIANCE.md` — Article 14 + Article 73 rows landed via #67 / #69, no further changes needed

## Test plan

- [x] `pytest -q` — 424 passed, 12 skipped (matches the `[0.8.0]` shipped state)
- [x] `ruff check src/vaara` clean
- [x] `python -c "import vaara; print(vaara.__version__)"` → `0.8.0`

## Release checklist (post-merge)

- [ ] Tag `v0.8.0` on the merge commit
- [ ] Push tag
- [ ] GitHub Release v0.8.0 marked Latest, body = CHANGELOG block
- [ ] `python -m build && twine upload dist/vaara-0.8.0*`

Generated with [Claude Code](https://claude.com/claude-code)