### PR TITLE
docs: v0.9.0 CHANGELOG fixes (date + provenance note)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
-## [0.9.0] - 2026-05-14
+## [0.9.0] - 2026-05-15
 
 **Theme: policy artifact validate + test framework.** v0.9.0 ships the
 two CLI surfaces that turn the YAML / JSON policy from "a config file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ Backwards-compatible. Pure addition. No existing module signatures
 change. `Policy` and the load path are unchanged; the new modules
 sit beside them under `vaara.policy.*`.
 
+### Provenance note
+The PyPI artifact for v0.9.0 was uploaded via `twine` (not via
+trusted publishing) after a GitHub Actions infrastructure outage on
+2026-05-15 caused the Release workflow's Build job to fail at the
+artifact upload step, which skipped the downstream
+trusted-publishing job. The wheel and sdist on PyPI are bit-identical
+to what `python -m build` produced from commit `ea201fe`. Subsequent
+releases use trusted publishing as standard.
+
 ## [0.8.0] - 2026-05-14
 
 **Theme: Article 73 serious-incident export (interim).** Adds the export


### PR DESCRIPTION
## Summary

- Correct the v0.9.0 release date in `CHANGELOG.md` from 2026-05-14 to 2026-05-15. Tag and merge landed 2026-05-15 EEST (commit `ea201fe`). Aligns with the date convention used by every prior release entry.
- Add a `### Provenance note` to the v0.9.0 entry documenting that the PyPI artifact was uploaded via `twine` after a GitHub Actions infrastructure outage on 2026-05-15 caused the Release workflow's Build job to fail at the artifact upload step, which in turn skipped the trusted-publishing job. The wheel and sdist on PyPI are bit-identical to what `python -m build` produced from commit `ea201fe`. Subsequent releases use trusted publishing as standard.

Docs-only. No code, schema, or behaviour changes.

## Test plan

- [ ] CI passes (5 of 5 required status checks)
- [ ] CHANGELOG renders correctly on the rendered page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release date for version 0.9.0. Added provenance documentation detailing the artifact upload process and confirming reproducibility of wheel and source distributions. Included notes on future trusted publishing practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->