### PR TITLE
docs: drop hardcoded EU AI Act enforcement date from engine docstring

### DIFF
--- a/src/vaara/compliance/engine.py
+++ b/src/vaara/compliance/engine.py
@@ -20,8 +20,6 @@ Supported regulatory frameworks:
 The engine is declarative — it doesn't know what "good" looks like in absolute
 terms.  Instead, it maps evidence to requirements and flags where evidence
 is missing, insufficient, or stale.
-
-EU AI Act enforcement for high-risk systems: August 2, 2026.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Removes a single line from the compliance engine module docstring that hardcoded "August 2, 2026" as the EU AI Act high-risk enforcement date. The date moved with the Digital Omnibus political agreement and may move again. The engine does not key behavior on the date, so the line was load-bearing only as a claim with a short shelf life.

## Test plan

- [ ] CI green on the 5 required status checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal module documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->