### PR TITLE
feat: OVERT 1.0 Protocol Profile 1.0 Base Envelope emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- **OVERT 1.0 Protocol Profile 1.0 Base Envelope emitter (`vaara[attestation]` extra).**
+  First OSS Python reference implementation of the OVERT 1.0 AAL-3
+  Phase 2 (Provisional Receipt) emission path. New module
+  `vaara.attestation.overt` produces 9-field closed-schema Base
+  Envelopes per Annex B.6, canonically CBOR-encoded per RFC 8949
+  Section 4.2, Ed25519-signed per RFC 8032, with HMAC-SHA256 keyed
+  request commitments per Annex B.4 and SHA-256 encoder-identity
+  derivation. IEEE-754 floats are rejected at the canonical-encoding
+  boundary per Protocol Profile 1.0 numeric rules. Vaara operates as
+  the **Arbiter** in OVERT terms; external Independent Attestation
+  Providers promote AAL-3 emission to AAL-4 by attaching Phase 3
+  notary signatures and transparency-log inclusion proofs. Public API:
+  `BaseEnvelope`, `emit_base_envelope`, `verify_base_envelope`,
+  `make_request_commitment`, `encoder_binary_identity`, `canonical_cbor`.
+- 13 new attestation tests (`tests/test_attestation_overt.py`).
+  Round-trip verification, IEEE-754-float rejection at every nesting
+  level, key-identifier binding, monotonic-counter binding, tampered-field
+  rejection.
+
 ### Documentation
 - **COMPLIANCE.md** gains two sections under the deployer-vs-Vaara
   ownership boundary: an explicit eIDAS NOTICE (Vaara hash chains and

--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ curl -sX POST http://localhost:8000/v1/score \
 
 The contract is in [docs/openapi.yaml](docs/openapi.yaml). Vaara defines the interface; control-plane and orchestration vendors call it. Integration recipes for adopters live under `examples/recipes/`.
 
+## OVERT 1.0 attestation
+
+Vaara is the first OSS Python reference implementation of the OVERT 1.0 ([overt.is](https://overt.is/), Glacis Technologies, March 2026) Protocol Profile 1.0 Base Envelope at AAL-3 Phase 2 (Provisional Receipt). Closed-schema 9-field structure, canonical CBOR encoding, Ed25519 signatures, HMAC-SHA256 keyed commitments, IEEE-754 float rejection. External Independent Attestation Providers can promote AAL-3 emission to AAL-4 by attaching Phase 3 notary signatures and transparency-log inclusion proofs.
+
+```
+pip install 'vaara[attestation]'
+```
+
+```python
+from vaara.attestation.overt import emit_base_envelope, make_request_commitment, encoder_binary_identity
+
+envelope = emit_base_envelope(
+    signing_key=key,
+    request_commitment=make_request_commitment(payload, operator_key=op_key),
+    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.11.0", policy_hash=ph),
+    non_content_metadata={"action_class": "tx.transfer", "decision": "escalate"},
+    monotonic_counter=42,
+    arbiter_instance_identifier=uuid_bytes,
+)
+```
+
+Vaara operates as the **Arbiter** in OVERT terms. See [COMPLIANCE.md](COMPLIANCE.md) "Position relative to open runtime-attestation standards" for the architectural framing.
+
 ## Where things live
 
 - [docs/formal_specification.md](docs/formal_specification.md): math. MWU regret bound O(sqrt(T log N)), conformal coverage guarantees, security properties.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ export = ["cryptography>=41.0"]
 ml = ["xgboost>=2.0", "scikit-learn>=1.3", "joblib>=1.3", "numpy>=1.24"]
 yaml = ["pyyaml>=6.0"]
 server = ["fastapi>=0.110", "uvicorn>=0.27"]
+attestation = ["cbor2>=5.4", "cryptography>=41.0"]
 
 [project.scripts]
 vaara = "vaara.cli:main"

--- a/src/vaara/attestation/__init__.py
+++ b/src/vaara/attestation/__init__.py
@@ -1,0 +1,36 @@
+"""OVERT 1.0 Protocol Profile 1.0 attestation envelope emission.
+
+Vaara's structural position relative to OVERT 1.0 (Glacis Technologies,
+overt.is): Vaara is the third-party runtime kernel that intercepts agent
+actions, scores risk, and writes the audit trail. In OVERT terms Vaara is
+the **Arbiter** at AAL-3 (operator-controlled notary model). Phase 1
+(Enforcement) and Phase 2 (Provisional Receipt) are emitted by Vaara
+directly. Phase 3 (Full Attestation) requires an external Independent
+Attestation Provider (IAP) and is intentionally out of scope.
+
+The `BaseEnvelope` produced here implements Protocol Profile 1.0 Annex B.6
+verbatim: a 9-field closed-schema CBOR-encoded structure signed with
+Ed25519. Any OVERT-aware verifier (auditor, IAP, relying party) can
+recompute the canonical encoding and verify the signature offline.
+
+Install: ``pip install 'vaara[attestation]'``.
+
+See COMPLIANCE.md "Position relative to open runtime-attestation standards"
+for the full architectural framing.
+"""
+
+from vaara.attestation.overt import (
+    BaseEnvelope,
+    EnvelopeError,
+    canonical_cbor,
+    emit_base_envelope,
+    verify_base_envelope,
+)
+
+__all__ = [
+    "BaseEnvelope",
+    "EnvelopeError",
+    "canonical_cbor",
+    "emit_base_envelope",
+    "verify_base_envelope",
+]

--- a/src/vaara/attestation/overt.py
+++ b/src/vaara/attestation/overt.py
@@ -1,0 +1,344 @@
+"""OVERT 1.0 Protocol Profile 1.0 Base Envelope (Annex B.6).
+
+The Base Envelope is a 9-field closed-schema structure emitted for every
+in-scope AI action. Per Protocol Profile 1.0 it is canonically encoded as
+deterministic CBOR (RFC 8949 Section 4.2) and signed with Ed25519 (RFC 8032).
+
+Field set is FIXED — no additional fields permitted (closed schema). The
+field names below match Annex B.6 of OVERT 1.0. Numeric rules per Protocol
+Profile 1.0 Section B.3: IEEE-754 floats are PROHIBITED. Timestamps are
+uint64 nanoseconds since the Unix epoch. Rates and probabilities, when
+they appear inside `non_content_metadata`, MUST be decimal strings.
+
+This emitter is AAL-3 Phase 2 only (Provisional Receipt with arbiter
+signature). AAL-4 promotion requires an external IAP to attach Phase 3
+notary attestation and transparency-log inclusion proof; that workflow is
+outside Vaara's scope.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+class EnvelopeError(RuntimeError):
+    """Raised when envelope construction or verification fails."""
+
+
+@dataclass(frozen=True)
+class BaseEnvelope:
+    """OVERT 1.0 Protocol Profile 1.0 Base Envelope — Annex B.6.
+
+    Field order matches the spec. The schema is closed: any verifier
+    rejecting additional fields will reject envelopes that carry extras.
+
+    Attributes:
+        blinded_identifier: Opaque per-action identifier. 32 bytes.
+        request_commitment: HMAC-SHA256 keyed commitment over the request
+            content digest. The raw content NEVER leaves the operator
+            environment; only this commitment crosses the trust boundary.
+        encoder_binary_identity: SHA-256 hash identifying the arbiter
+            implementation + version + policy hash at the time of
+            attestation. At AAL-3 this is operator-derived; at AAL-4 it
+            would be notary-derived via a measurement pipeline.
+        non_content_metadata: A CBOR-serializable map of structural
+            classification fields (action class, severity, decision, etc.)
+            that contain no protected content. Operator decides what is
+            safe to include.
+        monotonic_counter: Strictly increasing per-arbiter-instance
+            sequence number. Detects gaps.
+        nanosecond_timestamp: uint64 nanoseconds since Unix epoch.
+        key_identifier: Identifier (e.g., SHA-256 fingerprint) of the
+            Ed25519 public key used to sign this envelope.
+        arbiter_instance_identifier: UUID of the specific Vaara instance
+            that produced this envelope.
+        signature: Ed25519 signature (64 bytes) over the canonical CBOR
+            encoding of the OTHER 8 fields in order.
+    """
+
+    blinded_identifier: bytes
+    request_commitment: bytes
+    encoder_binary_identity: bytes
+    non_content_metadata: dict
+    monotonic_counter: int
+    nanosecond_timestamp: int
+    key_identifier: bytes
+    arbiter_instance_identifier: bytes
+    signature: bytes
+
+    def to_dict(self) -> dict[str, Any]:
+        """Plain-dict form for JSON consumers. Bytes are hex-encoded."""
+        return {
+            "blinded_identifier": self.blinded_identifier.hex(),
+            "request_commitment": self.request_commitment.hex(),
+            "encoder_binary_identity": self.encoder_binary_identity.hex(),
+            "non_content_metadata": self.non_content_metadata,
+            "monotonic_counter": self.monotonic_counter,
+            "nanosecond_timestamp": self.nanosecond_timestamp,
+            "key_identifier": self.key_identifier.hex(),
+            "arbiter_instance_identifier": self.arbiter_instance_identifier.hex(),
+            "signature": self.signature.hex(),
+        }
+
+
+# Domain separation prefix for request commitments — Protocol Profile 1.0
+# uses versioned prefixes on every HMAC operation (Annex B.2). Vaara uses
+# this single prefix for v1 commitments. Profile-defined exact bytes live
+# in the registered Protocol Profile document; this is Vaara's chosen
+# operator-implementation-specific prefix, scoped via the
+# `encoder_binary_identity` field.
+_REQUEST_COMMITMENT_PREFIX = b"vaara/overt-pp1/request-commitment/v1\x00"
+_ENCODER_IDENTITY_PREFIX = b"vaara/overt-pp1/encoder-identity/v1\x00"
+
+
+def _now_ns() -> int:
+    return time.time_ns()
+
+
+def _hmac_sha256(key: bytes, message: bytes) -> bytes:
+    return hmac.new(key, message, hashlib.sha256).digest()
+
+
+def _sha256(message: bytes) -> bytes:
+    return hashlib.sha256(message).digest()
+
+
+def canonical_cbor(value: Any) -> bytes:
+    """Canonical deterministic CBOR encoding per RFC 8949 Section 4.2.
+
+    Uses cbor2 with canonical=True (definite-length, sorted keys, smallest
+    int encoding, no floats). IEEE-754 floats are rejected at the boundary
+    per Protocol Profile 1.0 numeric rules — callers must pass scaled
+    integers or decimal strings for rates and probabilities.
+    """
+    try:
+        import cbor2
+    except ImportError as exc:
+        raise EnvelopeError(
+            "cbor2 not installed. Install with: pip install 'vaara[attestation]'"
+        ) from exc
+
+    _reject_floats(value)
+    return cbor2.dumps(value, canonical=True)
+
+
+def _reject_floats(value: Any, path: str = "") -> None:
+    """Recursively check that no IEEE-754 floats are present."""
+    if isinstance(value, float):
+        raise EnvelopeError(
+            f"IEEE-754 float at {path or '<root>'} is prohibited by "
+            f"Protocol Profile 1.0 numeric rules. Use a scaled integer or "
+            f"decimal string instead."
+        )
+    if isinstance(value, dict):
+        for k, v in value.items():
+            _reject_floats(v, f"{path}.{k}")
+    elif isinstance(value, (list, tuple)):
+        for i, v in enumerate(value):
+            _reject_floats(v, f"{path}[{i}]")
+
+
+def make_request_commitment(
+    request_content: bytes,
+    *,
+    operator_key: bytes,
+) -> bytes:
+    """HMAC-SHA256 keyed commitment over a request content digest.
+
+    The operator_key is derived from the operator's root secret via HKDF in
+    a Protocol-Profile-conformant deployment. For Vaara's reference
+    implementation the operator passes the key directly. Per Annex B.4 the
+    raw content digest stays local; only this keyed commitment crosses the
+    trust boundary.
+    """
+    if not isinstance(operator_key, (bytes, bytearray)):
+        raise EnvelopeError("operator_key must be bytes")
+    if not isinstance(request_content, (bytes, bytearray)):
+        raise EnvelopeError("request_content must be bytes")
+    digest = _sha256(bytes(request_content))
+    return _hmac_sha256(bytes(operator_key), _REQUEST_COMMITMENT_PREFIX + digest)
+
+
+def encoder_binary_identity(
+    *,
+    arbiter_version: str,
+    policy_hash: bytes,
+) -> bytes:
+    """SHA-256 over (vaara version + policy hash).
+
+    At AAL-3 this is operator-derived. At AAL-4 a notary measurement
+    pipeline would replace this with a hardware-rooted attestation of the
+    arbiter binary.
+    """
+    if not isinstance(policy_hash, (bytes, bytearray)):
+        raise EnvelopeError("policy_hash must be bytes")
+    payload = (
+        _ENCODER_IDENTITY_PREFIX
+        + arbiter_version.encode("utf-8")
+        + b"\x00"
+        + bytes(policy_hash)
+    )
+    return _sha256(payload)
+
+
+def _canonical_signing_payload(
+    blinded_identifier: bytes,
+    request_commitment: bytes,
+    encoder_binary_identity: bytes,
+    non_content_metadata: dict,
+    monotonic_counter: int,
+    nanosecond_timestamp: int,
+    key_identifier: bytes,
+    arbiter_instance_identifier: bytes,
+) -> bytes:
+    """Canonical CBOR encoding of the 8 signable Base Envelope fields.
+
+    Field order matches Annex B.6. The `signature` field is intentionally
+    excluded — it is the result, not an input to itself.
+    """
+    payload = {
+        "blinded_identifier": blinded_identifier,
+        "request_commitment": request_commitment,
+        "encoder_binary_identity": encoder_binary_identity,
+        "non_content_metadata": non_content_metadata,
+        "monotonic_counter": int(monotonic_counter),
+        "nanosecond_timestamp": int(nanosecond_timestamp),
+        "key_identifier": key_identifier,
+        "arbiter_instance_identifier": arbiter_instance_identifier,
+    }
+    return canonical_cbor(payload)
+
+
+def emit_base_envelope(
+    *,
+    signing_key,
+    request_commitment: bytes,
+    encoder_binary_identity: bytes,
+    non_content_metadata: dict,
+    monotonic_counter: int,
+    arbiter_instance_identifier: bytes,
+    blinded_identifier: Optional[bytes] = None,
+    nanosecond_timestamp: Optional[int] = None,
+) -> BaseEnvelope:
+    """Build, canonical-CBOR-encode, and Ed25519-sign a Base Envelope.
+
+    The Base Envelope is the AAL-3 Phase 2 Provisional Receipt for a
+    single action. An external IAP can co-sign it later to produce the
+    AAL-4 Phase 3 attestation; Vaara does not do that work.
+
+    Args:
+        signing_key: A cryptography Ed25519PrivateKey instance. Vaara's
+            existing key infrastructure (vaara keygen, signing-keys.md)
+            applies.
+        request_commitment: HMAC-SHA256 keyed commitment (see
+            make_request_commitment).
+        encoder_binary_identity: SHA-256 identity (see
+            encoder_binary_identity).
+        non_content_metadata: Structural metadata containing no protected
+            content. Floats are rejected.
+        monotonic_counter: Strictly increasing per-arbiter sequence.
+        arbiter_instance_identifier: 16 bytes (UUID) identifying the
+            Vaara arbiter instance.
+        blinded_identifier: 32 random bytes if not supplied.
+        nanosecond_timestamp: Override timestamp; default uses time.time_ns().
+    """
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+        )
+    except ImportError as exc:
+        raise EnvelopeError(
+            "cryptography not installed. Install with: pip install "
+            "'vaara[attestation]'"
+        ) from exc
+    if not isinstance(signing_key, Ed25519PrivateKey):
+        raise EnvelopeError("signing_key must be an Ed25519PrivateKey")
+
+    if blinded_identifier is None:
+        blinded_identifier = uuid.uuid4().bytes + uuid.uuid4().bytes
+    if nanosecond_timestamp is None:
+        nanosecond_timestamp = _now_ns()
+    if len(arbiter_instance_identifier) != 16:
+        raise EnvelopeError(
+            "arbiter_instance_identifier must be 16 bytes (UUID)"
+        )
+
+    pub = signing_key.public_key()
+    pub_raw = pub.public_bytes_raw() if hasattr(pub, "public_bytes_raw") else _legacy_raw(pub)
+    key_identifier = _sha256(pub_raw)
+
+    signing_payload = _canonical_signing_payload(
+        blinded_identifier=blinded_identifier,
+        request_commitment=request_commitment,
+        encoder_binary_identity=encoder_binary_identity,
+        non_content_metadata=non_content_metadata,
+        monotonic_counter=monotonic_counter,
+        nanosecond_timestamp=nanosecond_timestamp,
+        key_identifier=key_identifier,
+        arbiter_instance_identifier=arbiter_instance_identifier,
+    )
+    signature = signing_key.sign(signing_payload)
+
+    return BaseEnvelope(
+        blinded_identifier=blinded_identifier,
+        request_commitment=request_commitment,
+        encoder_binary_identity=encoder_binary_identity,
+        non_content_metadata=non_content_metadata,
+        monotonic_counter=monotonic_counter,
+        nanosecond_timestamp=nanosecond_timestamp,
+        key_identifier=key_identifier,
+        arbiter_instance_identifier=arbiter_instance_identifier,
+        signature=signature,
+    )
+
+
+def verify_base_envelope(envelope: BaseEnvelope, public_key_raw: bytes) -> bool:
+    """Verify an envelope's Ed25519 signature against the raw 32-byte pubkey.
+
+    Returns True iff the canonical CBOR encoding of the 8 signable fields
+    matches the signature under the supplied public key, AND the supplied
+    public key's SHA-256 matches the envelope's `key_identifier`.
+    """
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+    except ImportError as exc:
+        raise EnvelopeError(
+            "cryptography not installed. Install with: pip install "
+            "'vaara[attestation]'"
+        ) from exc
+
+    if _sha256(public_key_raw) != envelope.key_identifier:
+        return False
+    payload = _canonical_signing_payload(
+        blinded_identifier=envelope.blinded_identifier,
+        request_commitment=envelope.request_commitment,
+        encoder_binary_identity=envelope.encoder_binary_identity,
+        non_content_metadata=envelope.non_content_metadata,
+        monotonic_counter=envelope.monotonic_counter,
+        nanosecond_timestamp=envelope.nanosecond_timestamp,
+        key_identifier=envelope.key_identifier,
+        arbiter_instance_identifier=envelope.arbiter_instance_identifier,
+    )
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key_raw).verify(
+            envelope.signature, payload,
+        )
+        return True
+    except InvalidSignature:
+        return False
+
+
+def _legacy_raw(pub) -> bytes:
+    from cryptography.hazmat.primitives import serialization
+    return pub.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )

--- a/tests/test_attestation_overt.py
+++ b/tests/test_attestation_overt.py
@@ -1,0 +1,165 @@
+"""OVERT 1.0 Protocol Profile 1.0 Base Envelope emission tests."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import cbor2  # noqa: F401
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+
+    from vaara.attestation.overt import (
+        BaseEnvelope,
+        EnvelopeError,
+        canonical_cbor,
+        emit_base_envelope,
+        encoder_binary_identity,
+        make_request_commitment,
+        verify_base_envelope,
+    )
+except ImportError:
+    pytest.skip(
+        "attestation extra not installed (pip install 'vaara[attestation]')",
+        allow_module_level=True,
+    )
+
+
+@pytest.fixture
+def signing_key():
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture
+def pub_raw(signing_key):
+    return signing_key.public_key().public_bytes_raw()
+
+
+def _arbiter_id() -> bytes:
+    return b"\x00" * 16
+
+
+def _emit_default(signing_key, **overrides):
+    kwargs = dict(
+        signing_key=signing_key,
+        request_commitment=make_request_commitment(
+            b"action-payload", operator_key=b"\x42" * 32,
+        ),
+        encoder_binary_identity=encoder_binary_identity(
+            arbiter_version="vaara/0.11.0", policy_hash=b"\xaa" * 32,
+        ),
+        non_content_metadata={"action_class": "data.read", "decision": "allow"},
+        monotonic_counter=1,
+        arbiter_instance_identifier=_arbiter_id(),
+    )
+    kwargs.update(overrides)
+    return emit_base_envelope(**kwargs)
+
+
+def test_emit_produces_signed_envelope(signing_key, pub_raw):
+    env = _emit_default(signing_key)
+    assert isinstance(env, BaseEnvelope)
+    assert len(env.signature) == 64
+    assert len(env.blinded_identifier) == 32
+    assert env.monotonic_counter == 1
+    assert env.non_content_metadata["decision"] == "allow"
+    assert verify_base_envelope(env, pub_raw) is True
+
+
+def test_envelope_verification_rejects_tampered_metadata(signing_key, pub_raw):
+    env = _emit_default(signing_key)
+    tampered = BaseEnvelope(
+        blinded_identifier=env.blinded_identifier,
+        request_commitment=env.request_commitment,
+        encoder_binary_identity=env.encoder_binary_identity,
+        non_content_metadata={**env.non_content_metadata, "decision": "deny"},
+        monotonic_counter=env.monotonic_counter,
+        nanosecond_timestamp=env.nanosecond_timestamp,
+        key_identifier=env.key_identifier,
+        arbiter_instance_identifier=env.arbiter_instance_identifier,
+        signature=env.signature,
+    )
+    assert verify_base_envelope(tampered, pub_raw) is False
+
+
+def test_envelope_verification_rejects_wrong_key(signing_key):
+    env = _emit_default(signing_key)
+    wrong_pub = Ed25519PrivateKey.generate().public_key().public_bytes_raw()
+    assert verify_base_envelope(env, wrong_pub) is False
+
+
+def test_canonical_cbor_rejects_ieee754_floats():
+    with pytest.raises(EnvelopeError) as exc:
+        canonical_cbor({"rate": 0.42})
+    assert "float" in str(exc.value).lower()
+
+
+def test_canonical_cbor_rejects_floats_in_nested_structure():
+    with pytest.raises(EnvelopeError):
+        canonical_cbor({"a": {"b": [1, 2, 3.14]}})
+
+
+def test_canonical_cbor_accepts_decimal_strings_for_rates():
+    blob = canonical_cbor({"rate": "0.42", "ci_lower": "0.30", "ci_upper": "0.55"})
+    assert isinstance(blob, bytes)
+    assert len(blob) > 0
+
+
+def test_canonical_cbor_is_deterministic():
+    a = canonical_cbor({"b": 2, "a": 1})
+    b = canonical_cbor({"a": 1, "b": 2})
+    assert a == b
+
+
+def test_emit_rejects_floats_in_metadata(signing_key):
+    with pytest.raises(EnvelopeError):
+        _emit_default(
+            signing_key,
+            non_content_metadata={"risk_score": 0.42},
+        )
+
+
+def test_emit_rejects_bad_arbiter_id_length(signing_key):
+    with pytest.raises(EnvelopeError):
+        _emit_default(signing_key, arbiter_instance_identifier=b"\x00" * 8)
+
+
+def test_request_commitment_is_keyed_and_deterministic():
+    c1 = make_request_commitment(b"payload", operator_key=b"k" * 32)
+    c2 = make_request_commitment(b"payload", operator_key=b"k" * 32)
+    c3 = make_request_commitment(b"payload", operator_key=b"j" * 32)
+    assert c1 == c2
+    assert c1 != c3
+    assert len(c1) == 32
+
+
+def test_encoder_binary_identity_varies_on_inputs():
+    a = encoder_binary_identity(arbiter_version="vaara/0.11.0", policy_hash=b"\x00" * 32)
+    b = encoder_binary_identity(arbiter_version="vaara/0.12.0", policy_hash=b"\x00" * 32)
+    c = encoder_binary_identity(arbiter_version="vaara/0.11.0", policy_hash=b"\x01" * 32)
+    assert len({a, b, c}) == 3
+    assert len(a) == 32
+
+
+def test_envelope_to_dict_is_json_serializable(signing_key):
+    import json
+    env = _emit_default(signing_key)
+    d = env.to_dict()
+    json.dumps(d)  # raises if any non-JSON value sneaks through
+
+
+def test_monotonic_counter_is_in_signed_payload(signing_key, pub_raw):
+    env = _emit_default(signing_key, monotonic_counter=1)
+    tampered = BaseEnvelope(
+        blinded_identifier=env.blinded_identifier,
+        request_commitment=env.request_commitment,
+        encoder_binary_identity=env.encoder_binary_identity,
+        non_content_metadata=env.non_content_metadata,
+        monotonic_counter=2,  # only field changed
+        nanosecond_timestamp=env.nanosecond_timestamp,
+        key_identifier=env.key_identifier,
+        arbiter_instance_identifier=env.arbiter_instance_identifier,
+        signature=env.signature,
+    )
+    assert verify_base_envelope(tampered, pub_raw) is False


### PR DESCRIPTION
## Summary

First OSS Python reference implementation of OVERT 1.0 ([overt.is](https://overt.is/), Glacis Technologies, March 2026) at AAL-3 Phase 2.

Vaara now emits OVERT Protocol Profile 1.0 Base Envelopes per Annex B.6: 9-field closed schema, canonical CBOR per RFC 8949 Section 4.2, Ed25519 signatures per RFC 8032, HMAC-SHA256 keyed commitments per Annex B.4, SHA-256 encoder-identity derivation. IEEE-754 floats are rejected at the canonical-encoding boundary per Protocol Profile 1.0 numeric rules.

Vaara is the **Arbiter** in OVERT terms. AAL-3 Phase 2 (Provisional Receipt with arbiter signature) is in scope. AAL-4 Phase 3 (notary t-of-n signatures + transparency-log inclusion proofs) requires an external Independent Attestation Provider and is intentionally out of scope per Vaara's always-OSS-kernel rule.

New module `vaara.attestation` (optional extra: `pip install 'vaara[attestation]'`). Public surface: `BaseEnvelope`, `emit_base_envelope`, `verify_base_envelope`, `make_request_commitment`, `encoder_binary_identity`, `canonical_cbor`.

13 new tests, full suite 512 / 512 pass.

## Test plan

- [ ] CI green on the 5 required status checks
- [ ] `pip install 'vaara[attestation]'` in a fresh env
- [ ] `from vaara.attestation.overt import emit_base_envelope` works
- [ ] Round-trip emit + verify_base_envelope returns True
- [ ] Tampered metadata → verify_base_envelope returns False
- [ ] Passing a Python float in `non_content_metadata` raises `EnvelopeError`
