### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-16
+
+**Theme: first OSS Python reference implementation of OVERT 1.0.** v0.11.0
+ships an emitter for the OVERT 1.0 Protocol Profile 1.0 Base Envelope
+(Glacis Technologies, overt.is, March 2026) at AAL-3 Phase 2 (Provisional
+Receipt). Vaara operates as the Arbiter in OVERT terms. Phase 3 notary
+attestation and AAL-4 promotion are left to external Independent
+Attestation Providers, per OVERT's structural-independence principle and
+Vaara's always-OSS-kernel rule. Plus eIDAS NOTICE and OVERT position
+statement in COMPLIANCE.md.
+
 ### Added
 - **OVERT 1.0 Protocol Profile 1.0 Base Envelope emitter (`vaara[attestation]` extra).**
   First OSS Python reference implementation of the OVERT 1.0 AAL-3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.10.0"
+version = "0.11.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Version bump + CHANGELOG
  section roll-up for the OVERT 1.0 Base Envelope emitter shipped in #77. Pure release commit, no code changes. v0.11.0
   will publish to PyPI on tag push after merge.