### PR TITLE
docs: CR follow-ups and finish audit pass

### DIFF
--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -262,9 +262,9 @@ agent boundaries, capability mediation, agent disclosure, human-in-
 the-loop attestation, and behavioural drift governance. The mapping
 below states, control by control, whether Vaara satisfies the
 requirement today (✅), partially satisfies it (◐), or leaves it as
-explicit gap-to-deployer or future-work (◯). Per OVERT Annex F.2 this
-mapping does not establish legal compliance with any regulation. It
-records technical correspondence.
+explicit gap-to-deployer or future-work (◯). This mapping does not
+establish legal compliance with any regulation. It records technical
+correspondence.
 
 ### Section 11 - Tool-Call Governance
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The contract is in [docs/openapi.yaml](docs/openapi.yaml). Vaara defines the int
 
 ## OVERT 1.0 attestation
 
-Vaara implements the OVERT 1.0 ([overt.is](https://overt.is/)) Protocol Profile 1.0 Base Envelope. OVERT 1.0 is an open standard for runtime trust in AI systems, authored by Glacis Technologies and published in March 2026. Closed-schema 9-field structure at AAL-3 Phase 2 (Provisional Receipt), canonical CBOR (RFC 8949), Ed25519 signatures, HMAC-SHA256 keyed commitments, IEEE-754 float rejection. External Independent Attestation Providers can promote AAL-3 emission to AAL-4 by attaching Phase 3 notary signatures and transparency-log inclusion proofs.
+Vaara implements the OVERT 1.0 ([overt.is](https://overt.is/)) Protocol Profile 1.0 Base Envelope. OVERT 1.0 is an open standard for runtime trust in AI systems, authored by Glacis Technologies and published 25 March 2026. Closed-schema 9-field structure at AAL-3 Phase 2 (Provisional Receipt), canonical CBOR (RFC 8949), Ed25519 signatures, HMAC-SHA256 keyed commitments, IEEE-754 float rejection. External Independent Attestation Providers can promote AAL-3 emission to AAL-4 by attaching Phase 3 notary signatures and transparency-log inclusion proofs.
 
 ```
 pip install 'vaara[attestation]'

--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -19,7 +19,7 @@ what each tool actually does. If you are an AI Act Article 14
 deployer comparing options, read the matrix. If you want the longer
 prose, read the sections below it.
 
-## Capability matrix
+## Capability matrix (as of 2026-05-16)
 
 | Concern                                          | Vaara | NeMo Guardrails | Guardrails AI | OpenAI Guardrails | LangChain callbacks | OWASP LLM Top 10 | Glacis Python SDK | MS Agent Governance Toolkit |
 | ------------------------------------------------ | :---: | :-------------: | :-----------: | :---------------: | :-----------------: | :--------------: | :---------------: | :-------------------------: |
@@ -152,6 +152,20 @@ tools wired in. If you are running agents in production, you want
 Vaara plus Microsoft AGT for the identity, capability, and sandboxing
 layer Vaara does not cover. They run in different places in the
 stack and the matrix above shows where each tool lives.
+
+## Sources
+
+Each row in the matrix is grounded in publicly available project documentation
+or source code. Verified as of 2026-05-16.
+
+- **Vaara**: this repository at [github.com/vaaraio/vaara](https://github.com/vaaraio/vaara).
+- **NVIDIA NeMo Guardrails**: [github.com/NVIDIA/NeMo-Guardrails](https://github.com/NVIDIA/NeMo-Guardrails).
+- **Guardrails AI**: [github.com/guardrails-ai/guardrails](https://github.com/guardrails-ai/guardrails).
+- **OpenAI Guardrails** (for OpenAI Agents SDK): [openai.github.io/openai-agents-python/guardrails/](https://openai.github.io/openai-agents-python/guardrails/).
+- **LangChain callback handlers**: [python.langchain.com/docs/concepts/callbacks/](https://python.langchain.com/docs/concepts/callbacks/).
+- **OWASP LLM Top 10**: [genai.owasp.org/llm-top-10/](https://genai.owasp.org/llm-top-10/).
+- **Glacis Python SDK**: [github.com/Glacis-io/glacis-python](https://github.com/Glacis-io/glacis-python). Capabilities recorded by source-read of the repository on 2026-05-16.
+- **Microsoft Agent Governance Toolkit**: [github.com/microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit).
 
 ## Numbers we publish
 

--- a/docs/formal_specification.md
+++ b/docs/formal_specification.md
@@ -1,4 +1,4 @@
-# Vaara Adaptive Risk Scoring — Formal Specification
+# Vaara Adaptive Risk Scoring - Formal Specification
 
 **Version**: 0.1.0
 **Date**: 2026-04-10
@@ -7,7 +7,7 @@
 
 Let an AI agent **A** operate in an environment **E** by executing a sequence of actions **a₁, a₂, ..., aₜ** drawn from an action space **A**. Each action **aₜ** has a true but unknown risk **r*(aₜ) ∈ [0, 1]**, where 0 denotes no harm and 1 denotes catastrophic harm.
 
-**The compositional safety problem**: Individual actions may be safe — r*(aᵢ) ≈ 0 for all i — yet the *sequence* (a₁, ..., aₖ) produces compound risk R*(a₁, ..., aₖ) ≫ max{r*(aᵢ)}. Example: {read_data, export_data, delete_data} is a data exfiltration pattern where each step alone is benign.
+**The compositional safety problem**: Individual actions may be safe - r*(aᵢ) ≈ 0 for all i - yet the *sequence* (a₁, ..., aₖ) produces compound risk R*(a₁, ..., aₖ) ≫ max{r*(aᵢ)}. Example: {read_data, export_data, delete_data} is a data exfiltration pattern where each step alone is benign.
 
 **Goal**: Construct an adaptive risk scorer **f: A × H → [0, 1]** and a conformal prediction set **C(aₜ) ⊆ [0, 1]** such that:
 
@@ -24,11 +24,11 @@ An action type **τ ∈ T** is characterized by a tuple:
     τ = (c, v, b, u, R)
 
 where:
-- **c ∈ {financial, data, comm, infra, identity, governance, physical}** — category
-- **v ∈ {fully, partially, irreversible}** — reversibility
-- **b ∈ {self, local, shared, global}** — blast radius
-- **u ∈ {deferrable, timely, immediate, irrevocable}** — urgency class
-- **R ⊂ {EU_AI_Act, GDPR, MiFID2, DORA, NIS2, ...}** — regulatory domains
+- **c ∈ {financial, data, comm, infra, identity, governance, physical}** - category
+- **v ∈ {fully, partially, irreversible}** - reversibility
+- **b ∈ {self, local, shared, global}** - blast radius
+- **u ∈ {deferrable, timely, immediate, irrevocable}** - urgency class
+- **R ⊂ {EU_AI_Act, GDPR, MiFID2, DORA, NIS2, ...}** - regulatory domains
 
 ### 2.2 Base Risk Score
 
@@ -50,7 +50,7 @@ The scorer maintains **K** expert signals, each producing a risk estimate sₖ(a
 
 ### 3.1 Default Expert Set (K = 5)
 
-1. **Taxonomy base** (s₁): s₁(aₜ) = β(τ(aₜ)) — the static base risk from §2.2.
+1. **Taxonomy base** (s₁): s₁(aₜ) = β(τ(aₜ)) - the static base risk from §2.2.
 
 2. **Agent history** (s₂): Blends the agent's denial rate and bad outcome rate:
 
@@ -144,7 +144,7 @@ Let C(aₜ) = [f(aₜ) − q̂, f(aₜ) + q̂] be the conformal interval. The de
 
 This is **conservative by construction**: the decision is based on the worst-case risk within the 1 − α confidence set. If even the worst case is safe, allow. If even the best case is dangerous, deny. Between: escalate for human judgment.
 
-**Proposition 5.2**: Let θ_allow = 0.3 and θ_deny = 0.7 (defaults). Before calibration, the interval is [f(a) − 0.3, f(a) + 0.3]. A raw score of f(a) ≤ 0.0 is needed for auto-allow, and f(a) ≥ 0.4 for auto-deny. This means the pre-calibration scorer is maximally cautious — most actions will be escalated, which is the correct cold-start behavior.
+**Proposition 5.2**: Let θ_allow = 0.3 and θ_deny = 0.7 (defaults). Before calibration, the interval is [f(a) − 0.3, f(a) + 0.3]. A raw score of f(a) ≤ 0.0 is needed for auto-allow, and f(a) ≥ 0.4 for auto-deny. This means the pre-calibration scorer is maximally cautious - most actions will be escalated, which is the correct cold-start behavior.
 
 ## 6. Temporal Sequence Scoring
 
@@ -152,9 +152,9 @@ This is **conservative by construction**: the decision is based on the worst-cas
 
 A dangerous pattern **p = (p₁, p₂, ..., pₘ)** is an ordered tuple of action names. Pattern p *matches* in history h = (h₁, ..., hₙ) if there exist indices i₁ < i₂ < ... < iₘ ≤ n such that h_{iⱼ} = pⱼ for all j.
 
-The matching is **ordered but not contiguous** — interleaving benign actions does not break the match. This catches evasion attempts where an attacker inserts harmless actions between the dangerous ones.
+The matching is **ordered but not contiguous** - interleaving benign actions does not break the match. This catches evasion attempts where an attacker inserts harmless actions between the dangerous ones.
 
-**Complexity**: Subsequence matching is O(n·m) per pattern per action, where n = window size and m = pattern length. With W patterns each of length ≤ M, total cost per action is O(W·n·M). With default values (W = 7, n = 10, M = 3), this is O(210) — negligible.
+**Complexity**: Subsequence matching is O(n·m) per pattern per action, where n = window size and m = pattern length. With W patterns each of length ≤ M, total cost per action is O(W·n·M). With default values (W = 7, n = 10, M = 3), this is O(210) - negligible.
 
 ### 6.2 Compositional Risk
 
@@ -162,7 +162,7 @@ The sequence risk boost δₚ is additive to the base score, not multiplicative:
 
     f_seq(aₜ) = f(aₜ) + max{δₚ : p matches}
 
-This ensures that a benign action (f(a) = 0.1) in a dangerous sequence (δ = 0.5) is scored as 0.6 — elevated but not automatically blocked. The conformal interval then widens to [0.3, 0.9], which triggers escalation.
+This ensures that a benign action (f(a) = 0.1) in a dangerous sequence (δ = 0.5) is scored as 0.6 - elevated but not automatically blocked. The conformal interval then widens to [0.3, 0.9], which triggers escalation.
 
 ## 7. Regulatory Compliance
 
@@ -172,7 +172,7 @@ Each audit record **r** is tagged with a set of regulatory articles **A(r) ⊆ A
 
     Coverage(article) = |{r : article ∈ A(r)}| / min_evidence
 
-An article has **sufficient evidence** if Coverage ≥ 1 and evidence is not stale (age < staleness_hours). **Partial** if some evidence exists but insufficient. **Insufficient** if no evidence. This is an evidence-status classification, not a compliance verdict — the deployer (and, where required, a Notified Body) makes the conformity determination.
+An article has **sufficient evidence** if Coverage ≥ 1 and evidence is not stale (age < staleness_hours). **Partial** if some evidence exists but insufficient. **Insufficient** if no evidence. This is an evidence-status classification, not a compliance verdict - the deployer (and, where required, a Notified Body) makes the conformity determination.
 
 ### 7.2 Hash Chain Integrity
 
@@ -217,11 +217,11 @@ The system transitions from rule-based to calibrated mode after 30 outcomes (min
 
 **Claim**: An adversarial agent cannot reliably evade the scorer by manipulating observable signals.
 
-- s₁ (taxonomy) is immutable per action type — the agent cannot change what "tx.transfer" means.
-- s₂ (history) is computed from the agent's own track record — the only way to improve it is to behave well.
-- s₃ (sequence) uses non-contiguous subsequence matching — interleaving benign actions doesn't help.
-- s₄ (burst) counts actions in a time window — cannot be gamed without slowing down.
-- s₅ (confidence) penalizes overcalibrated confidence claims — lying about confidence increases risk.
+- s₁ (taxonomy) is immutable per action type - the agent cannot change what "tx.transfer" means.
+- s₂ (history) is computed from the agent's own track record - the only way to improve it is to behave well.
+- s₃ (sequence) uses non-contiguous subsequence matching - interleaving benign actions doesn't help.
+- s₄ (burst) counts actions in a time window - cannot be gamed without slowing down.
+- s₅ (confidence) penalizes overcalibrated confidence claims - lying about confidence increases risk.
 
 The remaining attack vector is **outcome manipulation**: if the agent can influence the reported outcome severity, it can bias MWU weights. Defense: outcomes should be reported by an independent monitoring system, not by the agent itself.
 

--- a/docs/signing-keys.md
+++ b/docs/signing-keys.md
@@ -1,8 +1,8 @@
 # Signing keys for Vaara audit exports
 
 Vaara signs every audit-trail export with an Ed25519 detached signature.
-The signature lets a third party — auditor, regulator, internal conformity
-reviewer — verify that an exported trail came from you and has not been
+The signature lets a third party - auditor, regulator, internal conformity
+reviewer - verify that an exported trail came from you and has not been
 tampered with.
 
 This document describes how to manage the signing key. It is written for
@@ -48,20 +48,20 @@ signing API.
 
 Supported providers:
 
-- **AWS KMS** — create an `ECC_NIST_P256` or `EDDSA` key,
+- **AWS KMS** - create an `ECC_NIST_P256` or `EDDSA` key,
   grant `kms:Sign` to the role your exporter runs as.
-- **Google Cloud KMS** — create an `EC_SIGN_ED25519` asymmetric key.
-- **Azure Key Vault** — create an EC key with curve `P-256` and the
+- **Google Cloud KMS** - create an `EC_SIGN_ED25519` asymmetric key.
+- **Azure Key Vault** - create an EC key with curve `P-256` and the
   `sign` operation enabled.
-- **YubiHSM / Nitrokey HSM** — Ed25519 keys with the `sign-eddsa`
+- **YubiHSM / Nitrokey HSM** - Ed25519 keys with the `sign-eddsa`
   capability.
 
 For any of these, do not export the PEM. In the 0.4.x series
 `export_signed` accepts a loaded `Ed25519PrivateKey` instance (or a PEM
-path / PEM bytes) — integrate by loading the key material into that
+path / PEM bytes) - integrate by loading the key material into that
 object inside your signing host's memory, never on a developer laptop.
 A pluggable signer-adapter interface (call an HSM/KMS `sign` API
-without materializing the key) is tracked for a future release; until
+without materializing the key) is tracked for a future release. Until
 then, HSM integration requires a small wrapper in your deployment code
 that fetches the key into a short-lived `Ed25519PrivateKey`.
 
@@ -103,7 +103,7 @@ Plan rotation before you need it. A concrete schedule:
 - Keep the previous public key available: a regulator who received a
   trail last quarter must still be able to verify it.
 - Do **not** re-export old trails with the new key. Signatures are
-  historical — each trail belongs to the key that signed it when
+  historical - each trail belongs to the key that signed it when
   exported.
 
 Keep a fingerprint ledger, versioned in git:
@@ -134,7 +134,7 @@ The verifier needs your public key. Two channels:
    `signer_pubkey.pem` inside the zip. If no `--pubkey` is passed the
    verifier uses the embedded one. This proves the trail is
    *internally consistent* but not that the signer is who they claim to
-   be — the auditor should always verify the fingerprint matches
+   be - the auditor should always verify the fingerprint matches
    something they received out-of-band.
 
 ---

--- a/docs/vaara-audit-cli.md
+++ b/docs/vaara-audit-cli.md
@@ -1,4 +1,4 @@
-# `vaara-audit` — third-party auditor CLI
+# `vaara-audit` - third-party auditor CLI
 
 Vaara signs its audit trail with Ed25519 and chains every record with SHA-256. Regulators, internal reviewers, and external auditors need a way to inspect those trails without running the full Vaara agent stack. `vaara-audit` is that CLI.
 
@@ -58,10 +58,10 @@ deny       11   7.7%    0.732
 
 Four rule-based detectors:
 
-- `missing_completion` — `action_requested` without a matching `decision_emitted`. Flags trail truncation, enforcement crashes, or gate bypasses. Skipped if the trail has no `decision_emitted` events at all (pure request logs are not flagged).
-- `timestamp_regression` — a record with a timestamp earlier than the previous record for the same agent. Suggests clock skew, replay, or tampering that the signature check missed (it would not — but useful belt-and-braces).
-- `rate_burst` — agent emits ≥20 records in ≤10 seconds. Default thresholds catch automated loops running away; tune in a follow-up PR if false positives appear on busy agents.
-- `unknown_spike` — ≥25% of an agent's recent 50-record window has `action_type=unknown`. Suggests the agent is using tools Vaara has no registered classification for, which is a classification gap worth investigating.
+- `missing_completion` - `action_requested` without a matching `decision_emitted`. Flags trail truncation, enforcement crashes, or gate bypasses. Skipped if the trail has no `decision_emitted` events at all (pure request logs are not flagged).
+- `timestamp_regression` - a record with a timestamp earlier than the previous record for the same agent. Suggests clock skew, replay, or tampering that the signature check missed (it would not - but useful belt-and-braces).
+- `rate_burst` - agent emits ≥20 records in ≤10 seconds. Default thresholds catch automated loops running away. Tune in a follow-up PR if false positives appear on busy agents.
+- `unknown_spike` - ≥25% of an agent's recent 50-record window has `action_type=unknown`. Suggests the agent is using tools Vaara has no registered classification for, which is a classification gap worth investigating.
 
 All rules can run together (`--rules all`, default) or in isolation (`--rules rate_burst,unknown_spike`). Exit code `0` if no findings, `1` otherwise.
 
@@ -88,4 +88,4 @@ Every subcommand supports `--json` for pipeline integration.
 
 ## Relationship to `vaara` CLI
 
-The existing `vaara trail verify` subcommand provides the same verify function wrapped in the main CLI. `vaara-audit` is the third-party entry point — a standalone name for the regulator-facing workflow, with richer `inspect`, `stats`, and `anomalies` capabilities beyond verify-only.
+The existing `vaara trail verify` subcommand provides the same verify function wrapped in the main CLI. `vaara-audit` is the third-party entry point - a standalone name for the regulator-facing workflow, with richer `inspect`, `stats`, and `anomalies` capabilities beyond verify-only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-keywords = ["ai", "agents", "governance", "risk", "compliance", "eu-ai-act", "conformal-prediction", "audit"]
+keywords = ["ai", "ai-agents", "ai-governance", "agent-governance", "ai-act", "eu-ai-act", "article-14", "compliance", "audit-trail", "risk-scoring", "conformal-prediction", "overt", "attestation", "runtime-monitoring"]
 
 [project.urls]
 Homepage = "https://vaara.io"


### PR DESCRIPTION
## Summary

Addresses CodeRabbit findings on PR #80 plus completes the public-doc audit pass for four files that did not make it into the previous commit.

## CodeRabbit fixes

- `README.md`: precise OVERT 1.0 publication date. "March 2026" replaced with "25 March 2026" per the canonical reference at overt.is.
- `COMPLIANCE.md`: removed unverifiable "Per OVERT Annex F.2" citation. The OVERT 1.0 specification does not contain an Annex F.2. The disclaimer that follows stands on its own.
- `bench/COMPARISON.md`: added "(as of 2026-05-16)" date stamp to the capability matrix heading and a new "Sources" subsection listing the canonical documentation or repository URL for each tool. Glacis Python SDK capabilities recorded by source-read of `Glacis-io/glacis-python` on 2026-05-16.

## Audit pass completion

Public-prose audit (em-dash and semicolon removal outside fenced code blocks) for four files that were modified in the working tree but did not make it into PR #80:

- `docs/formal_specification.md`
- `docs/signing-keys.md`
- `docs/vaara-audit-cli.md`
- `pyproject.toml`: broadened `keywords` for runtime AI governance discoverability. Adds `agent-governance`, `article-14`, `overt`, `attestation`, `runtime-monitoring`, `risk-scoring`, `audit-trail`. Drops subsumed entries.

## Test plan

- [ ] CI passes
- [ ] All edited docs render correctly on GitHub
- [ ] No broken cross-references
