### PR TITLE
feat: v0.14.0 ML-DSA-65 signer option, external-scorer composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-17
+
+**Theme: audit-retention horizon + composer position.** Two additions.
+A pluggable signer abstraction lets operators sign the regulator-handoff
+export envelope with ML-DSA-65 (FIPS 204) for retention horizons that
+cross the credible quantum threshold. A composite-scorer module reuses
+Vaara's own v0.10.0 /v1/score wire contract on the inbound side so
+external scorers (NeMo Guardrails, another Vaara instance, any peer)
+slot in alongside Vaara's adaptive scorer with a single object.
+
+### Added
+- **Pluggable signer abstraction (`vaara.audit.signer`).** New
+  ``Signer`` / ``Verifier`` protocols with ``Ed25519Signer`` and
+  ``MLDSA65Signer`` implementations. ``export_signed`` accepts a
+  ``signer=`` keyword (mutually exclusive with the legacy
+  ``signer_key`` Ed25519 PEM path). The export manifest carries
+  ``signature_algorithm`` so verifiers dispatch automatically.
+  Ed25519 exports still write ``signer_pubkey.pem`` for backward-
+  compatible verification by older clients; ML-DSA-65 exports write
+  ``signer_pubkey.bin`` (raw bytes, 1,952 bytes). ``verify_signed``
+  reads the algorithm field and routes to the right verifier.
+  ML-DSA-65 requires the new ``vaara[pq]`` extra
+  (``pip install 'vaara[pq]'``), which pulls pure-Python
+  ``dilithium-py``.
+- **External-scorer composition (`vaara.scorer.composition`,
+  `vaara.scorer.composite`).** ``ExternalScorer(url)`` calls a remote
+  ``/v1/score`` endpoint (any service that implements the Vaara
+  v0.10.0 wire contract) and returns the result in Vaara's internal
+  scorer dict shape. Transport errors, malformed bodies, and non-JSON
+  responses fail closed to ``deny`` with a structured reason in the
+  ``raw_result``. ``CompositeScorer(scorers, combine="max"|"mean"|
+  callable)`` runs Vaara's ``AdaptiveScorer`` alongside one or more
+  external scorers and merges the results. The composite preserves
+  the strongest decision (``deny`` > ``escalate`` > ``allow``) so one
+  member firing high blocks the action. The composite's
+  ``evaluate(context) -> dict`` shape matches what
+  ``InterceptionPipeline`` already expects, so it drops into existing
+  pipelines as a direct replacement.
+- 20 new tests (10 signer + Ed25519 + ML-DSA-65 round-trip and zip
+  tamper-detection; 10 composition + external-scorer error handling
+  + composite combine modes).
+
 ## [0.13.0] - 2026-05-17
 
 **Theme: operator surface + OVERT Phase 3 path.** Four additions that

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The contract is in [docs/openapi.yaml](docs/openapi.yaml). Vaara defines the int
 
 v0.13.0 adds three operator-facing endpoints. `POST /v1/policy/reload` atomically swaps the running policy without restarting the agent process (start with `vaara serve --policy PATH` to enable; in-flight requests keep the old thresholds, the next request sees the new ones). `POST /v1/detect/injection` and `POST /v1/detect/pii` expose Vaara's adversarial scorer and a zero-dependency PII extractor as named buyer-visible endpoints; the corresponding `vaara detect injection` and `vaara detect pii` CLI subcommands exit non-zero when the detector fires, so they slot into CI gates. `vaara compliance dashboard --db PATH --out site/` renders a single-file static HTML article-coverage page from the same evidence model as `vaara compliance report`.
 
+v0.14.0 adds an optional ML-DSA-65 (FIPS 204) signer for the regulator-handoff export envelope (`pip install 'vaara[pq]'`), suitable for retention horizons that cross the credible quantum threshold. The same release adds `vaara.scorer.composition.ExternalScorer` and `vaara.scorer.composite.CompositeScorer` so Vaara's adaptive scorer can be run alongside external scorers (NeMo Guardrails, another Vaara instance, any service that implements the `/v1/score` wire contract); the composite preserves the strongest decision across members.
+
 ## OVERT 1.0 attestation
 
 Vaara implements the OVERT 1.0 ([overt.is](https://overt.is/)) Protocol Profile 1.0 Base Envelope. OVERT 1.0 is an open standard for runtime trust in AI systems, authored by Glacis Technologies and published 25 March 2026. Closed-schema 9-field structure at AAL-3 Phase 2 (Provisional Receipt), canonical CBOR (RFC 8949), Ed25519 signatures, HMAC-SHA256 keyed commitments, IEEE-754 float rejection. v0.13.0 adds a reference Phase 3 IAP (`vaara.attestation.iap`) that notary-signs the Provisional Receipt and anchors it in a transparency log; production deployments can swap in sigstore Rekor or an equivalent independently-operated log at the same call sites.
@@ -89,7 +91,7 @@ from vaara.attestation.overt import emit_base_envelope, make_request_commitment,
 envelope = emit_base_envelope(
     signing_key=key,
     request_commitment=make_request_commitment(payload, operator_key=op_key),
-    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.13.0", policy_hash=ph),
+    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.14.0", policy_hash=ph),
     non_content_metadata={"action_class": "tx.transfer", "decision": "escalate"},
     monotonic_counter=42,
     arbiter_instance_identifier=uuid_bytes,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.13.0"
+version = "0.14.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -44,6 +44,7 @@ ml = ["xgboost>=2.0", "scikit-learn>=1.3", "joblib>=1.3", "numpy>=1.24"]
 yaml = ["pyyaml>=6.0"]
 server = ["fastapi>=0.110", "uvicorn>=0.27"]
 attestation = ["cbor2>=5.4", "cryptography>=41.0"]
+pq = ["dilithium-py>=1.4.0"]
 
 [project.scripts]
 vaara = "vaara.cli:main"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/audit/export.py
+++ b/src/vaara/audit/export.py
@@ -26,7 +26,7 @@ import time
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 try:
     from cryptography.exceptions import UnsupportedAlgorithm
@@ -40,6 +40,7 @@ except ImportError:
     _HAS_CRYPTO = False
 
 if TYPE_CHECKING:
+    from vaara.audit.signer import Signer
     from vaara.audit.trail import AuditTrail
 
 logger = logging.getLogger(__name__)
@@ -112,7 +113,9 @@ def _build_manifest(
     first_hash: str,
     last_hash: str,
     chain_intact: bool,
-    public_key: "Ed25519PublicKey",
+    *,
+    signer_fingerprint: str,
+    signature_algorithm: str,
     vaara_version: str,
     agent_id: str = "",
 ) -> dict:
@@ -125,8 +128,8 @@ def _build_manifest(
         "last_hash": last_hash,
         "chain_intact_at_export": chain_intact,
         "trail_sha256": hashlib.sha256(trail_jsonl_bytes).hexdigest(),
-        "signer_pubkey_fingerprint": _pubkey_fingerprint(public_key),
-        "signature_algorithm": "Ed25519",
+        "signer_pubkey_fingerprint": signer_fingerprint,
+        "signature_algorithm": signature_algorithm,
         "signature_over": "sha256(trail.jsonl_bytes || manifest.json_bytes_without_signature)",
         "agent_id": agent_id or "",
     }
@@ -135,8 +138,10 @@ def _build_manifest(
 def export_signed(
     trail: "AuditTrail",
     out_path: Union[str, Path],
-    signer_key: Union[str, Path, bytes, "Ed25519PrivateKey"],
+    signer_key: Union[str, Path, bytes, "Ed25519PrivateKey", None] = None,
     agent_id: str = "",
+    *,
+    signer: Optional["Signer"] = None,
 ) -> ExportResult:
     """Produce a signed, regulator-handoff zip of the audit trail.
 
@@ -144,19 +149,42 @@ def export_signed(
         trail: The :class:`AuditTrail` to export.
         out_path: Where to write the zip file. Parent directory must exist.
         signer_key: Ed25519 private key — accepts a PEM path, PEM bytes, or
-            a loaded ``Ed25519PrivateKey`` object. For production, use keys
-            from a KMS/HSM/Vault — see ``docs/signing-keys.md``.
+            a loaded ``Ed25519PrivateKey`` object. Backward-compatible
+            shortcut for the default Ed25519 path. Mutually exclusive
+            with ``signer``.
         agent_id: Optional scope hint written to the manifest. Does not
             filter the exported records (export is whole-trail).
+        signer: A ``vaara.audit.signer.Signer`` instance — currently
+            ``Ed25519Signer`` or ``MLDSA65Signer`` (v0.14.0). Set this
+            when promoting an operator's retention horizon past the
+            credible quantum threshold. Manifest carries the algorithm
+            identifier so verifiers dispatch automatically.
 
     Returns:
         ExportResult with the output path, manifest dict, and chain status.
 
     Raises:
-        ImportError: If the ``cryptography`` package is not installed.
+        ImportError: If the ``cryptography`` package is not installed
+            for the Ed25519 path, or ``dilithium-py`` for the ML-DSA-65
+            path (install with ``pip install 'vaara[pq]'``).
         FileNotFoundError: If ``out_path`` parent directory does not exist.
+        ValueError: If both ``signer_key`` and ``signer`` are supplied,
+            or neither is.
     """
-    _require_crypto()
+    from vaara.audit.signer import Ed25519Signer
+
+    if signer is not None and signer_key is not None:
+        raise ValueError(
+            "export_signed: pass `signer` or `signer_key`, not both"
+        )
+    if signer is None and signer_key is None:
+        raise ValueError(
+            "export_signed: one of `signer` or `signer_key` is required"
+        )
+
+    if signer is None:
+        _require_crypto()
+        signer = Ed25519Signer(_load_private_key(signer_key))
 
     # Local import avoids a package-level dep on the trail module for tooling
     # that only imports the export helpers.
@@ -173,9 +201,6 @@ def export_signed(
         raise FileNotFoundError(
             f"Output directory does not exist: {out_path.parent}"
         )
-
-    private_key = _load_private_key(signer_key)
-    public_key = private_key.public_key()
 
     # Snapshot under the trail's own lock by using its existing exporter.
     # Use a temp path next to the final zip so we can stream large trails
@@ -206,25 +231,34 @@ def export_signed(
         first_hash=first_hash,
         last_hash=last_hash,
         chain_intact=chain_intact,
-        public_key=public_key,
+        signer_fingerprint=signer.public_key_fingerprint()[:32],
+        signature_algorithm=signer.algorithm,
         vaara_version=vaara_version,
         agent_id=agent_id,
     )
     manifest_bytes = json.dumps(manifest, sort_keys=True, indent=2).encode("utf-8")
 
     to_sign = hashlib.sha256(trail_bytes + manifest_bytes).digest()
-    signature = private_key.sign(to_sign)
-
-    pubkey_pem = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
+    signature = signer.sign(to_sign)
 
     with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("trail.jsonl", trail_bytes)
         zf.writestr("manifest.json", manifest_bytes)
         zf.writestr("trail.sig", signature)
-        zf.writestr("signer_pubkey.pem", pubkey_pem)
+        if signer.algorithm == "Ed25519":
+            # Preserve the existing PEM-encoded public-key file for back-
+            # compatible verification by older Vaara clients.
+            from cryptography.hazmat.primitives import serialization
+            from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+                Ed25519PublicKey,
+            )
+            pub = Ed25519PublicKey.from_public_bytes(signer.public_key_bytes())
+            zf.writestr("signer_pubkey.pem", pub.public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo,
+            ))
+        else:
+            zf.writestr("signer_pubkey.bin", signer.public_key_bytes())
 
     logger.info(
         "Exported signed trail: %s (%d records, chain_intact=%s, fingerprint=%s)",

--- a/src/vaara/audit/signer.py
+++ b/src/vaara/audit/signer.py
@@ -1,0 +1,158 @@
+"""Pluggable signers for the audit-trail export envelope.
+
+Vaara's default signer is Ed25519 via ``cryptography``. v0.14.0 adds an
+optional ML-DSA-65 (FIPS 204) signer via the pure-Python
+``dilithium-py`` library, installed with ``pip install 'vaara[pq]'``.
+
+Operators with retention horizons that cross the credible quantum
+threshold (10+ year audit trails under the EU AI Act's technical-file
+retention rules, financial-services or healthcare audit holds) can
+swap the signer without changing the rest of the export pipeline. The
+manifest carries the algorithm identifier so verifiers can dispatch.
+
+The Signer / Verifier protocols are intentionally narrow — sign a
+message, expose the raw public key bytes — so a future HSM-backed or
+KMS-backed implementation drops in at the same call sites.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Signer(Protocol):
+    """Sign byte strings and expose the verifier-side public key bytes."""
+
+    algorithm: str
+
+    def sign(self, message: bytes) -> bytes: ...
+
+    def public_key_bytes(self) -> bytes: ...
+
+    def public_key_fingerprint(self) -> str: ...
+
+
+@runtime_checkable
+class Verifier(Protocol):
+    """Verify a (message, signature) pair under a fixed public key."""
+
+    algorithm: str
+
+    def verify(self, message: bytes, signature: bytes) -> bool: ...
+
+
+_ALGORITHM_ED25519 = "Ed25519"
+_ALGORITHM_MLDSA65 = "ML-DSA-65"
+
+
+def _fingerprint(public_key_bytes: bytes) -> str:
+    return hashlib.sha256(public_key_bytes).hexdigest()
+
+
+class Ed25519Signer:
+    """Signer wrapping a ``cryptography`` Ed25519 private key."""
+
+    algorithm = _ALGORITHM_ED25519
+
+    def __init__(self, private_key) -> None:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+        )
+        if not isinstance(private_key, Ed25519PrivateKey):
+            raise TypeError("Ed25519Signer requires an Ed25519PrivateKey")
+        self._key = private_key
+
+    def sign(self, message: bytes) -> bytes:
+        return self._key.sign(message)
+
+    def public_key_bytes(self) -> bytes:
+        pub = self._key.public_key()
+        if hasattr(pub, "public_bytes_raw"):
+            return pub.public_bytes_raw()
+        from cryptography.hazmat.primitives import serialization
+        return pub.public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+
+    def public_key_fingerprint(self) -> str:
+        return _fingerprint(self.public_key_bytes())
+
+
+class Ed25519Verifier:
+    """Verifier wrapping a 32-byte raw Ed25519 public key."""
+
+    algorithm = _ALGORITHM_ED25519
+
+    def __init__(self, public_key_raw: bytes) -> None:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+        self._pub = Ed25519PublicKey.from_public_bytes(public_key_raw)
+
+    def verify(self, message: bytes, signature: bytes) -> bool:
+        from cryptography.exceptions import InvalidSignature
+        try:
+            self._pub.verify(signature, message)
+            return True
+        except (InvalidSignature, ValueError):
+            return False
+
+
+class MLDSA65Signer:
+    """ML-DSA-65 (FIPS 204) signer via dilithium-py.
+
+    Requires ``pip install 'vaara[pq]'``. Signatures are ~3.3 KB versus
+    Ed25519's 64 bytes; the rest of the export envelope is unchanged.
+    """
+
+    algorithm = _ALGORITHM_MLDSA65
+
+    def __init__(self, secret_key: bytes) -> None:
+        if not isinstance(secret_key, (bytes, bytearray)):
+            raise TypeError("MLDSA65Signer requires raw bytes secret key")
+        self._sk = bytes(secret_key)
+
+    def sign(self, message: bytes) -> bytes:
+        from dilithium_py.ml_dsa import ML_DSA_65
+        return ML_DSA_65.sign(self._sk, message)
+
+    def public_key_bytes(self) -> bytes:
+        from dilithium_py.ml_dsa import ML_DSA_65
+        return ML_DSA_65.pk_from_sk(self._sk)
+
+    def public_key_fingerprint(self) -> str:
+        return _fingerprint(self.public_key_bytes())
+
+    @classmethod
+    def generate(cls) -> tuple["MLDSA65Signer", bytes]:
+        """Generate a fresh keypair. Returns (signer, public_key_bytes)."""
+        from dilithium_py.ml_dsa import ML_DSA_65
+        pk, sk = ML_DSA_65.keygen()
+        return cls(sk), pk
+
+
+class MLDSA65Verifier:
+    """ML-DSA-65 verifier via dilithium-py. Pairs with ``MLDSA65Signer``."""
+
+    algorithm = _ALGORITHM_MLDSA65
+
+    def __init__(self, public_key: bytes) -> None:
+        if not isinstance(public_key, (bytes, bytearray)):
+            raise TypeError("MLDSA65Verifier requires raw bytes public key")
+        self._pk = bytes(public_key)
+
+    def verify(self, message: bytes, signature: bytes) -> bool:
+        from dilithium_py.ml_dsa import ML_DSA_65
+        return bool(ML_DSA_65.verify(self._pk, message, signature))
+
+
+def verifier_for(algorithm: str, public_key_bytes: bytes) -> Verifier:
+    """Dispatch a verifier instance by manifest ``signature_algorithm``."""
+    if algorithm == _ALGORITHM_ED25519:
+        return Ed25519Verifier(public_key_bytes)
+    if algorithm == _ALGORITHM_MLDSA65:
+        return MLDSA65Verifier(public_key_bytes)
+    raise ValueError(f"unknown signature_algorithm: {algorithm!r}")

--- a/src/vaara/audit/verify.py
+++ b/src/vaara/audit/verify.py
@@ -172,9 +172,14 @@ def verify_signed(
             trail_bytes = zf.read("trail.jsonl")
             manifest_bytes = zf.read("manifest.json")
             signature = zf.read("trail.sig")
-            embedded_pubkey = (
+            embedded_pubkey_pem = (
                 zf.read("signer_pubkey.pem")
                 if "signer_pubkey.pem" in names
+                else None
+            )
+            embedded_pubkey_bin = (
+                zf.read("signer_pubkey.bin")
+                if "signer_pubkey.bin" in names
                 else None
             )
     except zipfile.BadZipFile as e:
@@ -197,25 +202,68 @@ def verify_signed(
             "(trail was tampered after export)"
         )
 
-    if public_key is None:
-        if embedded_pubkey is None:
+    algorithm = manifest.get("signature_algorithm", "Ed25519")
+    to_verify = hashlib.sha256(trail_bytes + manifest_bytes).digest()
+
+    if algorithm == "Ed25519":
+        if public_key is None:
+            if embedded_pubkey_pem is None:
+                return VerifyResult(
+                    ok=False,
+                    errors=errors + [
+                        "no public_key argument and no signer_pubkey.pem in zip",
+                    ],
+                    manifest=manifest,
+                )
+            pk = _load_public_key(embedded_pubkey_pem)
+        else:
+            pk = _load_public_key(public_key)
+        try:
+            pk.verify(signature, to_verify)
+        except InvalidSignature:
+            errors.append(
+                "Ed25519 signature did not verify "
+                "(wrong public key, tampered manifest, or tampered trail)"
+            )
+    elif algorithm == "ML-DSA-65":
+        try:
+            from vaara.audit.signer import MLDSA65Verifier
+        except ImportError as exc:
             return VerifyResult(
                 ok=False,
-                errors=errors + ["no public_key argument and no signer_pubkey.pem in zip"],
+                errors=errors + [
+                    f"ML-DSA-65 verify requires the pq extra: {exc}",
+                ],
                 manifest=manifest,
             )
-        pk = _load_public_key(embedded_pubkey)
+        if public_key is None:
+            if embedded_pubkey_bin is None:
+                return VerifyResult(
+                    ok=False,
+                    errors=errors + [
+                        "no public_key argument and no signer_pubkey.bin in zip",
+                    ],
+                    manifest=manifest,
+                )
+            pk_bytes = embedded_pubkey_bin
+        elif isinstance(public_key, (bytes, bytearray)):
+            pk_bytes = bytes(public_key)
+        else:
+            return VerifyResult(
+                ok=False,
+                errors=errors + [
+                    "ML-DSA-65 verify requires public_key as raw bytes",
+                ],
+                manifest=manifest,
+            )
+        verifier = MLDSA65Verifier(pk_bytes)
+        if not verifier.verify(to_verify, signature):
+            errors.append(
+                "ML-DSA-65 signature did not verify "
+                "(wrong public key, tampered manifest, or tampered trail)"
+            )
     else:
-        pk = _load_public_key(public_key)
-
-    to_verify = hashlib.sha256(trail_bytes + manifest_bytes).digest()
-    try:
-        pk.verify(signature, to_verify)
-    except InvalidSignature:
-        errors.append(
-            "Ed25519 signature did not verify "
-            "(wrong public key, tampered manifest, or tampered trail)"
-        )
+        errors.append(f"unknown signature_algorithm: {algorithm!r}")
 
     chain_error = _verify_chain_bytes(trail_bytes)
     if chain_error is not None:

--- a/src/vaara/scorer/composite.py
+++ b/src/vaara/scorer/composite.py
@@ -1,0 +1,114 @@
+"""CompositeScorer — run Vaara alongside external scorers, combine results.
+
+The composite implements the same ``evaluate(context) -> dict`` shape
+that ``InterceptionPipeline`` expects, so it drops into existing
+pipelines as a direct replacement for ``AdaptiveScorer``.
+
+Combine modes (v1):
+
+- ``"max"`` (default): highest point estimate wins; decision is the
+  strongest of any member. Conservative — any scorer firing high
+  produces an escalation.
+- ``"mean"``: arithmetic mean across point estimates; decision is the
+  strongest of any member.
+- A callable ``Callable[[list[dict]], dict]`` for custom merge logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Protocol, Union
+
+
+class ScorerBackend(Protocol):
+    """Anything that maps an action context to a Vaara-shaped scorer dict."""
+
+    def evaluate(self, context: dict[str, Any]) -> dict[str, Any]: ...
+
+    @property
+    def name(self) -> str: ...
+
+
+CombineFn = Callable[[list[dict[str, Any]]], dict[str, Any]]
+
+_DECISION_RANK = {"allow": 0, "escalate": 1, "deny": 2}
+_RANK_DECISION = {v: k for k, v in _DECISION_RANK.items()}
+
+
+class CompositeScorer:
+    """Run Vaara's scorer alongside one or more peers; combine results."""
+
+    def __init__(
+        self,
+        scorers: Iterable[ScorerBackend],
+        *,
+        combine: Union[str, CombineFn] = "max",
+        name: str = "composite",
+    ) -> None:
+        self._scorers = list(scorers)
+        if not self._scorers:
+            raise ValueError("CompositeScorer requires at least one scorer")
+        if isinstance(combine, str) and combine not in ("max", "mean"):
+            raise ValueError(
+                f"unknown combine mode: {combine!r}; use 'max', 'mean', or a callable"
+            )
+        self._combine = combine
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def evaluate(self, context: dict[str, Any]) -> dict[str, Any]:
+        results = [s.evaluate(context) for s in self._scorers]
+        combine = self._combine
+        if isinstance(combine, str):
+            merged = _combine_max(results) if combine == "max" else _combine_mean(results)
+        else:
+            merged = combine(results)
+        merged["backend"] = self._name
+        merged["composition"] = {
+            "members": [r.get("backend", "?") for r in results],
+            "mode": self._combine if isinstance(self._combine, str) else "callable",
+        }
+        return merged
+
+
+def _combine_max(results: list[dict[str, Any]]) -> dict[str, Any]:
+    top_score = -1.0
+    top_idx = 0
+    top_decision_rank = 0
+    for i, r in enumerate(results):
+        try:
+            s = float(r.get("point_estimate", 0.5))
+        except (TypeError, ValueError):
+            s = 0.5
+        if s > top_score:
+            top_score = s
+            top_idx = i
+        dr = _DECISION_RANK.get(r.get("decision", "allow"), 0)
+        if dr > top_decision_rank:
+            top_decision_rank = dr
+    base = dict(results[top_idx])
+    base["decision"] = _RANK_DECISION.get(top_decision_rank, "allow")
+    return base
+
+
+def _combine_mean(results: list[dict[str, Any]]) -> dict[str, Any]:
+    scores: list[float] = []
+    for r in results:
+        try:
+            scores.append(float(r.get("point_estimate", 0.5)))
+        except (TypeError, ValueError):
+            scores.append(0.5)
+    avg = sum(scores) / len(scores)
+    top_decision_rank = max(
+        _DECISION_RANK.get(r.get("decision", "allow"), 0) for r in results
+    )
+    return {
+        "point_estimate": avg,
+        "decision": _RANK_DECISION.get(top_decision_rank, "allow"),
+        "raw_result": {
+            "point_estimate": avg,
+            "conformal_interval": [min(scores), max(scores)],
+        },
+    }

--- a/src/vaara/scorer/composition.py
+++ b/src/vaara/scorer/composition.py
@@ -1,0 +1,120 @@
+"""ExternalScorer — call a remote /v1/score endpoint as a scorer backend.
+
+The v0.10.0 HTTP API defines a stable wire contract for scorers; this
+module reuses the same contract on the inbound side. The remote can be
+another Vaara instance, a NeMo Guardrails service, or any peer that
+implements the /v1/score request/response shape.
+
+Fail-closed deny on any transport error or malformed response so a
+``CompositeScorer`` cannot silently downgrade a decision because one
+member was unreachable.
+
+Pair with ``vaara.scorer.composite.CompositeScorer`` to run Vaara's
+``AdaptiveScorer`` alongside external scorers and merge the results.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Optional
+
+
+class ExternalScorerError(RuntimeError):
+    """Raised when an external scorer returns an unusable response."""
+
+
+class ExternalScorer:
+    """Vaara-compatible scorer that POSTs to a remote /v1/score endpoint."""
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        name: Optional[str] = None,
+        timeout: float = 5.0,
+        headers: Optional[dict[str, str]] = None,
+    ) -> None:
+        if not url:
+            raise ValueError("ExternalScorer requires a non-empty url")
+        self._url = url
+        self._name = name or url
+        self._timeout = float(timeout)
+        self._headers = {
+            "content-type": "application/json",
+            **(headers or {}),
+        }
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def evaluate(self, context: dict[str, Any]) -> dict[str, Any]:
+        body = json.dumps(context).encode("utf-8")
+        req = urllib.request.Request(
+            self._url, data=body, headers=self._headers, method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                payload = resp.read()
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as exc:
+            return _fail_closed(
+                self._name,
+                f"external scorer transport failure: {exc.__class__.__name__}",
+            )
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return _fail_closed(self._name, "external scorer returned non-JSON body")
+        return _coerce_external_result(self._name, data)
+
+
+def _fail_closed(name: str, message: str) -> dict[str, Any]:
+    return {
+        "point_estimate": 1.0,
+        "decision": "deny",
+        "backend": name,
+        "raw_result": {
+            "point_estimate": 1.0,
+            "conformal_interval": [1.0, 1.0],
+            "fail_closed_reason": message,
+        },
+    }
+
+
+def _coerce_external_result(name: str, data: Any) -> dict[str, Any]:
+    """Map a remote /v1/score response into Vaara's internal scorer dict."""
+    if not isinstance(data, dict):
+        return _fail_closed(name, "external scorer returned non-object body")
+    risk = data.get("risk") or data.get("raw_result") or {}
+    if isinstance(risk, dict):
+        point = risk.get("point", risk.get("point_estimate"))
+        lower = risk.get("lower", point)
+        upper = risk.get("upper", point)
+        interval = risk.get("conformal_interval", [lower, upper])
+    else:
+        point, interval = data.get("point_estimate"), None
+    try:
+        point = float(point) if point is not None else 0.5
+    except (TypeError, ValueError):
+        point = 0.5
+    point = max(0.0, min(1.0, point))
+    decision = data.get("decision") or _decision_from_score(point)
+    return {
+        "point_estimate": point,
+        "decision": decision,
+        "backend": name,
+        "raw_result": {
+            "point_estimate": point,
+            "conformal_interval": interval or [point, point],
+        },
+    }
+
+
+def _decision_from_score(score: float) -> str:
+    if score >= 0.7:
+        return "deny"
+    if score >= 0.4:
+        return "escalate"
+    return "allow"

--- a/tests/test_scorer_composition.py
+++ b/tests/test_scorer_composition.py
@@ -1,0 +1,123 @@
+"""Tests for ExternalScorer + CompositeScorer."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from vaara.scorer.composite import CompositeScorer
+from vaara.scorer.composition import ExternalScorer, _coerce_external_result
+
+
+class _Stub:
+    def __init__(self, *, score: float, decision: str, name: str = "stub") -> None:
+        self._score = score
+        self._decision = decision
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def evaluate(self, _context: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "point_estimate": self._score,
+            "decision": self._decision,
+            "backend": self._name,
+            "raw_result": {
+                "point_estimate": self._score,
+                "conformal_interval": [self._score, self._score],
+            },
+        }
+
+
+# ── ExternalScorer ──────────────────────────────────────────────────
+
+
+def test_external_scorer_requires_url():
+    with pytest.raises(ValueError):
+        ExternalScorer("")
+
+
+def test_external_scorer_fail_closed_on_transport_error():
+    sc = ExternalScorer("http://127.0.0.1:1/score", timeout=0.05)
+    r = sc.evaluate({"tool_name": "x"})
+    assert r["decision"] == "deny"
+    assert r["point_estimate"] == 1.0
+    assert "fail_closed_reason" in r["raw_result"]
+
+
+def test_coerce_external_result_decodes_vaara_score_shape():
+    r = _coerce_external_result(
+        "peer",
+        {
+            "risk": {"point": 0.62, "lower": 0.55, "upper": 0.71},
+            "decision": "escalate",
+        },
+    )
+    assert r["point_estimate"] == 0.62
+    assert r["decision"] == "escalate"
+    assert r["backend"] == "peer"
+    assert r["raw_result"]["conformal_interval"] == [0.55, 0.71]
+
+
+def test_coerce_external_result_handles_non_object_body():
+    r = _coerce_external_result("peer", "not-an-object")
+    assert r["decision"] == "deny"
+    assert "fail_closed_reason" in r["raw_result"]
+
+
+def test_coerce_external_result_clamps_out_of_range_score():
+    r = _coerce_external_result("peer", {"risk": {"point": 1.7}})
+    assert 0.0 <= r["point_estimate"] <= 1.0
+
+
+# ── CompositeScorer ─────────────────────────────────────────────────
+
+
+def test_composite_requires_at_least_one_scorer():
+    with pytest.raises(ValueError):
+        CompositeScorer([])
+
+
+def test_composite_max_picks_highest_score_member():
+    a = _Stub(score=0.2, decision="allow", name="vaara")
+    b = _Stub(score=0.81, decision="deny", name="peer")
+    c = _Stub(score=0.4, decision="escalate", name="other")
+    composite = CompositeScorer([a, b, c], combine="max")
+    out = composite.evaluate({"tool_name": "tx.transfer"})
+    assert out["backend"] == "composite"
+    assert out["point_estimate"] == 0.81
+    assert out["decision"] == "deny"
+    assert out["composition"]["members"] == ["vaara", "peer", "other"]
+    assert out["composition"]["mode"] == "max"
+
+
+def test_composite_mean_averages_scores_and_keeps_strongest_decision():
+    a = _Stub(score=0.2, decision="allow", name="a")
+    b = _Stub(score=0.8, decision="escalate", name="b")
+    composite = CompositeScorer([a, b], combine="mean")
+    out = composite.evaluate({})
+    assert out["point_estimate"] == pytest.approx(0.5)
+    assert out["decision"] == "escalate"
+
+
+def test_composite_callable_combine_runs():
+    seen: list[list[dict[str, Any]]] = []
+
+    def merge(results: list[dict[str, Any]]) -> dict[str, Any]:
+        seen.append(results)
+        return {"point_estimate": 0.99, "decision": "deny"}
+
+    a = _Stub(score=0.1, decision="allow", name="a")
+    composite = CompositeScorer([a], combine=merge)
+    out = composite.evaluate({})
+    assert seen and len(seen[0]) == 1
+    assert out["composition"]["mode"] == "callable"
+    assert out["point_estimate"] == 0.99
+
+
+def test_composite_rejects_unknown_combine_string():
+    with pytest.raises(ValueError):
+        CompositeScorer([_Stub(score=0.1, decision="allow")], combine="median")

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,0 +1,183 @@
+"""Tests for the pluggable signer abstraction (Ed25519 + ML-DSA-65)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+except ImportError:
+    pytest.skip(
+        "cryptography not installed (pip install 'vaara[export]')",
+        allow_module_level=True,
+    )
+
+from vaara.audit.export import export_signed
+from vaara.audit.signer import (
+    Ed25519Signer,
+    Ed25519Verifier,
+    Signer,
+    Verifier,
+    verifier_for,
+)
+from vaara.audit.trail import AuditTrail
+from vaara.audit.verify import verify_signed
+from vaara.taxonomy.actions import (
+    ActionCategory,
+    ActionRequest,
+    ActionType,
+    BlastRadius,
+    RegulatoryDomain,
+    Reversibility,
+    UrgencyClass,
+)
+
+
+def _populated_trail() -> AuditTrail:
+    trail = AuditTrail()
+    action_type = ActionType(
+        name="data.read",
+        category=ActionCategory.DATA,
+        reversibility=Reversibility.FULLY,
+        blast_radius=BlastRadius.LOCAL,
+        urgency=UrgencyClass.DEFERRABLE,
+        regulatory_domains=frozenset({RegulatoryDomain.EU_AI_ACT}),
+    )
+    req = ActionRequest(
+        agent_id="a-1", tool_name="data.read",
+        action_type=action_type, parameters={}, confidence=0.9,
+    )
+    action_id = trail.record_action_requested(req)
+    trail.record_decision(
+        action_id=action_id, agent_id="a-1", tool_name="data.read",
+        decision="allow", reason="ok", risk_score=0.1,
+        regulatory_domains=frozenset({RegulatoryDomain.EU_AI_ACT}),
+    )
+    return trail
+
+
+# ── Ed25519 surface ──────────────────────────────────────────────────
+
+
+def test_ed25519_signer_implements_protocol():
+    key = Ed25519PrivateKey.generate()
+    signer = Ed25519Signer(key)
+    assert isinstance(signer, Signer)
+    assert signer.algorithm == "Ed25519"
+    sig = signer.sign(b"hello")
+    assert len(sig) == 64
+
+
+def test_ed25519_signer_rejects_wrong_key_type():
+    with pytest.raises(TypeError):
+        Ed25519Signer("not-a-key")  # type: ignore[arg-type]
+
+
+def test_ed25519_verifier_round_trip():
+    key = Ed25519PrivateKey.generate()
+    signer = Ed25519Signer(key)
+    verifier = Ed25519Verifier(signer.public_key_bytes())
+    assert isinstance(verifier, Verifier)
+    msg = b"audit-message"
+    sig = signer.sign(msg)
+    assert verifier.verify(msg, sig) is True
+    assert verifier.verify(b"tampered", sig) is False
+
+
+def test_export_signed_via_signer_argument(tmp_path: Path):
+    key = Ed25519PrivateKey.generate()
+    signer = Ed25519Signer(key)
+    result = export_signed(
+        _populated_trail(), tmp_path / "trail.zip", signer=signer,
+    )
+    assert result.path.is_file()
+    assert result.manifest["signature_algorithm"] == "Ed25519"
+    verify = verify_signed(result.path)
+    assert verify.ok, verify.errors
+
+
+def test_export_signed_rejects_both_arguments(tmp_path: Path):
+    key = Ed25519PrivateKey.generate()
+    with pytest.raises(ValueError, match="not both"):
+        export_signed(
+            _populated_trail(), tmp_path / "x.zip",
+            signer_key=key, signer=Ed25519Signer(key),
+        )
+
+
+def test_export_signed_rejects_neither_argument(tmp_path: Path):
+    with pytest.raises(ValueError, match="required"):
+        export_signed(_populated_trail(), tmp_path / "x.zip")
+
+
+def test_verifier_for_dispatches_by_algorithm():
+    key = Ed25519PrivateKey.generate()
+    signer = Ed25519Signer(key)
+    v = verifier_for("Ed25519", signer.public_key_bytes())
+    assert v.algorithm == "Ed25519"
+    with pytest.raises(ValueError):
+        verifier_for("RSA-PSS", b"not-a-key")
+
+
+# ── ML-DSA-65 surface (requires vaara[pq]) ──────────────────────────
+
+
+def _require_pq():
+    return pytest.importorskip("dilithium_py")
+
+
+def test_mldsa_signer_round_trip():
+    _require_pq()
+    from vaara.audit.signer import MLDSA65Signer, MLDSA65Verifier
+
+    signer, pub = MLDSA65Signer.generate()
+    assert signer.algorithm == "ML-DSA-65"
+    sig = signer.sign(b"hello pq")
+    assert len(sig) > 1000  # ML-DSA-65 sigs are ~3.3 KB
+    verifier = MLDSA65Verifier(pub)
+    assert verifier.verify(b"hello pq", sig) is True
+    assert verifier.verify(b"tampered", sig) is False
+
+
+def test_mldsa_signer_via_export_zip(tmp_path: Path):
+    _require_pq()
+    from vaara.audit.signer import MLDSA65Signer
+
+    signer, _ = MLDSA65Signer.generate()
+    result = export_signed(
+        _populated_trail(), tmp_path / "trail-pq.zip", signer=signer,
+    )
+    assert result.manifest["signature_algorithm"] == "ML-DSA-65"
+    verify = verify_signed(result.path)
+    assert verify.ok, verify.errors
+
+
+def test_mldsa_zip_rejects_tampered_trail(tmp_path: Path):
+    import zipfile
+    _require_pq()
+    from vaara.audit.signer import MLDSA65Signer
+
+    signer, _ = MLDSA65Signer.generate()
+    zpath = tmp_path / "trail-pq.zip"
+    export_signed(_populated_trail(), zpath, signer=signer)
+
+    # Tamper the trail inside the zip.
+    with zipfile.ZipFile(zpath, "r") as zin:
+        trail_bytes = zin.read("trail.jsonl")
+        manifest_bytes = zin.read("manifest.json")
+        sig_bytes = zin.read("trail.sig")
+        pub_bytes = zin.read("signer_pubkey.bin")
+    tampered = trail_bytes.replace(b'"allow"', b'"deny"')
+    bad_zip = tmp_path / "tampered.zip"
+    with zipfile.ZipFile(bad_zip, "w", zipfile.ZIP_DEFLATED) as zout:
+        zout.writestr("trail.jsonl", tampered)
+        zout.writestr("manifest.json", manifest_bytes)
+        zout.writestr("trail.sig", sig_bytes)
+        zout.writestr("signer_pubkey.bin", pub_bytes)
+
+    result = verify_signed(bad_zip)
+    assert not result.ok


### PR DESCRIPTION
## Summary

Theme: **audit-retention horizon + composer position.** Two additions.

- **B2 ML-DSA-65 signer option.** `vaara.audit.signer` adds a `Signer` / `Verifier` protocol with `Ed25519Signer` and `MLDSA65Signer` implementations. `export_signed` accepts a `signer=` keyword (mutually exclusive with the legacy `signer_key` Ed25519 PEM path). The manifest carries `signature_algorithm` so verifiers dispatch automatically. Ed25519 exports keep writing `signer_pubkey.pem` for backward-compatible verification by older clients; ML-DSA-65 exports write `signer_pubkey.bin` (raw 1,952-byte public key). ML-DSA-65 requires the new `vaara[pq]` extra (pure-Python `dilithium-py`).
- **B3 External-scorer composition.** `vaara.scorer.composition.ExternalScorer(url)` calls a remote `/v1/score` endpoint (any service that implements the v0.10.0 wire contract) and returns Vaara's internal scorer dict shape. Transport errors and malformed bodies fail closed to `deny` with a structured reason in `raw_result`. `vaara.scorer.composite.CompositeScorer(scorers, combine="max"|"mean"|callable)` runs Vaara's `AdaptiveScorer` alongside external scorers and merges results, preserving the strongest decision across members.

CHANGELOG and README updated.

## Test plan

- [x] 606 tests pass, 12 skipped (20 new tests across signer + composition).
- [x] ML-DSA-65 round-trip emit + verify via `export_signed` / `verify_signed`.
- [x] Tampered ML-DSA-65 zip rejected at verify time.
- [x] Composite picks strongest decision when one member denies.
- [x] ExternalScorer fail-closed on dead URL (transport-error path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
