### PR TITLE
feat: v0.16.0 PDF article-evidence export

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,3 +87,38 @@ jobs:
             dist/*.sigstore.json
           generate_release_notes: true
           fail_on_unmatched_files: true
+
+  publish-npm:
+    name: Publish TypeScript client to npm
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ vars.NPM_PUBLISH_ENABLED == 'true' }}
+    permissions:
+      contents: read
+      id-token: write  # required for npm provenance
+    defaults:
+      run:
+        working-directory: clients/ts
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v6.0.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install (npm ci)
+        run: npm ci --no-audit --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: node --test test/*.test.mjs
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-05-17
+
+**Theme: auditor-shippable PDF.** The article-evidence report has rendered
+as Markdown, JSON, and narrative since v0.13.0; auditors and Notified
+Bodies consume PDFs. ``vaara compliance report --format pdf --out FILE``
+now ships a styled, single-file PDF suitable for attaching to a conformity
+submission or compliance binder. No new wire-format surface. The underlying
+``ConformityReport`` is the same artefact in a different render.
+
+### Added
+- **`render_pdf(report, path)` in `vaara.compliance.render`.** Single-file
+  PDF: cover with system metadata + integrity, per-domain article tables,
+  per-article detail sections with status, strength, evidence age, gaps,
+  recommendations, and sample record IDs. Layout mirrors the Markdown
+  rendering. Returns bytes written.
+- **`vaara compliance report --format pdf --out FILE` CLI option.**
+  ``--out`` is required for ``pdf`` (binary output, no stdout path).
+  Missing reportlab raises a clear ``ImportError`` pointing at
+  ``pip install 'vaara[pdf]'``.
+- **`vaara[pdf]` optional extra.** ``reportlab>=4.0``. Pure-Python, no
+  native deps. Keeps the base install lean for deployers who only need
+  Markdown/JSON.
+- 4 new tests in ``test_compliance_render.py``: PDF magic bytes + EOF
+  marker, HTML metachar escaping in ``system_name`` (so a hostile
+  deployer name cannot smuggle ``<b>`` into a regulator-facing PDF),
+  broken-chain rendering, and the missing-reportlab error path.
+
+### Notes
+- A3 commit-prove receipt pair is **already shipped** as of v0.13.0
+  (``vaara.audit.receipts``, ``vaara trail receipt`` CLI); this release
+  closes the remaining A-tier item from the post-v0.15.0 competitive
+  differentiation move list.
+- 610 tests pass (was 606 + 4 new).
+
 ## [0.15.0] - 2026-05-17
 
 **Theme: Vaara reaches JavaScript.** First-party TypeScript HTTP client

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ v0.15.0 ships the first-party TypeScript client at [`clients/ts`](clients/ts) an
 npm install @vaara/client
 ```
 
+v0.16.0 adds a PDF render to the article-evidence report. `vaara compliance report --db PATH --format pdf --out report.pdf` writes a styled single-file PDF (per-domain article tables plus per-article detail sections) suitable for attaching to a conformity submission or internal-audit binder. Requires `pip install 'vaara[pdf]'`. Markdown, JSON, and narrative renders remain unchanged.
+
 ```ts
 import { VaaraClient } from "@vaara/client";
 const vaara = new VaaraClient({ baseUrl: "http://localhost:8000" });

--- a/clients/ts/package-lock.json
+++ b/clients/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vaara/client",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vaara/client",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.0"

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "TypeScript client for the Vaara HTTP API — conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.15.0"
+version = "0.16.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -45,6 +45,7 @@ yaml = ["pyyaml>=6.0"]
 server = ["fastapi>=0.110", "uvicorn>=0.27"]
 attestation = ["cbor2>=5.4", "cryptography>=41.0"]
 pq = ["dilithium-py>=1.4.0"]
+pdf = ["reportlab>=4.0"]
 
 [project.scripts]
 vaara = "vaara.cli:main"

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -651,6 +651,25 @@ def _cmd_compliance_report(args: argparse.Namespace) -> int:
         system_version=args.system_version,
     )
 
+    if args.format == "pdf":
+        if not args.out:
+            print(
+                "--out is required when --format pdf (binary output)",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            from vaara.compliance.render import render_pdf
+        except ImportError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        try:
+            render_pdf(report, Path(args.out).expanduser())
+        except ImportError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        return 0
+
     if args.format == "md":
         text = render_markdown(report)
     elif args.format == "json":
@@ -1030,12 +1049,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to the audit SQLite DB to read evidence from",
     )
     pcrep.add_argument(
-        "--format", choices=["md", "json", "narrative"], default="md",
-        help="Output format (default: md)",
+        "--format", choices=["md", "json", "narrative", "pdf"], default="md",
+        help="Output format (default: md). 'pdf' requires the 'pdf' extra "
+             "and writes binary, so --out is required for pdf.",
     )
     pcrep.add_argument(
         "--out", default=None,
-        help="Write to file (default: stdout)",
+        help="Write to file (default: stdout; required for --format pdf)",
     )
     pcrep.add_argument(
         "--system-name", default="Vaara-governed AI system",

--- a/src/vaara/compliance/render.py
+++ b/src/vaara/compliance/render.py
@@ -5,21 +5,23 @@ Each rendering produces a deployer-shippable artefact:
 - ``render_markdown`` — Markdown with per-domain sections, article tables,
   evidence status badges, and gap/recommendation lists. The canonical
   human-shipped format; reviewable in a PR, diffable in CI, attachable to
-  a regulator submission as `.md`.
+  a regulator submission as ``.md``.
 - ``render_narrative`` — Plain-text narrative (existing
-  `ConformityReport.narrative` property, re-exposed here for symmetry).
-- ``render_json`` — Strict-JSON dict (existing `ConformityReport.to_dict`,
+  ``ConformityReport.narrative`` property, re-exposed here for symmetry).
+- ``render_json`` — Strict-JSON dict (existing ``ConformityReport.to_dict``,
   also re-exposed).
-
-PDF export is intentionally NOT in v1: a clean Markdown render can be piped
-through `pandoc` or `weasyprint` by the deployer's own pipeline. Vaara
-defines the article-evidence content; format conversion is downstream.
+- ``render_pdf`` — Styled, single-file PDF suitable for attaching to a
+  Notified-Body submission or internal-audit binder. Requires the ``pdf``
+  extra (``pip install 'vaara[pdf]'``). The content mirrors the Markdown
+  rendering; the PDF form is what auditors actually consume.
 """
 
 from __future__ import annotations
 
 import json
 import time
+from pathlib import Path
+from typing import Union
 
 from vaara.compliance.engine import (
     ArticleEvidence,
@@ -177,4 +179,264 @@ def render_markdown(report: ConformityReport) -> str:
     return "\n".join(lines)
 
 
-__all__ = ["render_markdown", "render_narrative", "render_json"]
+_PDF_STATUS_LABEL = {
+    EvidenceStatus.EVIDENCE_SUFFICIENT: "sufficient",
+    EvidenceStatus.EVIDENCE_PARTIAL: "partial",
+    EvidenceStatus.EVIDENCE_INSUFFICIENT: "insufficient",
+    EvidenceStatus.NOT_APPLICABLE: "not applicable",
+}
+
+
+def render_pdf(report: ConformityReport, path: Union[str, Path]) -> int:
+    """Render the report as a single-file PDF.
+
+    Returns the number of bytes written. Requires the ``pdf`` extra
+    (``pip install 'vaara[pdf]'``); raises ``ImportError`` with a
+    pointer to the extra if reportlab is missing.
+
+    Layout mirrors the Markdown rendering: cover block, integrity,
+    summary, critical gaps, per-domain article tables, per-article
+    detail sections. One file per assessment, auditor-friendly and
+    Notified-Body-attachable.
+    """
+    flow, doc = _pdf_build(report, path)
+    doc.build(flow)
+    return Path(path).expanduser().stat().st_size
+
+
+def _pdf_build(report: ConformityReport, path: Union[str, Path]):
+    """Construct the flowable list and SimpleDocTemplate for ``render_pdf``.
+
+    Returns ``(flow, doc)``. Kept separate so the public entrypoint stays
+    short enough to read at a glance and the heavy reportlab import is
+    confined to one place.
+    """
+    try:
+        from reportlab.lib import colors
+        from reportlab.lib.pagesizes import A4
+        from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+        from reportlab.lib.units import cm
+        from reportlab.platypus import (
+            PageBreak,
+            Paragraph,
+            SimpleDocTemplate,
+            Spacer,
+            Table,
+            TableStyle,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "PDF export requires the 'pdf' extra: pip install 'vaara[pdf]'"
+        ) from exc
+
+    out_path = Path(path).expanduser()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    styles = getSampleStyleSheet()
+    body, h1, h2, h3 = (
+        styles["BodyText"], styles["Heading1"],
+        styles["Heading2"], styles["Heading3"],
+    )
+    small = ParagraphStyle(
+        "small", parent=body, fontSize=8, leading=10, textColor=colors.grey,
+    )
+    disclaimer = ParagraphStyle(
+        "disclaimer", parent=body, fontSize=9, leading=12, leftIndent=12,
+        textColor=colors.HexColor("#444444"),
+    )
+    flow: list = []
+    ts = time.strftime("%Y-%m-%d %H:%M UTC", time.gmtime(report.generated_at))
+    flow.append(Paragraph("Article-level evidence report", h1))
+    flow.append(Spacer(1, 0.3 * cm))
+    flow.append(Paragraph(
+        "This is an evidence artefact assembled from the Vaara runtime "
+        "audit trail. It is <b>not</b> a conformity determination. The "
+        "deployer (and where applicable a Notified Body) owns the "
+        "conformity verdict under the EU AI Act and other applicable law.",
+        disclaimer,
+    ))
+    flow.append(Spacer(1, 0.4 * cm))
+    flow.append(Paragraph("System", h2))
+    meta_table = Table(
+        [
+            ["Name", _pdf_escape(report.system_name)],
+            ["Version", _pdf_escape(report.system_version)],
+            ["Generated", ts],
+            ["Overall evidence status", report.overall_status.value],
+        ],
+        colWidths=[5 * cm, 11 * cm],
+    )
+    meta_table.setStyle(TableStyle([
+        ("BOX", (0, 0), (-1, -1), 0.4, colors.grey),
+        ("INNERGRID", (0, 0), (-1, -1), 0.2, colors.lightgrey),
+        ("FONTNAME", (0, 0), (0, -1), "Helvetica-Bold"),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 4),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+        ("TOPPADDING", (0, 0), (-1, -1), 3),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+    ]))
+    flow.append(meta_table)
+    flow.append(Spacer(1, 0.4 * cm))
+    flow.append(Paragraph("Audit trail integrity", h2))
+    chain_state = "intact" if report.trail_chain_intact else "<b>BROKEN</b>"
+    flow.append(Paragraph(
+        f"Trail size: {report.trail_size} records. Hash chain: {chain_state}.",
+        body,
+    ))
+    if not report.trail_chain_intact:
+        flow.append(Spacer(1, 0.2 * cm))
+        flow.append(Paragraph(
+            "The hash chain is broken. Every article below is reported as "
+            "insufficient until the chain is reconstructed or re-verified.",
+            disclaimer,
+        ))
+    flow.append(Spacer(1, 0.4 * cm))
+    flow.append(Paragraph("Summary", h2))
+    flow.append(Paragraph(_pdf_escape(report.summary or ""), body))
+    flow.append(Spacer(1, 0.4 * cm))
+    if report.critical_gaps:
+        flow.append(Paragraph("Critical gaps", h2))
+        for gap in report.critical_gaps:
+            flow.append(Paragraph("• " + _pdf_escape(gap), body))
+        flow.append(Spacer(1, 0.4 * cm))
+    _pdf_append_articles(flow, report, PageBreak, Paragraph, Spacer, Table,
+                         TableStyle, colors, cm, body, h2, h3, small,
+                         disclaimer)
+    flow.append(Spacer(1, 0.5 * cm))
+    flow.append(Paragraph(
+        "Generated by Vaara. Article-level evidence is collected from the "
+        "runtime audit trail; deployer owns the conformity decision.",
+        small,
+    ))
+    doc = SimpleDocTemplate(
+        str(out_path),
+        pagesize=A4,
+        title=f"Vaara evidence report: {report.system_name}",
+        author="Vaara",
+        leftMargin=2 * cm, rightMargin=2 * cm,
+        topMargin=2 * cm, bottomMargin=2 * cm,
+    )
+    return flow, doc
+
+
+def _pdf_append_articles(
+    flow, report, PageBreak, Paragraph, Spacer, Table, TableStyle, colors,
+    cm, body, h2, h3, small, disclaimer,
+) -> None:
+    """Append per-domain article tables and per-article detail sections."""
+    by_domain: dict[str, list[ArticleEvidence]] = {}
+    for a in report.articles:
+        by_domain.setdefault(a.requirement.domain.value, []).append(a)
+    for domain in sorted(by_domain):
+        articles = by_domain[domain]
+        flow.append(PageBreak())
+        flow.append(Paragraph(
+            f"{domain.upper()} — article evidence", h2,
+        ))
+        flow.append(Spacer(1, 0.2 * cm))
+        table_rows = [["Article", "Title", "Status", "Strength", "Records"]]
+        for art in articles:
+            table_rows.append([
+                art.requirement.article,
+                _pdf_escape(art.requirement.title),
+                _PDF_STATUS_LABEL.get(art.status, art.status.value),
+                art.strength.value,
+                str(art.evidence_count),
+            ])
+        article_table = Table(
+            table_rows,
+            colWidths=[2.8 * cm, 6.5 * cm, 2.6 * cm, 2.2 * cm, 1.8 * cm],
+            repeatRows=1,
+        )
+        article_table.setStyle(TableStyle([
+            ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#eeeeee")),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, -1), 8),
+            ("BOX", (0, 0), (-1, -1), 0.4, colors.grey),
+            ("INNERGRID", (0, 0), (-1, -1), 0.2, colors.lightgrey),
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 3),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 3),
+            ("TOPPADDING", (0, 0), (-1, -1), 2),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+        ]))
+        flow.append(article_table)
+        flow.append(Spacer(1, 0.4 * cm))
+        for art in articles:
+            flow.append(Paragraph(
+                f"{domain.upper()} {art.requirement.article} — "
+                f"{_pdf_escape(art.requirement.title)}",
+                h3,
+            ))
+            status_label = _PDF_STATUS_LABEL.get(art.status, art.status.value)
+            flow.append(Paragraph(
+                f"<b>Status:</b> {status_label} &nbsp; "
+                f"<b>Strength:</b> {art.strength.value} &nbsp; "
+                f"<b>Records:</b> {art.evidence_count}",
+                body,
+            ))
+            if art.evidence_count > 0:
+                age_bits = []
+                if (art.freshest_evidence_age_hours is not None
+                        and art.freshest_evidence_age_hours != float("inf")):
+                    age_bits.append(
+                        f"freshest {art.freshest_evidence_age_hours:.1f}h"
+                    )
+                if (art.oldest_evidence_age_hours is not None
+                        and art.oldest_evidence_age_hours != float("inf")):
+                    age_bits.append(
+                        f"oldest {art.oldest_evidence_age_hours:.1f}h"
+                    )
+                if age_bits:
+                    flow.append(Paragraph(
+                        "<b>Evidence age:</b> " + ", ".join(age_bits),
+                        body,
+                    ))
+            if art.requirement.description:
+                flow.append(Spacer(1, 0.15 * cm))
+                flow.append(Paragraph(
+                    _pdf_escape(art.requirement.description), disclaimer,
+                ))
+            if art.gaps:
+                flow.append(Spacer(1, 0.1 * cm))
+                flow.append(Paragraph("<b>Gaps:</b>", body))
+                for gap in art.gaps:
+                    flow.append(Paragraph("• " + _pdf_escape(gap), body))
+            if art.recommendations:
+                flow.append(Spacer(1, 0.1 * cm))
+                flow.append(Paragraph("<b>Recommendations:</b>", body))
+                for rec in art.recommendations:
+                    flow.append(Paragraph("• " + _pdf_escape(rec), body))
+            if art.sample_record_ids:
+                flow.append(Spacer(1, 0.1 * cm))
+                flow.append(Paragraph(
+                    "<b>Sample audit record IDs:</b> "
+                    + ", ".join(
+                        f"<font face='Courier' size='8'>{rid}</font>"
+                        for rid in art.sample_record_ids[:5]
+                    ),
+                    small,
+                ))
+            flow.append(Spacer(1, 0.3 * cm))
+
+
+def _pdf_escape(value: object) -> str:
+    """Escape user-controlled text so reportlab Paragraph cannot be tricked
+    into rendering forged markup. `system_name`, gaps, recommendations, and
+    article titles flow through Paragraph which parses a tiny HTML subset;
+    a `<b>` smuggled by a hostile deployer name would otherwise render bold
+    text in a regulator-facing PDF.
+    """
+    if value is None:
+        return ""
+    s = str(value)
+    return (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+__all__ = [
+    "render_markdown", "render_narrative", "render_json", "render_pdf",
+]

--- a/tests/test_compliance_render.py
+++ b/tests/test_compliance_render.py
@@ -1,8 +1,10 @@
-"""Tests for Markdown / narrative / JSON renderers of ConformityReport."""
+"""Tests for Markdown / narrative / JSON / PDF renderers of ConformityReport."""
 
 from __future__ import annotations
 
 import json
+
+import pytest
 
 from vaara.audit.trail import AuditTrail
 from vaara.compliance.engine import create_default_engine
@@ -11,6 +13,15 @@ from vaara.compliance.render import (
     render_markdown,
     render_narrative,
 )
+
+try:
+    import reportlab  # noqa: F401
+
+    from vaara.compliance.render import render_pdf
+
+    _HAS_REPORTLAB = True
+except ImportError:
+    _HAS_REPORTLAB = False
 from vaara.taxonomy.actions import (
     ActionCategory,
     ActionRequest,
@@ -111,3 +122,67 @@ def test_render_markdown_includes_summary_section():
     report = create_default_engine().assess(trail)
     md = render_markdown(report)
     assert "## Summary" in md
+
+
+@pytest.mark.skipif(not _HAS_REPORTLAB, reason="reportlab not installed")
+def test_render_pdf_produces_valid_pdf(tmp_path):
+    trail = _populated_trail()
+    report = create_default_engine().assess(
+        trail, system_name="PDFSys", system_version="0.16.0",
+    )
+    out = tmp_path / "report.pdf"
+    size = render_pdf(report, out)
+    assert size > 0
+    data = out.read_bytes()
+    assert data.startswith(b"%PDF-")
+    assert data.rstrip().endswith(b"%%EOF")
+    assert size == len(data)
+
+
+@pytest.mark.skipif(not _HAS_REPORTLAB, reason="reportlab not installed")
+def test_render_pdf_escapes_html_metachars_in_system_name(tmp_path):
+    """A hostile system_name must not inject reportlab markup."""
+    trail = _populated_trail()
+    report = create_default_engine().assess(
+        trail,
+        system_name="<script>alert('x')</script>",
+        system_version="<b>1.0</b>",
+    )
+    out = tmp_path / "escaped.pdf"
+    render_pdf(report, out)
+    data = out.read_bytes()
+    # PDF stream is compressed by default; just confirm valid magic and the
+    # function did not raise during Paragraph parsing.
+    assert data.startswith(b"%PDF-")
+
+
+@pytest.mark.skipif(not _HAS_REPORTLAB, reason="reportlab not installed")
+def test_render_pdf_handles_broken_chain(tmp_path):
+    trail = _populated_trail()
+    trail._records[1].record_hash = "0" * 64
+    report = create_default_engine().assess(trail)
+    out = tmp_path / "broken.pdf"
+    size = render_pdf(report, out)
+    assert size > 0
+    assert out.read_bytes().startswith(b"%PDF-")
+
+
+def test_render_pdf_raises_helpful_error_when_reportlab_missing(
+    tmp_path, monkeypatch,
+):
+    """If reportlab is unimportable, render_pdf must point at the extra."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name, *a, **kw):
+        if name.startswith("reportlab"):
+            raise ImportError("simulated missing reportlab")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    from vaara.compliance.render import render_pdf as rp
+    trail = _populated_trail()
+    report = create_default_engine().assess(trail)
+    with pytest.raises(ImportError, match=r"vaara\[pdf\]"):
+        rp(report, tmp_path / "missing.pdf")


### PR DESCRIPTION
## Summary

Adds a single-file PDF render to the article-evidence report. `vaara compliance report --db PATH --format pdf --out FILE` writes a styled PDF (per-domain article tables plus per-article detail sections) suitable for attaching to a conformity submission or internal-audit binder. The content mirrors the existing Markdown render. Requires `pip install 'vaara[pdf]'` (pure-Python reportlab, no native deps).

Closes the last A-tier item from the v0.15.0 competitive differentiation move list. A3 (commit-prove receipt pair) was already shipped in v0.13.0 as `vaara.audit.receipts` plus the `vaara trail receipt` CLI.

## What ships

- `render_pdf(report, path)` in `vaara.compliance.render`. Cover with system metadata and integrity, per-domain article tables, per-article detail sections with status, strength, evidence age, gaps, recommendations, and sample record IDs.
- `vaara compliance report --format pdf --out FILE`. `--out` is required for `pdf` (binary output, no stdout path). Missing reportlab raises an `ImportError` pointing at `pip install 'vaara[pdf]'`.
- `vaara[pdf]` optional extra (`reportlab>=4.0`). Pure-Python, no system libraries. Base install stays lean.
- `@vaara/client` bumped to 0.16.0 for PyPI/npm lockstep. No TypeScript code change in this release.

## Tests

4 new render tests in `tests/test_compliance_render.py`:

- PDF magic bytes plus `%%EOF` trailer
- HTML metachar escape in `system_name` (so a hostile deployer name cannot smuggle `<b>` into a regulator-facing PDF)
- Broken chain still renders cleanly
- Missing-reportlab `ImportError` path

Suite: 610 Python pass / 12 skip (was 606). 6 TypeScript tests pass.

## Test plan

- [ ] `pip install 'vaara[pdf]'` then `vaara compliance report --db audit.db --format pdf --out /tmp/report.pdf` produces a valid PDF
- [ ] PyPI Trusted Publish lands `vaara 0.16.0`
- [ ] publish-npm job publishes `@vaara/client 0.16.0` (NPM_PUBLISH_ENABLED is set, NPM_TOKEN rotated)
- [ ] Sigstore-signed GitHub Release produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF rendering capability for compliance reports, enabling generation of styled single-file PDFs
  * Includes article tables and detail sections for comprehensive report documentation
  * Requires optional `vaara[pdf]` package extra

* **Chores**
  * Version bumped to 0.16.0 for both Python and TypeScript packages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->