### PR TITLE
feat: v0.17.0 OVERT 1.0 reference verifier CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-17
+
+**Theme: Vaara as the OVERT 1.0 reference verifier.** Vaara has emitted
+OVERT 1.0 Protocol Profile 1.0 Base Envelopes since v0.10.0 and Phase 3
+IAP attestations since v0.13.0. This release adds the CLI surface so any
+operator, auditor, or Independent Attestation Provider can verify a Base
+Envelope produced by any conformant emitter, not only Vaara. The verifier
+is implementation-agnostic and reads the canonical CBOR wire format
+defined in Annex B.6 verbatim.
+
+### Added
+- **`vaara overt verify RECEIPT.cbor --pubkey-file PUB.bin` CLI.**
+  Validates an OVERT 1.0 Base Envelope from a canonical CBOR file against
+  a supplied raw 32-byte Ed25519 public key. The schema is closed per
+  the OVERT 1.0 spec, so envelopes carrying unknown fields are rejected.
+  Exit 0 on valid, 1 on invalid envelope or signature mismatch, 2 on
+  argument or I/O errors. Requires the existing `vaara[attestation]`
+  extra (already present for emission). Accepts `--pubkey-hex` as an
+  inline alternative to `--pubkey-file`.
+- 10 new tests in `tests/test_overt_verify_cli.py` covering happy path,
+  wrong pubkey, hex form, malformed hex, wrong-length pubkey, missing
+  receipt, malformed CBOR, missing required fields, closed-schema
+  rejection of extra fields, and tampered-signature rejection.
+
+### Notes
+- Anyone implementing OVERT 1.0 (overt.is) can route their conformance
+  check through `vaara overt verify` without taking a runtime dependency
+  on Vaara's emitter side. The CLI reads only the Annex B.6 wire format.
+- 620 Python tests pass (was 610 + 10 new). TypeScript client bumped to
+  0.17.0 for PyPI/npm lockstep, no code change.
+
 ## [0.16.0] - 2026-05-17
 
 **Theme: auditor-shippable PDF.** The article-evidence report has rendered

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ npm install @vaara/client
 
 v0.16.0 adds a PDF render to the article-evidence report. `vaara compliance report --db PATH --format pdf --out report.pdf` writes a styled single-file PDF (per-domain article tables plus per-article detail sections) suitable for attaching to a conformity submission or internal-audit binder. Requires `pip install 'vaara[pdf]'`. Markdown, JSON, and narrative renders remain unchanged.
 
+v0.17.0 adds an OVERT 1.0 Base Envelope verifier CLI. `vaara overt verify RECEIPT.cbor --pubkey-file PUB.bin` validates any canonical-CBOR Base Envelope (Annex B.6) against a supplied raw 32-byte Ed25519 public key. The schema is closed per the OVERT 1.0 spec, so envelopes carrying unknown fields are rejected. The verifier reads only the wire format and takes no dependency on Vaara's emitter, so any OVERT-conformant implementation can route its conformance check through it. Requires the `vaara[attestation]` extra.
+
 ```ts
 import { VaaraClient } from "@vaara/client";
 const vaara = new VaaraClient({ baseUrl: "http://localhost:8000" });

--- a/clients/ts/package-lock.json
+++ b/clients/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vaara/client",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vaara/client",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.0"

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "TypeScript client for the Vaara HTTP API — conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.16.0"
+version = "0.17.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/attestation/__init__.py
+++ b/src/vaara/attestation/__init__.py
@@ -5,8 +5,13 @@ overt.is): Vaara is the third-party runtime kernel that intercepts agent
 actions, scores risk, and writes the audit trail. In OVERT terms Vaara is
 the **Arbiter** at AAL-3 (operator-controlled notary model). Phase 1
 (Enforcement) and Phase 2 (Provisional Receipt) are emitted by Vaara
-directly. Phase 3 (Full Attestation) requires an external Independent
-Attestation Provider (IAP) and is intentionally out of scope.
+directly. Phase 3 (Full Attestation) is provided by ``vaara.attestation.iap``
+since v0.13.0 as a reference Independent Attestation Provider that
+notary-signs the Provisional Receipt and anchors it in a transparency
+log. Production deployments can swap in sigstore Rekor or an equivalent
+independently-operated log at the same call sites. As of v0.17.0, the
+``vaara overt verify`` CLI validates any OVERT 1.0 Base Envelope produced
+by a conformant emitter, Vaara or otherwise.
 
 The `BaseEnvelope` produced here implements Protocol Profile 1.0 Annex B.6
 verbatim: a 9-field closed-schema CBOR-encoded structure signed with

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -718,6 +718,149 @@ def _cmd_detect_pii(args: argparse.Namespace) -> int:
     return 1 if result.detected else 0
 
 
+_OVERT_ENVELOPE_KEYS = (
+    "blinded_identifier",
+    "request_commitment",
+    "encoder_binary_identity",
+    "non_content_metadata",
+    "monotonic_counter",
+    "nanosecond_timestamp",
+    "key_identifier",
+    "arbiter_instance_identifier",
+    "signature",
+)
+
+
+def _cmd_overt_verify(args: argparse.Namespace) -> int:
+    """Verify an OVERT 1.0 Protocol Profile 1.0 Base Envelope.
+
+    Reads a canonical CBOR file produced by any conformant implementation,
+    decodes the 9-field structure, and validates the Ed25519 signature
+    against a supplied raw 32-byte public key. Implementation-agnostic —
+    Vaara is the reference verifier for Annex B.6 envelopes.
+    """
+    try:
+        import cbor2
+    except ImportError:
+        print(
+            "vaara overt verify requires the attestation extra. "
+            "Install with: pip install 'vaara[attestation]'",
+            file=sys.stderr,
+        )
+        return 2
+
+    from vaara.attestation.overt import BaseEnvelope, verify_base_envelope
+
+    receipt_path = Path(args.receipt).expanduser()
+    if not receipt_path.is_file():
+        print(f"vaara overt verify: not a file: {receipt_path}", file=sys.stderr)
+        return 2
+
+    pubkey_raw = _load_overt_pubkey(args)
+    if pubkey_raw is None:
+        return 2
+    if len(pubkey_raw) != 32:
+        print(
+            f"vaara overt verify: public key must be 32 raw bytes, got "
+            f"{len(pubkey_raw)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        decoded = cbor2.loads(receipt_path.read_bytes())
+    except Exception as exc:
+        print(f"vaara overt verify: CBOR decode failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not isinstance(decoded, dict):
+        print(
+            "vaara overt verify: envelope CBOR must decode to a map; "
+            f"got {type(decoded).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+
+    missing = [k for k in _OVERT_ENVELOPE_KEYS if k not in decoded]
+    if missing:
+        print(
+            "vaara overt verify: envelope missing required fields: "
+            + ", ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+    extras = set(decoded.keys()) - set(_OVERT_ENVELOPE_KEYS)
+    if extras:
+        print(
+            "vaara overt verify: envelope carries unknown fields (the OVERT "
+            "1.0 schema is closed): " + ", ".join(sorted(extras)),
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        envelope = BaseEnvelope(
+            blinded_identifier=decoded["blinded_identifier"],
+            request_commitment=decoded["request_commitment"],
+            encoder_binary_identity=decoded["encoder_binary_identity"],
+            non_content_metadata=decoded["non_content_metadata"],
+            monotonic_counter=int(decoded["monotonic_counter"]),
+            nanosecond_timestamp=int(decoded["nanosecond_timestamp"]),
+            key_identifier=decoded["key_identifier"],
+            arbiter_instance_identifier=decoded["arbiter_instance_identifier"],
+            signature=decoded["signature"],
+        )
+    except (TypeError, ValueError) as exc:
+        print(
+            f"vaara overt verify: envelope field types are invalid: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if verify_base_envelope(envelope, pubkey_raw):
+        result = {
+            "valid": True,
+            "key_identifier": envelope.key_identifier.hex(),
+            "arbiter_instance_identifier": (
+                envelope.arbiter_instance_identifier.hex()
+            ),
+            "monotonic_counter": envelope.monotonic_counter,
+            "nanosecond_timestamp": envelope.nanosecond_timestamp,
+        }
+        print(json.dumps(result, indent=2))
+        return 0
+
+    print(
+        "vaara overt verify: signature verification failed "
+        "(either the supplied public key does not match the envelope's "
+        "key_identifier, or the signature is invalid for the canonical "
+        "CBOR of the 8 signable fields)",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _load_overt_pubkey(args: argparse.Namespace) -> Optional[bytes]:
+    """Resolve --pubkey-file or --pubkey-hex to raw bytes. None on error."""
+    if args.pubkey_file:
+        pubkey_path = Path(args.pubkey_file).expanduser()
+        if not pubkey_path.is_file():
+            print(
+                f"vaara overt verify: pubkey file not found: {pubkey_path}",
+                file=sys.stderr,
+            )
+            return None
+        return pubkey_path.read_bytes()
+    try:
+        return bytes.fromhex(args.pubkey_hex)
+    except ValueError as exc:
+        print(
+            f"vaara overt verify: --pubkey-hex is not valid hex: {exc}",
+            file=sys.stderr,
+        )
+        return None
+
+
 def _cmd_serve(args: argparse.Namespace) -> int:
     try:
         import uvicorn
@@ -1159,6 +1302,39 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_text_input_args(pdpii)
     pdpii.set_defaults(func=_cmd_detect_pii)
+
+    povert = sub.add_parser(
+        "overt",
+        help=(
+            "OVERT 1.0 attestation commands (Protocol Profile 1.0 Annex B.6)"
+        ),
+    )
+    osub = povert.add_subparsers(dest="overt_cmd", required=True)
+    pov_verify = osub.add_parser(
+        "verify",
+        help=(
+            "Verify an OVERT 1.0 Base Envelope from any conformant emitter. "
+            "Requires the attestation extra."
+        ),
+    )
+    pov_verify.add_argument(
+        "receipt",
+        help="Path to a canonical CBOR file containing one Base Envelope",
+    )
+    pov_pk_group = pov_verify.add_mutually_exclusive_group(required=True)
+    pov_pk_group.add_argument(
+        "--pubkey-file",
+        dest="pubkey_file",
+        default=None,
+        help="Path to a file containing the raw 32-byte Ed25519 public key",
+    )
+    pov_pk_group.add_argument(
+        "--pubkey-hex",
+        dest="pubkey_hex",
+        default=None,
+        help="Raw 32-byte Ed25519 public key encoded as 64 hex characters",
+    )
+    pov_verify.set_defaults(func=_cmd_overt_verify)
 
     preload = psub.add_parser(
         "reload",

--- a/tests/test_overt_verify_cli.py
+++ b/tests/test_overt_verify_cli.py
@@ -1,0 +1,173 @@
+"""Tests for ``vaara overt verify`` — OVERT 1.0 Base Envelope reference verifier."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cbor2")
+pytest.importorskip("cryptography")
+
+import cbor2
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vaara.attestation import emit_base_envelope
+from vaara.attestation.iap import envelope_to_canonical_cbor
+from vaara.attestation.overt import (
+    encoder_binary_identity,
+    make_request_commitment,
+)
+from vaara.cli import main
+
+
+def _emit_test_envelope(tmp_path: Path) -> tuple[Path, Path]:
+    sk = Ed25519PrivateKey.generate()
+    pub_raw = sk.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    op_key = os.urandom(32)
+    env = emit_base_envelope(
+        signing_key=sk,
+        request_commitment=make_request_commitment(
+            b"request-bytes", operator_key=op_key,
+        ),
+        encoder_binary_identity=encoder_binary_identity(
+            arbiter_version="vaara-test", policy_hash=b"p" * 32,
+        ),
+        non_content_metadata={
+            "action_class": "tool_call", "decision": "allow",
+        },
+        monotonic_counter=1,
+        arbiter_instance_identifier=os.urandom(16),
+    )
+    receipt = tmp_path / "env.cbor"
+    pubkey = tmp_path / "pub.bin"
+    receipt.write_bytes(envelope_to_canonical_cbor(env))
+    pubkey.write_bytes(pub_raw)
+    return receipt, pubkey
+
+
+def test_overt_verify_accepts_valid_envelope(tmp_path, capsys):
+    receipt, pubkey = _emit_test_envelope(tmp_path)
+    rc = main([
+        "overt", "verify", str(receipt), "--pubkey-file", str(pubkey),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"valid": true' in out
+    assert '"key_identifier":' in out
+
+
+def test_overt_verify_rejects_wrong_pubkey(tmp_path, capsys):
+    receipt, _ = _emit_test_envelope(tmp_path)
+    wrong = tmp_path / "wrong.bin"
+    wrong.write_bytes(os.urandom(32))
+    rc = main([
+        "overt", "verify", str(receipt), "--pubkey-file", str(wrong),
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "signature verification failed" in err
+
+
+def test_overt_verify_pubkey_hex_form_works(tmp_path, capsys):
+    receipt, pubkey = _emit_test_envelope(tmp_path)
+    rc = main([
+        "overt", "verify", str(receipt),
+        "--pubkey-hex", pubkey.read_bytes().hex(),
+    ])
+    assert rc == 0
+
+
+def test_overt_verify_rejects_bad_hex(tmp_path, capsys):
+    receipt, _ = _emit_test_envelope(tmp_path)
+    rc = main([
+        "overt", "verify", str(receipt), "--pubkey-hex", "not-hex",
+    ])
+    assert rc == 2
+    assert "not valid hex" in capsys.readouterr().err
+
+
+def test_overt_verify_rejects_wrong_pubkey_length(tmp_path, capsys):
+    receipt, _ = _emit_test_envelope(tmp_path)
+    short = tmp_path / "short.bin"
+    short.write_bytes(b"\x00" * 16)
+    rc = main([
+        "overt", "verify", str(receipt), "--pubkey-file", str(short),
+    ])
+    assert rc == 2
+    assert "32 raw bytes" in capsys.readouterr().err
+
+
+def test_overt_verify_rejects_missing_receipt(tmp_path, capsys):
+    pubkey = tmp_path / "pub.bin"
+    pubkey.write_bytes(os.urandom(32))
+    rc = main([
+        "overt", "verify", str(tmp_path / "nope.cbor"),
+        "--pubkey-file", str(pubkey),
+    ])
+    assert rc == 2
+    assert "not a file" in capsys.readouterr().err
+
+
+def test_overt_verify_rejects_bad_cbor(tmp_path, capsys):
+    """Either CBOR decode fails, or it decodes to a non-map. Both → exit 1."""
+    bad = tmp_path / "bad.cbor"
+    bad.write_bytes(b"not cbor")
+    pubkey = tmp_path / "pub.bin"
+    pubkey.write_bytes(os.urandom(32))
+    rc = main([
+        "overt", "verify", str(bad), "--pubkey-file", str(pubkey),
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "CBOR" in err or "decode" in err or "must decode to a map" in err
+
+
+def test_overt_verify_rejects_envelope_missing_required_field(
+    tmp_path, capsys,
+):
+    receipt, pubkey = _emit_test_envelope(tmp_path)
+    decoded = cbor2.loads(receipt.read_bytes())
+    decoded.pop("signature")
+    receipt.write_bytes(cbor2.dumps(decoded, canonical=True))
+    rc = main([
+        "overt", "verify", str(receipt), "--pubkey-file", str(pubkey),
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "missing required fields" in err
+    assert "signature" in err
+
+
+def test_overt_verify_rejects_envelope_with_extra_field(tmp_path, capsys):
+    """OVERT 1.0 schema is closed. Unknown fields must be rejected."""
+    receipt, pubkey = _emit_test_envelope(tmp_path)
+    decoded = cbor2.loads(receipt.read_bytes())
+    decoded["smuggled_field"] = b"x"
+    receipt.write_bytes(cbor2.dumps(decoded, canonical=True))
+    rc = main([
+        "overt", "verify", str(receipt), "--pubkey-file", str(pubkey),
+    ])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "unknown fields" in err
+    assert "smuggled_field" in err
+
+
+def test_overt_verify_rejects_tampered_signature(tmp_path, capsys):
+    receipt, pubkey = _emit_test_envelope(tmp_path)
+    decoded = cbor2.loads(receipt.read_bytes())
+    sig = bytearray(decoded["signature"])
+    sig[0] ^= 0xFF
+    decoded["signature"] = bytes(sig)
+    receipt.write_bytes(cbor2.dumps(decoded, canonical=True))
+    rc = main([
+        "overt", "verify", str(receipt), "--pubkey-file", str(pubkey),
+    ])
+    assert rc == 1
+    assert "signature verification failed" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Adds `vaara overt verify RECEIPT.cbor --pubkey-file PUB.bin` so any operator, auditor, or Independent Attestation Provider can validate an OVERT 1.0 Protocol Profile 1.0 Base Envelope (Annex B.6) produced by any conformant emitter, not only Vaara. Reads canonical CBOR per the spec, verifies the Ed25519 signature against a supplied raw 32-byte public key, and rejects envelopes that carry unknown fields (the schema is closed).

Vaara has emitted Base Envelopes since v0.10.0 and Phase 3 IAP attestations since v0.13.0. This release adds the verifier CLI so anyone implementing OVERT can route their conformance check through Vaara without taking a runtime dependency on the emitter side.

## What ships

- `vaara overt verify RECEIPT.cbor` subcommand. `--pubkey-file PATH` and `--pubkey-hex HEX` are mutually exclusive and one is required.
- Exit codes: 0 on valid, 1 on invalid envelope or signature mismatch, 2 on argument or I/O errors.
- Closed-schema enforcement: envelopes carrying fields outside the 9 defined by Annex B.6 are rejected with a structured stderr message.
- `vaara.attestation` module docstring corrected: Phase 3 IAP shipped in v0.13.0, verifier in v0.17.0.
- `@vaara/client` bumped to 0.17.0 for PyPI/npm lockstep. No TypeScript code change.

## Tests

10 new tests in `tests/test_overt_verify_cli.py`:

- Happy path with `--pubkey-file`
- Wrong pubkey returns 1 with structured error
- `--pubkey-hex` form works
- Malformed hex returns 2
- Wrong-length pubkey returns 2
- Missing receipt file returns 2
- Malformed CBOR returns 1
- Envelope missing a required field returns 1
- Envelope with an extra (unknown) field rejected per closed schema
- Tampered signature returns 1

Suite: 620 Python pass / 12 skip (was 610). 6 TypeScript tests pass.

## Test plan

- [ ] `pip install 'vaara[attestation]'` then emit a Base Envelope via the existing `emit_base_envelope` API and verify with `vaara overt verify`
- [ ] PyPI Trusted Publish lands `vaara 0.17.0`
- [ ] publish-npm publishes `@vaara/client 0.17.0`
- [ ] Sigstore-signed GitHub Release produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
