### PR TITLE
docs: add evidence specimen to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,54 @@ Vaara intercepts agent tool calls, scores each one with a conformal risk interva
 
 For broader agent governance (zero-trust identity, capability-based access control, multi-language SDKs) see Microsoft's [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
 
+## What evidence looks like
+
+`vaara compliance report --format json` against a real audit trail produces an article-level evidence record an auditor can read directly. Status is reported honestly: articles without recorded events return `evidence_insufficient`, not a rubber-stamp.
+
+```json
+{
+  "system_name": "Acme HR Assistant",
+  "system_version": "2.4.1",
+  "overall_status": "evidence_insufficient",
+  "trail_integrity": {
+    "size": 105,
+    "chain_intact": true
+  },
+  "articles": [
+    {
+      "article": "Article 12(1)",
+      "title": "Record-Keeping (Logging)",
+      "status": "evidence_sufficient",
+      "strength": "strong",
+      "evidence_count": 105
+    },
+    {
+      "article": "Article 9(2)(a)",
+      "title": "Risk Identification and Analysis",
+      "status": "evidence_sufficient",
+      "strength": "strong",
+      "evidence_count": 35
+    },
+    {
+      "article": "Article 15(1)",
+      "title": "Accuracy, Robustness and Cybersecurity",
+      "status": "evidence_insufficient",
+      "strength": "absent",
+      "evidence_count": 0
+    },
+    {
+      "article": "Article 61(1)",
+      "title": "Post-Market Monitoring",
+      "status": "evidence_insufficient",
+      "strength": "absent",
+      "evidence_count": 0
+    }
+  ]
+}
+```
+
+The same data renders as a styled PDF for Notified Bodies (`--format pdf`), a static HTML dashboard (`vaara compliance dashboard`), or a Sigstore-signed regulator-handoff envelope (`vaara trail export`).
+
 ## Numbers
 
 - 5,955-entry adversarial corpus (3,422 attack across 8 categories, 2,533 benign)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
 </p>
 
+Vaara is the runtime evidence layer for AI Act compliance. Open source, no SaaS, no telemetry.
+
 Vaara intercepts agent tool calls, scores each one with a conformal risk interval, and writes a hash-chained audit record. Online learning across five expert signals via Multiplicative Weight Update. Distribution-free conformal coverage on the score.
 
 For broader agent governance (zero-trust identity, capability-based access control, multi-language SDKs) see Microsoft's [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit).
@@ -55,6 +57,17 @@ else:
 ```
 
 `report_outcome` closes the loop. MWU reweights signals based on which ones predicted the outcome.
+
+## Framework integrations
+
+Native adapters in `src/vaara/integrations/` route the major Python agent frameworks through Vaara's pipeline. Each adapter intercepts tool calls via the framework's own callback or hook surface, scores them, gates them, and emits the same audit events as a direct `pipeline.intercept()` call. Frameworks are not hard dependencies (lazy import, duck typing), so the base `pip install vaara` keeps a clean dependency tree.
+
+- **LangChain** — `VaaraCallbackHandler` slots into `config={"callbacks": [...]}` and gates every tool invocation automatically. `vaara_wrap_tool(tool, pipeline)` is the per-tool variant for fine-grained control.
+- **CrewAI** — `VaaraCrewGovernance` wraps a crew so every agent action passes through the same scoring and audit chain.
+- **OpenAI Agents SDK** — `VaaraToolGuardrail` plus `vaara_wrap_function` wrap function-tool calls before they execute. Compatible with the Responses API and the Agents-SDK tracing model.
+- **MCP server** — `vaara.integrations.mcp_server` exposes scoring, audit emission, and policy reload as MCP tools so any MCP-compatible agent can route through Vaara without a custom client.
+
+All four adapters share the same in-process pipeline, so audit records hash-chain together regardless of which framework the action came through. Each adapter has its own docstring with the two integration patterns it supports.
 
 ## HTTP API
 

--- a/src/vaara/integrations/__init__.py
+++ b/src/vaara/integrations/__init__.py
@@ -1,1 +1,1 @@
-"""Framework integrations — drop-in middleware for LangChain, CrewAI, OpenAI Agents."""
+"""Framework integrations: drop-in middleware for LangChain, CrewAI, OpenAI Agents SDK, and MCP."""


### PR DESCRIPTION
## Summary

Adds a `What evidence looks like` section between the new hero and `Numbers`. The hero now lands the reader with `Vaara is the runtime evidence layer for AI Act compliance` but doesn't yet show them what evidence looks like coming out of the system. This closes that gap with a `vaara compliance report --format json` excerpt: system metadata, hash-chain integrity, and four article rows showing two `evidence_sufficient` plus two `evidence_insufficient` outcomes.

The honest-reporting beat is the point: articles without recorded events return `evidence_insufficient`, not a rubber-stamp `OK`. A buyer or auditor landing on the README now sees that up front, before any technical detail.

The section also closes with one line naming the three other render targets the same data flows into (`--format pdf` for Notified Bodies, `vaara compliance dashboard` HTML, Sigstore-signed `vaara trail export`).

## What ships

- New `## What evidence looks like` section in README between the hero and `## Numbers`.
- Real JSON excerpt (48 lines added total).

No code change.

## Test plan

- [ ] README renders cleanly on GitHub with JSON syntax highlighting
- [ ] No version bump needed (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "What evidence looks like" section with JSON examples demonstrating audit evidence output format and compliance report structure.
  * Added "Framework integrations" section documenting native adapter support for LangChain, CrewAI, OpenAI Agents SDK, and MCP server, explaining audit event routing and hash-chained record sharing across frameworks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->