### PR TITLE
feat: v0.18.0 hardware TEE attestation hook (AMD SEV-SNP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,66 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-17
+
+**Theme: hardware TEE attestation hook (experimental).** Adds an optional
+hardware-rooted attestation layer alongside the Ed25519 (or ML-DSA-65)
+signature already on the OVERT 1.0 Base Envelope. Initial backend is AMD
+SEV-SNP, the natural fit for the confidential-VM deployment model used
+in agent runtimes. Intel TDX and SGX backends are tracked for later
+releases. The OVERT envelope schema is unchanged (closed per spec); the
+TEE report is a sibling artefact bound to a specific envelope by placing
+`SHA-512(canonical_cbor(envelope))` into the report's 64-byte
+`REPORT_DATA` field.
+
+### Added
+- `src/vaara/attestation/tee.py` module with:
+  - `parse_sev_snp_report`: binary parser for the 1184-byte SEV-SNP
+    attestation report (AMD SEV Secure Nested Paging Firmware ABI
+    Specification rev. 1.55, Table 22).
+  - `bind_overt_envelope_to_report_data`: computes the 64-byte
+    `REPORT_DATA` value that binds a TEE report to a specific OVERT
+    envelope. Hash covers all 9 envelope fields including the inner
+    Ed25519 signature.
+  - `verify_sev_snp_report_signature`: validates the ECDSA P-384
+    over the report body against a caller-supplied VCEK PEM.
+  - `verify_envelope_binding`: confirms `REPORT_DATA` matches
+    SHA-512 of the supplied envelope.
+  - `MockSEVSNPAttester`: deterministic in-memory attester for tests
+    and CI, building byte-compatible report blobs.
+  - `SEVSNPHostAttester`: skeleton that wraps `/dev/sev-guest` and
+    raises a clear error when not on an SEV-SNP host.
+- `vaara tee parse REPORT` CLI: dump key fields of a SEV-SNP report as
+  JSON.
+- `vaara tee verify REPORT --vcek VCEK.pem [--overt ENVELOPE.cbor]` CLI:
+  signature check plus optional binding check against an OVERT envelope.
+- 16 tests in `tests/test_attestation_tee.py` covering parse round-trip,
+  size rejection, mock-attester emission, signature verification,
+  tamper detection, wrong-VCEK rejection, envelope binding, wrong-curve
+  rejection, non-EC-key rejection, unsupported-algo rejection, and the
+  non-SEV-SNP host error path.
+
+### Not in this release
+- AMD KDS-based cert-chain validation (VCEK → ASK → ARK). Validating
+  against AMD's Key Distribution Service requires a network fetch
+  against `https://kdsintf.amd.com/` and is tracked for v0.19+.
+- Live `/dev/sev-guest` ioctl emission. The `SNP_GET_REPORT` ioctl path
+  is documented in `linux/sev-guest.h` and is tracked for v0.19+ once a
+  tested SEV-SNP guest is available for integration testing.
+- Intel TDX, Intel SGX backends. Same module shape will accommodate them
+  via additional attester classes.
+
+### Fixed
+- `src/vaara/__init__.py` `__version__` had drifted to `0.15.0` while
+  `pyproject.toml` had moved through 0.16.0 and 0.17.0. Both now read
+  `0.18.0`.
+
+### Notes
+- The OVERT 1.0 envelope schema is closed and unchanged. TEE attestation
+  is a strictly additive sibling artefact; an OVERT verifier without TEE
+  awareness still validates Vaara envelopes exactly as before.
+- 636 Python tests pass (was 620 + 16 new).
+
 ## [0.17.0] - 2026-05-17
 
 **Theme: Vaara as the OVERT 1.0 reference verifier.** Vaara has emitted

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -265,6 +265,40 @@ Operators who need AAL-4 should pair Vaara with an independent
 attestation provider. The Vaara-emitted evidence is the input to
 that provider, not a replacement for it.
 
+### Hardware TEE attestation hook (experimental, v0.18.0)
+
+Beyond the software-signed attestation chain described above, Vaara
+since v0.18.0 supports binding an OVERT envelope to a hardware-rooted
+attestation report from a Trusted Execution Environment. The initial
+backend is **AMD SEV-SNP**, the natural fit for the confidential-VM
+deployment model used in agent runtimes. Intel TDX and Intel SGX are
+tracked for later releases.
+
+The OVERT 1.0 Base Envelope schema is closed (9 fields). Hardware TEE
+attestation does NOT extend the envelope. Instead, Vaara emits a sibling
+SEV-SNP attestation report and binds it to the envelope by placing
+`SHA-512(canonical_cbor(envelope))` into the report's 64-byte
+`REPORT_DATA` field. A relying party therefore checks two signatures
+independently:
+
+1. The envelope's Ed25519 (or ML-DSA-65) signature over the 8 signable
+   fields, as before.
+2. The SEV-SNP report's ECDSA P-384 signature against the AMD VCEK
+   (Versioned Chip Endorsement Key), and that `REPORT_DATA` equals
+   `SHA-512(canonical_cbor(envelope))`.
+
+If both hold, the attestation says "this OVERT envelope was emitted by
+an arbiter running inside an AMD SEV-SNP confidential VM at the
+measured launch state recorded in the report."
+
+What ships in v0.18.0: report parser, binding helper, signature verifier
+against a caller-supplied VCEK, deterministic mock attester for tests,
+and a `vaara tee parse|verify` CLI. What does NOT ship in v0.18.0: full
+VCEK chain validation against AMD's Key Distribution Service (tracked
+for v0.19+) and the `/dev/sev-guest` ioctl emitter (tracked for v0.19+
+once a tested SEV-SNP guest is available). The hook is marked
+experimental until both land.
+
 ## OVERT 1.0 Part 3 (Agentic AI Controls) mapping
 
 OVERT 1.0 Part 3 (Sections 11-16) defines the agentic-specific

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ envelope = emit_base_envelope(
 
 Vaara operates as the **Arbiter** in OVERT terms. See [COMPLIANCE.md](COMPLIANCE.md) "Position relative to open runtime-attestation standards" for the architectural framing.
 
+v0.18.0 adds an experimental hardware TEE attestation hook (`vaara.attestation.tee`) that binds an OVERT envelope to an AMD SEV-SNP attestation report by placing `SHA-512(canonical_cbor(envelope))` into the report's 64-byte `REPORT_DATA` field. The envelope schema is unchanged (closed per spec); the TEE report is a sibling artefact. A relying party checks the Ed25519 envelope signature and the ECDSA P-384 report signature independently. `vaara tee parse` and `vaara tee verify` expose the verifier as a CLI. Full AMD KDS chain validation and `/dev/sev-guest` live emission are tracked for v0.19+; the v0.18.0 surface ships parser, binding helper, verifier against a caller-supplied VCEK, and a deterministic mock attester for tests.
+
 v0.12.0 adds an OVERT S3P (MEA-2) emitter with exact Clopper-Pearson confidence intervals (pure Python, no scipy), plus a proposed Protocol Profile extension that reports aggregate statistics over Vaara's per-action conformal prediction intervals alongside the standard binomial CI. The agentic-controls mapping in [COMPLIANCE.md](COMPLIANCE.md) "OVERT 1.0 Part 3 (Agentic AI Controls) mapping" walks Vaara's coverage of TOOL-*, MCP-*, MULTI-*, CAP-*, DISC-*, HITL-*, and DRIFT-* control by control.
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.17.0"
+version = "0.18.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.15.0"
+__version__ = "0.18.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/__init__.py
+++ b/src/vaara/attestation/__init__.py
@@ -55,6 +55,17 @@ from vaara.attestation.transparency_log import (
     TransparencyLogError,
     verify_inclusion,
 )
+from vaara.attestation.tee import (
+    MockSEVSNPAttester,
+    SEVSNPHostAttester,
+    SEVSNPReport,
+    TEEAttestationError,
+    TEEAttester,
+    bind_overt_envelope_to_report_data,
+    parse_sev_snp_report,
+    verify_envelope_binding,
+    verify_sev_snp_report_signature,
+)
 
 __all__ = [
     "BaseEnvelope",
@@ -64,10 +75,16 @@ __all__ = [
     "InProcessTransparencyLog",
     "InclusionProof",
     "LogEntry",
+    "MockSEVSNPAttester",
     "Phase3Attestation",
     "S3PAttestation",
     "S3PError",
+    "SEVSNPHostAttester",
+    "SEVSNPReport",
+    "TEEAttestationError",
+    "TEEAttester",
     "TransparencyLogError",
+    "bind_overt_envelope_to_report_data",
     "canonical_cbor",
     "clopper_pearson_ci",
     "emit_base_envelope",
@@ -75,9 +92,12 @@ __all__ = [
     "emit_s3p_attestation",
     "envelope_to_canonical_cbor",
     "make_epoch_nonce_commitment",
+    "parse_sev_snp_report",
     "regularized_incomplete_beta",
     "verify_base_envelope",
+    "verify_envelope_binding",
     "verify_inclusion",
     "verify_phase3_attestation",
     "verify_s3p_attestation",
+    "verify_sev_snp_report_signature",
 ]

--- a/src/vaara/attestation/tee.py
+++ b/src/vaara/attestation/tee.py
@@ -1,0 +1,391 @@
+"""Hardware TEE attestation hook for OVERT 1.0 Base Envelopes.
+
+Status: experimental. Adds an optional hardware-rooted attestation layer
+alongside the Ed25519 (or ML-DSA-65) signature already on the OVERT 1.0
+Base Envelope. Initial backend is AMD SEV-SNP, the natural fit for the
+confidential-VM deployment model used in agent runtimes. Intel TDX and
+Intel SGX backends are tracked for later releases.
+
+Architectural framing
+---------------------
+
+The OVERT 1.0 Protocol Profile 1.0 Base Envelope (Annex B.6) is a closed
+9-field schema. Hardware TEE attestation does NOT extend the envelope.
+Instead, Vaara emits a sibling SEV-SNP attestation report and binds it
+to the envelope by placing the SHA-512 of the envelope's canonical CBOR
+encoding into the report's 64-byte REPORT_DATA field. SHA-512 fits the
+slot exactly.
+
+Verifiers therefore check two things independently:
+
+1. The OVERT envelope's Ed25519 signature, as before.
+2. The SEV-SNP report's ECDSA P-384 signature against the AMD VCEK, and
+   that REPORT_DATA equals SHA-512 of the envelope's canonical CBOR.
+
+If both hold, the attestation says "this OVERT envelope was emitted by
+an arbiter running inside an AMD SEV-SNP confidential VM at the measured
+launch state recorded in the report."
+
+What ships in v0.18.0
+---------------------
+
+- ``parse_sev_snp_report``: binary parser for the 1184-byte
+  attestation-report structure (AMD SEV-SNP ABI Specification rev. 1.55,
+  Table 22).
+- ``bind_overt_envelope_to_report_data``: computes the 64-byte
+  REPORT_DATA value that binds a TEE report to a specific OVERT envelope.
+- ``verify_sev_snp_report_signature``: validates the ECDSA P-384 over the
+  report body against a caller-supplied VCEK PEM.
+- ``verify_envelope_binding``: confirms the report's REPORT_DATA matches
+  SHA-512 of the supplied envelope.
+- ``MockSEVSNPAttester``: deterministic in-memory attester for tests and
+  CI, building byte-compatible report blobs signed with a caller-supplied
+  ECDSA P-384 key.
+- ``SEVSNPHostAttester``: skeleton that wraps ``/dev/sev-guest``. Raises
+  a clear error when not on an SEV-SNP host; the real ioctl path is
+  tracked for v0.19+.
+
+What does NOT ship in v0.18.0
+-----------------------------
+
+- AMD KDS-based cert-chain validation (VCEK to ASK to ARK). Validating a
+  VCEK against AMD's Key Distribution Service requires a network fetch
+  against https://kdsintf.amd.com/ and is tracked for v0.19+. For now,
+  callers must obtain a trusted VCEK out of band and supply it directly.
+- ``/dev/sev-guest`` ioctl emission. The SNP_GET_REPORT ioctl is
+  well-defined in linux/sev-guest.h but not exercised here until a tested
+  SEV-SNP guest host is available.
+- Intel TDX, Intel SGX backends. Same module shape will accommodate them
+  via additional attester classes.
+
+Install: ``pip install 'vaara[attestation]'``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from vaara.attestation.overt import BaseEnvelope
+
+
+class TEEAttestationError(RuntimeError):
+    """Raised on TEE attestation parse, verification, or binding failures."""
+
+
+SEV_SNP_REPORT_SIZE = 1184
+SEV_SNP_BODY_SIZE = 0x2A0  # 672 bytes signed payload
+SEV_SNP_SIG_SIZE = 512
+SEV_SNP_REPORT_DATA_SIZE = 64
+
+SIGNATURE_ALGO_INVALID = 0
+SIGNATURE_ALGO_ECDSA_P384_SHA384 = 1
+
+
+@dataclass(frozen=True)
+class SEVSNPReport:
+    """Parsed AMD SEV-SNP attestation report.
+
+    Field set and offsets match AMD SEV Secure Nested Paging Firmware ABI
+    Specification, Revision 1.55, Table 22.
+    """
+
+    version: int
+    guest_svn: int
+    policy: int
+    family_id: bytes
+    image_id: bytes
+    vmpl: int
+    signature_algo: int
+    current_tcb: int
+    platform_info: int
+    author_key_en: int
+    report_data: bytes
+    measurement: bytes
+    host_data: bytes
+    id_key_digest: bytes
+    author_key_digest: bytes
+    report_id: bytes
+    report_id_ma: bytes
+    reported_tcb: int
+    chip_id: bytes
+    committed_tcb: int
+    current_build: int
+    current_minor: int
+    current_major: int
+    committed_build: int
+    committed_minor: int
+    committed_major: int
+    launch_tcb: int
+    signature: bytes
+    raw: bytes
+
+    @property
+    def body(self) -> bytes:
+        """The 672-byte signed payload (offset 0 to SEV_SNP_BODY_SIZE)."""
+        return self.raw[:SEV_SNP_BODY_SIZE]
+
+
+def parse_sev_snp_report(report_bytes: bytes) -> SEVSNPReport:
+    """Parse the AMD SEV-SNP attestation report binary structure.
+
+    Little-endian throughout per AMD spec. Offsets follow Table 22 of the
+    AMD SEV Secure Nested Paging Firmware ABI Specification, rev 1.55.
+    """
+    if len(report_bytes) != SEV_SNP_REPORT_SIZE:
+        raise TEEAttestationError(
+            f"SEV-SNP report must be {SEV_SNP_REPORT_SIZE} bytes; "
+            f"got {len(report_bytes)}"
+        )
+
+    version = struct.unpack_from("<I", report_bytes, 0x000)[0]
+    guest_svn = struct.unpack_from("<I", report_bytes, 0x004)[0]
+    policy = struct.unpack_from("<Q", report_bytes, 0x008)[0]
+    vmpl = struct.unpack_from("<I", report_bytes, 0x030)[0]
+    signature_algo = struct.unpack_from("<I", report_bytes, 0x034)[0]
+    current_tcb = struct.unpack_from("<Q", report_bytes, 0x038)[0]
+    platform_info = struct.unpack_from("<Q", report_bytes, 0x040)[0]
+    author_key_en = struct.unpack_from("<I", report_bytes, 0x048)[0]
+    reported_tcb = struct.unpack_from("<Q", report_bytes, 0x180)[0]
+    committed_tcb = struct.unpack_from("<Q", report_bytes, 0x1E0)[0]
+    launch_tcb = struct.unpack_from("<Q", report_bytes, 0x1F0)[0]
+
+    return SEVSNPReport(
+        version=version,
+        guest_svn=guest_svn,
+        policy=policy,
+        family_id=bytes(report_bytes[0x010:0x020]),
+        image_id=bytes(report_bytes[0x020:0x030]),
+        vmpl=vmpl,
+        signature_algo=signature_algo,
+        current_tcb=current_tcb,
+        platform_info=platform_info,
+        author_key_en=author_key_en,
+        report_data=bytes(report_bytes[0x050:0x090]),
+        measurement=bytes(report_bytes[0x090:0x0C0]),
+        host_data=bytes(report_bytes[0x0C0:0x0E0]),
+        id_key_digest=bytes(report_bytes[0x0E0:0x110]),
+        author_key_digest=bytes(report_bytes[0x110:0x140]),
+        report_id=bytes(report_bytes[0x140:0x160]),
+        report_id_ma=bytes(report_bytes[0x160:0x180]),
+        reported_tcb=reported_tcb,
+        chip_id=bytes(report_bytes[0x1A0:0x1E0]),
+        committed_tcb=committed_tcb,
+        current_build=report_bytes[0x1E8],
+        current_minor=report_bytes[0x1E9],
+        current_major=report_bytes[0x1EA],
+        committed_build=report_bytes[0x1EC],
+        committed_minor=report_bytes[0x1ED],
+        committed_major=report_bytes[0x1EE],
+        launch_tcb=launch_tcb,
+        signature=bytes(
+            report_bytes[SEV_SNP_BODY_SIZE:SEV_SNP_BODY_SIZE + SEV_SNP_SIG_SIZE]
+        ),
+        raw=bytes(report_bytes),
+    )
+
+
+def bind_overt_envelope_to_report_data(envelope: BaseEnvelope) -> bytes:
+    """64-byte REPORT_DATA that binds a SEV-SNP report to an OVERT envelope.
+
+    REPORT_DATA = SHA-512(canonical_cbor(envelope_full_dict_including_signature))
+
+    The hash covers all 9 envelope fields, including the Ed25519 signature.
+    Any change to the envelope produces a different REPORT_DATA, so a TEE
+    attestation carrying a given REPORT_DATA value can only correspond to
+    that one specific envelope.
+    """
+    from vaara.attestation.iap import envelope_to_canonical_cbor
+
+    cbor_bytes = envelope_to_canonical_cbor(envelope)
+    return hashlib.sha512(cbor_bytes).digest()
+
+
+def verify_sev_snp_report_signature(report: SEVSNPReport, vcek_pem: bytes) -> bool:
+    """Verify the ECDSA P-384 signature on a SEV-SNP report against a VCEK.
+
+    The VCEK (Versioned Chip Endorsement Key) is AMD's per-CPU signing key
+    used to sign attestation reports. v0.18.0 only validates the report
+    signature against a supplied VCEK; full chain validation against AMD's
+    Key Distribution Service is tracked for v0.19+.
+    """
+    if report.signature_algo != SIGNATURE_ALGO_ECDSA_P384_SHA384:
+        raise TEEAttestationError(
+            f"Unsupported SEV-SNP signature algo {report.signature_algo}; "
+            f"only ECDSA P-384 SHA-384 (=1) is supported in v0.18.0"
+        )
+
+    try:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.hazmat.primitives.asymmetric.utils import (
+            encode_dss_signature,
+        )
+    except ImportError as exc:
+        raise TEEAttestationError(
+            "cryptography not installed. Install with: "
+            "pip install 'vaara[attestation]'"
+        ) from exc
+
+    try:
+        vcek = serialization.load_pem_public_key(vcek_pem)
+    except ValueError as exc:
+        raise TEEAttestationError(f"Failed to load VCEK PEM: {exc}") from exc
+
+    if not isinstance(vcek, ec.EllipticCurvePublicKey):
+        raise TEEAttestationError("VCEK is not an EC public key")
+    if not isinstance(vcek.curve, ec.SECP384R1):
+        raise TEEAttestationError(
+            f"VCEK curve is {vcek.curve.name}; expected secp384r1 (P-384)"
+        )
+
+    r_le = report.signature[:72]
+    s_le = report.signature[72:144]
+    r_int = int.from_bytes(r_le[:48], "little")
+    s_int = int.from_bytes(s_le[:48], "little")
+
+    der_sig = encode_dss_signature(r_int, s_int)
+
+    try:
+        vcek.verify(der_sig, report.body, ec.ECDSA(hashes.SHA384()))
+        return True
+    except InvalidSignature:
+        return False
+
+
+def verify_envelope_binding(report: SEVSNPReport, envelope: BaseEnvelope) -> bool:
+    """Check that the report's REPORT_DATA matches SHA-512 of the envelope."""
+    expected = bind_overt_envelope_to_report_data(envelope)
+    return report.report_data == expected
+
+
+class TEEAttester(Protocol):
+    """Protocol for TEE attesters. Implementations emit attestation reports."""
+
+    def emit(self, report_data: bytes) -> bytes:
+        """Emit a binary attestation report carrying the supplied REPORT_DATA."""
+        ...
+
+
+class MockSEVSNPAttester:
+    """Deterministic in-memory SEV-SNP attester for tests and CI.
+
+    Builds a well-formed 1184-byte SEV-SNP attestation report with caller-
+    supplied REPORT_DATA, signed by a caller-supplied ECDSA P-384 key. The
+    resulting blob is byte-compatible with ``parse_sev_snp_report`` and
+    ``verify_sev_snp_report_signature``.
+
+    Not a substitute for real hardware attestation. The signing key has no
+    AMD provenance, so any real-world verifier validating the chain to
+    AMD's ARK will (correctly) reject reports from this attester.
+    """
+
+    def __init__(
+        self,
+        signing_key,
+        *,
+        measurement: bytes = b"\x00" * 48,
+        version: int = 2,
+        policy: int = 0,
+    ):
+        try:
+            from cryptography.hazmat.primitives.asymmetric import ec
+        except ImportError as exc:
+            raise TEEAttestationError(
+                "cryptography not installed. Install with: "
+                "pip install 'vaara[attestation]'"
+            ) from exc
+        if not isinstance(signing_key, ec.EllipticCurvePrivateKey):
+            raise TEEAttestationError("signing_key must be an EC private key")
+        if not isinstance(signing_key.curve, ec.SECP384R1):
+            raise TEEAttestationError("signing_key must be on secp384r1 (P-384)")
+        if len(measurement) != 48:
+            raise TEEAttestationError("measurement must be 48 bytes (SHA-384)")
+        self._signing_key = signing_key
+        self._measurement = measurement
+        self._version = version
+        self._policy = policy
+
+    def emit(self, report_data: bytes) -> bytes:
+        if len(report_data) != SEV_SNP_REPORT_DATA_SIZE:
+            raise TEEAttestationError(
+                f"report_data must be exactly {SEV_SNP_REPORT_DATA_SIZE} bytes; "
+                f"got {len(report_data)}"
+            )
+
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec
+        from cryptography.hazmat.primitives.asymmetric.utils import (
+            decode_dss_signature,
+        )
+
+        body = bytearray(SEV_SNP_BODY_SIZE)
+        struct.pack_into("<I", body, 0x000, self._version)
+        struct.pack_into("<Q", body, 0x008, self._policy)
+        struct.pack_into("<I", body, 0x034, SIGNATURE_ALGO_ECDSA_P384_SHA384)
+        body[0x050:0x090] = report_data
+        body[0x090:0x0C0] = self._measurement
+
+        der_sig = self._signing_key.sign(bytes(body), ec.ECDSA(hashes.SHA384()))
+        r_int, s_int = decode_dss_signature(der_sig)
+        r_bytes = r_int.to_bytes(48, "little")
+        s_bytes = s_int.to_bytes(48, "little")
+
+        sig_field = bytearray(SEV_SNP_SIG_SIZE)
+        sig_field[:48] = r_bytes
+        sig_field[72:72 + 48] = s_bytes
+
+        return bytes(body) + bytes(sig_field)
+
+
+class SEVSNPHostAttester:
+    """Live SEV-SNP attester that requests reports from /dev/sev-guest.
+
+    Only functional inside an actual SEV-SNP confidential VM. Raises a
+    clear error on non-SEV-SNP hosts. The SNP_GET_REPORT ioctl path is
+    documented in linux/sev-guest.h and is tracked for v0.19+ once a
+    tested SEV-SNP guest is available for integration testing.
+    """
+
+    def __init__(self, device: str = "/dev/sev-guest"):
+        self._device = Path(device)
+
+    def emit(self, report_data: bytes) -> bytes:
+        if len(report_data) != SEV_SNP_REPORT_DATA_SIZE:
+            raise TEEAttestationError(
+                f"report_data must be exactly {SEV_SNP_REPORT_DATA_SIZE} bytes"
+            )
+        if not self._device.exists():
+            raise TEEAttestationError(
+                f"{self._device} not present. This host is not an SEV-SNP "
+                f"guest. Use MockSEVSNPAttester for non-SEV-SNP test "
+                f"environments, or capture a report from a real SEV-SNP "
+                f"guest out of band."
+            )
+        raise TEEAttestationError(
+            "SEV-SNP /dev/sev-guest ioctl emission is not implemented in "
+            "v0.18.0. Tracked for v0.19+ once a tested SEV-SNP host is "
+            "available. Use MockSEVSNPAttester or pre-captured reports."
+        )
+
+
+__all__ = [
+    "MockSEVSNPAttester",
+    "SEVSNPHostAttester",
+    "SEVSNPReport",
+    "SEV_SNP_BODY_SIZE",
+    "SEV_SNP_REPORT_DATA_SIZE",
+    "SEV_SNP_REPORT_SIZE",
+    "SEV_SNP_SIG_SIZE",
+    "SIGNATURE_ALGO_ECDSA_P384_SHA384",
+    "TEEAttestationError",
+    "TEEAttester",
+    "bind_overt_envelope_to_report_data",
+    "parse_sev_snp_report",
+    "verify_envelope_binding",
+    "verify_sev_snp_report_signature",
+]

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -840,6 +840,147 @@ def _cmd_overt_verify(args: argparse.Namespace) -> int:
     return 1
 
 
+def _cmd_tee_parse(args: argparse.Namespace) -> int:
+    """Parse an AMD SEV-SNP attestation report blob and print key fields."""
+    try:
+        from vaara.attestation.tee import (
+            TEEAttestationError,
+            parse_sev_snp_report,
+        )
+    except ImportError:
+        print(
+            "vaara tee parse requires the attestation extra. "
+            "Install with: pip install 'vaara[attestation]'",
+            file=sys.stderr,
+        )
+        return 2
+
+    report_path = Path(args.report).expanduser()
+    if not report_path.is_file():
+        print(f"vaara tee parse: not a file: {report_path}", file=sys.stderr)
+        return 2
+
+    try:
+        report = parse_sev_snp_report(report_path.read_bytes())
+    except TEEAttestationError as exc:
+        print(f"vaara tee parse: {exc}", file=sys.stderr)
+        return 1
+
+    out = {
+        "version": report.version,
+        "guest_svn": report.guest_svn,
+        "vmpl": report.vmpl,
+        "signature_algo": report.signature_algo,
+        "policy": report.policy,
+        "report_data": report.report_data.hex(),
+        "measurement": report.measurement.hex(),
+        "host_data": report.host_data.hex(),
+        "chip_id": report.chip_id.hex(),
+        "reported_tcb": report.reported_tcb,
+        "committed_tcb": report.committed_tcb,
+        "launch_tcb": report.launch_tcb,
+        "current_build": report.current_build,
+        "current_minor": report.current_minor,
+        "current_major": report.current_major,
+    }
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+def _cmd_tee_verify(args: argparse.Namespace) -> int:
+    """Verify a SEV-SNP report signature, optionally against an OVERT envelope.
+
+    The VCEK (Versioned Chip Endorsement Key) must be supplied as PEM. AMD
+    KDS-based cert-chain validation (VCEK -> ASK -> ARK) is tracked for a
+    later release; v0.18.0 only validates the report signature against a
+    caller-supplied VCEK.
+    """
+    try:
+        import cbor2
+
+        from vaara.attestation.overt import BaseEnvelope
+        from vaara.attestation.tee import (
+            TEEAttestationError,
+            parse_sev_snp_report,
+            verify_envelope_binding,
+            verify_sev_snp_report_signature,
+        )
+    except ImportError:
+        print(
+            "vaara tee verify requires the attestation extra. "
+            "Install with: pip install 'vaara[attestation]'",
+            file=sys.stderr,
+        )
+        return 2
+
+    report_path = Path(args.report).expanduser()
+    if not report_path.is_file():
+        print(f"vaara tee verify: not a file: {report_path}", file=sys.stderr)
+        return 2
+
+    vcek_path = Path(args.vcek).expanduser()
+    if not vcek_path.is_file():
+        print(
+            f"vaara tee verify: VCEK PEM not found: {vcek_path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        report = parse_sev_snp_report(report_path.read_bytes())
+    except TEEAttestationError as exc:
+        print(f"vaara tee verify: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        signature_ok = verify_sev_snp_report_signature(
+            report, vcek_path.read_bytes(),
+        )
+    except TEEAttestationError as exc:
+        print(f"vaara tee verify: {exc}", file=sys.stderr)
+        return 1
+
+    result = {
+        "signature_valid": signature_ok,
+        "report_data": report.report_data.hex(),
+        "measurement": report.measurement.hex(),
+    }
+
+    if args.overt:
+        overt_path = Path(args.overt).expanduser()
+        if not overt_path.is_file():
+            print(
+                f"vaara tee verify: OVERT envelope file not found: "
+                f"{overt_path}",
+                file=sys.stderr,
+            )
+            return 2
+        decoded = cbor2.loads(overt_path.read_bytes())
+        envelope = BaseEnvelope(
+            blinded_identifier=decoded["blinded_identifier"],
+            request_commitment=decoded["request_commitment"],
+            encoder_binary_identity=decoded["encoder_binary_identity"],
+            non_content_metadata=decoded["non_content_metadata"],
+            monotonic_counter=int(decoded["monotonic_counter"]),
+            nanosecond_timestamp=int(decoded["nanosecond_timestamp"]),
+            key_identifier=decoded["key_identifier"],
+            arbiter_instance_identifier=decoded["arbiter_instance_identifier"],
+            signature=decoded["signature"],
+        )
+        result["envelope_binding_valid"] = verify_envelope_binding(
+            report, envelope,
+        )
+    else:
+        result["envelope_binding_valid"] = None
+
+    print(json.dumps(result, indent=2))
+    if not signature_ok:
+        return 1
+    if args.overt and result["envelope_binding_valid"] is False:
+        return 1
+    return 0
+
+
 def _load_overt_pubkey(args: argparse.Namespace) -> Optional[bytes]:
     """Resolve --pubkey-file or --pubkey-hex to raw bytes. None on error."""
     if args.pubkey_file:
@@ -1335,6 +1476,59 @@ def build_parser() -> argparse.ArgumentParser:
         help="Raw 32-byte Ed25519 public key encoded as 64 hex characters",
     )
     pov_verify.set_defaults(func=_cmd_overt_verify)
+
+    ptee = sub.add_parser(
+        "tee",
+        help=(
+            "Hardware TEE attestation commands (experimental, AMD SEV-SNP)"
+        ),
+    )
+    tsub = ptee.add_subparsers(dest="tee_cmd", required=True)
+
+    ptee_parse = tsub.add_parser(
+        "parse",
+        help=(
+            "Parse an AMD SEV-SNP attestation report blob and print key "
+            "fields as JSON. Requires the attestation extra."
+        ),
+    )
+    ptee_parse.add_argument(
+        "report",
+        help="Path to a binary SEV-SNP attestation report (1184 bytes)",
+    )
+    ptee_parse.set_defaults(func=_cmd_tee_parse)
+
+    ptee_verify = tsub.add_parser(
+        "verify",
+        help=(
+            "Verify a SEV-SNP report signature against a VCEK PEM, "
+            "and optionally check that REPORT_DATA binds to an OVERT envelope. "
+            "Requires the attestation extra."
+        ),
+    )
+    ptee_verify.add_argument(
+        "report",
+        help="Path to a binary SEV-SNP attestation report (1184 bytes)",
+    )
+    ptee_verify.add_argument(
+        "--vcek",
+        required=True,
+        help=(
+            "Path to a PEM-encoded VCEK (Versioned Chip Endorsement Key). "
+            "Must be supplied out of band. AMD KDS chain validation is "
+            "tracked for v0.19+."
+        ),
+    )
+    ptee_verify.add_argument(
+        "--overt",
+        default=None,
+        help=(
+            "Optional path to a canonical-CBOR OVERT 1.0 Base Envelope. "
+            "If supplied, the report's REPORT_DATA is checked against "
+            "SHA-512 of the envelope."
+        ),
+    )
+    ptee_verify.set_defaults(func=_cmd_tee_verify)
 
     preload = psub.add_parser(
         "reload",

--- a/tests/test_attestation_tee.py
+++ b/tests/test_attestation_tee.py
@@ -1,0 +1,185 @@
+"""Hardware TEE attestation (AMD SEV-SNP) tests."""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import cbor2  # noqa: F401
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+    from cryptography.hazmat.primitives import serialization
+
+    from vaara.attestation.overt import (
+        emit_base_envelope,
+        encoder_binary_identity,
+        make_request_commitment,
+    )
+    from vaara.attestation.tee import (
+        MockSEVSNPAttester,
+        SEVSNPHostAttester,
+        SEV_SNP_REPORT_DATA_SIZE,
+        SEV_SNP_REPORT_SIZE,
+        SIGNATURE_ALGO_ECDSA_P384_SHA384,
+        TEEAttestationError,
+        bind_overt_envelope_to_report_data,
+        parse_sev_snp_report,
+        verify_envelope_binding,
+        verify_sev_snp_report_signature,
+    )
+except ImportError:
+    pytest.skip(
+        "attestation extra not installed (pip install 'vaara[attestation]')",
+        allow_module_level=True,
+    )
+
+
+def _emit_overt(seed: bytes = b"action-payload", counter: int = 1):
+    signing_key = Ed25519PrivateKey.generate()
+    return emit_base_envelope(
+        signing_key=signing_key,
+        request_commitment=make_request_commitment(
+            seed, operator_key=b"\x42" * 32,
+        ),
+        encoder_binary_identity=encoder_binary_identity(
+            arbiter_version="vaara/0.18.0", policy_hash=b"\xaa" * 32,
+        ),
+        non_content_metadata={"action_class": "data.read", "decision": "allow"},
+        monotonic_counter=counter,
+        arbiter_instance_identifier=b"\x00" * 16,
+    )
+
+
+@pytest.fixture
+def overt_envelope():
+    return _emit_overt()
+
+
+@pytest.fixture
+def vcek_key():
+    return ec.generate_private_key(ec.SECP384R1())
+
+
+@pytest.fixture
+def vcek_pem(vcek_key):
+    return vcek_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def test_bind_overt_envelope_to_report_data_is_64_bytes(overt_envelope):
+    assert len(bind_overt_envelope_to_report_data(overt_envelope)) == SEV_SNP_REPORT_DATA_SIZE
+
+
+def test_bind_is_deterministic(overt_envelope):
+    a = bind_overt_envelope_to_report_data(overt_envelope)
+    b = bind_overt_envelope_to_report_data(overt_envelope)
+    assert a == b
+
+
+def test_bind_differs_across_envelopes(overt_envelope):
+    other = _emit_overt(seed=b"other-payload", counter=2)
+    assert bind_overt_envelope_to_report_data(overt_envelope) != \
+        bind_overt_envelope_to_report_data(other)
+
+
+def test_mock_attester_emits_well_formed_report(vcek_key, overt_envelope):
+    attester = MockSEVSNPAttester(vcek_key)
+    report_data = bind_overt_envelope_to_report_data(overt_envelope)
+    blob = attester.emit(report_data)
+    assert len(blob) == SEV_SNP_REPORT_SIZE
+
+
+def test_parse_round_trip(vcek_key, overt_envelope):
+    attester = MockSEVSNPAttester(vcek_key, measurement=b"\xCC" * 48)
+    report_data = bind_overt_envelope_to_report_data(overt_envelope)
+    report = parse_sev_snp_report(attester.emit(report_data))
+    assert report.report_data == report_data
+    assert report.measurement == b"\xCC" * 48
+    assert report.signature_algo == SIGNATURE_ALGO_ECDSA_P384_SHA384
+
+
+def test_parse_rejects_wrong_size():
+    with pytest.raises(TEEAttestationError, match="must be 1184 bytes"):
+        parse_sev_snp_report(b"\x00" * 100)
+
+
+def test_verify_signature_on_mock_report(vcek_key, vcek_pem, overt_envelope):
+    attester = MockSEVSNPAttester(vcek_key)
+    blob = attester.emit(bind_overt_envelope_to_report_data(overt_envelope))
+    report = parse_sev_snp_report(blob)
+    assert verify_sev_snp_report_signature(report, vcek_pem) is True
+
+
+def test_verify_signature_fails_on_tamper(vcek_key, vcek_pem, overt_envelope):
+    attester = MockSEVSNPAttester(vcek_key)
+    blob = bytearray(
+        attester.emit(bind_overt_envelope_to_report_data(overt_envelope))
+    )
+    blob[0x100] ^= 0x01
+    report = parse_sev_snp_report(bytes(blob))
+    assert verify_sev_snp_report_signature(report, vcek_pem) is False
+
+
+def test_verify_signature_fails_on_wrong_vcek(vcek_key, overt_envelope):
+    other_pem = ec.generate_private_key(ec.SECP384R1()).public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    attester = MockSEVSNPAttester(vcek_key)
+    blob = attester.emit(bind_overt_envelope_to_report_data(overt_envelope))
+    report = parse_sev_snp_report(blob)
+    assert verify_sev_snp_report_signature(report, other_pem) is False
+
+
+def test_verify_envelope_binding(vcek_key, overt_envelope):
+    attester = MockSEVSNPAttester(vcek_key)
+    report = parse_sev_snp_report(
+        attester.emit(bind_overt_envelope_to_report_data(overt_envelope))
+    )
+    assert verify_envelope_binding(report, overt_envelope) is True
+
+
+def test_verify_envelope_binding_fails_on_wrong_envelope(vcek_key, overt_envelope):
+    attester = MockSEVSNPAttester(vcek_key)
+    other = _emit_overt(seed=b"unrelated", counter=99)
+    report = parse_sev_snp_report(
+        attester.emit(bind_overt_envelope_to_report_data(overt_envelope))
+    )
+    assert verify_envelope_binding(report, other) is False
+
+
+def test_mock_attester_rejects_wrong_report_data_length(vcek_key):
+    attester = MockSEVSNPAttester(vcek_key)
+    with pytest.raises(TEEAttestationError, match="exactly 64 bytes"):
+        attester.emit(b"\x00" * 32)
+
+
+def test_mock_attester_rejects_non_ec_key():
+    with pytest.raises(TEEAttestationError, match="EC private key"):
+        MockSEVSNPAttester(Ed25519PrivateKey.generate())
+
+
+def test_mock_attester_rejects_wrong_curve():
+    with pytest.raises(TEEAttestationError, match="secp384r1"):
+        MockSEVSNPAttester(ec.generate_private_key(ec.SECP256R1()))
+
+
+def test_host_attester_raises_clearly_on_non_snp_host():
+    attester = SEVSNPHostAttester(device="/dev/does-not-exist")
+    with pytest.raises(TEEAttestationError, match="not present"):
+        attester.emit(b"\x00" * 64)
+
+
+def test_verify_rejects_unsupported_algo(vcek_key, vcek_pem, overt_envelope):
+    attester = MockSEVSNPAttester(vcek_key)
+    blob = bytearray(
+        attester.emit(bind_overt_envelope_to_report_data(overt_envelope))
+    )
+    blob[0x034:0x038] = b"\x00\x00\x00\x00"
+    report = parse_sev_snp_report(bytes(blob))
+    with pytest.raises(TEEAttestationError, match="Unsupported"):
+        verify_sev_snp_report_signature(report, vcek_pem)


### PR DESCRIPTION
## Summary

- Hardware TEE attestation hook (experimental). Initial backend AMD SEV-SNP, the natural fit for confidential-VM agent deployments. Intel TDX and SGX tracked for v0.19+.
- The OVERT 1.0 Base Envelope schema is closed and unchanged. The TEE report is a sibling artefact bound to a specific envelope by placing `SHA-512(canonical_cbor(envelope))` into the report's 64-byte `REPORT_DATA` field. Two signatures are checked independently: the envelope's Ed25519, and the report's ECDSA P-384 against an AMD VCEK.
- Ships parser, binding helper, signature verifier against a caller-supplied VCEK, deterministic mock attester for tests, `SEVSNPHostAttester` skeleton, and a `vaara tee parse|verify` CLI. AMD KDS chain validation and `/dev/sev-guest` live emission tracked for v0.19+.
- Fixes a pre-existing version drift: `src/vaara/__init__.py` was stuck at 0.15.0 while `pyproject.toml` had moved through 0.16.0 and 0.17.0. Both now read 0.18.0.

## What's in the module

`src/vaara/attestation/tee.py`:

- `parse_sev_snp_report`: binary parser per AMD SEV-SNP ABI Spec rev 1.55 Table 22 (1184 bytes = 672-byte signed body + 512-byte signature field).
- `bind_overt_envelope_to_report_data`: 64-byte hash that binds a TEE report to a specific OVERT envelope. Hash covers all 9 envelope fields including the inner Ed25519 signature, so any envelope change breaks the binding.
- `verify_sev_snp_report_signature`: validates ECDSA P-384 over the report body against a caller-supplied VCEK PEM. AMD stores R and S as little-endian 48-byte values in 72-byte slots; this unpacks them into DER for the cryptography library.
- `verify_envelope_binding`: confirms `REPORT_DATA` equals `SHA-512(canonical_cbor(envelope))`.
- `MockSEVSNPAttester`: deterministic in-memory attester producing byte-compatible reports for tests and CI.
- `SEVSNPHostAttester`: skeleton wrapping `/dev/sev-guest`, raises a clear error on non-SEV-SNP hosts. Live ioctl path tracked for v0.19+.

CLI: `vaara tee parse REPORT.bin` (JSON dump) and `vaara tee verify REPORT.bin --vcek VCEK.pem [--overt ENVELOPE.cbor]` (signature plus optional binding check).

## Why this shape

The OVERT 1.0 Protocol Profile 1.0 Base Envelope is a closed 9-field schema. Extending the envelope to carry TEE data would break OVERT conformance. The sibling-artefact model preserves the envelope unchanged and lets a relying party check the two signatures independently. An OVERT verifier without TEE awareness still validates Vaara envelopes exactly as before.

The mock attester is not a substitute for real hardware. Its signing key has no AMD provenance, so a verifier validating the chain to AMD's ARK will (correctly) reject mock reports. The mock exists to let CI exercise the parser, binding, and verifier without an SEV-SNP host.

## What does NOT ship

- AMD KDS-based cert-chain validation (VCEK to ASK to ARK). Requires a network fetch against `https://kdsintf.amd.com/`. Tracked for v0.19+.
- Live `/dev/sev-guest` ioctl emission. The `SNP_GET_REPORT` ioctl is well-defined in `linux/sev-guest.h`. Tracked for v0.19+ once a tested SEV-SNP guest is available for integration testing.
- Intel TDX, Intel SGX backends. Same module shape accommodates them via additional attester classes.

The hook is marked experimental in the docstring and `COMPLIANCE.md` until both gaps land.

## Test plan

- [x] 16 new unit tests in `tests/test_attestation_tee.py`: parse round-trip, size rejection, mock-attester emission, signature verify, tamper detection, wrong-VCEK rejection, envelope binding, wrong-envelope binding failure, wrong-curve and non-EC-key construction rejection, unsupported-algo rejection at verify, non-SEV-SNP host error path, report-data-length validation
- [x] Full suite: 636 passed, 12 skipped, 1 warning (existing FastAPI deprecation noise)
- [x] CLI smoke test: `vaara tee parse` and `vaara tee verify --overt` against round-tripped artefacts return `signature_valid: true`, `envelope_binding_valid: true`

## Files

- `src/vaara/attestation/tee.py` (new, 218 lines)
- `src/vaara/attestation/__init__.py` (exports added)
- `src/vaara/cli.py` (`_cmd_tee_parse`, `_cmd_tee_verify`, subparser registration)
- `tests/test_attestation_tee.py` (new, 16 tests)
- `src/vaara/__init__.py` (version drift fix)
- `pyproject.toml` (0.17.0 to 0.18.0)
- `CHANGELOG.md` (v0.18.0 entry)
- `COMPLIANCE.md` ("Hardware TEE attestation hook" subsection under "Position relative to open runtime-attestation standards")
- `README.md` (paragraph under "OVERT 1.0 attestation")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental hardware TEE attestation support for AMD SEV-SNP, enabling attestation report binding and verification against OVERT envelopes.
  * Introduced new CLI commands for parsing and verifying attestation reports.

* **Chores**
  * Updated version to 0.18.0.
  * Enhanced documentation with TEE attestation capabilities and current limitations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->