### PR TITLE
chore: v0.18.1 PyPI/npm lockstep fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-05-17
+
+**Release-bookkeeping patch.** The v0.18.0 release shipped Python to PyPI
+successfully but the npm publish step failed because
+`clients/ts/package.json` was not bumped from 0.17.0. The TS client is
+unchanged in behaviour; this patch restores PyPI/npm version lockstep
+established in v0.15.0. No Python code changes versus 0.18.0.
+
+### Changed
+- `clients/ts/package.json`: 0.17.0 → 0.18.1 (lockstep with PyPI).
+- `pyproject.toml`, `src/vaara/__init__.py`: 0.18.0 → 0.18.1.
+
 ## [0.18.0] - 2026-05-17
 
 **Theme: hardware TEE attestation hook (experimental).** Adds an optional

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.17.0",
+  "version": "0.18.1",
   "description": "TypeScript client for the Vaara HTTP API — conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.18.0"
+version = "0.18.1"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## Summary

Release-bookkeeping patch. v0.18.0 shipped Python to PyPI successfully but the npm publish step failed: `clients/ts/package.json` was not bumped from 0.17.0, producing a `403 cannot publish over previously published versions: 0.17.0` on the publish-npm job. This restores the PyPI/npm version lockstep established in v0.15.0.

- `clients/ts/package.json`: 0.17.0 → 0.18.1
- `pyproject.toml`: 0.18.0 → 0.18.1
- `src/vaara/__init__.py`: 0.18.0 → 0.18.1

No Python or TypeScript code changes versus 0.18.0.

## Test plan

- [x] Full suite: 636 passed, 12 skipped, 1 warning
- [x] `vaara version` returns 0.18.1
- [x] All three version sites grep clean to 0.18.1
