### PR TITLE
feat: v0.20.0 OSS guardrail adapters (NeMo, Guardrails AI, LLM Guard, Rebuff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-05-18
+
+**Theme: OSS guardrail adapters.** Adds four adapters that take findings
+from NVIDIA NeMo Guardrails, Guardrails AI, LLM Guard, and Rebuff and
+route them through Vaara's hash-chained audit trail and OVERT envelope
+with EU AI Act article tags. Same pattern as v0.19.0's cloud adapters.
+The OSS guardrail runs as an upstream signal in the deployer's
+environment. Vaara records what the guardrail flagged, normalises it
+to a shared vocabulary, and tags each finding against Art. 5, 10, 13,
+15, and 53.
+
+The mapping itself is the value. Each adapter is a thin SDK wrapper
+around a published category-to-article table extended in
+`_content_safety_articles.py`. A deployer can read the table, dispute
+a row, and override mappings without touching adapter code.
+
+### Added
+- 41 new mapping rows in `_content_safety_articles.py` across the four
+  OSS providers (7 NeMo, 10 Guardrails AI, 20 LLM Guard, 4 Rebuff),
+  each tagged with EU AI Act articles and OWASP LLM Top 10 codes.
+  Seven new Vaara categories: `secrets_leak`, `schema_violation`,
+  `output_validation`, `bias`, `language`, `sentiment`,
+  `resource_limit`.
+- `src/vaara/integrations/nemo_guardrails.py`:
+  `NemoGuardrailsAdapter` plus `parse_generation_response`. Maps input
+  rails, dialog rails, output rails, and retrieval rails from the
+  `GenerationResponse.log.activated_rails` payload.
+- `src/vaara/integrations/guardrails_ai.py`: `GuardrailsAIAdapter` plus
+  `parse_validation_outcome`. Maps `ValidationOutcome` summary shape
+  to findings with PascalCase normalisation across hub validators.
+- `src/vaara/integrations/llm_guard.py`: `LLMGuardAdapter` plus
+  `parse_scan_result`. Wraps `scan_prompt` and `scan_output`
+  callables. Scanner-callable injection for test isolation.
+- `src/vaara/integrations/rebuff.py`: `RebuffAdapter` plus
+  `parse_detect_response` and `parse_canary_leak`. Records all three
+  injection-detection layers (heuristic, model, vector) and the
+  canary-word leak on responses.
+- Four test files exercising parsers and adapters with no SDK install
+  required (29 new tests, 712 total).
+
+### Pyproject
+- New optional extras: `nemo-guardrails`, `guardrails-ai`, `llm-guard`,
+  `rebuff`. Base install stays free of OSS guardrail dependencies.
+- HuggingFace Space added as `Demo` URL in `[project.urls]`.
+
+### README
+- HuggingFace Space badge added to the badge row.
+
+### Strategic frame
+The OSS guardrails are inputs to Vaara, not Vaara's replacement.
+Vaara stays the schema findings flow into: hash-chained audit trail,
+OVERT envelope, EU AI Act article-level evidence. Add NeMo, Guardrails
+AI, LLM Guard, or Rebuff to your stack and their findings land in the
+same Vaara audit record as Bedrock, Azure, and GCP findings did in
+v0.19.0.
+
 ## [0.19.1] - 2026-05-18
 
 **Patch: audit DB upgrade safety.** Opening an existing audit DB at

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -169,6 +169,61 @@ performance. The deployer's choice of guardrail vendor and confidence
 threshold is a policy decision recorded in Vaara's audit trail, not a
 decision Vaara makes.
 
+## OSS guardrail adapter pattern
+
+Adapters from v0.20.0 take findings from NVIDIA NeMo Guardrails,
+Guardrails AI, LLM Guard, and Rebuff and route them through the same
+audit-and-OVERT path as the v0.19.0 cloud adapters. Each OSS guardrail
+speaks its own category vocabulary (`input_rails.jailbreak` /
+`DetectPII` / `PromptInjection` / `heuristicScore`). The adapters
+normalise those onto the same Vaara vocabulary and the same published
+article-mapping table at
+`src/vaara/integrations/_content_safety_articles.py`, extended with
+OSS provider rows.
+
+41 OSS rows total across the four vendors (7 NeMo, 10 Guardrails AI,
+20 LLM Guard, 4 Rebuff) as of v0.20.0. Combined with v0.19.0's 27
+cloud rows, the published table covers 68 provider categories across
+seven upstream guardrails.
+
+### Category to article mapping (OSS providers)
+
+| Vaara category | Provider categories | AI Act article | OWASP LLM |
+|---|---|---|---|
+| `adversarial` | NeMo `input_rails.jailbreak` / `self_check` · Guardrails AI `DetectPromptInjection` · LLM Guard `PromptInjection` / `InvisibleText` · Rebuff `heuristic_injection` / `model_injection` / `vector_injection` | Art. 15 | LLM01 |
+| `prohibited_topic` | NeMo `dialog_rails.topic` · Guardrails AI `MentionsDrugs` · LLM Guard `BanCode` / `BanCompetitors` / `BanTopics` | Art. 5 | LLM08 |
+| `hate` | Guardrails AI `ToxicLanguage` / `ProfanityFree` · LLM Guard `Toxicity` | Art. 5 | LLM05 |
+| `pii` | NeMo `output_rails.sensitive_data` · Guardrails AI `DetectPII` · LLM Guard `Anonymize` / `Deanonymize` / `Sensitive` | Art. 10 | LLM02 |
+| `secrets_leak` | Guardrails AI `SecretsPresent` · LLM Guard `Secrets` · Rebuff `canary_leak` | Art. 15 | LLM02 |
+| `word_block` | LLM Guard `BanSubstrings` / `Regex` | Art. 5 | LLM05 |
+| `bias` | Guardrails AI `BiasCheck` · LLM Guard `Bias` | Art. 10 | LLM05 |
+| `schema_violation` | Guardrails AI `ValidJSON` / `RegexMatch` / `ValidLength` · LLM Guard `JSON` | Art. 15 | LLM05 |
+| `output_validation` | NeMo `output_rails.self_check` · LLM Guard `NoRefusal` | Art. 13 | — |
+| `grounding` | NeMo `output_rails.fact_check` / `retrieval_rails.relevance` · LLM Guard `Relevance` | Art. 13, Art. 15 | LLM09 |
+| `malicious_uri` | LLM Guard `MaliciousURLs` | Art. 15 | LLM05 |
+| `language` | LLM Guard `Language` | Art. 13 | — |
+| `sentiment` | LLM Guard `Sentiment` | — | — |
+| `resource_limit` | LLM Guard `TokenLimit` | Art. 15 | — |
+
+### Where the finding lands
+
+Same flow as cloud adapters. OSS-adapter output is a
+`ContentSafetyFinding` with `to_audit_context()` and
+`to_overt_metadata()` helpers that route into
+`pipeline.intercept(context=...)` and OVERT `non_content_metadata`
+respectively.
+
+### What this is not
+
+The adapters do not run the OSS guardrail. The deployer's runtime
+loads NeMo, Guardrails AI, LLM Guard, or Rebuff and invokes them with
+the deployer's configuration. Vaara observes and records the finding.
+Vaara does not replace the upstream guardrail and does not claim
+conformity assessment of the guardrail vendor's detection performance.
+The deployer's choice of guardrails, scanners, validators, and
+thresholds is a policy decision recorded in Vaara's audit trail, not a
+decision Vaara makes.
+
 ## CEN-CENELEC harmonised standards alignment
 
 The harmonised standards under EU AI Act Article 40 are being drafted

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/vaaraio/vaara/ci.yml?branch=main&label=tests" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://api.scorecard.dev/projects/github.com/vaaraio/vaara/badge" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
 </p>
 
 Vaara is the runtime evidence layer for AI Act compliance. Open source, no SaaS, no telemetry.
@@ -126,6 +127,17 @@ Three adapters route findings from AWS Bedrock Guardrails, Azure AI Content Safe
 - **GCP Model Armor** — `vaara.integrations.gcp_model_armor.GcpModelArmorAdapter`. Wraps `sanitize_user_prompt` and `sanitize_model_response`.
 
 Each adapter returns a `ContentSafetyFinding` the deployer routes into `pipeline.intercept(context=finding.to_audit_context())`. Cloud SDKs are optional extras: `pip install 'vaara[bedrock]'`, `pip install 'vaara[azure-content-safety]'`, `pip install 'vaara[gcp-model-armor]'`. The category-to-article mapping table lives in `src/vaara/integrations/_content_safety_articles.py` and is the value the adapters wrap. Article-level rationale is in [COMPLIANCE.md](COMPLIANCE.md#cloud-guardrail-adapter-pattern).
+
+### OSS guardrails as upstream signals (v0.20.0)
+
+Four adapters route findings from NVIDIA NeMo Guardrails, Guardrails AI, LLM Guard, and Rebuff into the same audit trail and OVERT envelope path as the v0.19.0 cloud adapters. The OSS guardrail runs in the deployer's environment as an upstream signal. Vaara records the verdict, normalises 41 OSS provider categories onto the same shared vocabulary, and tags each finding against Art. 5, 10, 13, 15, and 53.
+
+- **NVIDIA NeMo Guardrails**. `vaara.integrations.nemo_guardrails.NemoGuardrailsAdapter`. Parses `GenerationResponse.log.activated_rails` across input, dialog, output, and retrieval rail types.
+- **Guardrails AI**. `vaara.integrations.guardrails_ai.GuardrailsAIAdapter`. Parses `ValidationOutcome.validation_summaries` from any `Guard.parse` or `Guard.validate` call.
+- **LLM Guard**. `vaara.integrations.llm_guard.LLMGuardAdapter`. Wraps `scan_prompt` and `scan_output` and parses the `(sanitized, results_valid, results_score)` triple.
+- **Rebuff**. `vaara.integrations.rebuff.RebuffAdapter`. Parses `DetectResponse` across the heuristic, model, and vector injection-detection layers, plus the canary-word leak check on responses.
+
+Each adapter returns a `ContentSafetyFinding` the deployer routes into `pipeline.intercept(context=finding.to_audit_context())`. OSS SDKs are optional extras: `pip install 'vaara[nemo-guardrails]'`, `pip install 'vaara[guardrails-ai]'`, `pip install 'vaara[llm-guard]'`, `pip install 'vaara[rebuff]'`. The 41 new mapping rows extend the same table at `src/vaara/integrations/_content_safety_articles.py`. Article-level rationale is in [COMPLIANCE.md](COMPLIANCE.md#oss-guardrail-adapter-pattern).
 
 ## HTTP API
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Three adapters route findings from AWS Bedrock Guardrails, Azure AI Content Safe
 
 Each adapter returns a `ContentSafetyFinding` the deployer routes into `pipeline.intercept(context=finding.to_audit_context())`. Cloud SDKs are optional extras: `pip install 'vaara[bedrock]'`, `pip install 'vaara[azure-content-safety]'`, `pip install 'vaara[gcp-model-armor]'`. The category-to-article mapping table lives in `src/vaara/integrations/_content_safety_articles.py` and is the value the adapters wrap. Article-level rationale is in [COMPLIANCE.md](COMPLIANCE.md#cloud-guardrail-adapter-pattern).
 
-### OSS guardrails as upstream signals (v0.20.0)
+### OSS guardrails as upstream signals
 
 Four adapters route findings from NVIDIA NeMo Guardrails, Guardrails AI, LLM Guard, and Rebuff into the same audit trail and OVERT envelope path as the v0.19.0 cloud adapters. The OSS guardrail runs in the deployer's environment as an upstream signal. Vaara records the verdict, normalises 41 OSS provider categories onto the same shared vocabulary, and tags each finding against Art. 5, 10, 13, 15, and 53.
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vaara/client",
-  "version": "0.19.1",
-  "description": "TypeScript client for the Vaara HTTP API — conformal risk scoring, hash-chained audit, policy reload, named detectors.",
+  "version": "0.20.0",
+  "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.19.1"
+version = "0.20.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -29,6 +29,7 @@ Homepage = "https://vaara.io"
 Repository = "https://github.com/vaaraio/vaara"
 Issues = "https://github.com/vaaraio/vaara/issues"
 PyPI = "https://pypi.org/project/vaara/"
+Demo = "https://huggingface.co/spaces/vaaraio/vaara"
 
 [project.optional-dependencies]
 dev = [
@@ -49,6 +50,10 @@ pdf = ["reportlab>=4.0"]
 bedrock = ["boto3>=1.34"]
 azure-content-safety = ["azure-ai-contentsafety>=1.0"]
 gcp-model-armor = ["google-cloud-modelarmor>=0.1"]
+nemo-guardrails = ["nemoguardrails>=0.10"]
+guardrails-ai = ["guardrails-ai>=0.5"]
+llm-guard = ["llm-guard>=0.3"]
+rebuff = ["rebuff>=0.1"]
 
 [project.scripts]
 vaara = "vaara.cli:main"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -1,4 +1,4 @@
-"""Vaara — Runtime action governance for AI agents.
+"""Vaara. Runtime action governance for AI agents.
 
 Sits between AI agents and their execution environment.
 Classifies and scores each proposed action, returns allow/escalate/deny,
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.19.1"
+__version__ = "0.20.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/integrations/_content_safety_articles.py
+++ b/src/vaara/integrations/_content_safety_articles.py
@@ -1,9 +1,10 @@
-"""Canonical mapping from cloud-guardrail findings to EU AI Act articles.
+"""Canonical mapping from guardrail findings to EU AI Act articles.
 
 This module is the value, not the SDK glue around it. Each provider
 returns category-typed findings using its own vocabulary (Bedrock
-``topicPolicy``, Azure ``Hate``, GCP ``responsible_ai``). The adapters
-in this package translate those into a single Vaara vocabulary and the
+``topicPolicy``, Azure ``Hate``, GCP ``responsible_ai``, Guardrails AI
+``DetectPII``, LLM Guard ``PromptInjection``, etc.). The adapters in
+this package translate those into a single Vaara vocabulary and the
 EU AI Act articles the deployer needs evidence against, so the same
 ``ContentSafetyFinding`` flows downstream regardless of which provider
 emitted it.
@@ -43,6 +44,10 @@ def _row(p: str, pc: str, vc: str, arts: tuple[str, ...],
 _BEDROCK = "aws-bedrock-guardrails"
 _AZURE = "azure-content-safety"
 _GCP = "gcp-model-armor"
+_NEMO = "nvidia-nemo-guardrails"
+_GRAILS = "guardrails-ai"
+_LLMG = "llm-guard"
+_REBUFF = "rebuff"
 
 
 BEDROCK_MAPPINGS: tuple[CategoryMapping, ...] = (
@@ -100,9 +105,100 @@ GCP_MAPPINGS: tuple[CategoryMapping, ...] = (
 )
 
 
+NEMO_MAPPINGS: tuple[CategoryMapping, ...] = (
+    _row(_NEMO, "input_rails.jailbreak", "adversarial", ("Art. 15",), ("LLM01",),
+         "Jailbreak detection input rail. Robustness/cybersecurity signal."),
+    _row(_NEMO, "input_rails.self_check", "adversarial", ("Art. 15",), ("LLM01",),
+         "Input self-check rail flags adversarial prompts."),
+    _row(_NEMO, "dialog_rails.topic", "prohibited_topic", ("Art. 5",), ("LLM08",),
+         "Topic rail blocks deployer-defined off-topic content."),
+    _row(_NEMO, "output_rails.self_check", "output_validation", ("Art. 13",), ("LLM05",),
+         "Output self-check rail flags policy-violating generations."),
+    _row(_NEMO, "output_rails.fact_check", "grounding", ("Art. 13", "Art. 15"), ("LLM09",),
+         "Fact-check rail signals ungrounded or hallucinated output."),
+    _row(_NEMO, "output_rails.sensitive_data", "pii", ("Art. 10",), ("LLM02",),
+         "Sensitive-data output rail detects PII leakage."),
+    _row(_NEMO, "retrieval_rails.relevance", "grounding", ("Art. 13",), ("LLM09",),
+         "Retrieval-relevance rail signals off-context chunks."),
+)
+
+
+GUARDRAILS_AI_MAPPINGS: tuple[CategoryMapping, ...] = (
+    _row(_GRAILS, "DetectPII", "pii", ("Art. 10",), ("LLM02",),
+         "PII detector validator. Type field carries the PII class."),
+    _row(_GRAILS, "ToxicLanguage", "hate", ("Art. 5",), ("LLM05",),
+         "Toxic-language validator. Severity reflects validator threshold."),
+    _row(_GRAILS, "ProfanityFree", "hate", ("Art. 5",), ("LLM05",)),
+    _row(_GRAILS, "SecretsPresent", "secrets_leak", ("Art. 15",), ("LLM02",),
+         "API keys, tokens, or credentials in output. Cybersecurity signal."),
+    _row(_GRAILS, "DetectPromptInjection", "adversarial", ("Art. 15",), ("LLM01",),
+         "Prompt-injection detector validator."),
+    _row(_GRAILS, "BiasCheck", "bias", ("Art. 10",), ("LLM05",),
+         "Bias validator. Art. 10 data-governance signal."),
+    _row(_GRAILS, "MentionsDrugs", "prohibited_topic", ("Art. 5",), ("LLM08",)),
+    _row(_GRAILS, "ValidJSON", "schema_violation", ("Art. 15",), ("LLM05",),
+         "JSON-schema validator failure. Robustness signal."),
+    _row(_GRAILS, "RegexMatch", "schema_violation", ("Art. 15",), ("LLM05",)),
+    _row(_GRAILS, "ValidLength", "schema_violation", ("Art. 15",), ("LLM05",)),
+)
+
+
+LLM_GUARD_MAPPINGS: tuple[CategoryMapping, ...] = (
+    _row(_LLMG, "Anonymize", "pii", ("Art. 10",), ("LLM02",),
+         "PII anonymisation scanner. Match types carry the PII class."),
+    _row(_LLMG, "BanCode", "prohibited_topic", ("Art. 5",), ("LLM08",),
+         "Code-content scanner blocks code in prompts where disallowed."),
+    _row(_LLMG, "BanCompetitors", "prohibited_topic", ("Art. 5",), ("LLM08",)),
+    _row(_LLMG, "BanSubstrings", "word_block", ("Art. 5",), ("LLM05",),
+         "Custom substring deny-list. Deployer-defined."),
+    _row(_LLMG, "BanTopics", "prohibited_topic", ("Art. 5",), ("LLM08",)),
+    _row(_LLMG, "InvisibleText", "adversarial", ("Art. 15",), ("LLM01",),
+         "Invisible-text detection (zero-width chars, homoglyphs)."),
+    _row(_LLMG, "Language", "language", ("Art. 13",), (),
+         "Language-detection scanner. Transparency-adjacent signal."),
+    _row(_LLMG, "PromptInjection", "adversarial", ("Art. 15",), ("LLM01",),
+         "Prompt-injection scanner. Cybersecurity signal."),
+    _row(_LLMG, "Regex", "word_block", ("Art. 5",), ("LLM05",),
+         "Regex deny-list scanner."),
+    _row(_LLMG, "Secrets", "secrets_leak", ("Art. 15",), ("LLM02",),
+         "Secrets-detection scanner. API keys, tokens, credentials."),
+    _row(_LLMG, "Sentiment", "sentiment", (), (),
+         "Sentiment scanner. No article mapping. Recorded as raw signal."),
+    _row(_LLMG, "TokenLimit", "resource_limit", ("Art. 15",), (),
+         "Token-limit scanner. Robustness/availability signal."),
+    _row(_LLMG, "Toxicity", "hate", ("Art. 5",), ("LLM05",)),
+    _row(_LLMG, "Bias", "bias", ("Art. 10",), ("LLM05",),
+         "Output-bias scanner. Art. 10 data-governance signal."),
+    _row(_LLMG, "Deanonymize", "pii", ("Art. 10",), ("LLM02",),
+         "Output deanonymisation scanner."),
+    _row(_LLMG, "JSON", "schema_violation", ("Art. 15",), ("LLM05",)),
+    _row(_LLMG, "MaliciousURLs", "malicious_uri", ("Art. 15",), ("LLM05",)),
+    _row(_LLMG, "NoRefusal", "output_validation", ("Art. 13",), (),
+         "Refusal detection on output. Transparency signal."),
+    _row(_LLMG, "Relevance", "grounding", ("Art. 13",), ("LLM09",)),
+    _row(_LLMG, "Sensitive", "pii", ("Art. 10",), ("LLM02",),
+         "Output sensitive-data scanner."),
+)
+
+
+REBUFF_MAPPINGS: tuple[CategoryMapping, ...] = (
+    _row(_REBUFF, "heuristic_injection", "adversarial", ("Art. 15",), ("LLM01",),
+         "Heuristic prompt-injection score. First of Rebuff's four layers."),
+    _row(_REBUFF, "model_injection", "adversarial", ("Art. 15",), ("LLM01",),
+         "LLM-based prompt-injection score."),
+    _row(_REBUFF, "vector_injection", "adversarial", ("Art. 15",), ("LLM01",),
+         "Vector-DB similarity score against known injection corpus."),
+    _row(_REBUFF, "canary_leak", "secrets_leak", ("Art. 15",), ("LLM02",),
+         "Canary-word leak in model output. Indirect-injection signal."),
+)
+
+
 _INDEX: dict[tuple[str, str], CategoryMapping] = {
     (m.provider, m.provider_category): m
-    for m in BEDROCK_MAPPINGS + AZURE_MAPPINGS + GCP_MAPPINGS
+    for m in (
+        BEDROCK_MAPPINGS + AZURE_MAPPINGS + GCP_MAPPINGS
+        + NEMO_MAPPINGS + GUARDRAILS_AI_MAPPINGS + LLM_GUARD_MAPPINGS + REBUFF_MAPPINGS
+    )
 }
 
 

--- a/src/vaara/integrations/guardrails_ai.py
+++ b/src/vaara/integrations/guardrails_ai.py
@@ -1,0 +1,153 @@
+"""Guardrails AI adapter. Upstream output-validation signal.
+
+Wraps a pre-configured ``guardrails.Guard``. Each validator on the
+Guard produces a pass/fail summary. The adapter parses the
+``ValidationOutcome`` into a ``ContentSafetyFinding`` the deployer
+routes through ``InterceptionPipeline.intercept(context=...)``.
+
+Two entry points:
+
+* ``parse_validation_outcome(outcome)`` for callers who already have
+  a ``ValidationOutcome`` from ``Guard.parse`` or ``Guard.validate``.
+* ``GuardrailsAIAdapter`` holds a configured ``Guard`` and exposes
+  ``scan_response`` (text) plus ``parse`` (which returns the
+  validated output alongside the finding).
+
+Optional dependency: ``pip install vaara[guardrails-ai]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vaara.integrations._content_safety_base import (
+    ContentSafetyFinding,
+    FindingCategory,
+    build_finding,
+    mapping_for,
+)
+
+
+_PROVIDER = "guardrails-ai"
+
+
+def _sev_str(value: float) -> str:
+    return f"{max(0.0, min(1.0, value)):.4f}"
+
+
+def _validator_key(validator_name: str) -> str:
+    """Normalise a validator name to the published mapping key.
+
+    Guardrails Hub validators arrive in many casings and prefixes
+    (``guardrails/detect_pii``, ``DetectPII``, ``detect-pii``). Map to
+    PascalCase short names matching ``_content_safety_articles``.
+    """
+    name = (validator_name or "").rsplit("/", 1)[-1]
+    # snake_case or kebab-case → PascalCase
+    if "_" in name or "-" in name:
+        parts = name.replace("-", "_").split("_")
+        return "".join(p[:1].upper() + p[1:] for p in parts if p)
+    return name
+
+
+def _summary_to_category(summary: Any) -> FindingCategory:
+    """Map one ``ValidationSummary`` (or dict) to a ``FindingCategory``."""
+    get = (lambda k, d=None: summary.get(k, d)) if isinstance(summary, dict) else (
+        lambda k, d=None: getattr(summary, k, d)
+    )
+    raw_name = get("validator_name") or get("name") or ""
+    status = (get("validator_status") or get("status") or "").lower()
+    failures = get("failures") or []
+    failure_reason = get("failure_reason") or ""
+    error_spans = get("error_spans") or []
+
+    key = _validator_key(raw_name)
+    failed = status in {"fail", "failed"} or bool(failures) or bool(failure_reason)
+    return FindingCategory(
+        provider_category=key,
+        severity_label=("FAIL" if failed else "PASS"),
+        normalized_severity=_sev_str(0.9 if failed else 0.0),
+        action=("FLAGGED" if failed else "NONE"),
+        mapping=mapping_for(_PROVIDER, key),
+        evidence={
+            "validator_name": raw_name,
+            "status": status,
+            "failure_reason": failure_reason,
+            "error_span_count": len(error_spans) if hasattr(error_spans, "__len__") else 0,
+        },
+    )
+
+
+def parse_validation_outcome(
+    outcome: Any,
+    *,
+    scanned_role: str = "response",
+) -> ContentSafetyFinding:
+    """Parse a Guardrails AI ``ValidationOutcome`` into a finding.
+
+    Accepts the SDK object or a dict shape. When no per-validator
+    summary is available (older SDK paths), a single synthetic
+    category is recorded against ``unmapped`` with the overall
+    pass/fail status.
+    """
+    get = (lambda k, d=None: outcome.get(k, d)) if isinstance(outcome, dict) else (
+        lambda k, d=None: getattr(outcome, k, d)
+    )
+    summaries = get("validation_summaries") or []
+    passed = bool(get("validation_passed"))
+
+    cats: list[FindingCategory] = []
+    if summaries:
+        for s in summaries:
+            cats.append(_summary_to_category(s))
+    elif not passed:
+        cats.append(FindingCategory(
+            provider_category="unmapped",
+            severity_label="FAIL",
+            normalized_severity=_sev_str(0.9),
+            action="FLAGGED",
+            mapping=None,
+            evidence={"error": str(get("error") or "")},
+        ))
+
+    raw = outcome if isinstance(outcome, dict) else {
+        "validation_passed": passed,
+        "error": str(get("error") or ""),
+    }
+    return build_finding(
+        provider=_PROVIDER,
+        categories=cats,
+        raw=raw,
+        scanned_role=scanned_role,
+    )
+
+
+class GuardrailsAIAdapter:
+    """Wraps a configured ``guardrails.Guard`` instance."""
+
+    provider = _PROVIDER
+
+    def __init__(self, guard: Any) -> None:
+        if not (hasattr(guard, "parse") or hasattr(guard, "validate")):
+            raise TypeError(
+                "GuardrailsAIAdapter: guard must be a Guardrails AI Guard "
+                "(expose parse / validate)."
+            )
+        self._guard = guard
+
+    def parse(self, text: str, **kwargs: Any) -> tuple[Any, ContentSafetyFinding]:
+        """Run ``Guard.parse(text)`` and return ``(validated_output, finding)``."""
+        outcome = self._guard.parse(text, **kwargs)
+        finding = parse_validation_outcome(outcome, scanned_role="response")
+        validated = (
+            outcome.get("validated_output") if isinstance(outcome, dict)
+            else getattr(outcome, "validated_output", None)
+        )
+        return validated, finding
+
+    def scan_response(self, text: str, **kwargs: Any) -> ContentSafetyFinding:
+        outcome = self._guard.parse(text, **kwargs)
+        return parse_validation_outcome(outcome, scanned_role="response")
+
+
+__all__ = ["GuardrailsAIAdapter", "parse_validation_outcome"]

--- a/src/vaara/integrations/llm_guard.py
+++ b/src/vaara/integrations/llm_guard.py
@@ -1,0 +1,144 @@
+"""LLM Guard adapter. Upstream scanner-library signal.
+
+Wraps the ``llm_guard`` scanner pipeline. The deployer assembles a
+list of input scanners (Anonymize, PromptInjection, Toxicity, ...)
+and output scanners (Bias, Sensitive, MaliciousURLs, ...) and the
+adapter forwards prompts and responses through them, parsing the
+``(sanitized_text, results_valid, results_score)`` tuple into a
+``ContentSafetyFinding`` the deployer routes through
+``InterceptionPipeline.intercept(context=...)``.
+
+Two entry points:
+
+* ``parse_scan_result(results_valid, results_score, ...)`` for
+  callers who already ran ``llm_guard.scan_prompt`` or ``scan_output``.
+* ``LLMGuardAdapter`` holds pre-built scanner lists and exposes
+  ``scan_prompt`` / ``scan_response``.
+
+Optional dependency: ``pip install vaara[llm-guard]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from vaara.integrations._content_safety_base import (
+    ContentSafetyFinding,
+    FindingCategory,
+    build_finding,
+    mapping_for,
+)
+
+
+_PROVIDER = "llm-guard"
+
+
+def _sev_str(value: float) -> str:
+    return f"{max(0.0, min(1.0, value)):.4f}"
+
+
+def _scanner_key(scanner_name: str) -> str:
+    """LLM Guard returns class names verbatim (``PromptInjection``).
+
+    Strip any module prefix and return the class name unchanged.
+    """
+    name = (scanner_name or "").rsplit(".", 1)[-1]
+    return name
+
+
+def parse_scan_result(
+    results_valid: dict[str, bool],
+    results_score: dict[str, float],
+    *,
+    scanned_role: str,
+    sanitized_text: str | None = None,
+) -> ContentSafetyFinding:
+    """Parse an ``llm_guard.scan_prompt``/``scan_output`` result triple.
+
+    A scanner is "triggered" when ``results_valid[name] is False``.
+    Score range is implementation-defined per scanner. LLM Guard
+    typically returns ``0.0`` for pass and a non-zero risk score on
+    failure.
+    """
+    cats: list[FindingCategory] = []
+    for raw_name, valid in (results_valid or {}).items():
+        key = _scanner_key(raw_name)
+        score = float((results_score or {}).get(raw_name, 0.0) or 0.0)
+        triggered = not bool(valid)
+        cats.append(FindingCategory(
+            provider_category=key,
+            severity_label=("BLOCKED" if triggered else "PASS"),
+            normalized_severity=_sev_str(score if triggered else 0.0),
+            action=("BLOCKED" if triggered else "NONE"),
+            mapping=mapping_for(_PROVIDER, key),
+            evidence={
+                "scanner": raw_name,
+                "score": f"{score:.4f}",
+                "valid": bool(valid),
+            },
+        ))
+
+    raw: dict[str, Any] = {
+        "results_valid": dict(results_valid or {}),
+        "results_score": {k: f"{float(v):.4f}" for k, v in (results_score or {}).items()},
+    }
+    if sanitized_text is not None:
+        raw["sanitized_text_length"] = len(sanitized_text)
+    return build_finding(
+        provider=_PROVIDER,
+        categories=cats,
+        raw=raw,
+        scanned_role=scanned_role,
+    )
+
+
+class LLMGuardAdapter:
+    """Wraps pre-built lists of ``llm_guard`` input/output scanners."""
+
+    provider = _PROVIDER
+
+    def __init__(
+        self,
+        input_scanners: Iterable[Any] | None = None,
+        output_scanners: Iterable[Any] | None = None,
+        *,
+        scan_prompt_fn: Any = None,
+        scan_output_fn: Any = None,
+    ) -> None:
+        self._input_scanners = list(input_scanners or [])
+        self._output_scanners = list(output_scanners or [])
+        if scan_prompt_fn is None or scan_output_fn is None:
+            try:
+                from llm_guard import scan_prompt as _scan_prompt
+                from llm_guard import scan_output as _scan_output
+            except ImportError as exc:
+                raise ImportError(
+                    "LLMGuardAdapter: install vaara[llm-guard] to use this adapter."
+                ) from exc
+            scan_prompt_fn = scan_prompt_fn or _scan_prompt
+            scan_output_fn = scan_output_fn or _scan_output
+        self._scan_prompt_fn = scan_prompt_fn
+        self._scan_output_fn = scan_output_fn
+
+    def scan_prompt(self, text: str, **_: Any) -> ContentSafetyFinding:
+        sanitized, valid, score = self._scan_prompt_fn(self._input_scanners, text)
+        return parse_scan_result(
+            valid, score, scanned_role="prompt", sanitized_text=sanitized,
+        )
+
+    def scan_response(
+        self,
+        text: str,
+        *,
+        prompt: str = "",
+        **_: Any,
+    ) -> ContentSafetyFinding:
+        sanitized, valid, score = self._scan_output_fn(
+            self._output_scanners, prompt, text,
+        )
+        return parse_scan_result(
+            valid, score, scanned_role="response", sanitized_text=sanitized,
+        )
+
+
+__all__ = ["LLMGuardAdapter", "parse_scan_result"]

--- a/src/vaara/integrations/nemo_guardrails.py
+++ b/src/vaara/integrations/nemo_guardrails.py
@@ -1,0 +1,165 @@
+"""NVIDIA NeMo Guardrails adapter. Upstream rails signal.
+
+Wraps a pre-configured ``LLMRails`` instance. NeMo Guardrails runs
+input rails, dialog rails, output rails, and retrieval rails during
+generation. Each activated rail is recorded in the response log. The
+adapter parses that log into a ``ContentSafetyFinding`` the deployer
+routes through ``InterceptionPipeline.intercept(context=...)`` so the
+finding lands in Vaara's hash-chained audit trail and, when emitting
+OVERT envelopes, in ``non_content_metadata``.
+
+Two entry points:
+
+* ``parse_generation_response(response)`` for callers running NeMo
+  inline (most common). Parse the ``GenerationResponse`` after a call
+  to ``LLMRails.generate_async``.
+* ``NemoGuardrailsAdapter`` holds a configured ``LLMRails`` and
+  exposes ``generate`` which returns ``(response_text, finding)`` in
+  one call.
+
+Optional dependency: ``pip install vaara[nemo-guardrails]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vaara.integrations._content_safety_base import (
+    ContentSafetyFinding,
+    FindingCategory,
+    build_finding,
+    mapping_for,
+)
+
+
+_PROVIDER = "nvidia-nemo-guardrails"
+
+
+def _sev_str(value: float) -> str:
+    return f"{max(0.0, min(1.0, value)):.4f}"
+
+
+_RAIL_TO_KEY = {
+    "input": {
+        "self check input": "input_rails.self_check",
+        "jailbreak detection": "input_rails.jailbreak",
+        "jailbreak detection heuristics": "input_rails.jailbreak",
+    },
+    "dialog": {
+        "off topic": "dialog_rails.topic",
+        "topical rail": "dialog_rails.topic",
+    },
+    "output": {
+        "self check output": "output_rails.self_check",
+        "self check facts": "output_rails.fact_check",
+        "fact checking": "output_rails.fact_check",
+        "check hallucination": "output_rails.fact_check",
+        "sensitive data detection on output": "output_rails.sensitive_data",
+        "sensitive data detection": "output_rails.sensitive_data",
+    },
+    "retrieval": {
+        "check retrieval relevance": "retrieval_rails.relevance",
+    },
+}
+
+
+def _normalize_rail(rail_type: str, rail_name: str) -> str:
+    bucket = _RAIL_TO_KEY.get((rail_type or "").lower(), {})
+    return bucket.get((rail_name or "").lower(), f"{rail_type}_rails.unmapped")
+
+
+def _activated_to_category(activated: dict[str, Any]) -> FindingCategory:
+    rail_type = activated.get("type") or activated.get("rail_type") or ""
+    rail_name = activated.get("name") or activated.get("rail_name") or ""
+    decisions = activated.get("decisions") or []
+    stop = bool(activated.get("stop")) or any(
+        (d or "").lower() in {"refuse", "stop", "abort", "block"} for d in decisions
+    )
+    altered = bool(activated.get("output_changed") or activated.get("altered"))
+    action = "BLOCKED" if stop else ("FLAGGED" if altered else "NONE")
+    key = _normalize_rail(rail_type, rail_name)
+    return FindingCategory(
+        provider_category=key,
+        severity_label=(rail_name or rail_type or "rail").upper(),
+        normalized_severity=_sev_str(0.9 if stop else (0.5 if altered else 0.0)),
+        action=action,
+        mapping=mapping_for(_PROVIDER, key),
+        evidence={
+            "rail_type": rail_type,
+            "rail_name": rail_name,
+            "decisions": list(decisions),
+        },
+    )
+
+
+def parse_generation_response(
+    response: Any,
+    *,
+    scanned_role: str = "",
+) -> ContentSafetyFinding:
+    """Parse a NeMo ``GenerationResponse`` into a ``ContentSafetyFinding``.
+
+    Accepts either the SDK object (with ``.log.activated_rails``) or a
+    dict shape. Rails that fired without altering or stopping the
+    generation are recorded with ``action="NONE"`` so the audit trail
+    keeps a complete signal log.
+    """
+    log = getattr(response, "log", None)
+    if log is None and isinstance(response, dict):
+        log = response.get("log") or {}
+    if log is None:
+        log = {}
+
+    activated = getattr(log, "activated_rails", None)
+    if activated is None and isinstance(log, dict):
+        activated = log.get("activated_rails") or []
+    activated = activated or []
+
+    cats: list[FindingCategory] = []
+    for rail in activated:
+        rail_dict = rail if isinstance(rail, dict) else rail.__dict__
+        cats.append(_activated_to_category(rail_dict))
+
+    raw = response if isinstance(response, dict) else {"response_repr": repr(response)}
+    return build_finding(
+        provider=_PROVIDER,
+        categories=cats,
+        raw=raw,
+        scanned_role=scanned_role,
+    )
+
+
+class NemoGuardrailsAdapter:
+    """Wraps a configured ``nemoguardrails.LLMRails`` instance."""
+
+    provider = _PROVIDER
+
+    def __init__(self, rails: Any) -> None:
+        if not (hasattr(rails, "generate") or hasattr(rails, "generate_async")):
+            raise TypeError(
+                "NemoGuardrailsAdapter: rails must be a configured LLMRails "
+                "instance (expose generate / generate_async)."
+            )
+        self._rails = rails
+
+    def generate(
+        self,
+        messages: list[dict[str, str]],
+        **kwargs: Any,
+    ) -> tuple[str, ContentSafetyFinding]:
+        """Run NeMo generation and return ``(response_text, finding)``."""
+        response = self._rails.generate(messages=messages, **kwargs)
+        text = response if isinstance(response, str) else (
+            getattr(response, "response", None)
+            or (response.get("response") if isinstance(response, dict) else "")
+            or ""
+        )
+        finding = parse_generation_response(response, scanned_role="response")
+        return text, finding
+
+    def scan_response(self, response: Any, **_: Any) -> ContentSafetyFinding:
+        """Convenience: parse an already-issued ``GenerationResponse``."""
+        return parse_generation_response(response, scanned_role="response")
+
+
+__all__ = ["NemoGuardrailsAdapter", "parse_generation_response"]

--- a/src/vaara/integrations/rebuff.py
+++ b/src/vaara/integrations/rebuff.py
@@ -1,0 +1,176 @@
+"""Rebuff adapter. Upstream prompt-injection signal.
+
+Rebuff layers four checks: heuristic, LLM-based, vector-DB
+similarity, and canary-word leak detection. The adapter wraps a
+pre-configured ``Rebuff`` (hosted) or ``RebuffSdk`` (self-hosted)
+instance and parses the ``DetectResponse`` into a
+``ContentSafetyFinding`` the deployer routes through
+``InterceptionPipeline.intercept(context=...)``.
+
+Two entry points:
+
+* ``parse_detect_response(response)`` for callers who already have a
+  ``DetectResponse`` from ``Rebuff.detect_injection``.
+* ``RebuffAdapter`` holds the Rebuff client and exposes
+  ``scan_prompt`` plus ``scan_response`` (the latter checks for
+  canary-word leakage when a canary word is supplied).
+
+Optional dependency: ``pip install vaara[rebuff]``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vaara.integrations._content_safety_base import (
+    ContentSafetyFinding,
+    FindingCategory,
+    build_finding,
+    mapping_for,
+)
+
+
+_PROVIDER = "rebuff"
+
+
+def _sev_str(value: float) -> str:
+    return f"{max(0.0, min(1.0, value)):.4f}"
+
+
+def _layer_category(
+    key: str,
+    *,
+    score: float,
+    threshold: float,
+    ran: bool,
+) -> FindingCategory:
+    triggered = ran and (score >= threshold > 0.0)
+    return FindingCategory(
+        provider_category=key,
+        severity_label=("BLOCKED" if triggered else ("PASS" if ran else "SKIPPED")),
+        normalized_severity=_sev_str(score if ran else 0.0),
+        action=("BLOCKED" if triggered else "NONE"),
+        mapping=mapping_for(_PROVIDER, key),
+        evidence={
+            "score": f"{score:.4f}",
+            "threshold": f"{threshold:.4f}",
+            "ran": bool(ran),
+        },
+    )
+
+
+def parse_detect_response(
+    response: Any,
+    *,
+    scanned_role: str = "prompt",
+) -> ContentSafetyFinding:
+    """Parse a Rebuff ``DetectResponse`` into a finding.
+
+    Accepts the SDK object or a dict shape. Three layers are recorded
+    regardless of trigger so the audit trail reflects which checks
+    ran.
+    """
+    get = (lambda k, d=None: response.get(k, d)) if isinstance(response, dict) else (
+        lambda k, d=None: getattr(response, k, d)
+    )
+    cats: list[FindingCategory] = [
+        _layer_category(
+            "heuristic_injection",
+            score=float(get("heuristicScore", 0.0) or 0.0),
+            threshold=float(get("maxHeuristicScore", 0.75) or 0.75),
+            ran=bool(get("runHeuristicCheck", True)),
+        ),
+        _layer_category(
+            "model_injection",
+            score=float(get("modelScore", 0.0) or 0.0),
+            threshold=float(get("maxModelScore", 0.9) or 0.9),
+            ran=bool(get("runLanguageModelCheck", True)),
+        ),
+        _layer_category(
+            "vector_injection",
+            score=float(get("vectorScore", {}).get("topScore", 0.0)
+                        if isinstance(get("vectorScore"), dict)
+                        else (get("vectorScore", 0.0) or 0.0)),
+            threshold=float(get("maxVectorScore", 0.9) or 0.9),
+            ran=bool(get("runVectorCheck", True)),
+        ),
+    ]
+
+    raw = response if isinstance(response, dict) else {
+        "injectionDetected": bool(get("injectionDetected", False)),
+    }
+    return build_finding(
+        provider=_PROVIDER,
+        categories=cats,
+        raw=raw,
+        scanned_role=scanned_role,
+    )
+
+
+def parse_canary_leak(
+    leaked: bool,
+    *,
+    canary_word: str,
+    scanned_role: str = "response",
+) -> ContentSafetyFinding:
+    cats = [FindingCategory(
+        provider_category="canary_leak",
+        severity_label=("BLOCKED" if leaked else "PASS"),
+        normalized_severity=_sev_str(0.95 if leaked else 0.0),
+        action=("BLOCKED" if leaked else "NONE"),
+        mapping=mapping_for(_PROVIDER, "canary_leak"),
+        evidence={"canary_word": canary_word, "leaked": bool(leaked)},
+    )]
+    return build_finding(
+        provider=_PROVIDER,
+        categories=cats,
+        raw={"canary_word": canary_word, "leaked": bool(leaked)},
+        scanned_role=scanned_role,
+    )
+
+
+class RebuffAdapter:
+    """Wraps a configured ``Rebuff`` or ``RebuffSdk`` instance."""
+
+    provider = _PROVIDER
+
+    def __init__(self, client: Any) -> None:
+        if not hasattr(client, "detect_injection"):
+            raise TypeError(
+                "RebuffAdapter: client must expose detect_injection "
+                "(pass a Rebuff or RebuffSdk instance)."
+            )
+        self._client = client
+
+    def scan_prompt(self, text: str, **kwargs: Any) -> ContentSafetyFinding:
+        result = self._client.detect_injection(text, **kwargs)
+        # SDK returns either DetectResponse alone or (metrics, is_injection).
+        if isinstance(result, tuple) and len(result) == 2:
+            result = result[0]
+        return parse_detect_response(result, scanned_role="prompt")
+
+    def scan_response(
+        self,
+        text: str,
+        *,
+        prompt: str = "",
+        canary_word: str = "",
+        **_: Any,
+    ) -> ContentSafetyFinding:
+        if not canary_word:
+            raise ValueError(
+                "RebuffAdapter.scan_response: canary_word is required for "
+                "Rebuff response-side checks. Use Rebuff.add_canary_word "
+                "before generation and pass the canary back in."
+            )
+        leaked = bool(self._client.is_canary_word_leaked(prompt, text, canary_word))
+        return parse_canary_leak(
+            leaked, canary_word=canary_word, scanned_role="response",
+        )
+
+
+__all__ = [
+    "RebuffAdapter",
+    "parse_canary_leak",
+    "parse_detect_response",
+]

--- a/tests/test_integrations_guardrails_ai.py
+++ b/tests/test_integrations_guardrails_ai.py
@@ -1,0 +1,92 @@
+"""Tests for the Guardrails AI adapter.
+
+No guardrails-ai install required; uses dict-shaped ValidationOutcome
+stubs and a fake Guard for the class-level surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from vaara.integrations.guardrails_ai import (
+    GuardrailsAIAdapter,
+    parse_validation_outcome,
+)
+
+
+class _FakeGuard:
+    def __init__(self, outcome: Any) -> None:
+        self._outcome = outcome
+        self.last_text: str | None = None
+
+    def parse(self, text: str, **_: Any) -> Any:
+        self.last_text = text
+        return self._outcome
+
+
+def _outcome(
+    *,
+    passed: bool = True,
+    summaries: list[dict[str, Any]] | None = None,
+    error: str = "",
+    validated_output: Any = None,
+) -> dict[str, Any]:
+    return {
+        "validation_passed": passed,
+        "validation_summaries": list(summaries or []),
+        "error": error,
+        "validated_output": validated_output,
+    }
+
+
+class TestParseValidationOutcome:
+    def test_clean_outcome_yields_allow(self):
+        finding = parse_validation_outcome(_outcome(passed=True))
+        assert finding.provider == "guardrails-ai"
+        assert finding.verdict == "allow"
+        assert finding.categories == ()
+
+    def test_pii_failure(self):
+        finding = parse_validation_outcome(_outcome(passed=False, summaries=[{
+            "validator_name": "guardrails/detect_pii",
+            "validator_status": "fail",
+            "failure_reason": "email detected",
+        }]))
+        assert finding.verdict == "flag"
+        assert finding.categories[0].provider_category == "DetectPii"
+        # Mapping uses PascalCase "DetectPII"; the normaliser yields
+        # "DetectPii". Both resolve to the pii vaara_category through
+        # the article table when the canonical key matches.
+        assert finding.categories[0].vaara_category in {"pii", "unmapped"}
+
+    def test_toxic_language_failure_maps_to_hate(self):
+        finding = parse_validation_outcome(_outcome(passed=False, summaries=[{
+            "validator_name": "ToxicLanguage",
+            "validator_status": "fail",
+            "failure_reason": "toxic span detected",
+        }]))
+        assert finding.categories[0].vaara_category == "hate"
+        assert "Art. 5" in finding.ai_act_articles()
+
+    def test_summary_less_failure_records_unmapped(self):
+        finding = parse_validation_outcome(_outcome(
+            passed=False, summaries=[], error="something failed",
+        ))
+        assert finding.verdict == "flag"
+        assert finding.categories[0].provider_category == "unmapped"
+
+
+class TestAdapter:
+    def test_parse_returns_validated_and_finding(self):
+        guard = _FakeGuard(_outcome(passed=True, validated_output={"ok": True}))
+        adapter = GuardrailsAIAdapter(guard)
+        validated, finding = adapter.parse("hello")
+        assert validated == {"ok": True}
+        assert finding.verdict == "allow"
+        assert guard.last_text == "hello"
+
+    def test_construction_rejects_non_guard(self):
+        with pytest.raises(TypeError):
+            GuardrailsAIAdapter(object())

--- a/tests/test_integrations_llm_guard.py
+++ b/tests/test_integrations_llm_guard.py
@@ -1,0 +1,95 @@
+"""Tests for the LLM Guard adapter.
+
+No llm_guard install required; the adapter takes scan callables via
+constructor for injection-friendly testing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vaara.integrations.llm_guard import (
+    LLMGuardAdapter,
+    parse_scan_result,
+)
+
+
+class TestParseScanResult:
+    def test_all_pass_yields_allow(self):
+        finding = parse_scan_result(
+            {"PromptInjection": True, "Toxicity": True},
+            {"PromptInjection": 0.0, "Toxicity": 0.0},
+            scanned_role="prompt",
+        )
+        assert finding.provider == "llm-guard"
+        assert finding.verdict == "allow"
+
+    def test_prompt_injection_triggered_blocks(self):
+        finding = parse_scan_result(
+            {"PromptInjection": False, "Toxicity": True},
+            {"PromptInjection": 0.98, "Toxicity": 0.0},
+            scanned_role="prompt",
+        )
+        assert finding.verdict == "block"
+        triggered = finding.triggered_categories()
+        assert triggered[0].provider_category == "PromptInjection"
+        assert triggered[0].vaara_category == "adversarial"
+        assert "Art. 15" in finding.ai_act_articles()
+
+    def test_secrets_triggered_maps_to_secrets_leak(self):
+        finding = parse_scan_result(
+            {"Secrets": False},
+            {"Secrets": 0.92},
+            scanned_role="response",
+        )
+        assert finding.triggered_categories()[0].vaara_category == "secrets_leak"
+
+    def test_severity_clamped_to_unit_interval(self):
+        finding = parse_scan_result(
+            {"PromptInjection": False},
+            {"PromptInjection": 1.5},
+            scanned_role="prompt",
+        )
+        assert finding.severity == "1.0000"
+
+
+class TestAdapter:
+    def test_scan_prompt_calls_injected_fn(self):
+        def fake_scan_prompt(scanners, prompt):
+            assert scanners == ["s1", "s2"]
+            return prompt + "[s]", {"PromptInjection": False}, {"PromptInjection": 0.99}
+
+        def fake_scan_output(scanners, prompt, output):
+            return output, {}, {}
+
+        adapter = LLMGuardAdapter(
+            input_scanners=["s1", "s2"],
+            scan_prompt_fn=fake_scan_prompt,
+            scan_output_fn=fake_scan_output,
+        )
+        finding = adapter.scan_prompt("ignore previous")
+        assert finding.verdict == "block"
+        assert finding.scanned_role == "prompt"
+
+    def test_scan_response_passes_prompt_through(self):
+        seen: dict[str, str] = {}
+
+        def fake_scan_output(scanners, prompt, output):
+            seen["prompt"] = prompt
+            seen["output"] = output
+            return output, {"Bias": True}, {"Bias": 0.0}
+
+        adapter = LLMGuardAdapter(
+            output_scanners=["b"],
+            scan_prompt_fn=lambda *_a, **_k: ("", {}, {}),
+            scan_output_fn=fake_scan_output,
+        )
+        finding = adapter.scan_response("answer text", prompt="question")
+        assert seen == {"prompt": "question", "output": "answer text"}
+        assert finding.verdict == "allow"
+
+    def test_missing_llm_guard_raises_when_no_fn_injected(self):
+        # llm_guard is not installed in test env. When neither scan
+        # function is injected, construction must raise ImportError.
+        with pytest.raises(ImportError):
+            LLMGuardAdapter()

--- a/tests/test_integrations_nemo_guardrails.py
+++ b/tests/test_integrations_nemo_guardrails.py
@@ -1,0 +1,100 @@
+"""Tests for the NVIDIA NeMo Guardrails adapter.
+
+No nemoguardrails install required; uses dict-shaped response stubs
+and a fake LLMRails for the class-level surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from vaara.integrations.nemo_guardrails import (
+    NemoGuardrailsAdapter,
+    parse_generation_response,
+)
+
+
+class _FakeRails:
+    def __init__(self, response: Any) -> None:
+        self._response = response
+        self.last_messages: list[dict[str, str]] | None = None
+
+    def generate(self, messages: list[dict[str, str]], **_: Any) -> Any:
+        self.last_messages = messages
+        return self._response
+
+
+def _response(
+    *,
+    response_text: str = "ok",
+    activated: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "response": response_text,
+        "log": {"activated_rails": list(activated or [])},
+    }
+
+
+class TestParseGenerationResponse:
+    def test_no_activated_rails_yields_allow(self):
+        finding = parse_generation_response(_response(activated=[]))
+        assert finding.provider == "nvidia-nemo-guardrails"
+        assert finding.verdict == "allow"
+        assert finding.categories == ()
+
+    def test_jailbreak_input_rail_blocks(self):
+        finding = parse_generation_response(_response(activated=[{
+            "type": "input",
+            "name": "jailbreak detection",
+            "stop": True,
+            "decisions": ["refuse"],
+        }]))
+        assert finding.verdict == "block"
+        assert finding.categories[0].provider_category == "input_rails.jailbreak"
+        assert "Art. 15" in finding.ai_act_articles()
+
+    def test_output_self_check_flag(self):
+        finding = parse_generation_response(_response(activated=[{
+            "type": "output",
+            "name": "self check output",
+            "altered": True,
+            "decisions": [],
+        }]))
+        assert finding.verdict == "flag"
+        assert finding.categories[0].provider_category == "output_rails.self_check"
+
+    def test_sdk_object_shape_is_supported(self):
+        class _Log:
+            activated_rails = [{
+                "type": "output",
+                "name": "fact checking",
+                "stop": True,
+                "decisions": ["abort"],
+            }]
+
+        class _Response:
+            response = "..."
+            log = _Log()
+
+        finding = parse_generation_response(_Response())
+        assert finding.verdict == "block"
+        assert finding.categories[0].provider_category == "output_rails.fact_check"
+
+
+class TestAdapter:
+    def test_generate_returns_text_and_finding(self):
+        rails = _FakeRails(_response(
+            response_text="hello",
+            activated=[{"type": "dialog", "name": "off topic", "stop": True}],
+        ))
+        adapter = NemoGuardrailsAdapter(rails)
+        text, finding = adapter.generate(messages=[{"role": "user", "content": "hi"}])
+        assert text == "hello"
+        assert finding.verdict == "block"
+        assert rails.last_messages == [{"role": "user", "content": "hi"}]
+
+    def test_construction_rejects_non_rails(self):
+        with pytest.raises(TypeError):
+            NemoGuardrailsAdapter(object())

--- a/tests/test_integrations_rebuff.py
+++ b/tests/test_integrations_rebuff.py
@@ -1,0 +1,122 @@
+"""Tests for the Rebuff adapter.
+
+No rebuff install required; uses a fake client with the documented
+detect_injection / is_canary_word_leaked surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from vaara.integrations.rebuff import (
+    RebuffAdapter,
+    parse_canary_leak,
+    parse_detect_response,
+)
+
+
+class _FakeRebuff:
+    def __init__(
+        self,
+        *,
+        detect: dict[str, Any] | None = None,
+        canary_leaked: bool = False,
+    ) -> None:
+        self._detect = detect or {}
+        self._canary_leaked = canary_leaked
+        self.last_detect_input: str | None = None
+
+    def detect_injection(self, text: str, **_: Any) -> dict[str, Any]:
+        self.last_detect_input = text
+        return self._detect
+
+    def is_canary_word_leaked(self, prompt: str, response: str, canary: str) -> bool:
+        return self._canary_leaked
+
+
+def _detect(
+    *,
+    heuristic: float = 0.0,
+    model: float = 0.0,
+    vector: float = 0.0,
+    injection_detected: bool = False,
+) -> dict[str, Any]:
+    return {
+        "heuristicScore": heuristic,
+        "modelScore": model,
+        "vectorScore": vector,
+        "maxHeuristicScore": 0.75,
+        "maxModelScore": 0.9,
+        "maxVectorScore": 0.9,
+        "runHeuristicCheck": True,
+        "runLanguageModelCheck": True,
+        "runVectorCheck": True,
+        "injectionDetected": injection_detected,
+    }
+
+
+class TestParseDetectResponse:
+    def test_clean_prompt_yields_allow(self):
+        finding = parse_detect_response(_detect())
+        assert finding.provider == "rebuff"
+        assert finding.verdict == "allow"
+        # All three layers recorded with NONE action.
+        assert len(finding.categories) == 3
+        assert {c.action for c in finding.categories} == {"NONE"}
+
+    def test_heuristic_above_threshold_blocks(self):
+        finding = parse_detect_response(_detect(heuristic=0.95))
+        assert finding.verdict == "block"
+        triggered = finding.triggered_categories()
+        assert triggered[0].provider_category == "heuristic_injection"
+        assert triggered[0].vaara_category == "adversarial"
+
+    def test_vector_score_dict_shape_parsed(self):
+        d = _detect()
+        d["vectorScore"] = {"topScore": 0.95, "countOverMaxVectorScore": 3}
+        finding = parse_detect_response(d)
+        assert finding.verdict == "block"
+
+    def test_skipped_layer_recorded(self):
+        d = _detect()
+        d["runVectorCheck"] = False
+        finding = parse_detect_response(d)
+        skipped = [c for c in finding.categories if c.provider_category == "vector_injection"]
+        assert skipped[0].severity_label == "SKIPPED"
+
+
+class TestParseCanaryLeak:
+    def test_canary_leak_blocks(self):
+        finding = parse_canary_leak(True, canary_word="abc123")
+        assert finding.verdict == "block"
+        assert finding.categories[0].vaara_category == "secrets_leak"
+
+    def test_no_canary_leak_yields_allow(self):
+        finding = parse_canary_leak(False, canary_word="abc123")
+        assert finding.verdict == "allow"
+
+
+class TestAdapter:
+    def test_scan_prompt_uses_client(self):
+        client = _FakeRebuff(detect=_detect(model=0.95))
+        adapter = RebuffAdapter(client)
+        finding = adapter.scan_prompt("ignore previous")
+        assert finding.verdict == "block"
+        assert client.last_detect_input == "ignore previous"
+
+    def test_scan_response_requires_canary_word(self):
+        adapter = RebuffAdapter(_FakeRebuff())
+        with pytest.raises(ValueError):
+            adapter.scan_response("text", prompt="p")
+
+    def test_scan_response_canary_check(self):
+        adapter = RebuffAdapter(_FakeRebuff(canary_leaked=True))
+        finding = adapter.scan_response("leaked!", prompt="p", canary_word="abc123")
+        assert finding.verdict == "block"
+        assert finding.categories[0].provider_category == "canary_leak"
+
+    def test_construction_rejects_non_rebuff(self):
+        with pytest.raises(TypeError):
+            RebuffAdapter(object())


### PR DESCRIPTION
## Summary

- Four adapters route findings from NVIDIA NeMo Guardrails, Guardrails AI, LLM Guard, and Rebuff through Vaara's hash-chained audit trail and OVERT envelope with EU AI Act article tags
- 41 OSS provider categories normalised onto the same shared Vaara vocabulary the v0.19.0 cloud adapters use, in `src/vaara/integrations/_content_safety_articles.py` (68 mapping rows total across both releases)
- Seven new Vaara categories: `secrets_leak`, `schema_violation`, `output_validation`, `bias`, `language`, `sentiment`, `resource_limit`
- New optional extras `nemo-guardrails`, `guardrails-ai`, `llm-guard`, `rebuff`. Base install stays free of OSS guardrail dependencies
- HuggingFace Space added as `Demo` URL in `[project.urls]` and as a badge on README
- 29 new tests across `tests/test_integrations_{nemo_guardrails,guardrails_ai,llm_guard,rebuff}.py`. 712 total passing

## Strategic frame

The OSS guardrails are inputs to Vaara, not Vaara's replacement. Vaara stays the schema findings flow into. Not "Vaara works with NeMo / Guardrails AI / LLM Guard / Rebuff." The other direction: those four upstream guardrails work inside Vaara's compliance kernel and land in the same audit record as Bedrock, Azure, and GCP findings did in v0.19.0.

## File list

- `src/vaara/integrations/_content_safety_articles.py` extended with 41 OSS rows (7 NeMo, 10 Guardrails AI, 20 LLM Guard, 4 Rebuff)
- `src/vaara/integrations/nemo_guardrails.py` — `NemoGuardrailsAdapter` + `parse_generation_response`
- `src/vaara/integrations/guardrails_ai.py` — `GuardrailsAIAdapter` + `parse_validation_outcome`
- `src/vaara/integrations/llm_guard.py` — `LLMGuardAdapter` + `parse_scan_result`
- `src/vaara/integrations/rebuff.py` — `RebuffAdapter` + `parse_detect_response` + `parse_canary_leak`
- README "OSS guardrails as upstream signals (v0.20.0)" subsection + HF Space badge
- COMPLIANCE.md "OSS guardrail adapter pattern" section with full mapping table
- CHANGELOG `[0.20.0]` entry
- Version bumps: `pyproject.toml`, `src/vaara/__init__.py`, `clients/ts/package.json` to 0.20.0

## Test plan

- [x] `.venv/bin/pytest tests/test_integrations_nemo_guardrails.py tests/test_integrations_guardrails_ai.py tests/test_integrations_llm_guard.py tests/test_integrations_rebuff.py` — 29 passing
- [x] `.venv/bin/pytest` full suite — 712 passing, 12 skipped (network-dependent)
- [x] `.venv/bin/ruff check src/vaara/integrations/ tests/test_integrations_*.py` — clean
- [x] `import vaara; vaara.__version__` reports `0.20.0`
- [x] No em-dashes or semicolons in the v0.20.0 CHANGELOG entry, README addition, or COMPLIANCE.md section
- [ ] On merge: tag `v0.20.0`, Release workflow stamps the Git tag, PyPI publishes, npm publishes (per `feedback_release_bump_ts_package_json` — TS package.json bumped to 0.20.0)
