### PR TITLE
docs(mcp-proxy): real upstream invocations, promote to top-level README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,6 @@ Four adapters route findings from NVIDIA NeMo Guardrails, Guardrails AI, LLM Gua
 
 Each adapter returns a `ContentSafetyFinding` the deployer routes into `pipeline.intercept(context=finding.to_audit_context())`. OSS SDKs are optional extras: `pip install 'vaara[nemo-guardrails]'`, `pip install 'vaara[guardrails-ai]'`, `pip install 'vaara[llm-guard]'`, `pip install 'vaara[rebuff]'`. The 41 new mapping rows extend the same table at `src/vaara/integrations/_content_safety_articles.py`. Article-level rationale is in [COMPLIANCE.md](COMPLIANCE.md#oss-guardrail-adapter-pattern).
 
-### MCP proxy (Vaara as a transparent governance layer)
-
-`vaara.integrations.mcp_proxy.VaaraMCPProxy` sits between an MCP client (Claude Code, Cursor, any MCP-capable host) and an upstream MCP server (SAP ADT MCP, SAP Graph API MCP, SAP Cloud ALM MCP, any community-built MCP server). Every `tools/call` request from the client routes through Vaara's interception pipeline before reaching the upstream. Allowed calls forward transparently and report the upstream outcome back to the scorer. Blocked calls return an MCP `isError: true` response with the block reason. Other MCP methods (initialize, tools/list, resources, notifications) forward unchanged.
-
-```bash
-python -m vaara.integrations.mcp_proxy --upstream npx --upstream-arg @sap/adt-mcp-server
-```
-
-Point your MCP client at the proxy instead of the upstream. The audit chain captures every tool call without changing client or upstream behavior. Distinct from `mcp_server`, which exposes Vaara itself as an MCP server for agents that consult Vaara as a tool.
-
 ## HTTP API
 
 The same scorer and audit trail are available over HTTP for non-Python agents and for control planes that prefer a network boundary. Install with the `server` extra:
@@ -155,6 +145,27 @@ const vaara = new VaaraClient({ baseUrl: "http://localhost:8000" });
 const r = await vaara.score({ tool_name: "tx.transfer", agent_id: "agent-007", base_risk_score: 0.6 });
 if (r.decision === "deny") throw new Error("blocked");
 ```
+
+## MCP proxy (Vaara as a transparent governance layer)
+
+`vaara.integrations.mcp_proxy.VaaraMCPProxy` sits between an MCP client (Claude Code, Cursor, any MCP-capable host) and an upstream MCP server. Every `tools/call` from the client routes through Vaara's interception pipeline before reaching the upstream. Allowed calls forward transparently and report the upstream outcome back to the scorer. Blocked calls return an MCP `isError: true` response with the block reason. Other MCP methods (initialize, tools/list, resources, notifications) forward unchanged.
+
+One-line example in front of [`@sap/mdk-mcp-server`](https://www.npmjs.com/package/@sap/mdk-mcp-server) (SAP's official Mobile Development Kit MCP server, on npm):
+
+```bash
+python -m vaara.integrations.mcp_proxy \
+  --upstream npx --upstream-arg -y --upstream-arg @sap/mdk-mcp-server \
+  --db ./mcp_audit.db
+```
+
+Point your MCP client at the proxy instead of the upstream. The audit chain captures every tool call without changing client or upstream behavior. Distinct from `mcp_server`, which exposes Vaara itself as an MCP server for agents that consult Vaara as a tool.
+
+Worked examples with real upstream servers:
+
+- [`examples/github-mcp-proxy-demo/`](examples/github-mcp-proxy-demo/). Vaara in front of [`github/github-mcp-server`](https://github.com/github/github-mcp-server) (GitHub's official MCP server, MIT-licensed). End-to-end verified: real subprocess, 42 tools advertised, hash-chained audit trail recorded.
+- [`examples/sap-mcp-proxy-demo/`](examples/sap-mcp-proxy-demo/). Vaara in front of community SAP MCP servers ([`SAP/mdk-mcp-server`](https://github.com/SAP/mdk-mcp-server), [`mario-andreschak/mcp-abap-abap-adt-api`](https://github.com/mario-andreschak/mcp-abap-abap-adt-api), [`lemaiwo/btp-sap-odata-to-mcp-server`](https://github.com/lemaiwo/btp-sap-odata-to-mcp-server)).
+
+The proxy is MCP-protocol-level, not vendor-specific. The same three-step recipe applies to any stdio-capable MCP server (Microsoft Graph MCP, Salesforce MCP, ServiceNow MCP, cloud-provider MCP servers, Databricks MCP, and so on).
 
 ## OVERT 1.0 attestation
 

--- a/examples/sap-mcp-proxy-demo/README.md
+++ b/examples/sap-mcp-proxy-demo/README.md
@@ -28,12 +28,12 @@ Every `tools/call` request from Claude Code routes through Vaara before reaching
 ## Prerequisites
 
 - Python 3.10+
-- An existing SAP MCP server. Examples of real community servers:
-  - [`mario-andreschak/mcp-abap-abap-adt-api`](https://github.com/mario-andreschak/mcp-abap-abap-adt-api) — wraps ABAP ADT API
-  - [`SAP/mdk-mcp-server`](https://github.com/SAP/mdk-mcp-server) — official SAP MCP server for Mobile Development Kit
-  - [`lemaiwo/btp-sap-odata-to-mcp-server`](https://github.com/lemaiwo/btp-sap-odata-to-mcp-server) — SAP OData via MCP
-  - See [`marianfoo/sap-ai-mcp-servers`](https://github.com/marianfoo/sap-ai-mcp-servers) for the curated index.
-- A SAP system the upstream MCP server can talk to (BTP free tier, S/4HANA dev, NetWeaver ABAP Developer Edition, etc.)
+- An existing SAP MCP server. Real community servers with their actual install paths:
+  - [`SAP/mdk-mcp-server`](https://github.com/SAP/mdk-mcp-server). Official SAP MCP server for Mobile Development Kit. Published on npm as [`@sap/mdk-mcp-server`](https://www.npmjs.com/package/@sap/mdk-mcp-server). Runnable via `npx -y @sap/mdk-mcp-server --schema-version 26.3`. No SAP-system credentials needed (uses your AI provider's API key, e.g. SAP AI Core via your IDE config).
+  - [`mario-andreschak/mcp-abap-abap-adt-api`](https://github.com/mario-andreschak/mcp-abap-abap-adt-api). Wraps the ABAP ADT API. Not published on npm. Install by `git clone`, then `npm install && npm run build`, then run with `node /path/to/dist/index.js`. Needs SAP system credentials (`SAP_URL`, `SAP_USER`, `SAP_PASSWORD`, `SAP_CLIENT`) for a NetWeaver ABAP Developer Edition, S/4HANA dev, or BTP backend.
+  - [`lemaiwo/btp-sap-odata-to-mcp-server`](https://github.com/lemaiwo/btp-sap-odata-to-mcp-server). SAP OData via MCP. Clone + build, same shape as Mario's.
+  - See [`marianfoo/sap-ai-mcp-servers`](https://github.com/marianfoo/sap-ai-mcp-servers) for the curated index of community SAP MCP servers.
+- A SAP system the upstream MCP server can talk to, where the chosen upstream needs one. MDK uses your AI provider config rather than a SAP backend directly. The ABAP and OData servers need SAP backend creds.
 - Claude Code or any other MCP-capable client
 
 ## Three-step setup
@@ -46,51 +46,43 @@ pip install vaara
 
 ### 2. Replace your Claude Code MCP server entry with the Vaara proxy
 
-Before — Claude Code config pointing directly at the SAP MCP server:
+Before. Claude Code config pointing directly at the SAP MDK MCP server:
 
 ```json
 {
   "mcpServers": {
-    "sap-adt": {
+    "sap-mdk": {
       "command": "npx",
-      "args": ["-y", "@mario-andreschak/mcp-abap-abap-adt-api"],
-      "env": {
-        "SAP_URL": "https://your-sap-server:44300",
-        "SAP_USER": "YOUR_USER",
-        "SAP_PASSWORD": "YOUR_PASSWORD",
-        "SAP_CLIENT": "100"
-      }
+      "args": ["-y", "@sap/mdk-mcp-server", "--schema-version", "26.3"]
     }
   }
 }
 ```
 
-After — Claude Code config pointing at the Vaara proxy, which spawns the same SAP MCP server as a subprocess:
+After. Claude Code config pointing at the Vaara proxy, which spawns the same SAP MDK MCP server as a subprocess:
 
 ```json
 {
   "mcpServers": {
-    "sap-adt-via-vaara": {
+    "sap-mdk-via-vaara": {
       "command": "python",
       "args": [
         "-m", "vaara.integrations.mcp_proxy",
         "--upstream", "npx",
         "--upstream-arg", "-y",
-        "--upstream-arg", "@mario-andreschak/mcp-abap-abap-adt-api",
+        "--upstream-arg", "@sap/mdk-mcp-server",
+        "--upstream-arg", "--schema-version",
+        "--upstream-arg", "26.3",
         "--db", "/path/to/vaara_audit.db"
-      ],
-      "env": {
-        "SAP_URL": "https://your-sap-server:44300",
-        "SAP_USER": "YOUR_USER",
-        "SAP_PASSWORD": "YOUR_PASSWORD",
-        "SAP_CLIENT": "100"
-      }
+      ]
     }
   }
 }
 ```
 
-The proxy inherits the environment, so SAP credentials flow through to the upstream MCP server unchanged. The upstream sees the same env it would see in the direct setup.
+For the clone+build servers (`mario-andreschak/mcp-abap-abap-adt-api`, `lemaiwo/btp-sap-odata-to-mcp-server`), the shape is the same but the upstream becomes `node` with the path to the built `dist/index.js`. See [`claude_code_config.example.json`](claude_code_config.example.json) for the `_alternative_abap_adt` and `_alternative_btp_odata` blocks with their respective env vars.
+
+The proxy inherits the environment, so any upstream credentials in `env` flow through unchanged. The upstream sees the same env it would see in the direct setup.
 
 A full example config lives at [`claude_code_config.example.json`](claude_code_config.example.json) in this directory.
 

--- a/examples/sap-mcp-proxy-demo/claude_code_config.example.json
+++ b/examples/sap-mcp-proxy-demo/claude_code_config.example.json
@@ -1,16 +1,33 @@
 {
-  "_comment": "Example Claude Code MCP config showing the Vaara proxy in front of a community SAP ADT MCP server. Replace SAP_URL/USER/PASSWORD/CLIENT with your own. Copy the relevant block into your Claude Code mcp config.",
+  "_comment": "Example Claude Code MCP config showing the Vaara proxy in front of community SAP MCP servers. The primary block uses @sap/mdk-mcp-server (SAP's official Mobile Development Kit MCP server, published on npm). Two sibling _alternative_* blocks show the same proxy shape with mario-andreschak/mcp-abap-abap-adt-api (clone+build) and lemaiwo/btp-sap-odata-to-mcp-server (clone+build). Copy the relevant block into your Claude Code mcp config.",
 
   "mcpServers": {
-    "sap-adt-via-vaara": {
+    "sap-mdk-via-vaara": {
       "command": "python",
       "args": [
         "-m", "vaara.integrations.mcp_proxy",
         "--upstream", "npx",
         "--upstream-arg", "-y",
-        "--upstream-arg", "@mario-andreschak/mcp-abap-abap-adt-api",
+        "--upstream-arg", "@sap/mdk-mcp-server",
+        "--upstream-arg", "--schema-version",
+        "--upstream-arg", "26.3",
         "--db", "${HOME}/.vaara/sap_audit.db",
-        "--agent-id", "claude-code-sap"
+        "--agent-id", "claude-code-sap-mdk"
+      ],
+      "env": {
+        "SAP_UX_FIORI_TOOLS_DISABLE_TELEMETRY": "true"
+      }
+    },
+
+    "_alternative_abap_adt": {
+      "_comment": "mario-andreschak/mcp-abap-abap-adt-api is not published to npm. Clone the repo, run npm install and npm run build, then point --upstream-arg at the built dist/index.js. SAP_URL/USER/PASSWORD/CLIENT come from your SAP system (NetWeaver ABAP Developer Edition, S/4HANA dev, BTP free tier, etc.).",
+      "command": "python",
+      "args": [
+        "-m", "vaara.integrations.mcp_proxy",
+        "--upstream", "node",
+        "--upstream-arg", "/PATH_TO_YOUR/mcp-abap-abap-adt-api/dist/index.js",
+        "--db", "${HOME}/.vaara/sap_audit.db",
+        "--agent-id", "claude-code-sap-abap"
       ],
       "env": {
         "SAP_URL": "https://your-sap-server:44300",
@@ -22,12 +39,12 @@
     },
 
     "_alternative_btp_odata": {
-      "_comment": "If you use lemaiwo/btp-sap-odata-to-mcp-server instead, the same proxy pattern applies. Replace the upstream command with the one that server documents, and route env vars accordingly.",
+      "_comment": "lemaiwo/btp-sap-odata-to-mcp-server: clone and build per that repo's README, then point --upstream-arg at the built entry point.",
       "command": "python",
       "args": [
         "-m", "vaara.integrations.mcp_proxy",
         "--upstream", "node",
-        "--upstream-arg", "/path/to/btp-sap-odata-to-mcp-server/dist/index.js",
+        "--upstream-arg", "/PATH_TO_YOUR/btp-sap-odata-to-mcp-server/dist/index.js",
         "--db", "${HOME}/.vaara/sap_audit.db",
         "--agent-id", "claude-code-sap-odata"
       ]


### PR DESCRIPTION
## Summary

Two problems shipped in #100 and #101, both fixed here:

1. **README's MCP proxy code example referenced a fictional npm package** (`@sap/adt-mcp-server`). It also buried the MCP proxy block as a third-tier subsection under Framework integrations, despite v0.21.0 being the headline ship and having two worked demos.
2. **SAP demo's example config used a broken npx invocation** (`npx -y @mario-andreschak/mcp-abap-abap-adt-api` — that package isn't published on npm under that scope). Real install path is clone + build + run with `node /path/to/dist/index.js`.

## Changes

### README.md

- Removed the buried `### MCP proxy` block from under Framework integrations.
- Added a new top-level `## MCP proxy` section between TypeScript client and OVERT.
- One-line worked example uses [`@sap/mdk-mcp-server`](https://www.npmjs.com/package/@sap/mdk-mcp-server), SAP's official Mobile Development Kit MCP server (published on npm, version 0.3.7, Apache-2.0, verified).
- Cross-links to both demo folders.

### examples/sap-mcp-proxy-demo/claude_code_config.example.json

- Primary block (`sap-mdk-via-vaara`) now uses the real `@sap/mdk-mcp-server` npx invocation with `--schema-version 26.3`.
- Sibling `_alternative_abap_adt` block uses the real `node /PATH_TO_YOUR/mcp-abap-abap-adt-api/dist/index.js` invocation per Mario's README.
- Sibling `_alternative_btp_odata` block clarified as the same clone+build shape for lemaiwo's server.

### examples/sap-mcp-proxy-demo/README.md

- Prereqs section now names each upstream's actual install path (npm-published for MDK, clone+build for the others).
- Before/After config blocks now show the real MDK invocation.
- Body text now steers ABAP/OData readers to the alternative blocks in the example config.

## Verification

All upstream package/repo references verified live this session:

- `@sap/mdk-mcp-server` on npm: version 0.3.7, bin `mdk-mcp`, description "Model Context Protocol (MCP) server for AI-assisted development of MDK applications" — runnable via `npx -y @sap/mdk-mcp-server`.
- `SAP/mdk-mcp-server` repo: 31 stars, Apache-2.0.
- `mario-andreschak/mcp-abap-abap-adt-api` repo: 134 stars, MIT, install path confirmed from its README is `node /path/to/dist/index.js` after clone + npm install + npm run build.
- `@mario-andreschak/mcp-abap-abap-adt-api` on npm: not found (was the broken reference).

Docs-only. No code changes, no test changes.
