### PR TITLE
release: v0.22.0 (MCP proxy operator allowlist/denylist for tools/list and tools/call)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,46 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-20
+
+**Theme: MCP proxy operator-side tool filtering.** Adds two repeatable
+CLI flags to the MCP proxy that let an operator shape the upstream
+tool surface visible to the AI client: `--allow-tool NAME` (if any are
+given, only those tools pass through) and `--deny-tool NAME` (those
+tools are filtered, wins on overlap with allowlist). Filtered tools
+are dropped from `tools/list` responses before the client sees them,
+and any `tools/call` to a filtered tool is rejected at the proxy
+perimeter with an MCP `isError: true` payload (`decision: "FILTERED"`,
+`reason: "Tool filtered by operator policy"`) without forwarding to
+the upstream or invoking the risk pipeline.
+
 ### Added
-- MCP proxy: operator-side tool filtering at the perimeter.
-  `python -m vaara.integrations.mcp_proxy` now accepts repeatable
-  `--allow-tool NAME` and `--deny-tool NAME` flags. Filtered tools are
-  dropped from `tools/list` responses before the client sees them, and
-  any `tools/call` to a filtered tool is rejected at the proxy with an
-  MCP `isError: true` payload (`decision: "FILTERED"`,
-  `reason: "Tool filtered by operator policy"`) without forwarding
-  upstream or invoking the risk pipeline. Denylist wins on overlap with
-  allowlist. Backward compatible: no flags = current passthrough
-  behavior. Use case: hide write/delete tools (e.g. `delete_repository`,
-  `create_branch`) from an MCP client when the upstream server exposes
-  more capability than the deployment policy allows.
+- `src/vaara/integrations/mcp_proxy.py`: `VaaraMCPProxy.__init__`
+  accepts `allowlist: Optional[set[str]]` and `denylist:
+  Optional[set[str]]`. New `_tool_filtered(name)` helper applied to
+  both `tools/list` (filters the `result.tools` array) and
+  `tools/call` (returns a `FILTERED` block payload before the
+  pipeline runs).
+- CLI: `--allow-tool NAME` and `--deny-tool NAME`, both repeatable.
+  Backward compatible: no flags = passthrough.
+- `tests/test_integrations_mcp_proxy.py`: eight new tests covering
+  denylist drops, allowlist restricts, denylist-wins-on-overlap,
+  no-policy passthrough, filtered tools/call returns block, and
+  allowlisted tools/call still routes through the pipeline.
+
+### Verified
+- End-to-end smoke against `github/github-mcp-server` (42 real tools):
+  `--deny-tool` drops named entries from `tools/list` and rejects
+  matching `tools/call`; `--allow-tool` restricts `tools/list` to the
+  allowlist and routes allowlisted calls through the pipeline as
+  before; no-flag run is identical to v0.21.0 behaviour.
+
+### Use case
+Hide write/delete tools (e.g. `delete_file`, `merge_pull_request`)
+when the upstream MCP server exposes more capability than the
+deployment policy allows. The LLM client never learns the tool
+exists, which is materially different from instructing the model
+not to call it.
 
 ## [0.21.0] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ python -m vaara.integrations.mcp_proxy \
 
 Point your MCP client at the proxy instead of the upstream. The audit chain captures every tool call without changing client or upstream behavior. Distinct from `mcp_server`, which exposes Vaara itself as an MCP server for agents that consult Vaara as a tool.
 
+**Operator-side tool filtering** (since v0.22.0). The proxy accepts repeatable `--allow-tool NAME` and `--deny-tool NAME` flags. Filtered tools are dropped from `tools/list` responses before the client sees them and any matching `tools/call` is rejected at the proxy perimeter without contacting the upstream. Use this to hide write/delete tools (e.g. `delete_file`, `merge_pull_request`) when the upstream server exposes more capability than the deployment policy allows. Denylist wins on overlap with allowlist. No flags = passthrough.
+
 Worked examples with real upstream servers:
 
 - [`examples/github-mcp-proxy-demo/`](examples/github-mcp-proxy-demo/). Vaara in front of [`github/github-mcp-server`](https://github.com/github/github-mcp-server) (GitHub's official MCP server, MIT-licensed). End-to-end verified: real subprocess, 42 tools advertised, hash-chained audit trail recorded.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.21.0"
+version = "0.22.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -5,6 +5,11 @@ upstream MCP server (SAP ADT MCP, SAP Graph API MCP, SAP Cloud ALM MCP, any
 community-built MCP server). Forwards every request to the upstream, but
 routes ``tools/call`` through Vaara's interception pipeline first. Allowed
 calls flow through transparently. Blocked calls return an MCP tool error.
+
+Optional operator-side filtering (``--allow-tool``/``--deny-tool``): when set,
+the proxy filters the upstream's ``tools/list`` response before the client
+sees it, and rejects ``tools/call`` to a filtered tool at the perimeter with
+a ``FILTERED`` block payload, without contacting the upstream.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Adds operator-side tool filtering to the MCP proxy via two new repeatable CLI flags:

- `--allow-tool NAME`: if any are given, only those tools pass through.
- `--deny-tool NAME`: those tools are filtered. Denylist wins on overlap.

Effects:

- `tools/list` responses are filtered before the client sees them. The LLM never learns that hidden tools exist.
- `tools/call` to a filtered tool is rejected at the perimeter with an MCP `isError: true` payload (`decision: "FILTERED"`, `reason: "Tool filtered by operator policy"`). The upstream is not contacted and the risk pipeline is not invoked.

Backward compatible: no flags means current passthrough behavior. The pipeline-based interception path is unchanged for non-filtered tool calls.

## Why

The proxy already governs each `tools/call` through the risk pipeline at runtime. That covers the "is this specific call safe right now" question. It does not cover the "should the LLM ever see this tool at all" question.

Example: an MCP client running against `github/github-mcp-server` is exposed to write tools like `delete_repository`, `create_branch`, `merge_pull_request`. A deployment may want a read-only posture without depending on the LLM to refrain. Denying those tools at the perimeter shapes the LLM's tool surface to match operator policy, independent of the risk score.

Small surface, real policy-semantic upgrade: from "score every call" to "score every call AND control what's reachable."

## Usage

```
python -m vaara.integrations.mcp_proxy \
  --upstream /path/to/github-mcp-server \
  --upstream-arg stdio \
  --allow-tool search_repositories \
  --allow-tool get_pull_request \
  --allow-tool list_issues
```

Read-only against GitHub MCP. Anything else returns `Tool filtered by operator policy` on call, and never appears in `tools/list` to begin with.

## Test plan

- [x] `pytest tests/test_integrations_mcp_proxy.py` — 14 tests pass (8 new, covering denylist drops, allowlist restricts, denylist-wins-on-overlap, no-policy passthrough, filtered tools/call returns block, allowlist tools/call still pipelines)
- [x] Full suite: 726 passed, 12 skipped, no regressions
- [ ] Smoke against real `github-mcp-server` with `--deny-tool delete_repository` and verify `tools/list` and `tools/call` both reject (deferred to follow-up unless reviewer wants it pre-merge)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.22.0

* **New Features**
  * Added operator-side MCP tool filtering with repeatable `--allow-tool` and `--deny-tool` CLI flags to control tool exposure
  * Filtered tools are removed from tool lists and requests targeting them are rejected at the proxy perimeter before reaching upstream
  * Denylist takes precedence when rules overlap; passthrough behavior maintained when no filters are specified

* **Documentation**
  * Updated CHANGELOG and README with new tool filtering feature documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->