### PR TITLE
release(v0.23.1): restore NPM_TOKEN env on npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,5 +118,7 @@ jobs:
       - name: Test
         run: node --test test/*.test.mjs
 
-      - name: Publish to npm with provenance (trusted publishing via OIDC)
+      - name: Publish to npm with provenance
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-05-20
+
+**Theme: CI fix.** The v0.23.0 release workflow flipped `npm publish` to
+OIDC-only trusted publishing, but the npmjs.com side of the
+`@vaara/client` package was not yet configured for a trusted publisher.
+The npm leg of the v0.23.0 release therefore failed with a 404 on PUT,
+even though PyPI shipped cleanly and the GitHub Release was signed and
+attached. This patch restores the token + provenance model that v0.22.0
+used.
+
+### Fixed
+- `.github/workflows/release.yml`: re-add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`
+  env on the npm publish step. The `--provenance` flag is preserved, so
+  the npm package still ships with a Sigstore-attested provenance
+  statement from the GitHub Actions OIDC token. Auth flows via the
+  token, provenance flows via OIDC. OIDC-only publishing can return
+  later once trusted publishing is configured on the npm package
+  settings page.
+
+### Unchanged
+- Library code, public API, audit chain format, OVERT envelope schema,
+  MCP proxy behavior. v0.23.1 is a pure CI fix.
+
 ## [0.23.0] - 2026-05-20
 
 **Theme: MCP proxy closes the surface-coverage gap.** Resources and

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.23.0"
+version = "0.23.1"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## Summary

v0.23.1 is a pure CI fix release. The v0.23.0 release workflow failed on the npm publish step because commit `1964893` flipped to OIDC-only trusted publishing, but the npmjs.com side of the `@vaara/client` package is still token-only. PyPI shipped cleanly and the GitHub Release was signed and attached for v0.23.0, but `@vaara/client@0.23.0` never reached the npm registry.

This patch restores the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env on the npm publish step, alongside the `--provenance` flag. Auth flows via the token, provenance flows via GitHub Actions OIDC. Same model that shipped v0.22.0 successfully.

No library code, public API, audit chain, OVERT envelope, or MCP proxy behavior changes. Pure release infrastructure fix.

## Test plan

- [ ] Required CI checks pass on this PR (tests 3.10-3.13, Pre-release smoke, Analyze Python, Analyze Actions, eval)
- [ ] CodeQL clean
- [ ] Squash-merge produces GitHub-signed commit on `main`
- [ ] Tag `v0.23.1`, push triggers release workflow
- [ ] PyPI publishes `vaara 0.23.1`
- [ ] npm publishes `@vaara/client@0.23.1` with provenance attestation
- [ ] GitHub Release signed and attached
