### PR TITLE
release(v0.24.0): MCP proxy emits OVERT 1.0 Base Envelopes per interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-05-20
+
+**Theme: MCP proxy emits OVERT 1.0 Base Envelopes per interaction.** With
+the v0.21-v0.23 surface coverage in place across tools, resources, and
+prompts, the next step is making each interaction independently verifiable
+by a regulator or auditor. The MCP proxy can now sign every governed
+interaction as an OVERT 1.0 Protocol Profile 1.0 Base Envelope and write
+it to disk in canonical CBOR, ready for `vaara overt verify` or any other
+conformant OVERT verifier. The OVERT substrate (emitter, verifier, schema,
+CLI) shipped in earlier releases. This release wires the emitter into the
+MCP proxy as the first concrete production-shape OSS OVERT 1.0 integration.
+
+### Added
+- `vaara-mcp-proxy` learns three new flags: `--overt-signing-key PATH`
+  (Ed25519 PEM private key), `--overt-operator-key PATH` (raw bytes for
+  the HMAC request_commitment, minimum 16 bytes; also accepts
+  `VAARA_OVERT_OPERATOR_KEY_HEX` from the environment), and
+  `--overt-receipts-dir DIR` (where canonical-CBOR envelopes land). All
+  three are off unless set. When set, every allowed and every
+  perimeter-blocked `tools/call`, `resources/read`, and `prompts/get`
+  produces one Base Envelope on disk.
+- `vaara.integrations._mcp_overt`: internal `OVERTReceiptEmitter` with
+  per-process monotonic counter under a lock, per-process
+  `arbiter_instance_identifier`, `encoder_binary_identity` derived from
+  the Vaara version plus SHA-256 of the canonical perimeter config
+  (allow/deny lists across all three primitives), and a pinned
+  `pubkey.bin` written into the receipts directory on emitter start.
+- Receipt layout: `DIR/{nanosecond_timestamp}-{counter:010d}.cbor` plus
+  `DIR/pubkey.bin` (32 raw Ed25519 public-key bytes).
+- `non_content_metadata` carries structural fields only: action class
+  (`mcp.tool.call` / `mcp.resource.read` / `mcp.prompt.get`),
+  tool/resource/prompt identifier, decision, reason, agent_id, action_id.
+  Request content never leaves the operator environment. Only its
+  HMAC-SHA256 commitment crosses the trust boundary, per OVERT Annex B.4.
+- Tests: `tests/test_integrations_mcp_proxy_overt.py`. Coverage includes
+  emitter-disabled-by-default, one envelope per call site (allowed and
+  filtered), monotonic counter strictly increases, envelopes verify
+  under the pinned public key via `verify_base_envelope`, and the CLI
+  rejects misconfigurations.
+
+### Unchanged
+- Pipeline, audit chain, perimeter allow/deny semantics, MCP wire format.
+  When `--overt-signing-key` is absent, proxy behavior is byte-identical
+  to v0.23.1.
+- OVERT envelope schema (closed 9-field Annex B.6) and `vaara overt
+  verify` semantics. The verifier reads canonical-CBOR files one at a
+  time, as it did since v0.17.0.
+
 ## [0.23.1] - 2026-05-20
 
 **Theme: CI fix.** The v0.23.0 release workflow flipped `npm publish` to

--- a/README.md
+++ b/README.md
@@ -168,6 +168,30 @@ Point your MCP client at the proxy instead of the upstream. The audit chain capt
 
 **Resources and prompts coverage** (since v0.23.0). The same perimeter shape extends to MCP's other two primitives. `--allow-resource URI` / `--deny-resource URI` gate `resources/list` and `resources/read`. `--allow-prompt NAME` / `--deny-prompt NAME` gate `prompts/list` and `prompts/get`. Every allowed `resources/read` and `prompts/get` writes a request+decision audit pair to the hash chain so a regulator can reconstruct exactly which resources the agent read and which prompts it retrieved. Resource reads and prompt gets are read-oriented MCP surfaces. They do not run through the risk scorer. The operator perimeter is the gate, and the audit chain captures the evidence.
 
+**OVERT 1.0 envelopes per interaction** (since v0.24.0). Off by default. When you pass `--overt-signing-key KEY.pem`, `--overt-operator-key OPKEY.bin`, and `--overt-receipts-dir DIR/`, the proxy writes one OVERT 1.0 Protocol Profile 1.0 Base Envelope (canonical CBOR, Ed25519, closed 9-field schema) per governed interaction into `DIR/{nanosecond_timestamp}-{counter:010d}.cbor`. Covers all four states: allowed `tools/call`, blocked `tools/call`, perimeter-filtered call, and perimeter-filtered `resources/read` / `prompts/get`. The arbiter public key is pinned alongside as `pubkey.bin`. Each envelope verifies offline under `vaara overt verify` against any conformant verifier. Three-step recipe:
+
+```bash
+# 1. Generate an Ed25519 signing key (evaluation/demo; for production use a KMS or HSM, see docs/signing-keys.md).
+vaara keygen --dev --out signing.pem
+
+# 2. Mint an operator HMAC key (>= 16 raw bytes). Used for request_commitment per OVERT Annex B.4.
+head -c 32 /dev/urandom > op.key
+
+# 3. Run the proxy with OVERT emission turned on.
+python -m vaara.integrations.mcp_proxy \
+  --upstream npx --upstream-arg -y --upstream-arg @sap/mdk-mcp-server \
+  --overt-signing-key signing.pem \
+  --overt-operator-key op.key \
+  --overt-receipts-dir ./overt_receipts
+
+# Each interaction now produces a Provisional Receipt:
+vaara overt verify ./overt_receipts/1779309684224332669-0000000001.cbor \
+  --pubkey-file ./overt_receipts/pubkey.bin
+# → {"valid": true, "monotonic_counter": 1, ...}
+```
+
+`non_content_metadata` carries structural fields only (action class, tool/resource/prompt identifier, decision, reason, agent_id, action_id). The request content itself never leaves the operator environment. Only its HMAC-SHA256 commitment crosses the trust boundary. The monotonic counter advances strictly across the whole proxy process so gaps are detectable. Emission failure is logged and swallowed: attestation problems must not block legitimate upstream traffic.
+
 Worked examples with real upstream servers:
 
 - [`examples/github-mcp-proxy-demo/`](examples/github-mcp-proxy-demo/). Vaara in front of [`github/github-mcp-server`](https://github.com/github/github-mcp-server) (GitHub's official MCP server, MIT-licensed). End-to-end verified: real subprocess, 42 tools advertised, hash-chained audit trail recorded.
@@ -191,7 +215,7 @@ from vaara.attestation.overt import emit_base_envelope, make_request_commitment,
 envelope = emit_base_envelope(
     signing_key=key,
     request_commitment=make_request_commitment(payload, operator_key=op_key),
-    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.23.0", policy_hash=ph),
+    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.24.0", policy_hash=ph),
     non_content_metadata={"action_class": "tx.transfer", "decision": "escalate"},
     monotonic_counter=42,
     arbiter_instance_identifier=uuid_bytes,

--- a/clients/ts/package-lock.json
+++ b/clients/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vaara/client",
-  "version": "0.17.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vaara/client",
-      "version": "0.17.0",
+      "version": "0.24.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.0"

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.23.1"
+version = "0.24.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.23.1"
+__version__ = "0.24.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/integrations/_mcp_overt.py
+++ b/src/vaara/integrations/_mcp_overt.py
@@ -1,0 +1,233 @@
+"""OVERT 1.0 Base Envelope emission for the Vaara MCP proxy.
+
+Internal helper that turns each governed MCP interaction (``tools/call``,
+``resources/read``, ``prompts/get`` — both allowed and perimeter-blocked)
+into a signed Protocol Profile 1.0 Annex B.6 Base Envelope written to a
+receipts directory. ``vaara overt verify`` consumes those files one by one.
+
+Off unless the operator wires the proxy with a signing key, operator HMAC
+key, and receipts directory. With none of those set, the proxy behaves as
+it did pre-v0.24.0 — no envelopes, no extra crypto, no extra disk writes.
+
+The receipts directory layout, per envelope:
+    {nanosecond_timestamp}-{counter:010d}.cbor
+plus a one-time ``pubkey.bin`` (32 raw Ed25519 public-key bytes) so the
+auditor knows which key to verify against.
+
+Internal module. Public surface is the ``--overt-*`` flags on ``vaara-mcp-proxy``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from vaara import __version__ as _VAARA_VERSION
+
+logger = logging.getLogger(__name__)
+
+
+class OVERTConfigError(RuntimeError):
+    """Operator-side OVERT configuration is incomplete or unusable."""
+
+
+class OVERTReceiptEmitter:
+    """Per-proxy OVERT 1.0 Base Envelope emitter.
+
+    One instance per proxy process. Owns the signing key, operator HMAC
+    key, monotonic counter, and arbiter-instance identifier. Thread-safe:
+    emission acquires a lock around counter increment and file write.
+    """
+
+    def __init__(
+        self,
+        *,
+        signing_key: Any,
+        operator_key: bytes,
+        receipts_dir: Path,
+        policy_hash: bytes,
+        arbiter_version: str = f"vaara/{_VAARA_VERSION}",
+    ) -> None:
+        from vaara.attestation.overt import encoder_binary_identity
+
+        self._signing_key = signing_key
+        self._operator_key = bytes(operator_key)
+        self._receipts_dir = Path(receipts_dir)
+        self._receipts_dir.mkdir(parents=True, exist_ok=True)
+        self._encoder_identity = encoder_binary_identity(
+            arbiter_version=arbiter_version, policy_hash=policy_hash,
+        )
+        self._arbiter_instance = uuid.uuid4().bytes
+        self._counter = 0
+        self._lock = threading.Lock()
+        self._write_pubkey_pin()
+
+    @property
+    def receipts_dir(self) -> Path:
+        return self._receipts_dir
+
+    @property
+    def arbiter_instance_identifier(self) -> bytes:
+        return self._arbiter_instance
+
+    def emit(self, *, request_payload: bytes, non_content_metadata: dict) -> Any:
+        """Build, sign, and persist one Base Envelope.
+
+        Returns the BaseEnvelope. The on-disk artifact is a canonical-CBOR
+        file inside ``receipts_dir`` named for its timestamp and counter.
+        """
+        from vaara.attestation import envelope_to_canonical_cbor
+        from vaara.attestation.overt import (
+            emit_base_envelope,
+            make_request_commitment,
+        )
+
+        commitment = make_request_commitment(
+            request_payload, operator_key=self._operator_key,
+        )
+        with self._lock:
+            self._counter += 1
+            counter = self._counter
+            envelope = emit_base_envelope(
+                signing_key=self._signing_key,
+                request_commitment=commitment,
+                encoder_binary_identity=self._encoder_identity,
+                non_content_metadata=non_content_metadata,
+                monotonic_counter=counter,
+                arbiter_instance_identifier=self._arbiter_instance,
+            )
+            cbor_bytes = envelope_to_canonical_cbor(envelope)
+            filename = (
+                f"{envelope.nanosecond_timestamp}-"
+                f"{envelope.monotonic_counter:010d}.cbor"
+            )
+            (self._receipts_dir / filename).write_bytes(cbor_bytes)
+        return envelope
+
+    def _write_pubkey_pin(self) -> None:
+        from cryptography.hazmat.primitives import serialization
+        pub = self._signing_key.public_key()
+        try:
+            pub_raw = pub.public_bytes_raw()
+        except AttributeError:
+            pub_raw = pub.public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        (self._receipts_dir / "pubkey.bin").write_bytes(pub_raw)
+
+
+def policy_hash_from_perimeter(
+    *,
+    tool_allow: Optional[set[str]],
+    tool_deny: set[str],
+    resource_allow: Optional[set[str]],
+    resource_deny: set[str],
+    prompt_allow: Optional[set[str]],
+    prompt_deny: set[str],
+) -> bytes:
+    """SHA-256 over canonical JSON of the operator perimeter configuration.
+
+    Stable across processes given identical perimeter config. The hash
+    flows into ``encoder_binary_identity`` so a regulator can detect any
+    silent perimeter change between two envelope batches signed by the
+    same arbiter instance.
+    """
+    config = {
+        "tool_allow": sorted(tool_allow) if tool_allow else None,
+        "tool_deny": sorted(tool_deny),
+        "resource_allow": sorted(resource_allow) if resource_allow else None,
+        "resource_deny": sorted(resource_deny),
+        "prompt_allow": sorted(prompt_allow) if prompt_allow else None,
+        "prompt_deny": sorted(prompt_deny),
+    }
+    payload = json.dumps(config, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).digest()
+
+
+def build_emitter(
+    *,
+    signing_key_path: Path,
+    operator_key_path: Optional[Path],
+    operator_key_hex: Optional[str],
+    receipts_dir: Path,
+    policy_hash: bytes,
+) -> OVERTReceiptEmitter:
+    """Load the Ed25519 PEM private key and HMAC operator key, return an emitter.
+
+    Raises OVERTConfigError if either key is missing or unusable, or if
+    the attestation extra is not installed.
+    """
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+        )
+    except ImportError as exc:
+        raise OVERTConfigError(
+            "vaara-mcp-proxy --overt-* flags require the attestation extra. "
+            "Install with: pip install 'vaara[attestation]'"
+        ) from exc
+
+    signing_key_path = Path(signing_key_path).expanduser()
+    if not signing_key_path.is_file():
+        raise OVERTConfigError(
+            f"--overt-signing-key file not found: {signing_key_path}"
+        )
+    try:
+        key = serialization.load_pem_private_key(
+            signing_key_path.read_bytes(), password=None,
+        )
+    except Exception as exc:
+        raise OVERTConfigError(
+            f"--overt-signing-key is not a usable PEM-encoded private key: {exc}"
+        ) from exc
+    if not isinstance(key, Ed25519PrivateKey):
+        raise OVERTConfigError(
+            "--overt-signing-key must be an Ed25519 private key "
+            "(vaara keygen --dev produces one)"
+        )
+
+    operator_key = _load_operator_key(operator_key_path, operator_key_hex)
+
+    return OVERTReceiptEmitter(
+        signing_key=key,
+        operator_key=operator_key,
+        receipts_dir=Path(receipts_dir).expanduser(),
+        policy_hash=policy_hash,
+    )
+
+
+def _load_operator_key(
+    path: Optional[Path], hex_value: Optional[str],
+) -> bytes:
+    if path is not None:
+        p = Path(path).expanduser()
+        if not p.is_file():
+            raise OVERTConfigError(
+                f"--overt-operator-key file not found: {p}"
+            )
+        data = p.read_bytes()
+    elif hex_value is not None:
+        try:
+            data = bytes.fromhex(hex_value.strip())
+        except ValueError as exc:
+            raise OVERTConfigError(
+                f"VAARA_OVERT_OPERATOR_KEY_HEX is not valid hex: {exc}"
+            ) from exc
+    else:
+        raise OVERTConfigError(
+            "OVERT emission requires an operator HMAC key. Pass "
+            "--overt-operator-key PATH (raw key bytes) or set "
+            "VAARA_OVERT_OPERATOR_KEY_HEX in the environment."
+        )
+    if len(data) < 16:
+        raise OVERTConfigError(
+            f"operator HMAC key must be at least 16 bytes; got {len(data)}"
+        )
+    return data

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -36,6 +36,12 @@ from typing import Any, Optional
 from vaara import __version__ as _VAARA_VERSION
 from vaara.audit.sqlite_backend import SQLiteAuditBackend
 from vaara.audit.trail import AuditTrail
+from vaara.integrations._mcp_overt import (
+    OVERTConfigError,
+    OVERTReceiptEmitter,
+    build_emitter,
+    policy_hash_from_perimeter,
+)
 from vaara.integrations._mcp_upstream import (
     ProxyError, UpstreamMCPClient, strict_json_dumps,
 )
@@ -62,6 +68,7 @@ class VaaraMCPProxy:
         resource_denylist: Optional[set[str]] = None,
         prompt_allowlist: Optional[set[str]] = None,
         prompt_denylist: Optional[set[str]] = None,
+        overt_emitter: Optional[OVERTReceiptEmitter] = None,
     ) -> None:
         if pipeline is not None:
             self._pipeline = pipeline
@@ -90,6 +97,7 @@ class VaaraMCPProxy:
             set(prompt_denylist) if prompt_denylist else set()
         )
         self._stdout_lock = threading.Lock()
+        self._overt = overt_emitter
         self._upstream = UpstreamMCPClient(
             command=upstream_command,
             on_notification=self._forward_notification_to_client,
@@ -250,6 +258,15 @@ class VaaraMCPProxy:
                 "decision": "FILTERED",
                 "tool": tool_name,
             }
+            self._overt_emit(
+                surface="mcp.tool.call",
+                identifier=tool_name,
+                identifier_field="tool_name",
+                request_obj={"tool": tool_name, "arguments": arguments},
+                decision="FILTERED",
+                reason="Tool filtered by operator policy",
+                extra={"agent_id": self._agent_id_default},
+            )
             return {
                 "jsonrpc": "2.0", "id": request.get("id"),
                 "result": {
@@ -268,12 +285,26 @@ class VaaraMCPProxy:
             agent_id=agent_id, tool_name=tool_name, parameters=arguments,
         )
         if not result.allowed:
+            decision = getattr(result, "decision", None) or "DENY"
+            reason = getattr(result, "reason", None) or "Blocked by Vaara policy"
             block_payload = {
                 "vaara_blocked": True,
-                "reason": getattr(result, "reason", None) or "Blocked by Vaara policy",
-                "decision": getattr(result, "decision", None),
+                "reason": reason,
+                "decision": decision,
                 "action_id": getattr(result, "action_id", None),
             }
+            self._overt_emit(
+                surface="mcp.tool.call",
+                identifier=tool_name,
+                identifier_field="tool_name",
+                request_obj={"tool": tool_name, "arguments": arguments},
+                decision=str(decision),
+                reason=reason,
+                extra={
+                    "agent_id": agent_id,
+                    "action_id": getattr(result, "action_id", None) or "",
+                },
+            )
             return {
                 "jsonrpc": "2.0", "id": request.get("id"),
                 "result": {
@@ -289,6 +320,19 @@ class VaaraMCPProxy:
             )
         except Exception:
             logger.exception("report_outcome failed for action_id=%s", result.action_id)
+        self._overt_emit(
+            surface="mcp.tool.call",
+            identifier=tool_name,
+            identifier_field="tool_name",
+            request_obj={"tool": tool_name, "arguments": arguments},
+            decision="allow",
+            reason="allowed by Vaara policy",
+            extra={
+                "agent_id": agent_id,
+                "action_id": getattr(result, "action_id", None) or "",
+                "outcome_severity": int(outcome_severity),
+            },
+        )
         return upstream_response
 
     def _handle_resources_read(self, request: dict) -> dict:
@@ -301,6 +345,15 @@ class VaaraMCPProxy:
         if self._resource_filtered(uri):
             logger.warning(
                 "resources/read rejected at perimeter (operator filter): %s", uri,
+            )
+            self._overt_emit(
+                surface="mcp.resource.read",
+                identifier=uri,
+                identifier_field="uri",
+                request_obj={"uri": uri},
+                decision="FILTERED",
+                reason="Resource filtered by operator policy",
+                extra={"agent_id": self._agent_id_default},
             )
             return self._perimeter_block(
                 request, code=-32000,
@@ -319,6 +372,15 @@ class VaaraMCPProxy:
             decision="allow",
             reason="resource within operator perimeter",
         )
+        self._overt_emit(
+            surface="mcp.resource.read",
+            identifier=uri,
+            identifier_field="uri",
+            request_obj={"uri": uri},
+            decision="allow",
+            reason="resource within operator perimeter",
+            extra={"agent_id": self._agent_id_default},
+        )
         return self._upstream.request(request)
 
     def _handle_prompts_get(self, request: dict) -> dict:
@@ -334,6 +396,15 @@ class VaaraMCPProxy:
         if self._prompt_filtered(name):
             logger.warning(
                 "prompts/get rejected at perimeter (operator filter): %s", name,
+            )
+            self._overt_emit(
+                surface="mcp.prompt.get",
+                identifier=name,
+                identifier_field="prompt_name",
+                request_obj={"name": name, "arguments": arguments},
+                decision="FILTERED",
+                reason="Prompt filtered by operator policy",
+                extra={"agent_id": self._agent_id_default},
             )
             return self._perimeter_block(
                 request, code=-32000,
@@ -351,6 +422,15 @@ class VaaraMCPProxy:
             parameters={"name": name, "arguments": arguments},
             decision="allow",
             reason="prompt within operator perimeter",
+        )
+        self._overt_emit(
+            surface="mcp.prompt.get",
+            identifier=name,
+            identifier_field="prompt_name",
+            request_obj={"name": name, "arguments": arguments},
+            decision="allow",
+            reason="prompt within operator perimeter",
+            extra={"agent_id": self._agent_id_default},
         )
         return self._upstream.request(request)
 
@@ -414,6 +494,44 @@ class VaaraMCPProxy:
         except Exception:
             logger.exception("Failed to record perimeter audit for %s", tool_name)
 
+    def _overt_emit(
+        self,
+        *,
+        surface: str,
+        identifier: str,
+        identifier_field: str,
+        request_obj: dict,
+        decision: str,
+        reason: str,
+        extra: Optional[dict] = None,
+    ) -> None:
+        """Emit one OVERT Base Envelope for an MCP interaction.
+
+        No-op when no emitter is configured. Failures are logged and
+        swallowed: an attestation-side failure must not block legitimate
+        upstream traffic, mirroring the perimeter-audit rule.
+        """
+        if self._overt is None:
+            return
+        try:
+            non_content_metadata = {
+                "action_class": surface,
+                identifier_field: identifier,
+                "decision": decision,
+                "reason": reason,
+            }
+            if extra:
+                non_content_metadata.update(extra)
+            request_payload = strict_json_dumps(
+                request_obj, sort_keys=True,
+            ).encode("utf-8")
+            self._overt.emit(
+                request_payload=request_payload,
+                non_content_metadata=non_content_metadata,
+            )
+        except Exception:
+            logger.exception("OVERT envelope emission failed for %s", surface)
+
     @staticmethod
     def _severity_from_response(response: dict) -> float:
         # Protocol/tool errors → 1.0 (failure signal). Clean success → 0.0.
@@ -476,24 +594,92 @@ def main(argv: Optional[list[str]] = None) -> None:
     parser.add_argument("--deny-prompt", action="append", default=[], dest="deny_prompts",
                         help="Filter this prompt name from prompts/list and reject any "
                              "prompts/get to it (repeatable). Denylist wins on overlap.")
+    parser.add_argument("--overt-signing-key", type=Path, default=None,
+                        help="Ed25519 PEM private key used to sign OVERT 1.0 Base "
+                             "Envelopes for every governed MCP interaction. Off when "
+                             "absent. Generate one with: vaara keygen --dev --out PATH.")
+    parser.add_argument("--overt-operator-key", type=Path, default=None,
+                        help="Raw bytes file holding the operator HMAC key for OVERT "
+                             "request_commitment (min 16 bytes). Required when "
+                             "--overt-signing-key is set, unless "
+                             "VAARA_OVERT_OPERATOR_KEY_HEX is set in the environment.")
+    parser.add_argument("--overt-receipts-dir", type=Path, default=None,
+                        help="Directory to write OVERT Base Envelopes into "
+                             "(one canonical-CBOR file per envelope). Required when "
+                             "--overt-signing-key is set.")
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(name)s %(levelname)s %(message)s",
                         stream=sys.stderr)
+    tool_allow = set(args.allow_tools) if args.allow_tools else None
+    tool_deny = set(args.deny_tools) if args.deny_tools else set()
+    resource_allow = set(args.allow_resources) if args.allow_resources else None
+    resource_deny = set(args.deny_resources) if args.deny_resources else set()
+    prompt_allow = set(args.allow_prompts) if args.allow_prompts else None
+    prompt_deny = set(args.deny_prompts) if args.deny_prompts else set()
+
+    overt_emitter = _build_overt_emitter_from_args(
+        args,
+        policy_hash=policy_hash_from_perimeter(
+            tool_allow=tool_allow, tool_deny=tool_deny,
+            resource_allow=resource_allow, resource_deny=resource_deny,
+            prompt_allow=prompt_allow, prompt_deny=prompt_deny,
+        ),
+    )
+
     proxy = VaaraMCPProxy(
         upstream_command=[args.upstream, *args.upstream_args],
         db_path=args.db, agent_id_default=args.agent_id,
-        allowlist=set(args.allow_tools) if args.allow_tools else None,
-        denylist=set(args.deny_tools) if args.deny_tools else None,
-        resource_allowlist=set(args.allow_resources) if args.allow_resources else None,
-        resource_denylist=set(args.deny_resources) if args.deny_resources else None,
-        prompt_allowlist=set(args.allow_prompts) if args.allow_prompts else None,
-        prompt_denylist=set(args.deny_prompts) if args.deny_prompts else None,
+        allowlist=tool_allow,
+        denylist=tool_deny if tool_deny else None,
+        resource_allowlist=resource_allow,
+        resource_denylist=resource_deny if resource_deny else None,
+        prompt_allowlist=prompt_allow,
+        prompt_denylist=prompt_deny if prompt_deny else None,
+        overt_emitter=overt_emitter,
     )
     try:
         proxy.run()
     finally:
         proxy.close()
+
+
+def _build_overt_emitter_from_args(
+    args: argparse.Namespace, *, policy_hash: bytes,
+) -> Optional[OVERTReceiptEmitter]:
+    """Construct the OVERT emitter from CLI args, or None if not configured.
+
+    Off when --overt-signing-key is absent. If signing-key is set, both
+    --overt-receipts-dir and an operator HMAC key (file or env var) must
+    also be present, or the proxy refuses to start.
+    """
+    if args.overt_signing_key is None:
+        if args.overt_receipts_dir is not None or args.overt_operator_key is not None:
+            print(
+                "vaara-mcp-proxy: --overt-receipts-dir and --overt-operator-key "
+                "have no effect without --overt-signing-key. Exiting.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        return None
+    if args.overt_receipts_dir is None:
+        print(
+            "vaara-mcp-proxy: --overt-signing-key requires --overt-receipts-dir.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    operator_key_hex = os.environ.get("VAARA_OVERT_OPERATOR_KEY_HEX")
+    try:
+        return build_emitter(
+            signing_key_path=args.overt_signing_key,
+            operator_key_path=args.overt_operator_key,
+            operator_key_hex=operator_key_hex,
+            receipts_dir=args.overt_receipts_dir,
+            policy_hash=policy_hash,
+        )
+    except OVERTConfigError as exc:
+        print(f"vaara-mcp-proxy: {exc}", file=sys.stderr)
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/tests/test_integrations_mcp_proxy_overt.py
+++ b/tests/test_integrations_mcp_proxy_overt.py
@@ -1,0 +1,264 @@
+"""OVERT 1.0 Base Envelope emission through the Vaara MCP proxy.
+
+Smoke-level: with a real emitter wired into the proxy, exercise each
+governed call site (allowed, blocked, perimeter-filtered) and confirm one
+canonical-CBOR envelope per interaction lands in the receipts directory,
+the monotonic counter advances strictly, and each envelope verifies under
+the pinned public key.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+cbor2 = pytest.importorskip("cbor2")
+pytest.importorskip("cryptography")
+
+
+@dataclass
+class _StubInterceptResult:
+    allowed: bool
+    action_id: str = "stub-action-id"
+    reason: str = ""
+    decision: str = "ALLOW"
+
+
+@pytest.fixture
+def signing_key_pem(tmp_path):
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+
+    key = Ed25519PrivateKey.generate()
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    path = tmp_path / "signing.pem"
+    path.write_bytes(pem)
+    pub_raw = key.public_key().public_bytes_raw()
+    return path, pub_raw
+
+
+@pytest.fixture
+def operator_key_path(tmp_path):
+    p = tmp_path / "op.key"
+    p.write_bytes(b"\x11" * 32)
+    return p
+
+
+@pytest.fixture
+def emitter(signing_key_pem, operator_key_path, tmp_path):
+    from vaara.integrations._mcp_overt import build_emitter
+
+    receipts = tmp_path / "receipts"
+    sk_path, _ = signing_key_pem
+    return build_emitter(
+        signing_key_path=sk_path,
+        operator_key_path=operator_key_path,
+        operator_key_hex=None,
+        receipts_dir=receipts,
+        policy_hash=b"\xab" * 32,
+    )
+
+
+def _make_proxy(monkeypatch, *, emitter, **kwargs):
+    from vaara.integrations import mcp_proxy
+
+    monkeypatch.setattr(mcp_proxy, "UpstreamMCPClient", MagicMock())
+    pipeline = MagicMock()
+    p = mcp_proxy.VaaraMCPProxy(
+        upstream_command=["echo"], pipeline=pipeline,
+        overt_emitter=emitter, **kwargs,
+    )
+    p._upstream = MagicMock()
+    return p, pipeline
+
+
+def _envelopes(receipts_dir: Path) -> list[dict]:
+    files = sorted(p for p in receipts_dir.iterdir() if p.suffix == ".cbor")
+    return [cbor2.loads(f.read_bytes()) for f in files]
+
+
+def test_emitter_disabled_by_default(monkeypatch, tmp_path):
+    from vaara.integrations import mcp_proxy
+    monkeypatch.setattr(mcp_proxy, "UpstreamMCPClient", MagicMock())
+    pipeline = MagicMock()
+    p = mcp_proxy.VaaraMCPProxy(upstream_command=["echo"], pipeline=pipeline)
+    p._upstream = MagicMock()
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="a-1")
+    p._upstream.request.return_value = {"jsonrpc": "2.0", "id": 1, "result": {}}
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "any", "arguments": {}},
+    })
+
+
+def test_allowed_tool_call_writes_one_envelope(monkeypatch, emitter):
+    p, pipeline = _make_proxy(monkeypatch, emitter=emitter)
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="a-1")
+    p._upstream.request.return_value = {"jsonrpc": "2.0", "id": 1, "result": {}}
+
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "sap.adt.read", "arguments": {"object": "ZCL"}},
+    })
+
+    envs = _envelopes(emitter.receipts_dir)
+    assert len(envs) == 1
+    meta = envs[0]["non_content_metadata"]
+    assert meta["action_class"] == "mcp.tool.call"
+    assert meta["tool_name"] == "sap.adt.read"
+    assert meta["decision"] == "allow"
+    assert meta["action_id"] == "a-1"
+
+
+def test_blocked_tool_call_still_writes_envelope(monkeypatch, emitter):
+    p, pipeline = _make_proxy(monkeypatch, emitter=emitter)
+    pipeline.intercept.return_value = _StubInterceptResult(
+        allowed=False, decision="DENY", reason="too risky", action_id="b-2",
+    )
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": {"name": "sap.abap.write", "arguments": {"path": "/etc/x"}},
+    })
+    envs = _envelopes(emitter.receipts_dir)
+    assert len(envs) == 1
+    meta = envs[0]["non_content_metadata"]
+    assert meta["decision"] == "DENY"
+    assert meta["reason"] == "too risky"
+
+
+def test_perimeter_filtered_tool_writes_envelope(monkeypatch, emitter):
+    p, _ = _make_proxy(
+        monkeypatch, emitter=emitter, denylist={"delete_repository"},
+    )
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+        "params": {"name": "delete_repository", "arguments": {}},
+    })
+    envs = _envelopes(emitter.receipts_dir)
+    assert len(envs) == 1
+    assert envs[0]["non_content_metadata"]["decision"] == "FILTERED"
+
+
+def test_resources_read_emits_envelopes_allowed_and_filtered(monkeypatch, emitter):
+    p, _ = _make_proxy(
+        monkeypatch, emitter=emitter,
+        resource_denylist={"file:///etc/secret"},
+    )
+    p._upstream.request.return_value = {"jsonrpc": "2.0", "id": 1, "result": {}}
+    p._handle_resources_read({
+        "jsonrpc": "2.0", "id": 1, "method": "resources/read",
+        "params": {"uri": "file:///etc/hosts"},
+    })
+    p._handle_resources_read({
+        "jsonrpc": "2.0", "id": 2, "method": "resources/read",
+        "params": {"uri": "file:///etc/secret"},
+    })
+    envs = _envelopes(emitter.receipts_dir)
+    assert len(envs) == 2
+    decisions = [e["non_content_metadata"]["decision"] for e in envs]
+    assert decisions == ["allow", "FILTERED"]
+
+
+def test_prompts_get_emits_envelopes_allowed_and_filtered(monkeypatch, emitter):
+    p, _ = _make_proxy(
+        monkeypatch, emitter=emitter,
+        prompt_denylist={"jailbreak"},
+    )
+    p._upstream.request.return_value = {"jsonrpc": "2.0", "id": 1, "result": {}}
+    p._handle_prompts_get({
+        "jsonrpc": "2.0", "id": 1, "method": "prompts/get",
+        "params": {"name": "summarize", "arguments": {}},
+    })
+    p._handle_prompts_get({
+        "jsonrpc": "2.0", "id": 2, "method": "prompts/get",
+        "params": {"name": "jailbreak", "arguments": {}},
+    })
+    envs = _envelopes(emitter.receipts_dir)
+    assert len(envs) == 2
+    assert envs[0]["non_content_metadata"]["prompt_name"] == "summarize"
+    assert envs[1]["non_content_metadata"]["decision"] == "FILTERED"
+
+
+def test_monotonic_counter_strictly_increases(monkeypatch, emitter):
+    p, pipeline = _make_proxy(monkeypatch, emitter=emitter)
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="a")
+    p._upstream.request.return_value = {"jsonrpc": "2.0", "id": 0, "result": {}}
+    for i in range(5):
+        p._handle_tools_call({
+            "jsonrpc": "2.0", "id": i, "method": "tools/call",
+            "params": {"name": "x", "arguments": {}},
+        })
+    counters = [e["monotonic_counter"] for e in _envelopes(emitter.receipts_dir)]
+    assert counters == [1, 2, 3, 4, 5]
+
+
+def test_emitted_envelopes_verify_with_pinned_pubkey(monkeypatch, emitter, signing_key_pem):
+    from vaara.attestation.overt import BaseEnvelope, verify_base_envelope
+    p, pipeline = _make_proxy(monkeypatch, emitter=emitter)
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="v-1")
+    p._upstream.request.return_value = {"jsonrpc": "2.0", "id": 1, "result": {}}
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "x", "arguments": {"k": 1}},
+    })
+
+    _, pub_raw = signing_key_pem
+    pinned = (emitter.receipts_dir / "pubkey.bin").read_bytes()
+    assert pinned == pub_raw
+
+    envs = _envelopes(emitter.receipts_dir)
+    assert len(envs) == 1
+    e = envs[0]
+    env = BaseEnvelope(
+        blinded_identifier=e["blinded_identifier"],
+        request_commitment=e["request_commitment"],
+        encoder_binary_identity=e["encoder_binary_identity"],
+        non_content_metadata=e["non_content_metadata"],
+        monotonic_counter=int(e["monotonic_counter"]),
+        nanosecond_timestamp=int(e["nanosecond_timestamp"]),
+        key_identifier=e["key_identifier"],
+        arbiter_instance_identifier=e["arbiter_instance_identifier"],
+        signature=e["signature"],
+    )
+    assert verify_base_envelope(env, pub_raw) is True
+
+
+def test_build_emitter_rejects_missing_operator_key(signing_key_pem, tmp_path):
+    from vaara.integrations._mcp_overt import (
+        OVERTConfigError, build_emitter,
+    )
+    sk_path, _ = signing_key_pem
+    with pytest.raises(OVERTConfigError):
+        build_emitter(
+            signing_key_path=sk_path,
+            operator_key_path=None,
+            operator_key_hex=None,
+            receipts_dir=tmp_path / "r",
+            policy_hash=b"\x00" * 32,
+        )
+
+
+def test_build_emitter_rejects_short_operator_key(signing_key_pem, tmp_path):
+    from vaara.integrations._mcp_overt import (
+        OVERTConfigError, build_emitter,
+    )
+    sk_path, _ = signing_key_pem
+    op = tmp_path / "short.key"
+    op.write_bytes(b"\x01" * 8)
+    with pytest.raises(OVERTConfigError):
+        build_emitter(
+            signing_key_path=sk_path,
+            operator_key_path=op,
+            operator_key_hex=None,
+            receipts_dir=tmp_path / "r",
+            policy_hash=b"\x00" * 32,
+        )


### PR DESCRIPTION
## Summary

- Wires the existing OVERT 1.0 Base Envelope emitter (substrate at `src/vaara/attestation/`) into the MCP proxy as the first concrete production-shape OSS OVERT 1.0 integration.
- Off by default. Three new flags on `vaara-mcp-proxy`: `--overt-signing-key`, `--overt-operator-key`, `--overt-receipts-dir`. With all three set, every allowed and every perimeter-blocked `tools/call`, `resources/read`, and `prompts/get` writes one canonical-CBOR envelope per interaction into the receipts directory, plus a pinned `pubkey.bin` for verifiers.
- `non_content_metadata` carries structural fields only (action class, identifier, decision, reason, agent_id, action_id). Request content stays in the operator environment. Only its HMAC-SHA256 commitment crosses the trust boundary, per OVERT Annex B.4. Monotonic counter advances strictly across the proxy process.
- When `--overt-signing-key` is absent, proxy behavior is byte-identical to v0.23.1.

## Test plan

- [x] `pytest tests/test_integrations_mcp_proxy.py tests/test_integrations_mcp_proxy_overt.py tests/test_attestation_overt.py tests/test_overt_verify_cli.py tests/test_attestation_iap.py` — 72 passed
- [x] Full suite — 749 passed, 12 skipped
- [x] End-to-end smoke: proxy emits a real `.cbor` envelope, `vaara overt verify ENVELOPE.cbor --pubkey-file pubkey.bin` returns `{"valid": true, "monotonic_counter": 1, ...}`
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced OVERT 1.0 Protocol integration enabling MCP proxy to emit signed attestation envelopes for each interaction
  * New CLI flags for configuring OVERT signing, operator keys, and receipt output directory
  * Offline verification workflow for receipt validation

* **Documentation**
  * Updated CHANGELOG and README with OVERT integration details and verification examples

* **Tests**
  * Added comprehensive integration tests for OVERT attestation and receipt emission

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->