### PR TITLE
release(v0.25.0): streaming MCP notifications inside the audit boundary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,5 +120,3 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-05-21
+
+**Theme: streaming notifications inside the audit boundary.** Long-running
+upstream MCP tools emit `notifications/progress` and `notifications/message`
+between the request and the final response. Until v0.25.0 those flowed
+through the proxy untouched: forwarded to the client, but invisible to the
+audit chain and the OVERT receipt directory. A regulator reconstructing the
+session from receipts only could see the request and the result, never the
+events the upstream emitted while working. v0.25.0 brings each notification
+inside the same audit + attestation perimeter that already governs
+`tools/call`, `resources/read`, and `prompts/get`. The notification still
+forwards to the client unchanged. Observation never blocks streaming.
+
+### Added
+- Streaming-notification interception in `vaara.integrations.mcp_proxy`.
+  When a `tools/call` arrives with `params._meta.progressToken` set, the
+  proxy records the token in an in-flight map alongside the originating
+  `action_id`, `agent_id`, and tool name. The map is cleared in a
+  `finally` block when the call returns or raises.
+- Every `notifications/progress` arriving from the upstream is recorded
+  as a perimeter audit pair (`tool_name="mcp.notification.progress"`,
+  `decision="observed"`) carrying the parent `action_id` and tool name
+  pulled from the in-flight map. When OVERT is configured, the
+  notification additionally emits a dedicated Base Envelope with action
+  class `mcp.notification.progress` and `parent_action_id` /
+  `parent_tool` / `progress_token` in `non_content_metadata`.
+- Every `notifications/message` arriving from the upstream is similarly
+  recorded as `mcp.notification.message` and, when OVERT is configured,
+  emits a Base Envelope carrying the `level` and `logger` fields.
+- Orphan progress notifications (token with no matching in-flight call)
+  still audit and emit, with an empty `parent_action_id`, so the
+  regulator can spot dangling events rather than have them disappear.
+- Tests: 10 new tests across `tests/test_integrations_mcp_proxy.py` and
+  `tests/test_integrations_mcp_proxy_overt.py`. Coverage includes
+  correlation to in-flight `tools/call`, map cleanup on success and on
+  raise, audit-failure-still-forwards (observation must not block
+  streaming), orphan-progress, and OVERT envelope contents for both
+  progress and message surfaces.
+
+### Changed
+- `.github/workflows/release.yml`: npm publish step reverts to OIDC-only
+  (no `NODE_AUTH_TOKEN`, no `NPM_TOKEN`) now that the `@vaara/client`
+  package has a Trusted Publisher configured. Provenance flag preserved.
+
+### Unchanged
+- Pipeline, audit chain hash format, perimeter allow/deny semantics, MCP
+  wire format, OVERT envelope closed-schema fields. Notifications still
+  forward to the client byte-identically. A v0.24.0 deployment behaves
+  the same when it does not see streaming traffic.
+
 ## [0.24.0] - 2026-05-20
 
 **Theme: MCP proxy emits OVERT 1.0 Base Envelopes per interaction.** With

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Point your MCP client at the proxy instead of the upstream. The audit chain capt
 
 **OVERT 1.0 envelopes per interaction** (since v0.24.0). Off by default. When you pass `--overt-signing-key KEY.pem`, `--overt-operator-key OPKEY.bin`, and `--overt-receipts-dir DIR/`, the proxy writes one OVERT 1.0 Protocol Profile 1.0 Base Envelope (canonical CBOR, Ed25519, closed 9-field schema) per governed interaction into `DIR/{nanosecond_timestamp}-{counter:010d}.cbor`. Covers all four states: allowed `tools/call`, blocked `tools/call`, perimeter-filtered call, and perimeter-filtered `resources/read` / `prompts/get`. The arbiter public key is pinned alongside as `pubkey.bin`. Each envelope verifies offline under `vaara overt verify` against any conformant verifier. Three-step recipe:
 
+**Streaming notifications inside the boundary** (since v0.25.0). Long-running upstream tools emit `notifications/progress` and `notifications/message` over the lifetime of a `tools/call`. The proxy now routes each notification through the same audit pair (request + decision) and, when OVERT is configured, emits a dedicated Base Envelope with action class `mcp.notification.progress` or `mcp.notification.message`. Progress events correlate to the originating call via the `_meta.progressToken` from the request, so a regulator reading the receipt directory can reconstruct what arrived between request and response. Notifications still forward to the client unchanged. Audit failures are logged and swallowed: observation never blocks streaming.
+
 ```bash
 # 1. Generate an Ed25519 signing key (evaluation/demo; for production use a KMS or HSM, see docs/signing-keys.md).
 vaara keygen --dev --out signing.pem
@@ -215,7 +217,7 @@ from vaara.attestation.overt import emit_base_envelope, make_request_commitment,
 envelope = emit_base_envelope(
     signing_key=key,
     request_commitment=make_request_commitment(payload, operator_key=op_key),
-    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.24.0", policy_hash=ph),
+    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.25.0", policy_hash=ph),
     non_content_metadata={"action_class": "tx.transfer", "decision": "escalate"},
     monotonic_counter=42,
     arbiter_instance_identifier=uuid_bytes,

--- a/clients/ts/package-lock.json
+++ b/clients/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vaara/client",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vaara/client",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.4.0"

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.24.0"
+version = "0.25.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.24.0"
+__version__ = "0.25.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -98,9 +98,16 @@ class VaaraMCPProxy:
         )
         self._stdout_lock = threading.Lock()
         self._overt = overt_emitter
+        # progressToken -> (action_id, agent_id, tool_name). Populated when a
+        # tools/call enters interception with params._meta.progressToken set,
+        # consulted by the upstream-notification handler so progress events
+        # arriving mid-call carry the originating action_id into the audit
+        # record and into the OVERT envelope's non_content_metadata.
+        self._inflight_progress: dict[Any, tuple[str, str, str]] = {}
+        self._inflight_lock = threading.Lock()
         self._upstream = UpstreamMCPClient(
             command=upstream_command,
-            on_notification=self._forward_notification_to_client,
+            on_notification=self._on_upstream_notification,
         )
 
     @staticmethod
@@ -284,6 +291,7 @@ class VaaraMCPProxy:
         result = self._pipeline.intercept(
             agent_id=agent_id, tool_name=tool_name, parameters=arguments,
         )
+        progress_token = self._progress_token(params)
         if not result.allowed:
             decision = getattr(result, "decision", None) or "DENY"
             reason = getattr(result, "reason", None) or "Blocked by Vaara policy"
@@ -312,7 +320,19 @@ class VaaraMCPProxy:
                     "isError": True,
                 },
             }
-        upstream_response = self._upstream.request(request)
+        if progress_token is not None:
+            with self._inflight_lock:
+                self._inflight_progress[progress_token] = (
+                    str(getattr(result, "action_id", None) or ""),
+                    agent_id,
+                    tool_name,
+                )
+        try:
+            upstream_response = self._upstream.request(request)
+        finally:
+            if progress_token is not None:
+                with self._inflight_lock:
+                    self._inflight_progress.pop(progress_token, None)
         outcome_severity = self._severity_from_response(upstream_response)
         try:
             self._pipeline.report_outcome(
@@ -542,8 +562,104 @@ class VaaraMCPProxy:
             return 1.0
         return 0.0
 
-    def _forward_notification_to_client(self, message: dict) -> None:
+    def _on_upstream_notification(self, message: dict) -> None:
+        """Audit + OVERT-emit upstream-originated notifications, then forward.
+
+        Streaming surfaces (notifications/progress, notifications/message) flow
+        upstream-to-client during a long-running tools/call. v0.25.0 brings
+        them inside the audit boundary: each notification is recorded as a
+        perimeter-style audit event (no scorer) and, when OVERT is configured,
+        emits its own Base Envelope. Progress events correlate to the
+        originating tools/call via params.progressToken when present. The
+        notification is then forwarded to the client unchanged — auditing is
+        observational, never blocking.
+        """
+        method = message.get("method") if isinstance(message, dict) else None
+        try:
+            if method == "notifications/progress":
+                self._audit_progress_notification(message)
+            elif method == "notifications/message":
+                self._audit_message_notification(message)
+        except Exception:
+            logger.exception("Streaming-notification audit failed for %s", method)
         self._write_to_client(message)
+
+    @staticmethod
+    def _progress_token(params: dict) -> Any:
+        meta = params.get("_meta") if isinstance(params, dict) else None
+        if not isinstance(meta, dict):
+            return None
+        token = meta.get("progressToken")
+        if isinstance(token, (str, int)):
+            return token
+        return None
+
+    def _audit_progress_notification(self, message: dict) -> None:
+        params = message.get("params") if isinstance(message, dict) else None
+        if not isinstance(params, dict):
+            params = {}
+        token = params.get("progressToken")
+        if not isinstance(token, (str, int)):
+            token = None
+        parent_action_id = ""
+        agent_id = self._agent_id_default
+        parent_tool = ""
+        if token is not None:
+            with self._inflight_lock:
+                entry = self._inflight_progress.get(token)
+            if entry is not None:
+                parent_action_id, agent_id, parent_tool = entry
+        self._record_perimeter_audit(
+            agent_id=agent_id,
+            tool_name="mcp.notification.progress",
+            parameters={
+                "progressToken": token,
+                "parent_action_id": parent_action_id,
+                "parent_tool": parent_tool,
+            },
+            decision="observed",
+            reason="upstream progress notification observed",
+        )
+        self._overt_emit(
+            surface="mcp.notification.progress",
+            identifier=str(token) if token is not None else "",
+            identifier_field="progress_token",
+            request_obj={k: v for k, v in params.items() if k != "_meta"},
+            decision="observed",
+            reason="upstream progress notification observed",
+            extra={
+                "agent_id": agent_id,
+                "parent_action_id": parent_action_id,
+                "parent_tool": parent_tool,
+            },
+        )
+
+    def _audit_message_notification(self, message: dict) -> None:
+        params = message.get("params") if isinstance(message, dict) else None
+        if not isinstance(params, dict):
+            params = {}
+        level = params.get("level", "")
+        if not isinstance(level, str):
+            level = ""
+        log_logger = params.get("logger", "")
+        if not isinstance(log_logger, str):
+            log_logger = ""
+        self._record_perimeter_audit(
+            agent_id=self._agent_id_default,
+            tool_name="mcp.notification.message",
+            parameters={"level": level, "logger": log_logger},
+            decision="observed",
+            reason="upstream log notification observed",
+        )
+        self._overt_emit(
+            surface="mcp.notification.message",
+            identifier=level,
+            identifier_field="level",
+            request_obj={"level": level, "logger": log_logger},
+            decision="observed",
+            reason="upstream log notification observed",
+            extra={"agent_id": self._agent_id_default},
+        )
 
     def _write_to_client(self, payload: dict) -> None:
         # Serialize stdout writes between main loop and upstream reader thread.

--- a/tests/test_integrations_mcp_proxy.py
+++ b/tests/test_integrations_mcp_proxy.py
@@ -447,6 +447,129 @@ def test_uninterpreted_method_still_forwards_verbatim(monkeypatch):
     pipeline.intercept.assert_not_called()
 
 
+# --- streaming notification audit (v0.25.0) ---------------------------------
+
+def test_progress_notification_records_perimeter_audit(monkeypatch):
+    p, pipeline = _make_proxy(monkeypatch)
+    p._on_upstream_notification({
+        "jsonrpc": "2.0", "method": "notifications/progress",
+        "params": {"progressToken": "tok-1", "progress": 25, "total": 100},
+    })
+    classify = pipeline.registry.classify
+    classify.assert_called_with("mcp.notification.progress", {
+        "progressToken": "tok-1", "parent_action_id": "", "parent_tool": "",
+    })
+    pipeline.trail.record_action_requested.assert_called_once()
+    pipeline.trail.record_decision.assert_called_once()
+
+
+def test_progress_notification_correlates_to_inflight_tools_call(monkeypatch):
+    p, pipeline = _make_proxy(monkeypatch)
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="parent-act-9")
+    progress_seen: list[dict] = []
+
+    def upstream_request(req):
+        if req["method"] == "tools/call":
+            # Simulate a progress notification arriving while the upstream
+            # works on the long-running call. The reader thread would invoke
+            # this callback from a separate thread in production; calling it
+            # synchronously here verifies the correlation logic.
+            p._on_upstream_notification({
+                "jsonrpc": "2.0", "method": "notifications/progress",
+                "params": {"progressToken": "tok-stream", "progress": 50, "total": 100},
+            })
+            progress_seen.append(
+                dict(p._inflight_progress),
+            )
+        return {"jsonrpc": "2.0", "id": req["id"], "result": {}}
+
+    p._upstream.request.side_effect = upstream_request
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 42, "method": "tools/call",
+        "params": {
+            "name": "long_tool", "arguments": {},
+            "_meta": {"progressToken": "tok-stream"},
+        },
+    })
+    assert progress_seen == [{"tok-stream": ("parent-act-9", "mcp-proxy-client", "long_tool")}]
+    # Map is cleaned up after the call returns.
+    assert p._inflight_progress == {}
+    # Audit was called for the progress event with the parent correlation.
+    classify_calls = [c for c in pipeline.registry.classify.call_args_list
+                      if c.args[0] == "mcp.notification.progress"]
+    assert len(classify_calls) == 1
+    params = classify_calls[0].args[1]
+    assert params["parent_action_id"] == "parent-act-9"
+    assert params["parent_tool"] == "long_tool"
+
+
+def test_progress_notification_forwards_to_client(monkeypatch):
+    p, _ = _make_proxy(monkeypatch)
+    forwarded: list[dict] = []
+    monkeypatch.setattr(p, "_write_to_client", forwarded.append)
+    msg = {
+        "jsonrpc": "2.0", "method": "notifications/progress",
+        "params": {"progressToken": "tok-2", "progress": 1, "total": 1},
+    }
+    p._on_upstream_notification(msg)
+    assert forwarded == [msg]
+
+
+def test_message_notification_records_perimeter_audit(monkeypatch):
+    p, pipeline = _make_proxy(monkeypatch)
+    p._on_upstream_notification({
+        "jsonrpc": "2.0", "method": "notifications/message",
+        "params": {"level": "info", "logger": "upstream", "data": "working"},
+    })
+    classify = pipeline.registry.classify
+    classify.assert_called_with("mcp.notification.message", {
+        "level": "info", "logger": "upstream",
+    })
+
+
+def test_non_governed_notification_still_forwards_without_audit(monkeypatch):
+    p, pipeline = _make_proxy(monkeypatch)
+    forwarded: list[dict] = []
+    monkeypatch.setattr(p, "_write_to_client", forwarded.append)
+    msg = {
+        "jsonrpc": "2.0", "method": "notifications/resources/list_changed",
+        "params": {},
+    }
+    p._on_upstream_notification(msg)
+    assert forwarded == [msg]
+    pipeline.registry.classify.assert_not_called()
+
+
+def test_audit_failure_in_notification_does_not_break_forwarding(monkeypatch):
+    p, pipeline = _make_proxy(monkeypatch)
+    pipeline.registry.classify.side_effect = RuntimeError("audit blew up")
+    forwarded: list[dict] = []
+    monkeypatch.setattr(p, "_write_to_client", forwarded.append)
+    msg = {
+        "jsonrpc": "2.0", "method": "notifications/message",
+        "params": {"level": "error"},
+    }
+    p._on_upstream_notification(msg)
+    # Forward still happens — audit failure must not block streaming.
+    assert forwarded == [msg]
+
+
+def test_inflight_map_cleaned_when_tools_call_raises(monkeypatch):
+    p, pipeline = _make_proxy(monkeypatch)
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="x")
+    from vaara.integrations._mcp_upstream import ProxyError
+    p._upstream.request.side_effect = ProxyError("boom")
+    with pytest.raises(ProxyError):
+        p._handle_tools_call({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {
+                "name": "t", "arguments": {},
+                "_meta": {"progressToken": "tok-err"},
+            },
+        })
+    assert p._inflight_progress == {}
+
+
 def test_upstream_request_raises_proxy_error_when_reader_exits_without_response(monkeypatch):
     """Regression: reader-thread exit during request must raise ProxyError, not AssertionError.
 

--- a/tests/test_integrations_mcp_proxy_overt.py
+++ b/tests/test_integrations_mcp_proxy_overt.py
@@ -232,6 +232,77 @@ def test_emitted_envelopes_verify_with_pinned_pubkey(monkeypatch, emitter, signi
     assert verify_base_envelope(env, pub_raw) is True
 
 
+def test_progress_notification_emits_envelope_with_parent_correlation(monkeypatch, emitter):
+    p, pipeline = _make_proxy(monkeypatch, emitter=emitter)
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="parent-7")
+
+    def upstream_request(req):
+        if req["method"] == "tools/call":
+            p._on_upstream_notification({
+                "jsonrpc": "2.0", "method": "notifications/progress",
+                "params": {"progressToken": "tok-z", "progress": 10, "total": 20},
+            })
+        return {"jsonrpc": "2.0", "id": req["id"], "result": {}}
+
+    p._upstream.request.side_effect = upstream_request
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {
+            "name": "slow_tool", "arguments": {},
+            "_meta": {"progressToken": "tok-z"},
+        },
+    })
+    envs = _envelopes(emitter.receipts_dir)
+    # tools/call envelope + the in-flight progress envelope.
+    assert len(envs) == 2
+    surfaces = [e["non_content_metadata"]["action_class"] for e in envs]
+    assert "mcp.notification.progress" in surfaces
+    progress_env = next(
+        e for e in envs
+        if e["non_content_metadata"]["action_class"] == "mcp.notification.progress"
+    )
+    meta = progress_env["non_content_metadata"]
+    assert meta["progress_token"] == "tok-z"
+    assert meta["parent_action_id"] == "parent-7"
+    assert meta["parent_tool"] == "slow_tool"
+    assert meta["decision"] == "observed"
+
+
+def test_message_notification_emits_envelope(monkeypatch, emitter):
+    p, _ = _make_proxy(monkeypatch, emitter=emitter)
+    p._on_upstream_notification({
+        "jsonrpc": "2.0", "method": "notifications/message",
+        "params": {"level": "warning", "logger": "upstream", "data": "slow"},
+    })
+    envs = _envelopes(emitter.receipts_dir)
+    assert len(envs) == 1
+    meta = envs[0]["non_content_metadata"]
+    assert meta["action_class"] == "mcp.notification.message"
+    assert meta["level"] == "warning"
+    assert meta["decision"] == "observed"
+
+
+def test_orphan_progress_without_inflight_call_still_emits(monkeypatch, emitter):
+    """Progress notifications with no matching tools/call still audit + emit.
+
+    The MCP spec allows progressTokens that don't correlate cleanly (e.g.,
+    upstream lagging past response, race between reader and handler). The
+    envelope still lands, just with an empty parent_action_id — the auditor
+    can spot the dangling event rather than having it disappear.
+    """
+    p, _ = _make_proxy(monkeypatch, emitter=emitter)
+    p._on_upstream_notification({
+        "jsonrpc": "2.0", "method": "notifications/progress",
+        "params": {"progressToken": "orphan", "progress": 5},
+    })
+    envs = _envelopes(emitter.receipts_dir)
+    assert len(envs) == 1
+    meta = envs[0]["non_content_metadata"]
+    assert meta["action_class"] == "mcp.notification.progress"
+    assert meta["progress_token"] == "orphan"
+    assert meta["parent_action_id"] == ""
+
+
 def test_build_emitter_rejects_missing_operator_key(signing_key_pem, tmp_path):
     from vaara.integrations._mcp_overt import (
         OVERTConfigError, build_emitter,


### PR DESCRIPTION
## Summary

Streaming MCP notifications now flow through the same audit + OVERT perimeter as `tools/call`, `resources/read`, and `prompts/get`.

- `notifications/progress` arriving from upstream during a `tools/call` is recorded as a perimeter audit pair and (when OVERT is configured) emits a Base Envelope with action class `mcp.notification.progress`. Correlated to the originating call via `params._meta.progressToken` so receipts reconstruct what arrived between request and response.
- `notifications/message` is recorded the same way with action class `mcp.notification.message`.
- Notifications still forward to the client unchanged. Audit failures are logged and swallowed: observation never blocks streaming. The in-flight map clears in a `finally` block.

Bundled with the release: revert the v0.23.1 `NODE_AUTH_TOKEN` workaround on the npm publish step now that `@vaara/client` has a Trusted Publisher configured. OIDC-only, provenance preserved.

## Test plan

- [x] `pytest -q` — 759 passed, 12 skipped
- [x] `npm test` in `clients/ts/` — 6/6 green
- [x] 10 new streaming tests cover: progress audit, in-flight correlation, map cleanup on success and on raise, audit-failure-still-forwards, orphan progress, OVERT envelope contents for both surfaces
- [ ] tag `v0.25.0` after merge to trigger Release workflow (first run against the new npm Trusted Publisher)
