### PR TITLE
release(v0.26.0): per-article verdict drill-down in compliance reports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write       # OIDC for SLSA provenance signing
+      attestations: write   # store attestations on the workflow run
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -31,6 +33,15 @@ jobs:
 
       - name: Build sdist and wheel
         run: python -m build
+
+      - name: Generate SLSA build provenance
+        # Emits a sigstore-backed attestation for each built artefact.
+        # The attestation binds the workflow + commit SHA + builder identity
+        # to the wheel/sdist digests, so downstream verifiers (slsa-verifier,
+        # gh attestation verify) can prove an artefact came from this repo.
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: 'dist/*'
 
       - name: Upload distributions
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,69 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-05-21
+
+**Theme: per-article verdict drill-down inside the compliance report.** A
+reviewer reading a v0.25 evidence report could see that Article 9(1) was
+`evidence_sufficient` with `strength: strong`, but had to re-run the engine
+or open the raw audit DB to learn which records the verdict sat on or which
+threshold pushed the strength up. v0.26.0 attaches that reasoning to every
+article so a regulator can trace status to threshold delta to concrete event
+in one read. The change extends existing report machinery and stays
+backwards compatible at the wire level. Existing fields keep their shape.
+Two new fields appear next to them.
+
+### Added
+- `ArticleEvidence.verdict_inputs`: dict of the threshold-vs-observed
+  inputs the engine compared against to produce status and strength.
+  Surfaces `min_evidence_count`, `staleness_hours`, `evidence_event_types`,
+  `evidence_count_observed`, `freshest_evidence_age_hours`,
+  `oldest_evidence_age_hours`, `future_timestamp_count`, `chain_intact`,
+  a `strength_thresholds` sub-dict (the 2x / staleness/4 bounds used for
+  `STRONG`), and a `verdict_reasons` list of human-readable rationale lines
+  explaining why this article landed at its current status and strength.
+  JSON-strict: no inf/NaN at the dict boundary.
+- `ArticleEvidence.contributing_events`: list of the most recent (up to 5)
+  qualifying audit records the verdict sits on. Each entry carries
+  `record_id`, `action_id`, `event_type`, `timestamp_iso`, `age_hours`,
+  `agent_id`, `tool_name`, the record's `narrative`, and a curated
+  `drill_down` dict containing only the data fields that directly fed
+  risk/decision/outcome reasoning (point estimate, conformal interval,
+  decision, reason, outcome severity, escalation target, resolution,
+  reviewer, override reason). Free-form `data` keys are not inlined so a
+  caller-supplied secret cannot leak into a regulator-facing summary.
+- Renderers updated end to end. `render_markdown` adds a `Verdict inputs`
+  table and `Contributing events` table per article. `render_narrative`
+  appends a `Why:` rationale line and an `Event:` line per article.
+  `render_pdf` adds the same two tables to each per-article section.
+  `compliance.dashboard.render_html` adds the same drill-down to each card
+  with HTML-escaped values. Still no JavaScript and no external assets.
+- Broken-chain handling extends to drill-down: when `verify_chain()`
+  fails, every article's `verdict_inputs.chain_intact` flips to `False`
+  and the rationale list prepends a chain-integrity warning, matching
+  the existing status / strength downgrade.
+- Tests: 11 new tests across `tests/test_compliance.py`,
+  `tests/test_compliance_render.py`, and `tests/test_compliance_dashboard.py`
+  covering verdict_inputs shape, contributing-events ordering, drill-down
+  key filtering (free-form data must not leak), broken-chain marking,
+  empty-trail INSUFFICIENT pinning, JSON strict-mode round-trip, and
+  renderer output across markdown / narrative / dashboard / PDF.
+
+### Changed
+- `.github/workflows/release.yml`: the `build` job now generates SLSA
+  build provenance via `actions/attest-build-provenance@v4.1.0` after the
+  wheel and sdist are built. The attestation binds workflow + commit SHA
+  + builder identity to the artefact digests and ships alongside the
+  Release for downstream `slsa-verifier` / `gh attestation verify` use.
+  Required new permissions on the build job: `id-token: write`,
+  `attestations: write`.
+
+### Unchanged
+- Hash chain format, OVERT envelope schema, MCP proxy perimeter semantics,
+  CLI surface (`vaara compliance report` still takes the same flags),
+  HTTP API. The `to_dict()` boundary adds two keys but does not rename or
+  remove existing ones, and v0.25 consumers ignore the additions cleanly.
+
 ## [0.25.0] - 2026-05-21
 
 **Theme: streaming notifications inside the audit boundary.** Long-running

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ else:
 
 The same data renders as a styled PDF for Notified Bodies (`vaara compliance report --format pdf`, requires `pip install 'vaara[pdf]'`), a static HTML dashboard (`vaara compliance dashboard`), or a Sigstore-signed regulator-handoff envelope (`vaara trail export`, optional ML-DSA-65 / FIPS 204 post-quantum signer via `pip install 'vaara[pq]'`).
 
+**Per-article verdict drill-down** (since v0.26.0). Each article in the report now carries two extra surfaces a reviewer can read without re-running the engine. `verdict_inputs` lists the threshold-vs-observed snapshot the engine compared against (minimum record count, staleness window, strong-strength bounds, future-timestamp and chain-integrity flags) plus a `verdict_reasons` list of human-readable rationale lines explaining why the status and strength landed where they did. `contributing_events` lists the most recent qualifying audit records the verdict sits on (record ID, action ID, ISO timestamp, agent, tool, and a filtered `drill_down` dict of just the data fields that fed the risk/decision/outcome: point estimate, conformal interval, decision, reason, outcome severity). The drill-down renders in every output format: JSON, markdown, narrative, PDF, and the HTML dashboard. An auditor reading the report can trace `status → threshold delta → concrete event` in one sitting.
+
 ## Numbers
 
 Concrete evidence the system performs at levels relevant to high-risk-use deployments. Each figure is reproducible from the public corpus or the bench harness in `bench/`.
@@ -217,7 +219,7 @@ from vaara.attestation.overt import emit_base_envelope, make_request_commitment,
 envelope = emit_base_envelope(
     signing_key=key,
     request_commitment=make_request_commitment(payload, operator_key=op_key),
-    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.25.0", policy_hash=ph),
+    encoder_binary_identity=encoder_binary_identity(arbiter_version="vaara/0.26.0", policy_hash=ph),
     non_content_metadata={"action_class": "tx.transfer", "decision": "escalate"},
     monotonic_counter=42,
     arbiter_instance_identifier=uuid_bytes,

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.25.0"
+version = "0.26.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/compliance/dashboard.py
+++ b/src/vaara/compliance/dashboard.py
@@ -119,8 +119,93 @@ def _article_detail(art: ArticleEvidence, domain: str) -> str:
         out.extend(f"<li><code>{_esc(rid)}</code></li>"
                    for rid in art.sample_record_ids[:5])
         out.append("</ul>")
+    _html_append_verdict_inputs(out, art)
+    _html_append_contributing_events(out, art)
     out.append("</div>")
     return "".join(out)
+
+
+def _html_append_verdict_inputs(out: list[str], art: ArticleEvidence) -> None:
+    """Render per-article 'Verdict inputs' threshold table + rationale list."""
+    vi = art.verdict_inputs or {}
+    if not vi:
+        return
+    fresh = vi.get("freshest_evidence_age_hours")
+    fresh_str = f"{fresh:.1f}h" if isinstance(fresh, (int, float)) else "n/a"
+    st = vi.get("strength_thresholds", {})
+    chain = "intact" if vi.get("chain_intact", True) else "BROKEN"
+    rows = [
+        ("Evidence record count",
+         f">= {vi.get('min_evidence_count', '?')}",
+         vi.get("evidence_count_observed", "?")),
+        ("Freshest evidence age",
+         f"<= {vi.get('staleness_hours', '?')}h",
+         fresh_str),
+        ("Strong-strength count",
+         f">= {st.get('strong_min_count', '?')}",
+         vi.get("evidence_count_observed", "?")),
+        ("Strong-strength freshness",
+         f"< {st.get('strong_max_age_hours', '?')}h",
+         fresh_str),
+        ("Future-timestamp records", "0",
+         vi.get("future_timestamp_count", 0)),
+        ("Chain integrity", "intact", chain),
+    ]
+    out.append("<strong>Verdict inputs</strong>")
+    out.append(
+        "<table><thead><tr><th>Parameter</th><th>Threshold</th>"
+        "<th>Observed</th></tr></thead><tbody>"
+    )
+    for name, threshold, observed in rows:
+        out.append(
+            f"<tr><td>{_esc(name)}</td><td>{_esc(threshold)}</td>"
+            f"<td>{_esc(observed)}</td></tr>"
+        )
+    out.append("</tbody></table>")
+    reasons = vi.get("verdict_reasons") or []
+    if reasons:
+        out.append("<strong>Verdict rationale</strong><ul>")
+        out.extend(f"<li>{_esc(r)}</li>" for r in reasons)
+        out.append("</ul>")
+
+
+def _html_append_contributing_events(out: list[str], art: ArticleEvidence) -> None:
+    """Render per-article 'Contributing events' table."""
+    events = art.contributing_events or []
+    if not events:
+        return
+    out.append(
+        "<strong>Contributing events</strong> (most recent first)"
+    )
+    out.append(
+        "<table><thead><tr><th>When</th><th>Event</th>"
+        "<th>Agent / tool</th><th>Drill-down</th><th>Record</th></tr>"
+        "</thead><tbody>"
+    )
+    for ev in events:
+        ts = ev.get("timestamp_iso") or "n/a"
+        age = ev.get("age_hours")
+        age_str = f" ({age:.2f}h)" if isinstance(age, (int, float)) else ""
+        agent = ev.get("agent_id", "?")
+        tool = ev.get("tool_name", "?")
+        drill = ev.get("drill_down") or {}
+        if drill:
+            drill_str = ", ".join(
+                f"<code>{_esc(k)}</code>=<code>{_esc(v)}</code>"
+                for k, v in drill.items()
+            )
+        else:
+            drill_str = "—"
+        out.append(
+            "<tr>"
+            f"<td>{_esc(ts)}{_esc(age_str)}</td>"
+            f"<td><code>{_esc(ev.get('event_type', '?'))}</code></td>"
+            f"<td>{_esc(agent)} / {_esc(tool)}</td>"
+            f"<td>{drill_str}</td>"
+            f"<td><code>{_esc(ev.get('record_id', '?'))}</code></td>"
+            "</tr>"
+        )
+    out.append("</tbody></table>")
 
 
 def render_html(report: ConformityReport) -> str:

--- a/src/vaara/compliance/engine.py
+++ b/src/vaara/compliance/engine.py
@@ -230,6 +230,12 @@ class ArticleEvidence:
     sample_record_ids: list[str] = field(default_factory=list)
     gaps: list[str] = field(default_factory=list)
     recommendations: list[str] = field(default_factory=list)
+    # v0.26 verdict drill-down: the parameter inputs that pushed the
+    # status/strength into their current bound, plus the specific
+    # audit events that drove the verdict. An auditor reading the
+    # report can trace status -> threshold deltas -> concrete events.
+    verdict_inputs: dict = field(default_factory=dict)
+    contributing_events: list[dict] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         # When evidence_count==0 the freshness ages are float('inf') sentinel
@@ -255,6 +261,8 @@ class ArticleEvidence:
             "gaps": self.gaps,
             "recommendations": self.recommendations,
             "sample_record_ids": self.sample_record_ids[:5],
+            "verdict_inputs": self.verdict_inputs,
+            "contributing_events": self.contributing_events,
         }
 
 
@@ -346,10 +354,269 @@ class ConformityReport:
                 if art.recommendations:
                     for rec in art.recommendations:
                         lines.append(f"       Rec: {rec}")
+                for reason in (art.verdict_inputs or {}).get(
+                    "verdict_reasons", []
+                ):
+                    lines.append(f"       Why: {reason}")
+                for ev in (art.contributing_events or [])[:3]:
+                    ts = ev.get("timestamp_iso") or "n/a"
+                    drill = ev.get("drill_down") or {}
+                    drill_str = (
+                        " " + ", ".join(f"{k}={v}" for k, v in drill.items())
+                        if drill else ""
+                    )
+                    lines.append(
+                        f"       Event: {ts} {ev.get('event_type', '?')} "
+                        f"{ev.get('tool_name', '?')}{drill_str}"
+                    )
             lines.append("")
 
         lines.append(f"SUMMARY: {self.summary}")
         return "\n".join(lines)
+
+
+# ── Verdict drill-down helpers ────────────────────────────────────────────
+#
+# Auditors reading an evidence report need to trace a status (sufficient /
+# partial / insufficient) back to (a) the threshold inputs the engine used
+# and (b) the specific audit events that pushed each input into its current
+# value. These helpers build the JSON-portable payload the renderers expose
+# under each article's `verdict_inputs` and `contributing_events`.
+
+# Per-event fields surfaced in the drill-down. Keep this list explicit:
+# the audit record's full `data` dict may contain caller-supplied payload
+# (action parameters, override reasons) that is fine to log but should not
+# be inlined verbatim into a regulator-facing report. Only the fields that
+# directly contribute to risk/decision/outcome reasoning are exposed here.
+_DRILL_DOWN_DATA_KEYS = (
+    "point_estimate",
+    "conformal_lower",
+    "conformal_upper",
+    "risk_score",
+    "decision",
+    "reason",
+    "outcome_severity",
+    "escalation_target",
+    "resolution",
+    "reviewer",
+    "override_reason",
+)
+
+
+def _external_evidence_verdict_inputs(req: RegulatoryRequirement) -> dict:
+    """Verdict inputs for articles that need external (non-runtime) evidence."""
+    return {
+        "min_evidence_count": req.min_evidence_count,
+        "staleness_hours": req.staleness_hours,
+        "evidence_event_types": [],
+        "evidence_count_observed": 0,
+        "freshest_evidence_age_hours": None,
+        "oldest_evidence_age_hours": None,
+        "future_timestamp_count": 0,
+        "chain_intact": True,
+        "strength_thresholds": {
+            "strong_min_count": req.min_evidence_count * 2,
+            "strong_max_age_hours": req.staleness_hours / 4 if req.staleness_hours else 0.0,
+            "moderate_min_count": req.min_evidence_count,
+            "moderate_max_age_hours": req.staleness_hours,
+        },
+        "verdict_reasons": [
+            "Requirement is documentary, not runtime-observable; "
+            "evidence must be supplied out-of-band.",
+        ],
+    }
+
+
+def _build_verdict_inputs(
+    req: RegulatoryRequirement,
+    *,
+    evidence_count: int,
+    freshest_age_hours: float,
+    oldest_age_hours: float,
+    future_timestamp_count: int,
+    status: "EvidenceStatus",
+    strength: "EvidenceStrength",
+) -> dict:
+    """Threshold-vs-actual snapshot that drove this article's verdict.
+
+    The returned dict is JSON-strict (no inf/NaN) and lists, in
+    ``verdict_reasons``, the human-readable rationale for why the status
+    and strength landed where they did.
+    """
+    import math as _math
+
+    def _finite_or_none(v: float) -> Optional[float]:
+        return round(v, 1) if _math.isfinite(v) else None
+
+    strong_min_count = req.min_evidence_count * 2
+    strong_max_age = req.staleness_hours / 4 if req.staleness_hours else 0.0
+
+    reasons = _verdict_reasons(
+        req,
+        evidence_count=evidence_count,
+        freshest_age_hours=freshest_age_hours,
+        future_timestamp_count=future_timestamp_count,
+        status=status,
+        strength=strength,
+        strong_min_count=strong_min_count,
+        strong_max_age=strong_max_age,
+    )
+
+    return {
+        "min_evidence_count": req.min_evidence_count,
+        "staleness_hours": req.staleness_hours,
+        "evidence_event_types": [et.value for et in req.evidence_event_types],
+        "evidence_count_observed": evidence_count,
+        "freshest_evidence_age_hours": _finite_or_none(freshest_age_hours),
+        "oldest_evidence_age_hours": _finite_or_none(oldest_age_hours),
+        "future_timestamp_count": future_timestamp_count,
+        "chain_intact": True,
+        "strength_thresholds": {
+            "strong_min_count": strong_min_count,
+            "strong_max_age_hours": round(strong_max_age, 2),
+            "moderate_min_count": req.min_evidence_count,
+            "moderate_max_age_hours": req.staleness_hours,
+        },
+        "verdict_reasons": reasons,
+    }
+
+
+def _verdict_reasons(
+    req: RegulatoryRequirement,
+    *,
+    evidence_count: int,
+    freshest_age_hours: float,
+    future_timestamp_count: int,
+    status: "EvidenceStatus",
+    strength: "EvidenceStrength",
+    strong_min_count: int,
+    strong_max_age: float,
+) -> list[str]:
+    """Render the human-readable rationale lines for the verdict_inputs payload."""
+    reasons: list[str] = []
+    if evidence_count == 0:
+        reasons.append(
+            f"No records of types {[et.value for et in req.evidence_event_types]} "
+            "found; status pinned to INSUFFICIENT."
+        )
+        return reasons
+
+    if status == EvidenceStatus.EVIDENCE_SUFFICIENT:
+        reasons.append(
+            f"Status SUFFICIENT: {evidence_count} record(s) >= threshold "
+            f"{req.min_evidence_count}, freshest {freshest_age_hours:.1f}h "
+            f"within {req.staleness_hours:.0f}h staleness window, "
+            "no clock-skew indicators."
+        )
+    elif status == EvidenceStatus.EVIDENCE_PARTIAL:
+        if freshest_age_hours > req.staleness_hours:
+            reasons.append(
+                f"Status PARTIAL: {evidence_count} record(s) meet count "
+                f"threshold {req.min_evidence_count} but freshest "
+                f"{freshest_age_hours:.1f}h exceeds {req.staleness_hours:.0f}h "
+                "staleness window."
+            )
+        else:
+            reasons.append(
+                f"Status PARTIAL: {evidence_count} record(s) present but one "
+                "or more freshness/integrity checks flagged a gap."
+            )
+    else:
+        short_by = max(0, req.min_evidence_count - evidence_count)
+        reasons.append(
+            f"Status INSUFFICIENT: {evidence_count} record(s) below threshold "
+            f"{req.min_evidence_count} (short by {short_by})."
+        )
+
+    if strength == EvidenceStrength.STRONG:
+        reasons.append(
+            f"Strength STRONG: {evidence_count} >= 2x threshold "
+            f"({strong_min_count}) and freshness {freshest_age_hours:.1f}h "
+            f"< staleness/4 ({strong_max_age:.1f}h)."
+        )
+    elif strength == EvidenceStrength.MODERATE:
+        if evidence_count < strong_min_count:
+            reasons.append(
+                f"Strength MODERATE: {evidence_count} below 2x threshold "
+                f"({strong_min_count}) needed for STRONG."
+            )
+        elif freshest_age_hours >= strong_max_age:
+            reasons.append(
+                f"Strength MODERATE: freshness {freshest_age_hours:.1f}h "
+                f">= staleness/4 ({strong_max_age:.1f}h) needed for STRONG."
+            )
+        else:
+            reasons.append("Strength MODERATE.")
+    elif strength == EvidenceStrength.WEAK:
+        reasons.append(
+            f"Strength WEAK: {evidence_count} record(s) below threshold "
+            f"{req.min_evidence_count} or freshness {freshest_age_hours:.1f}h "
+            f"exceeds {req.staleness_hours:.0f}h."
+        )
+    else:
+        reasons.append("Strength ABSENT: no qualifying records.")
+
+    if future_timestamp_count > 0:
+        reasons.append(
+            f"Strength downgraded one tier: {future_timestamp_count} record(s) "
+            "carry future timestamps; freshness signal cannot be trusted."
+        )
+    return reasons
+
+
+def _build_contributing_events(
+    records: list,
+    *,
+    now: float,
+    max_events: int = 5,
+) -> list[dict]:
+    """Pick the audit events that the per-article verdict sits on.
+
+    Strategy: the most recent ``max_events`` qualifying records (freshness
+    is the dominant verdict driver). Each event is serialised to a small
+    JSON-portable dict containing only the data fields that directly feed
+    risk/decision/outcome reasoning. Caller-supplied free-form payload is
+    not inlined — those belong in the audit record itself, not in a
+    regulator-facing summary.
+    """
+    import math as _math
+
+    if not records:
+        return []
+    by_recency = sorted(
+        records,
+        key=lambda r: (
+            r.timestamp
+            if isinstance(r.timestamp, (int, float)) and _math.isfinite(r.timestamp)
+            else float("-inf")
+        ),
+        reverse=True,
+    )
+    out: list[dict] = []
+    for r in by_recency[:max_events]:
+        ts = r.timestamp
+        if isinstance(ts, (int, float)) and _math.isfinite(ts):
+            ts_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
+            age_hours: Optional[float] = round(max(0.0, (now - ts) / 3600), 2)
+        else:
+            ts_iso = None
+            age_hours = None
+        drill: dict = {}
+        for key in _DRILL_DOWN_DATA_KEYS:
+            if isinstance(r.data, dict) and key in r.data:
+                drill[key] = r.data[key]
+        out.append({
+            "record_id": r.record_id,
+            "action_id": r.action_id,
+            "event_type": r.event_type.value,
+            "timestamp_iso": ts_iso,
+            "age_hours": age_hours,
+            "agent_id": r.agent_id,
+            "tool_name": r.tool_name,
+            "narrative": r.narrative,
+            "drill_down": drill,
+        })
+    return out
 
 
 # ── Compliance Engine ─────────────────────────────────────────────────────
@@ -420,6 +687,14 @@ class ComplianceEngine:
                     "Investigate chain break, restore from verified "
                     "backup, and re-run conformity assessment",
                 )
+                if evidence.verdict_inputs:
+                    evidence.verdict_inputs["chain_intact"] = False
+                    evidence.verdict_inputs.setdefault("verdict_reasons", []).insert(
+                        0,
+                        "Audit chain integrity compromised; status pinned to "
+                        "INSUFFICIENT and strength to ABSENT regardless of "
+                        "per-article evidence count.",
+                    )
             articles.append(evidence)
 
             if (
@@ -489,6 +764,8 @@ class ComplianceEngine:
                 recommendations=[
                     "Provide technical documentation as per Annex IV"
                 ],
+                verdict_inputs=_external_evidence_verdict_inputs(req),
+                contributing_events=[],
             )
 
         # Collect evidence records
@@ -515,6 +792,16 @@ class ComplianceEngine:
                     f"Enable {', '.join(et.value for et in req.evidence_event_types)} "
                     f"recording in the audit trail"
                 ],
+                verdict_inputs=_build_verdict_inputs(
+                    req,
+                    evidence_count=0,
+                    freshest_age_hours=float("inf"),
+                    oldest_age_hours=float("inf"),
+                    future_timestamp_count=0,
+                    status=EvidenceStatus.EVIDENCE_INSUFFICIENT,
+                    strength=EvidenceStrength.ABSENT,
+                ),
+                contributing_events=[],
             )
 
         # Analyze freshness. Drop NaN/inf timestamps so a single bad row
@@ -605,6 +892,24 @@ class ComplianceEngine:
         # Sample record IDs for reference
         sample_ids = [r.record_id for r in evidence_records[:5]]
 
+        # Verdict drill-down: the threshold inputs the engine compared
+        # against to produce status/strength, plus a handful of recent
+        # records the verdict actually sits on. The renderers surface
+        # this so an auditor can walk "verdict -> threshold delta ->
+        # specific event" without re-running the engine.
+        verdict_inputs = _build_verdict_inputs(
+            req,
+            evidence_count=evidence_count,
+            freshest_age_hours=freshest_age_hours,
+            oldest_age_hours=oldest_age_hours,
+            future_timestamp_count=future_timestamp_count,
+            status=status,
+            strength=strength,
+        )
+        contributing_events = _build_contributing_events(
+            evidence_records, now=now, max_events=5,
+        )
+
         return ArticleEvidence(
             requirement=req,
             status=status,
@@ -615,6 +920,8 @@ class ComplianceEngine:
             sample_record_ids=sample_ids,
             gaps=gaps,
             recommendations=recommendations,
+            verdict_inputs=verdict_inputs,
+            contributing_events=contributing_events,
         )
 
     # ── Utilities ─────────────────────────────────────────────────

--- a/src/vaara/compliance/render.py
+++ b/src/vaara/compliance/render.py
@@ -168,6 +168,8 @@ def render_markdown(report: ConformityReport) -> str:
                 lines.append("**Sample audit record IDs:**")
                 for rid in art.sample_record_ids[:5]:
                     lines.append(f"- `{rid}`")
+            _md_append_verdict_inputs(lines, art)
+            _md_append_contributing_events(lines, art)
             lines.append("")
 
     lines.append("---")
@@ -177,6 +179,91 @@ def render_markdown(report: ConformityReport) -> str:
         "runtime audit trail; deployer owns the conformity decision._"
     )
     return "\n".join(lines)
+
+
+def _md_append_verdict_inputs(lines: list[str], art: ArticleEvidence) -> None:
+    """Append the per-article 'Verdict inputs' subsection to the markdown body.
+
+    Surfaces threshold-vs-observed values and the verdict_reasons that the
+    engine produced. Auditors reading the markdown can trace the status
+    label back to the specific parameter that pushed it there.
+    """
+    vi = art.verdict_inputs or {}
+    if not vi:
+        return
+    lines.append("")
+    lines.append("**Verdict inputs:**")
+    lines.append("")
+    lines.append("| Parameter | Threshold | Observed |")
+    lines.append("|---|---|---|")
+    lines.append(
+        f"| Evidence record count | >= {vi.get('min_evidence_count', '?')} | "
+        f"{vi.get('evidence_count_observed', '?')} |"
+    )
+    fresh = vi.get("freshest_evidence_age_hours")
+    fresh_str = f"{fresh:.1f}h" if isinstance(fresh, (int, float)) else "n/a"
+    lines.append(
+        f"| Freshest evidence age | <= {vi.get('staleness_hours', '?')}h | "
+        f"{fresh_str} |"
+    )
+    st = vi.get("strength_thresholds", {})
+    lines.append(
+        f"| Strong-strength count | >= {st.get('strong_min_count', '?')} | "
+        f"{vi.get('evidence_count_observed', '?')} |"
+    )
+    lines.append(
+        f"| Strong-strength freshness | < {st.get('strong_max_age_hours', '?')}h | "
+        f"{fresh_str} |"
+    )
+    lines.append(
+        f"| Future-timestamp records | 0 | "
+        f"{vi.get('future_timestamp_count', 0)} |"
+    )
+    lines.append(
+        f"| Chain integrity | intact | "
+        f"{'intact' if vi.get('chain_intact', True) else 'BROKEN'} |"
+    )
+    reasons = vi.get("verdict_reasons") or []
+    if reasons:
+        lines.append("")
+        lines.append("**Verdict rationale:**")
+        for r in reasons:
+            lines.append(f"- {r}")
+
+
+def _md_append_contributing_events(lines: list[str], art: ArticleEvidence) -> None:
+    """Append the per-article 'Contributing events' subsection to the markdown body."""
+    events = art.contributing_events or []
+    if not events:
+        return
+    lines.append("")
+    lines.append("**Contributing events** (most recent first):")
+    lines.append("")
+    lines.append("| When | Event | Agent / tool | Drill-down |")
+    lines.append("|---|---|---|---|")
+    for ev in events:
+        ts = ev.get("timestamp_iso") or "n/a"
+        age = ev.get("age_hours")
+        age_str = f" ({age:.2f}h)" if isinstance(age, (int, float)) else ""
+        agent = ev.get("agent_id", "?")
+        tool = ev.get("tool_name", "?")
+        drill = ev.get("drill_down") or {}
+        if drill:
+            drill_bits = ", ".join(
+                f"`{k}`=`{v}`" for k, v in drill.items()
+            )
+        else:
+            drill_bits = "—"
+        lines.append(
+            f"| {ts}{age_str} | `{ev.get('event_type', '?')}` | "
+            f"{agent} / {tool} | {drill_bits} |"
+        )
+    lines.append("")
+    lines.append("Record IDs:")
+    for ev in events:
+        lines.append(
+            f"- `{ev.get('record_id', '?')}` (action `{ev.get('action_id', '?')}`)"
+        )
 
 
 _PDF_STATUS_LABEL = {
@@ -417,7 +504,123 @@ def _pdf_append_articles(
                     ),
                     small,
                 ))
+            _pdf_append_verdict_inputs(
+                flow, art, Paragraph, Spacer, Table, TableStyle, colors,
+                cm, body, small,
+            )
+            _pdf_append_contributing_events(
+                flow, art, Paragraph, Spacer, Table, TableStyle, colors,
+                cm, body, small,
+            )
             flow.append(Spacer(1, 0.3 * cm))
+
+
+def _pdf_append_verdict_inputs(
+    flow, art, Paragraph, Spacer, Table, TableStyle, colors, cm, body, small,
+) -> None:
+    """Append per-article 'Verdict inputs' table + rationale to a PDF flow."""
+    vi = art.verdict_inputs or {}
+    if not vi:
+        return
+    flow.append(Spacer(1, 0.15 * cm))
+    flow.append(Paragraph("<b>Verdict inputs:</b>", body))
+    fresh = vi.get("freshest_evidence_age_hours")
+    fresh_str = f"{fresh:.1f}h" if isinstance(fresh, (int, float)) else "n/a"
+    st = vi.get("strength_thresholds", {})
+    rows = [
+        ["Parameter", "Threshold", "Observed"],
+        ["Evidence record count",
+         f">= {vi.get('min_evidence_count', '?')}",
+         str(vi.get('evidence_count_observed', '?'))],
+        ["Freshest evidence age",
+         f"<= {vi.get('staleness_hours', '?')}h",
+         fresh_str],
+        ["Strong-strength count",
+         f">= {st.get('strong_min_count', '?')}",
+         str(vi.get('evidence_count_observed', '?'))],
+        ["Strong-strength freshness",
+         f"< {st.get('strong_max_age_hours', '?')}h",
+         fresh_str],
+        ["Future-timestamp records", "0",
+         str(vi.get('future_timestamp_count', 0))],
+        ["Chain integrity", "intact",
+         "intact" if vi.get('chain_intact', True) else "BROKEN"],
+    ]
+    table = Table(rows, colWidths=[6 * cm, 4.5 * cm, 5 * cm], repeatRows=1)
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#eeeeee")),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, -1), 8),
+        ("BOX", (0, 0), (-1, -1), 0.4, colors.grey),
+        ("INNERGRID", (0, 0), (-1, -1), 0.2, colors.lightgrey),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 3),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 3),
+        ("TOPPADDING", (0, 0), (-1, -1), 2),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+    ]))
+    flow.append(table)
+    reasons = vi.get("verdict_reasons") or []
+    if reasons:
+        flow.append(Spacer(1, 0.1 * cm))
+        flow.append(Paragraph("<b>Verdict rationale:</b>", body))
+        for r in reasons:
+            flow.append(Paragraph("• " + _pdf_escape(r), body))
+
+
+def _pdf_append_contributing_events(
+    flow, art, Paragraph, Spacer, Table, TableStyle, colors, cm, body, small,
+) -> None:
+    """Append per-article 'Contributing events' table to a PDF flow."""
+    events = art.contributing_events or []
+    if not events:
+        return
+    flow.append(Spacer(1, 0.15 * cm))
+    flow.append(Paragraph(
+        "<b>Contributing events</b> (most recent first):", body,
+    ))
+    rows = [["When", "Event", "Agent / tool", "Drill-down"]]
+    for ev in events:
+        ts = ev.get("timestamp_iso") or "n/a"
+        age = ev.get("age_hours")
+        age_str = f"\n({age:.2f}h)" if isinstance(age, (int, float)) else ""
+        agent = _pdf_escape(ev.get("agent_id", "?"))
+        tool = _pdf_escape(ev.get("tool_name", "?"))
+        drill = ev.get("drill_down") or {}
+        drill_str = _pdf_escape(
+            ", ".join(f"{k}={v}" for k, v in drill.items()) or "—"
+        )
+        rows.append([
+            ts + age_str,
+            ev.get("event_type", "?"),
+            f"{agent} / {tool}",
+            drill_str,
+        ])
+    table = Table(
+        rows,
+        colWidths=[3.6 * cm, 3.2 * cm, 4.5 * cm, 4.2 * cm],
+        repeatRows=1,
+    )
+    table.setStyle(TableStyle([
+        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#eeeeee")),
+        ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+        ("FONTSIZE", (0, 0), (-1, -1), 7),
+        ("BOX", (0, 0), (-1, -1), 0.4, colors.grey),
+        ("INNERGRID", (0, 0), (-1, -1), 0.2, colors.lightgrey),
+        ("VALIGN", (0, 0), (-1, -1), "TOP"),
+        ("LEFTPADDING", (0, 0), (-1, -1), 3),
+        ("RIGHTPADDING", (0, 0), (-1, -1), 3),
+        ("TOPPADDING", (0, 0), (-1, -1), 2),
+        ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+    ]))
+    flow.append(table)
+    flow.append(Spacer(1, 0.1 * cm))
+    rid_bits = "; ".join(
+        f"<font face='Courier' size='7'>{ev.get('record_id', '?')}</font>"
+        f" (action <font face='Courier' size='7'>{ev.get('action_id', '?')}</font>)"
+        for ev in events
+    )
+    flow.append(Paragraph("<b>Record IDs:</b> " + rid_bits, small))
 
 
 def _pdf_escape(value: object) -> str:

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -8,6 +8,7 @@ from vaara.compliance.engine import (
     EU_AI_ACT_REQUIREMENTS,
     ComplianceEngine,
     EvidenceStatus,
+    RegulatoryRequirement,
 )
 from vaara.taxonomy.actions import (
     ActionCategory,
@@ -195,6 +196,154 @@ class TestRequirements:
                 assert len(req.evidence_event_types) > 0, (
                     f"{req.article} has no evidence event types"
                 )
+
+
+class TestVerdictDrillDown:
+    """v0.26: ConformityReport articles carry verdict_inputs (threshold-vs-actual
+    + rationale) and contributing_events (the specific audit records the
+    verdict sits on). An auditor reading the report can trace status ->
+    threshold delta -> concrete event without re-running the engine."""
+
+    def test_verdict_inputs_present_for_populated_article(
+        self, engine, populated_trail
+    ):
+        report = engine.assess(populated_trail)
+        # Find an article that has runtime evidence (skip Article 11(1) docs).
+        runtime_articles = [
+            a for a in report.articles
+            if a.requirement.evidence_event_types
+        ]
+        assert runtime_articles, "populated trail should yield runtime articles"
+        for art in runtime_articles:
+            vi = art.verdict_inputs
+            assert vi, f"{art.requirement.article} missing verdict_inputs"
+            assert "min_evidence_count" in vi
+            assert "staleness_hours" in vi
+            assert "evidence_count_observed" in vi
+            assert "strength_thresholds" in vi
+            assert "verdict_reasons" in vi
+            assert isinstance(vi["verdict_reasons"], list)
+            assert vi["verdict_reasons"], "verdict_reasons must explain the verdict"
+
+    def test_contributing_events_populated_for_runtime_article(
+        self, engine, populated_trail
+    ):
+        report = engine.assess(populated_trail)
+        # Pick an article with sufficient/partial evidence — must list at
+        # least one contributing event.
+        for art in report.articles:
+            if art.evidence_count > 0:
+                assert art.contributing_events, (
+                    f"{art.requirement.article} has {art.evidence_count} "
+                    "records but no contributing_events"
+                )
+                ev = art.contributing_events[0]
+                assert "record_id" in ev
+                assert "action_id" in ev
+                assert "event_type" in ev
+                assert "timestamp_iso" in ev
+                assert "narrative" in ev
+                assert "drill_down" in ev
+                assert isinstance(ev["drill_down"], dict)
+                return
+        raise AssertionError("expected at least one article with evidence")
+
+    def test_contributing_events_are_most_recent_first(
+        self, engine, populated_trail
+    ):
+        report = engine.assess(populated_trail)
+        for art in report.articles:
+            events = art.contributing_events
+            if len(events) < 2:
+                continue
+            ages = [
+                e["age_hours"] for e in events
+                if isinstance(e.get("age_hours"), (int, float))
+            ]
+            assert ages == sorted(ages), (
+                f"{art.requirement.article} contributing_events not "
+                "ordered most-recent-first"
+            )
+
+    def test_drill_down_filters_to_known_keys(self, engine):
+        # Build a trail with a single RISK_SCORED event whose data carries
+        # both a known reasoning key (point_estimate) and a free-form key
+        # that must NOT leak into the regulator-facing drill_down.
+        trail = AuditTrail()
+        at = ActionType(
+            "x", ActionCategory.DATA, Reversibility.FULLY, BlastRadius.SELF,
+        )
+        req = ActionRequest(agent_id="a", tool_name="x", action_type=at)
+        action_id = trail.record_action_requested(req)
+        trail.record_risk_scored(
+            action_id=action_id, agent_id="a", tool_name="x",
+            assessment={
+                "risk": 0.4,
+                "point_estimate": 0.42,
+                "conformal_lower": 0.3,
+                "conformal_upper": 0.55,
+                "secret_payload": "should-not-appear",
+            },
+        )
+        custom = RegulatoryRequirement(
+            RegulatoryDomain.EU_AI_ACT, "Article 9(1)", "RMS", "...",
+            (EventType.RISK_SCORED,), min_evidence_count=1,
+        )
+        engine = ComplianceEngine(requirements=[custom])
+        report = engine.assess(trail)
+        ev = report.articles[0].contributing_events[0]
+        drill = ev["drill_down"]
+        assert drill.get("point_estimate") == 0.42
+        assert drill.get("conformal_lower") == 0.3
+        assert drill.get("conformal_upper") == 0.55
+        assert "secret_payload" not in drill, (
+            "free-form data fields must not leak into drill_down"
+        )
+
+    def test_empty_trail_verdict_inputs_pin_to_insufficient(
+        self, engine, trail
+    ):
+        report = engine.assess(trail)
+        runtime = [
+            a for a in report.articles
+            if a.requirement.evidence_event_types
+        ]
+        for art in runtime:
+            vi = art.verdict_inputs
+            assert vi["evidence_count_observed"] == 0
+            reasons = " ".join(vi["verdict_reasons"]).upper()
+            assert "INSUFFICIENT" in reasons
+            assert art.contributing_events == []
+
+    def test_broken_chain_marks_verdict_inputs(
+        self, engine, populated_trail
+    ):
+        populated_trail._records[5].data["tampered"] = True
+        report = engine.assess(populated_trail)
+        runtime = [
+            a for a in report.articles
+            if a.requirement.evidence_event_types
+        ]
+        for art in runtime:
+            vi = art.verdict_inputs
+            assert vi.get("chain_intact") is False
+            joined = " ".join(vi.get("verdict_reasons", [])).lower()
+            assert "chain integrity compromised" in joined
+
+    def test_to_dict_includes_verdict_drill_down(
+        self, engine, populated_trail
+    ):
+        import json
+        report = engine.assess(populated_trail)
+        d = report.to_dict()
+        # JSON round-trip with strict mode — no inf/NaN must leak through.
+        text = json.dumps(d, allow_nan=False)
+        assert "verdict_inputs" in text
+        assert "contributing_events" in text
+        # Every article carries the new keys.
+        for art in d["articles"]:
+            assert "verdict_inputs" in art
+            assert "contributing_events" in art
 
 
 class TestAddRequirementIdempotent:

--- a/tests/test_compliance_dashboard.py
+++ b/tests/test_compliance_dashboard.py
@@ -129,3 +129,16 @@ def test_html_critical_gaps_section_when_present(monkeypatch):
     out = render_html(report)
     assert "Critical gaps" in out
     assert "chain integrity broken" in out
+
+
+def test_html_surfaces_verdict_inputs_and_contributing_events():
+    """v0.26 drill-down: dashboard must expose the threshold-vs-actual table
+    and the contributing-events list under each runtime article."""
+    out = render_html(_report())
+    assert "Verdict inputs" in out
+    assert "Verdict rationale" in out
+    assert "Contributing events" in out
+    # Threshold/observed columns and a known parameter row.
+    assert "Threshold" in out
+    assert "Observed" in out
+    assert "Evidence record count" in out

--- a/tests/test_compliance_render.py
+++ b/tests/test_compliance_render.py
@@ -124,6 +124,46 @@ def test_render_markdown_includes_summary_section():
     assert "## Summary" in md
 
 
+def test_render_markdown_surfaces_verdict_inputs_and_events():
+    """v0.26 drill-down: markdown body must surface verdict thresholds and
+    the contributing event rows so an auditor can trace status without
+    re-running the engine."""
+    trail = _populated_trail()
+    report = create_default_engine().assess(trail)
+    md = render_markdown(report)
+    assert "**Verdict inputs:**" in md
+    assert "| Parameter | Threshold | Observed |" in md
+    assert "Evidence record count" in md
+    assert "Strong-strength count" in md
+    assert "**Verdict rationale:**" in md
+    assert "**Contributing events**" in md
+    # Drill-down values from the populated trail should appear.
+    assert "point_estimate" in md or "decision" in md
+
+
+def test_render_narrative_surfaces_verdict_reasoning():
+    trail = _populated_trail()
+    report = create_default_engine().assess(trail)
+    narr = render_narrative(report)
+    # Each runtime article narrative includes a "Why:" line and an "Event:"
+    # line so a regulator reading plain text gets the rationale + receipts.
+    assert "Why:" in narr
+    assert "Event:" in narr
+
+
+@pytest.mark.skipif(not _HAS_REPORTLAB, reason="reportlab not installed")
+def test_render_pdf_includes_verdict_drill_down(tmp_path):
+    """PDF flow must include verdict-inputs table + contributing-events table.
+    Exact byte search is hopeless inside a compressed PDF, so this verifies
+    the renderer doesn't crash on a populated trail with the new sections."""
+    trail = _populated_trail()
+    report = create_default_engine().assess(trail)
+    out = tmp_path / "drill.pdf"
+    size = render_pdf(report, out)
+    assert size > 0
+    assert out.read_bytes().startswith(b"%PDF-")
+
+
 @pytest.mark.skipif(not _HAS_REPORTLAB, reason="reportlab not installed")
 def test_render_pdf_produces_valid_pdf(tmp_path):
     trail = _populated_trail()


### PR DESCRIPTION
## Summary

v0.26.0 brings per-article verdict drill-down into the compliance evidence report. A reviewer reading a v0.25 report could see that Article 9(1) was `evidence_sufficient` with `strength: strong`, but had to re-run the engine or open the audit DB to learn which records the verdict sat on or which threshold pushed the strength up. v0.26.0 attaches that reasoning to every article so a regulator can trace status to threshold delta to concrete event in one read.

Two new fields on every `ArticleEvidence`:

- `verdict_inputs`: threshold-vs-observed snapshot (min record count, staleness window, strong-strength bounds, future-timestamp + chain-integrity flags) plus a `verdict_reasons` list of human-readable rationale lines explaining why the status and strength landed where they did. JSON-strict at the dict boundary (no inf/NaN).
- `contributing_events`: up to 5 most recent qualifying audit records the verdict sits on. Each carries `record_id`, `action_id`, `event_type`, `timestamp_iso`, `age_hours`, `agent_id`, `tool_name`, the record's `narrative`, and a curated `drill_down` dict containing only the data fields that fed the risk/decision/outcome reasoning. Free-form `data` keys are not inlined so caller-supplied payload cannot leak into a regulator-facing summary.

Drill-down renders end to end: `render_markdown` adds a `Verdict inputs` table and `Contributing events` table per article. `render_narrative` adds `Why:` and `Event:` lines. `render_pdf` adds the same two tables to each per-article section. `compliance.dashboard.render_html` adds the same drill-down to each card with HTML-escaped values, still no JavaScript and no external assets.

Broken-chain handling extends to drill-down: when `verify_chain()` fails, every article's `verdict_inputs.chain_intact` flips to `False` and the rationale list prepends a chain-integrity warning.

Bundled OpenSSF Scorecard move: `.github/workflows/release.yml` build job now generates SLSA build provenance via `actions/attest-build-provenance@v4.1.0`, binding workflow + commit SHA + builder identity to the artefact digests. Required new permissions on the build job: `id-token: write`, `attestations: write`.

Backwards compatible at the wire level. Existing fields keep their shape. Two new keys appear next to them. v0.25 consumers ignore the additions cleanly.

11 new tests (770 passed / 12 skipped, was 759/12). Ruff clean.

## Test plan

- [ ] `pytest -q` green locally and in CI
- [ ] `ruff check src/ tests/` clean
- [ ] `vaara compliance report --db DB --format md` shows the new `Verdict inputs` + `Contributing events` sections under each runtime article
- [ ] `vaara compliance report --db DB --format json` round-trips through `json.dumps(..., allow_nan=False)`
- [ ] `vaara compliance dashboard --db DB --out OUT.html` renders the new drill-down tables, no JavaScript
- [ ] PDF render path stays green on a populated trail
- [ ] Release workflow run shows a fresh `actions/attest-build-provenance` attestation for the wheel and the sdist


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-article verdict drill-down feature displaying verdict inputs, verdict reasoning, and contributing events across all output formats: JSON, Markdown, Narrative, PDF, and HTML Dashboard.
  * Shows threshold comparisons, observed values, and recent audit events that influenced each article's verdict determination.

* **Chores**
  * Enhanced build workflow with SLSA build provenance signing and attestations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->