### PR TITLE
release(v0.27.0): ClusterFuzzLite scaffolding + from_yaml OSError fix

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,17 @@
+# ClusterFuzzLite builder image for Vaara fuzz targets.
+#
+# Base image is OSS-Fuzz's `base-builder-python`, which already carries
+# atheris + compile_python_fuzzer plumbing. We layer Vaara's source tree
+# on top and install with the [yaml,attestation] extras so the policy
+# loader and OVERT envelope targets exercise the real PyYAML / cbor2
+# / cryptography code paths.
+FROM gcr.io/oss-fuzz-base/base-builder-python
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . $SRC/vaara
+WORKDIR $SRC/vaara
+
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eu
+# ClusterFuzzLite build script for Vaara fuzz targets.
+#
+# Installs Vaara with the optional extras the fuzz targets actually touch
+# (attestation = cbor2 + cryptography; yaml = pyyaml), then compiles each
+# `fuzz/fuzz_*.py` target with `compile_python_fuzzer` from base-builder.
+
+pip3 install --no-cache-dir ".[attestation,yaml]"
+
+for fuzzer in "$SRC/vaara/fuzz/"fuzz_*.py; do
+    compile_python_fuzzer "$fuzzer"
+done

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,0 +1,31 @@
+name: ClusterFuzzLite batch fuzzing
+
+on:
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  BatchFuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined]
+    steps:
+      - name: Build fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: python
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 3600
+          mode: batch
+          sanitizer: ${{ matrix.sanitizer }}

--- a/.github/workflows/cflite_cifuzz.yml
+++ b/.github/workflows/cflite_cifuzz.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite continuous build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - src/**
+      - fuzz/**
+      - .clusterfuzzlite/**
+      - .github/workflows/cflite_cifuzz.yml
+      - pyproject.toml
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined]
+    steps:
+      - name: Build fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: python
+          sanitizer: ${{ matrix.sanitizer }}
+          upload-build: true

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,42 @@
+name: ClusterFuzzLite PR fuzzing
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - src/**
+      - fuzz/**
+      - .clusterfuzzlite/**
+      - .github/workflows/cflite_pr.yml
+      - pyproject.toml
+
+permissions: read-all
+
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address, undefined]
+    steps:
+      - name: Build fuzzers (${{ matrix.sanitizer }})
+        id: build
+        # v1 tag — ClusterFuzzLite ships its action set under this moving ref;
+        # see https://google.github.io/clusterfuzzlite/build-integration/#step-3-create-the-github-actions-workflows
+        uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+        with:
+          language: python
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300
+          mode: code-change
+          sanitizer: ${{ matrix.sanitizer }}
+          output-sarif: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
     if: ${{ vars.NPM_PUBLISH_ENABLED == 'true' }}
     permissions:
       contents: read
+      id-token: write  # required for npm provenance
     defaults:
       run:
         working-directory: clients/ts
@@ -128,13 +129,5 @@ jobs:
       - name: Test
         run: node --test test/*.test.mjs
 
-      - name: Publish to npm
-        # Auth via NPM_TOKEN, no --provenance. Trusted Publishing OIDC was
-        # configured for v0.25 but kept 404ing on every release after a clean
-        # workflow filename save, so we fell back to the token path that
-        # ships reliably. SLSA build provenance still attests to the wheel,
-        # sdist, and GitHub Release artefacts via attest-build-provenance,
-        # only the npm-side attestation is dropped.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,6 @@ jobs:
     if: ${{ vars.NPM_PUBLISH_ENABLED == 'true' }}
     permissions:
       contents: read
-      id-token: write  # required for npm provenance
     defaults:
       run:
         working-directory: clients/ts
@@ -129,5 +128,13 @@ jobs:
       - name: Test
         run: node --test test/*.test.mjs
 
-      - name: Publish to npm with provenance
-        run: npm publish --provenance --access public
+      - name: Publish to npm
+        # Auth via NPM_TOKEN, no --provenance. Trusted Publishing OIDC was
+        # configured for v0.25 but kept 404ing on every release after a clean
+        # workflow filename save, so we fell back to the token path that
+        # ships reliably. SLSA build provenance still attests to the wheel,
+        # sdist, and GitHub Release artefacts via attest-build-provenance,
+        # only the npm-side attestation is dropped.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-05-22
+
+**Theme: continuous fuzzing on the parsers that ingest attacker-controlled
+input.** The OVERT envelope decoder, the audit-record `from_dict`
+deserialiser, and the policy YAML/JSON loader all sit at the boundary
+between Vaara and untrusted bytes. A crash, hang, or unhandled exception
+in any of them is a denial-of-service vector at minimum, and a
+deserialisation hazard at worst. This release wires ClusterFuzzLite into
+CI so those three parsers get continuously fuzzed on every PR and nightly
+in batch, and ships the first finding the local smoke test caught
+(`from_yaml` leaking `OSError(ENAMETOOLONG)` past the `PolicyError`
+contract).
+
+### Added
+- `fuzz/fuzz_overt_envelope.py`: atheris target that decodes attacker
+  CBOR bytes, validates the closed 9-field schema, reconstructs a
+  `BaseEnvelope`, and signature-checks against a dummy pubkey. Mirrors
+  the attack surface of `vaara overt verify`.
+- `fuzz/fuzz_audit_from_dict.py`: atheris target for `AuditRecord.from_dict`
+  + `compute_hash()` + the `narrative` property. Models the JSONL-replay
+  path where trail records get reloaded from disk.
+- `fuzz/fuzz_policy_loader.py`: atheris target for `from_json` and
+  `from_yaml`. Exercises both text paths with attacker-controlled strings.
+- `.clusterfuzzlite/Dockerfile` and `.clusterfuzzlite/build.sh`: builder
+  image based on `gcr.io/oss-fuzz-base/base-builder-python`, installs
+  Vaara with `[attestation,yaml]` extras, compiles each `fuzz/fuzz_*.py`
+  target with `compile_python_fuzzer`.
+- `.github/workflows/cflite_pr.yml`: PR-triggered fuzzing for 300s under
+  both address and undefined sanitizers, code-change mode.
+- `.github/workflows/cflite_batch.yml`: nightly cron, 3600s batch fuzzing
+  under both sanitizers.
+- `.github/workflows/cflite_cifuzz.yml`: build-sanity on push to main, so
+  a broken Dockerfile or build.sh surfaces immediately rather than at
+  next PR.
+- `tests/test_policy.py`:
+  `test_from_yaml_oversize_single_line_treated_as_content_not_path`
+  pins the regression behaviour of the loader fix below.
+- SECURITY.md: brief note on the continuous-fuzzing posture so reporters
+  know the parsers are under active fuzz coverage.
+
+### Fixed
+- `vaara.policy.loader.from_yaml`: a single-line YAML string longer than
+  the OS path limit (~255 bytes on most filesystems) previously caused
+  `Path(source).is_file()` to raise `OSError(ENAMETOOLONG)` directly,
+  bypassing the loader's `PolicyError` contract. Any caller that loads
+  YAML from attacker-controlled config could be DoS'd by an oversized
+  single-line payload. The is_file probe is now wrapped: any stat
+  failure is interpreted as "not a path" and the input falls through to
+  YAML parsing, where it surfaces as a normal `PolicyError`. Found by
+  the local smoke run of `fuzz_policy_loader.py` before any atheris
+  fuzzing ran.
+
+### Unchanged
+- Hash chain format, OVERT envelope schema, MCP proxy perimeter semantics,
+  CLI surface, HTTP API, release.yml SLSA provenance. The fuzz targets,
+  Dockerfile, and CFLite workflows are additive supply-chain
+  infrastructure; nothing in the runtime kernel moves.
+
 ## [0.26.0] - 2026-05-21
 
 **Theme: per-article verdict drill-down inside the compliance report.** A

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,6 +67,17 @@ receive patches at our discretion for severe issues.
 - When deploying signed audit exports, protect the signing private key using
   OS-level key management (hardware-backed keystore or HSM recommended).
 
+## Continuous Fuzzing
+
+The parsers that ingest attacker-controlled bytes — the OVERT envelope
+CBOR decoder, the audit-record `from_dict` deserialiser, and the policy
+YAML/JSON loader — are covered by ClusterFuzzLite under both AddressSanitizer
+and UndefinedBehaviorSanitizer. PRs that touch `src/`, `fuzz/`,
+`.clusterfuzzlite/`, or the CFLite workflows trigger short fuzz runs as a
+status check; a nightly cron runs a longer batch. Fuzz target sources
+live in `fuzz/fuzz_*.py`. Reports for crashes found by fuzzing should
+follow the same private-disclosure path as any other vulnerability.
+
 ## References
 
 - OWASP Top 10: <https://owasp.org/www-project-top-ten/>

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/fuzz/fuzz_audit_from_dict.py
+++ b/fuzz/fuzz_audit_from_dict.py
@@ -1,0 +1,58 @@
+"""Atheris fuzz target: AuditRecord.from_dict.
+
+Models the JSONL-replay path: trail records on disk get reloaded by
+deserialising untrusted JSON into `AuditRecord.from_dict`. Bad input
+must surface as `TypeError`/`ValueError`/`KeyError` — never silently
+construct a corrupt record and never crash the process.
+
+After deserialisation the target also exercises `compute_hash()` and
+the `narrative` property — both are reached when a regulator replays
+a trail, and both have already had defensive fixes (NaN/overflow
+timestamps, oversize agent_id) that fuzzing should keep honest.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from vaara.audit.trail import AuditRecord
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    raw = fdp.ConsumeUnicode(sys.maxsize)
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError, RecursionError):
+        return
+
+    if not isinstance(parsed, dict):
+        return
+
+    try:
+        record = AuditRecord.from_dict(parsed)
+    except (TypeError, ValueError, KeyError):
+        return
+
+    try:
+        record.compute_hash()
+    except (TypeError, ValueError):
+        return
+
+    try:
+        _ = record.narrative
+    except (TypeError, ValueError):
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_overt_envelope.py
+++ b/fuzz/fuzz_overt_envelope.py
@@ -1,0 +1,88 @@
+"""Atheris fuzz target: OVERT 1.0 envelope CBOR decode + verify.
+
+Mirrors the attack surface of `vaara overt verify`: attacker-controlled CBOR
+bytes that get loaded by `cbor2.loads`, structurally validated against the
+closed 9-field schema, mapped into a `BaseEnvelope`, then signature-checked.
+
+A finding is anything that escapes the documented error contract: any
+exception other than the ones the verifier path is expected to swallow
+(`EnvelopeError`, `CBORDecodeError`, `TypeError`, `ValueError`, `KeyError`,
+`OverflowError`, `MemoryError`). Hangs and uncaught crashes count too.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    import cbor2
+    from cbor2 import CBORDecodeError
+
+    from vaara.attestation.overt import (
+        BaseEnvelope,
+        EnvelopeError,
+        verify_base_envelope,
+    )
+
+_REQUIRED_KEYS = (
+    "blinded_identifier",
+    "request_commitment",
+    "encoder_binary_identity",
+    "non_content_metadata",
+    "monotonic_counter",
+    "nanosecond_timestamp",
+    "key_identifier",
+    "arbiter_instance_identifier",
+    "signature",
+)
+
+# Fixed 32-byte all-zero pubkey: cheap, deterministic, never collides with
+# a real key_identifier so verify_base_envelope must always reach the
+# signature path or reject earlier.
+_DUMMY_PUBKEY = b"\x00" * 32
+
+
+def TestOneInput(data: bytes) -> None:
+    try:
+        decoded = cbor2.loads(data)
+    except (CBORDecodeError, MemoryError, OverflowError, ValueError):
+        return
+    except Exception:
+        # Anything else from the CBOR decoder is interesting.
+        raise
+
+    if not isinstance(decoded, dict):
+        return
+    if any(k not in decoded for k in _REQUIRED_KEYS):
+        return
+
+    try:
+        envelope = BaseEnvelope(
+            blinded_identifier=decoded["blinded_identifier"],
+            request_commitment=decoded["request_commitment"],
+            encoder_binary_identity=decoded["encoder_binary_identity"],
+            non_content_metadata=decoded["non_content_metadata"],
+            monotonic_counter=int(decoded["monotonic_counter"]),
+            nanosecond_timestamp=int(decoded["nanosecond_timestamp"]),
+            key_identifier=decoded["key_identifier"],
+            arbiter_instance_identifier=decoded["arbiter_instance_identifier"],
+            signature=decoded["signature"],
+        )
+    except (TypeError, ValueError, OverflowError, KeyError):
+        return
+
+    try:
+        verify_base_envelope(envelope, _DUMMY_PUBKEY)
+    except (EnvelopeError, TypeError, ValueError):
+        return
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/fuzz/fuzz_policy_loader.py
+++ b/fuzz/fuzz_policy_loader.py
@@ -1,0 +1,63 @@
+"""Atheris fuzz target: policy JSON/YAML loader.
+
+The policy loader is what turns regulator/operator-supplied YAML or JSON
+into the in-memory `Policy` that gates every action at runtime. A loader
+that crashes on hostile input is a denial-of-service surface; a loader
+that silently produces a malformed `Policy` is worse.
+
+This target fuzzes the `from_json` text path (which is what file loads
+funnel into) plus the `from_yaml` text path when PyYAML is importable.
+Expected exceptions: `PolicyError`, `TypeError`, `ValueError`, `KeyError`.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import atheris
+
+with atheris.instrument_imports():
+    from vaara.policy.loader import from_json, from_yaml
+    from vaara.policy.schema import PolicyError
+
+try:
+    import yaml as _yaml  # noqa: F401
+
+    _HAS_YAML = True
+except ImportError:
+    _HAS_YAML = False
+
+
+def TestOneInput(data: bytes) -> None:
+    fdp = atheris.FuzzedDataProvider(data)
+    choice = fdp.ConsumeIntInRange(0, 1) if _HAS_YAML else 0
+    text = fdp.ConsumeUnicode(sys.maxsize)
+
+    if choice == 0:
+        try:
+            from_json(text)
+        except (PolicyError, TypeError, ValueError, KeyError, RecursionError):
+            return
+    else:
+        try:
+            from_yaml(text)
+        except (PolicyError, TypeError, ValueError, KeyError, RecursionError):
+            return
+        except Exception as exc:
+            # PyYAML raises subclasses of yaml.YAMLError on parse failure.
+            # The loader is supposed to wrap those into PolicyError; anything
+            # else leaking through is a finding.
+            import yaml
+
+            if isinstance(exc, yaml.YAMLError):
+                return
+            raise
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.26.0"
+version = "0.27.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/policy/loader.py
+++ b/src/vaara/policy/loader.py
@@ -260,8 +260,16 @@ def from_yaml(source: Union[str, Path]) -> Policy:
 
     if isinstance(source, Path):
         text = _read_policy_text(source)
-    elif isinstance(source, str) and "\n" not in source and Path(source).is_file():
-        text = _read_policy_text(Path(source))
+    elif isinstance(source, str) and "\n" not in source:
+        # An attacker-controlled string longer than the OS path limit makes
+        # Path(...).is_file() raise OSError(ENAMETOOLONG) directly, bypassing
+        # this loader's PolicyError contract. Treat any stat() failure as
+        # "not a path" and fall through to YAML parsing.
+        try:
+            looks_like_path = Path(source).is_file()
+        except OSError:
+            looks_like_path = False
+        text = _read_policy_text(Path(source)) if looks_like_path else source
     else:
         text = source
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -308,3 +308,20 @@ def test_from_yaml_path(tmp_path: Path) -> None:
     f.write_text(yaml.safe_dump(MINIMAL_POLICY))
     p = from_yaml(f)
     assert p.version == SCHEMA_VERSION
+
+
+def test_from_yaml_oversize_single_line_treated_as_content_not_path() -> None:
+    """A single-line YAML string longer than the OS path limit must not leak
+    OSError(ENAMETOOLONG) from the internal Path(...).is_file() probe.
+
+    Regression: the loader previously called Path(source).is_file() before
+    any exception handler ran, so a >255-byte single-line attacker input
+    bypassed the PolicyError contract and raised a bare OSError. Now any
+    stat() failure on the path-probe is interpreted as "not a path" and the
+    string falls through to the YAML parser, which then surfaces as a
+    PolicyError on invalid YAML or a malformed-policy error on valid YAML.
+    """
+    pytest.importorskip("yaml")
+    oversize = "a: " * 500
+    with pytest.raises(PolicyError):
+        from_yaml(oversize)


### PR DESCRIPTION
## Summary

- Wires ClusterFuzzLite into CI under address and undefined sanitizers for the three parsers that ingest attacker-controlled bytes: OVERT envelope CBOR, `AuditRecord.from_dict`, policy YAML/JSON loader.
- Three workflows: PR fuzzing (300s, code-change mode), nightly batch (3600s), build-sanity on push to main.
- Bundled fix: `vaara.policy.loader.from_yaml` leaked `OSError(ENAMETOOLONG)` past its `PolicyError` contract on single-line YAML strings longer than the OS path limit. Found by the local smoke run of `fuzz_policy_loader.py` before any atheris fuzzing ran. Regression test pinned in `tests/test_policy.py`.
- SECURITY.md now documents the continuous-fuzzing posture so external reporters know the parsers are under active fuzz coverage.

## Test plan

- [x] Full pytest suite green (771 passed, 12 skipped) including new regression test
- [x] Local structural smoke of all three fuzz targets clean after the loader fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed policy YAML loader to properly raise `PolicyError` for oversized single-line strings instead of leaking system errors.

* **Chores**
  * Bumped version to 0.27.0.
  * Added continuous fuzzing infrastructure to improve security coverage for parsers handling untrusted inputs.
  * Updated security documentation with fuzzing program details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->