### PR TITLE
docs: add Vaara trademark policy

### DIFF
--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,56 @@
+# Trademark Policy
+
+Last updated: 2026-05-22
+
+The Apache License 2.0 covers the source code in this repository. Apache 2.0 does not grant rights to the project name, the project wordmark, or any related marks. This file states how those marks may be used in connection with this open-source project.
+
+## Marks covered
+
+This policy covers the following when used in connection with AI Act compliance, runtime governance, audit-trail, attestation, or related software contexts where this project operates:
+
+- The word **Vaara** as the name of this open-source software project.
+- The Vaara wordmark images in `docs/vaara-wordmark-light.png` and `docs/vaara-wordmark-dark.png`.
+- Any visual identity derived from those wordmark images.
+
+These are referred to as "the Vaara project marks."
+
+## Scope and prior art
+
+"Vaara" is a common Finnish noun (meaning *danger* or *fell/hill*) and a frequent component of Finnish surnames and place names. This policy makes no claim to the word in unrelated contexts, jurisdictions, goods, or services. The marks asserted here are limited to the specific commercial context of this open-source software project.
+
+Henri Sirkkavaara asserts common-law trademark rights in the Vaara project marks based on continuous and substantial use in commerce in this context since the project's initial public release on PyPI. The marks are not formally registered. The project reserves the right to seek formal registration in relevant jurisdictions and classes.
+
+## Permitted use
+
+The following are explicitly allowed and need no permission:
+
+- Factual referential use: "This product integrates with Vaara", "Built with Vaara", "Compatible with Vaara".
+- Linking to vaara.io, the PyPI package, the GitHub repository, or any official Vaara channel.
+- Citing the project in academic papers, regulatory submissions, standards-body documents, conference talks, and similar substantive contexts.
+- Using the wordmark images unmodified to identify a product or service that integrates with this Vaara project, provided the use does not suggest endorsement.
+- Forks under Apache 2.0 retaining attribution to this Vaara project. A fork distributed under a different identity must rename itself.
+
+## Not permitted without written permission
+
+The following require written permission from the project maintainer:
+
+- Naming a fork, distribution, hosted service, or commercial product **Vaara**, or any name that incorporates the Vaara project marks in a way that suggests it is the canonical Vaara project.
+- Using the Vaara wordmark or any derivative as the primary visual identity of a product, service, or organization other than this open-source project.
+- Implying official endorsement, partnership, or affiliation with this Vaara project without an established relationship.
+- Using the marks in ways that disparage or misrepresent the project.
+
+The Apache 2.0 license to the source code remains intact regardless of trademark status. Forking the code is welcome. Forking the identity is not.
+
+## Permission requests
+
+Send permission requests to **hello@vaara.io**. Include:
+
+- Who you are.
+- What use you propose.
+- For commercial use, the product or service context.
+
+Decisions are at the maintainer's discretion.
+
+## Updates
+
+This policy may be updated. The current version always lives at `TRADEMARK.md` in the main branch of `github.com/vaaraio/vaara`.


### PR DESCRIPTION
Apache 2.0 does not grant trademark rights. This file states the project's trademark policy on the Vaara name and the wordmark images in docs/. Asserts common-law marks scoped narrowly to the AI Act compliance and runtime governance software context, with explicit acknowledgement that vaara is a Finnish common noun and surname component to avoid overclaiming.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the trademark policy to reflect current guidelines. The policy outlines permitted and prohibited uses of Vaara marks, clarifies the scope of common-law rights, and provides instructions for requesting permission for restricted uses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->