### PR TITLE
release(v0.28.0): evidence sufficiency reference and conformal explainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-05-22
+
+**Theme: making the evidence-sufficiency rules and the conformal
+interval readable by the people who use them.** The compliance engine
+has been producing `verdict_inputs` (the threshold-vs-observed snapshot
+that drove each article's verdict) and `verdict_reasons` (human-readable
+rationale lines) since v0.26.0, and conformal intervals on every risk
+score since the first public release. What was missing was a public,
+linkable reference for the threshold values per article and a
+plain-language explainer of the conformal interval for compliance
+reviewers and legal counsel who are not statisticians. This release
+ships both.
+
+### Added
+- `VERDICTS.md`: per-article evidence sufficiency reference. Documents
+  the EU AI Act (Articles 9, 11-15, 17, 61) and DORA (Articles 10, 12,
+  13) defaults the engine ships with: minimum record count, staleness
+  window, strong-strength count and freshness bounds, future-timestamp
+  downgrade, chain-integrity pin, and the status/strength decision
+  tree. Includes worked JSON examples of `verdict_inputs` for a
+  sufficient article and the same article after a chain break.
+  Cross-linked from `COMPLIANCE.md` and from the README "Where things
+  live" table.
+- `docs/conformal-prediction.md`: plain-language companion to
+  `docs/formal_specification.md`. Explains why a point risk score is
+  not enough, what the interval gives a reader, and how the
+  distribution-free coverage guarantee maps to Article 15(1)
+  ("appropriate level of accuracy") and Recital 133 (detection of
+  non-conformities). Cross-linked from the README "Where things live"
+  table and from `VERDICTS.md` Article 15(1) discussion.
+
+### Changed
+- `COMPLIANCE.md` "EU AI Act Article Mapping" intro now points readers
+  to `VERDICTS.md` for the threshold rules behind status assignment.
+
+### Notes for deployers
+- The threshold defaults in `VERDICTS.md` are the values shipped in
+  `EU_AI_ACT_REQUIREMENTS` and `DORA_REQUIREMENTS` in
+  `vaara/compliance/engine.py`. A deployer can override any of them
+  by registering a custom `RegulatoryRequirement` with the
+  `ComplianceEngine`. The document is the public starting point, not
+  a constraint.
+
 ## [0.27.0] - 2026-05-22
 
 **Theme: continuous fuzzing on the parsers that ingest attacker-controlled

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -20,7 +20,9 @@ from application logs after the fact.
 
 The table below maps each article Vaara addresses to the runtime event
 types that populate evidence for it. The list matches the default
-`ComplianceEngine` requirements in `vaara.compliance.engine`.
+`ComplianceEngine` requirements in `vaara.compliance.engine`. For the
+thresholds the engine uses to decide whether the evidence is sufficient,
+partial, or insufficient, see [VERDICTS.md](VERDICTS.md).
 
 | Article | Requirement | Evidence Vaara produces |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -257,7 +257,9 @@ See [COMPLIANCE.md](COMPLIANCE.md) "Position relative to open runtime-attestatio
 | Path | Contents |
 |---|---|
 | [docs/formal_specification.md](docs/formal_specification.md) | MWU regret bound, conformal coverage, security properties |
+| [docs/conformal-prediction.md](docs/conformal-prediction.md) | Plain-language explainer for compliance reviewers and legal counsel |
 | [COMPLIANCE.md](COMPLIANCE.md) | EU AI Act (Art. 9, 11 to 15, 61) and DORA (Art. 10, 12, 13) mapping, eval numbers, PAIR calibration |
+| [VERDICTS.md](VERDICTS.md) | Per-article evidence sufficiency thresholds and decision tree |
 | [CHANGELOG.md](CHANGELOG.md) | Version-by-version feature evolution |
 | [docs/signing-keys.md](docs/signing-keys.md) | Release signing and verification |
 | [SECURITY.md](SECURITY.md) | Security policy and reporting |

--- a/VERDICTS.md
+++ b/VERDICTS.md
@@ -1,0 +1,182 @@
+# Evidence Sufficiency Rules
+
+This document is the public reference for how Vaara's compliance engine
+decides whether the evidence collected for each regulatory article is
+sufficient, partial, or insufficient. It is the companion document to
+[COMPLIANCE.md](COMPLIANCE.md), which maps articles to the event types
+that feed them. COMPLIANCE.md answers "what runtime evidence does Vaara
+collect for Article X?" This document answers "given that evidence,
+what does Vaara conclude, and why?"
+
+The rules described here are the same rules executed by
+`vaara.compliance.engine.ComplianceEngine.assess_conformity`. Every
+report produced by `vaara compliance report` surfaces the inputs and
+the rationale per article in the `verdict_inputs` block.
+
+## Status and strength taxonomy
+
+A single article carries two orthogonal labels in a report:
+
+**Status.** Does the body of evidence meet the threshold?
+
+| Value | Meaning |
+|---|---|
+| `evidence_sufficient` | Records present, count at or above threshold, freshest record within the staleness window, no clock-skew or chain integrity issues. |
+| `evidence_partial` | Records present at or above the count threshold, but at least one freshness or integrity check flagged a gap. |
+| `evidence_insufficient` | Record count below threshold, or no qualifying records at all. |
+| `not_applicable` | Article does not apply to this system. |
+
+**Strength.** How good is the evidence beyond the minimum?
+
+| Value | Meaning |
+|---|---|
+| `strong` | Count at or above twice the minimum, freshest record younger than one quarter of the staleness window. |
+| `moderate` | Count at or above the minimum and freshest record inside the staleness window, but not at strong levels. |
+| `weak` | Records present, but either count below the minimum or freshest record beyond the staleness window. |
+| `absent` | No qualifying records, or chain integrity broken. |
+
+The status and strength labels are independent dimensions: a `weak`
+article can still be `evidence_partial` (e.g. enough records but stale),
+and a `strong` article is always `evidence_sufficient`.
+
+## Decision tree
+
+For each requirement, the engine collects records of the event types
+listed for that article, then evaluates in this order:
+
+1. **External-evidence requirements.** Articles like Article 11(1)
+   carry no runtime event types. They return `evidence_partial`,
+   `weak`, with the note "Requires manual verification (documentation,
+   design docs)." The Annex IV technical file is the deployer's
+   artefact. Vaara cannot synthesise it.
+2. **Chain integrity check.** If `AuditTrail.verify_chain()` returns
+   an error, every article is pinned to `evidence_insufficient` and
+   `absent`, regardless of per-article counts. `verdict_inputs.chain_intact`
+   flips to `false` and a chain-integrity warning is prepended to
+   `verdict_reasons`. A dashboard cannot render a green cell over a
+   broken chain.
+3. **Gap detection.** Three gap classes are checked independently:
+   - Count gap: fewer records than `min_evidence_count`.
+   - Freshness gap: freshest record older than `staleness_hours`.
+   - Clock-skew gap: at least one record carries a timestamp in the future.
+4. **Status assignment.** If no gaps, `evidence_sufficient`. Else if
+   the count threshold is met (only freshness or integrity gaps remain),
+   `evidence_partial`. Otherwise `evidence_insufficient`.
+5. **Strength assignment.** Count at or above `2 × min_evidence_count`
+   AND freshest age below `staleness_hours / 4` produces `strong`. Count
+   at or above the minimum AND freshest age inside the staleness window
+   produces `moderate`. Any qualifying records below those bars are
+   `weak`. No records are `absent`.
+6. **Future-timestamp downgrade.** If any record carries a future
+   timestamp, strength drops one tier (`strong` → `moderate`,
+   `moderate` → `weak`). The freshness signal cannot be trusted when
+   the clock cannot be trusted.
+
+## EU AI Act per-article thresholds
+
+The defaults below are the values shipped in
+`EU_AI_ACT_REQUIREMENTS` in `vaara/compliance/engine.py`. A deployer
+can override them by registering a custom `RegulatoryRequirement` with
+the engine.
+
+| Article | Title | Min count | Staleness window | Strong-count | Strong-freshness | Critical |
+|---|---|---|---|---|---|---|
+| 9(1) | Risk Management System | 10 | 720 h (30 d) | 20 | 180 h (7.5 d) | yes |
+| 9(2)(a) | Risk Identification and Analysis | 5 | 720 h | 10 | 180 h | yes |
+| 9(4)(a) | Risk Mitigation Measures | 3 | 720 h | 6 | 180 h | yes |
+| 9(7) | Testing Procedures | 10 | 720 h | 20 | 180 h | yes |
+| 11(1) | Technical Documentation | n/a | n/a | n/a | n/a | yes (external) |
+| 12(1) | Record-Keeping (Logging) | 20 | 720 h | 40 | 180 h | yes |
+| 13(1) | Transparency and Provision of Information | 5 | 720 h | 10 | 180 h | yes |
+| 14(1) | Human Oversight: Design | 1 | 720 h | 2 | 180 h | yes |
+| 14(4)(d) | Human Oversight: Override Capability | 1 | 720 h | 2 | 180 h | no |
+| 15(1) | Accuracy, Robustness and Cybersecurity | 10 | 168 h (7 d) | 20 | 42 h | yes |
+| 61(1) | Post-Market Monitoring | 20 | 720 h | 40 | 180 h | yes |
+
+Article 11(1) is the external-evidence row. It does not consume runtime
+events. The threshold table is intentionally blank.
+
+Article 15(1) is the only EU AI Act row with a non-default staleness
+window. It defaults to 168 hours (one week) because accuracy and
+robustness signals are expected to be refreshed on a roughly weekly
+calibration cadence, not a monthly one.
+
+A requirement marked `is_critical=True` participates in the
+overall-status roll-up. The overall report status is the worst status
+across all critical articles: any critical `evidence_insufficient`
+collapses the report to `evidence_insufficient` overall.
+
+## DORA per-article thresholds
+
+| Article | Title | Min count | Staleness window | Strong-count | Strong-freshness | Critical |
+|---|---|---|---|---|---|---|
+| 10(1) | ICT Risk Management: Protection and Prevention | 5 | 720 h | 10 | 180 h | yes |
+| 12(1) | ICT Incident Detection | 10 | 720 h | 20 | 180 h | yes |
+| 13(1) | ICT Incident Response and Learning | 5 | 720 h | 10 | 180 h | no |
+
+## What an auditor sees
+
+Every `ArticleEvidence` entry in a report carries a `verdict_inputs`
+block with the threshold values the engine compared against and the
+actual values it observed. Example (abbreviated) for Article 12(1):
+
+```json
+{
+  "article": "Article 12(1)",
+  "status": "evidence_sufficient",
+  "strength": "strong",
+  "evidence_count": 47,
+  "freshest_evidence_age_hours": 1.3,
+  "oldest_evidence_age_hours": 168.7,
+  "verdict_inputs": {
+    "min_evidence_count": 20,
+    "staleness_hours": 720.0,
+    "evidence_count_observed": 47,
+    "freshest_evidence_age_hours": 1.3,
+    "future_timestamp_count": 0,
+    "chain_intact": true,
+    "strength_thresholds": {
+      "strong_min_count": 40,
+      "strong_max_age_hours": 180.0,
+      "moderate_min_count": 20,
+      "moderate_max_age_hours": 720.0
+    },
+    "verdict_reasons": [
+      "Status SUFFICIENT: 47 record(s) >= threshold 20, freshest 1.3h within 720h staleness window, no clock-skew indicators.",
+      "Strength STRONG: 47 >= 2x threshold (40) and freshness 1.3h < staleness/4 (180.0h)."
+    ]
+  }
+}
+```
+
+The same article rendered after a broken chain produces:
+
+```json
+{
+  "article": "Article 12(1)",
+  "status": "evidence_insufficient",
+  "strength": "absent",
+  "verdict_inputs": {
+    "chain_intact": false,
+    "verdict_reasons": [
+      "Audit chain integrity compromised; status pinned to INSUFFICIENT and strength to ABSENT regardless of per-article evidence count.",
+      "Status SUFFICIENT: 47 record(s) >= threshold 20, freshest 1.3h within 720h staleness window, no clock-skew indicators.",
+      "Strength STRONG: 47 >= 2x threshold (40) and freshness 1.3h < staleness/4 (180.0h)."
+    ]
+  }
+}
+```
+
+The second and third lines are preserved so an auditor can see what the
+verdict would have been on the underlying evidence had the chain held.
+The first line is the pin.
+
+## What this document is not
+
+This is an evidence-sufficiency reference, not a conformity
+determination. The engine produces structured evidence with rationale.
+A conformity verdict under the EU AI Act is made by the deployer (and,
+for high-risk systems, a Notified Body), not by a library. The
+deployer's auditor reads the per-article thresholds in this document
+alongside the rationale lines in `verdict_inputs.verdict_reasons` and
+forms their own judgement.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/docs/conformal-prediction.md
+++ b/docs/conformal-prediction.md
@@ -1,0 +1,104 @@
+# Conformal prediction in plain language
+
+This document is the non-technical companion to Vaara's formal
+specification of adaptive risk scoring. The formal version lives at
+[`docs/formal_specification.md`](formal_specification.md). If you are a
+compliance reviewer, legal counsel, or procurement officer reading a
+Vaara report and wondering what the conformal interval next to each
+risk score actually means, this is the document for you.
+
+## What is a risk score, and why is one number not enough?
+
+When Vaara intercepts an action by an LLM agent (a tool call to read a
+file, send an email, transfer funds, and so on), it produces a risk
+score between 0 and 1. A score of 0 means "no harm expected" and a
+score of 1 means "catastrophic harm expected." The score is the
+system's best guess at the action's true risk.
+
+A single number is not enough on its own. The same score of 0.6 can
+come from two very different places: a confident estimate based on
+many similar past actions, or an uncertain guess based on weak
+signals. A compliance reviewer who only sees the number cannot tell
+which one they are looking at.
+
+This is the gap conformal prediction fills.
+
+## What conformal prediction gives you
+
+Instead of one number, conformal prediction gives you an **interval**.
+A typical Vaara output looks like this:
+
+> Risk score: 0.6, interval [0.42, 0.78].
+
+The interval is read as "the true risk is somewhere between 0.42 and
+0.78, and we have a known probability of being right about that range."
+
+Two properties make the interval useful:
+
+1. **Distribution-free.** The interval is valid without assuming the
+   data follows any particular shape (normal, uniform, anything). This
+   matters because real-world action sequences from LLM agents do not
+   follow a textbook distribution.
+2. **Coverage guarantee.** You set an error budget (say, 10%), and
+   the interval comes with the guarantee that the true risk lands
+   inside the interval at least 90% of the time, on average, over many
+   actions. The guarantee holds without assuming the model is
+   well-calibrated to begin with.
+
+A narrow interval like [0.58, 0.62] tells a reviewer the system is
+confident. A wide interval like [0.2, 0.95] tells them it is not. The
+risk score itself can be identical in both cases. The interval is what
+makes the difference visible.
+
+## Why this matters under the EU AI Act
+
+Two parts of the AI Act point at this directly.
+
+**Article 15(1)** requires high-risk AI systems to "be designed and
+developed in such a way that they achieve an appropriate level of
+accuracy, robustness and cybersecurity, and perform consistently in
+those respects throughout their lifecycle." The phrase "appropriate
+level" is meaningless without a way to measure it. A point score
+cannot be measured against an accuracy target because it has no
+notion of how often it is wrong. A conformal interval is measurable: a
+deployer can publish the guarantee (e.g. "the interval covers the true
+risk at least 90% of the time") and an auditor can check it against
+observed outcomes.
+
+**Recital 133** discusses the detection of "violations or
+non-conformities" by AI systems and the need to "regularly verify the
+results obtained." A point estimate does not surface non-conformity
+until after the fact. An interval that widens or narrows is itself a
+real-time signal that the model is moving into or out of a region
+where its predictions are trustworthy.
+
+In short: a conformal interval converts "trust me, the score is 0.6"
+into "the score is 0.6, here is the range we expect to be in, here is
+the error rate, and you can hold us to it."
+
+## What this is not
+
+Conformal prediction is not a confidence score in the
+common-marketing sense (e.g. "the model is 87% confident"). Those
+numbers usually have no formal meaning and degrade silently as the
+underlying distribution shifts. The conformal interval has a
+mathematical guarantee that holds without distributional assumptions.
+
+Conformal prediction is also not a substitute for ground-truth outcome
+labels. The system still needs to observe what actually happened after
+each action to update its calibration. Vaara records that signal via
+`OUTCOME_RECORDED` events. See [`COMPLIANCE.md`](../COMPLIANCE.md) for
+the article mapping and [`VERDICTS.md`](../VERDICTS.md) for the
+staleness windows the engine applies to those records.
+
+## Where to read more
+
+- Formal definition, coverage proof, and the exact scorer Vaara
+  ships: [`docs/formal_specification.md`](formal_specification.md).
+- How outcome records feed the calibration loop, and the staleness
+  rules that decide when calibration is fresh enough to trust:
+  [`VERDICTS.md`](../VERDICTS.md), Article 15(1) row.
+- The original conformal prediction literature (Vovk, Gammerman,
+  Shafer) is a good academic anchor if you want the textbook proof.
+  Vaara implements split-conformal prediction, the most operationally
+  practical variant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.27.0"
+version = "0.28.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.27.0"
+__version__ = "0.28.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
**Theme: making the per-article evidence-sufficiency rules and the conformal interval readable by the people who use them.**

The compliance engine has been producing `verdict_inputs` (the threshold-vs-observed snapshot that drove each article's verdict) and `verdict_reasons` (human-readable rationale lines) since v0.26.0, and conformal intervals on every risk score since the first public release. What was missing was a public, linkable reference for the threshold values per article and a plain-language explainer of the conformal interval for compliance reviewers and legal counsel who are not statisticians. This release ships both.

### Added

- `VERDICTS.md`: per-article evidence sufficiency reference. Documents the EU AI Act (Articles 9, 11-15, 17, 61) and DORA (Articles 10, 12, 13) defaults the engine ships with: minimum record count, staleness window, strong-strength count and freshness bounds, future-timestamp downgrade, chain-integrity pin, and the status/strength decision tree. Includes worked JSON examples of `verdict_inputs` for a sufficient article and the same article after a chain break. Cross-linked from `COMPLIANCE.md` and from the README "Where things live" table.
- `docs/conformal-prediction.md`: plain-language companion to `docs/formal_specification.md`. Explains why a point risk score is not enough, what the interval gives a reader, and how the distribution-free coverage guarantee maps to Article 15(1) ("appropriate level of accuracy") and Recital 133 (detection of non-conformities). Cross-linked from the README "Where things live" table.

### Changed

- `COMPLIANCE.md` "EU AI Act Article Mapping" intro now points readers to `VERDICTS.md` for the threshold rules behind status assignment.

### Notes for deployers

The threshold defaults in `VERDICTS.md` are the values shipped in `EU_AI_ACT_REQUIREMENTS` and `DORA_REQUIREMENTS` in `vaara/compliance/engine.py`. A deployer can override any of them by registering a custom `RegulatoryRequirement` with the `ComplianceEngine`. The document is the public starting point, not a constraint.

### Tests

771 passed, 12 skipped. No code changes.
