### PR TITLE
fix(docs): drop Recital 133 misattribution from conformal explainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,8 @@ ships both.
   `docs/formal_specification.md`. Explains why a point risk score is
   not enough, what the interval gives a reader, and how the
   distribution-free coverage guarantee maps to Article 15(1)
-  ("appropriate level of accuracy") and Recital 133 (detection of
-  non-conformities). Cross-linked from the README "Where things live"
-  table and from `VERDICTS.md` Article 15(1) discussion.
+  ("appropriate level of accuracy"). Cross-linked from the README
+  "Where things live" table.
 
 ### Changed
 - `COMPLIANCE.md` "EU AI Act Article Mapping" intro now points readers

--- a/docs/conformal-prediction.md
+++ b/docs/conformal-prediction.md
@@ -52,8 +52,6 @@ makes the difference visible.
 
 ## Why this matters under the EU AI Act
 
-Two parts of the AI Act point at this directly.
-
 **Article 15(1)** requires high-risk AI systems to "be designed and
 developed in such a way that they achieve an appropriate level of
 accuracy, robustness and cybersecurity, and perform consistently in
@@ -65,12 +63,10 @@ deployer can publish the guarantee (e.g. "the interval covers the true
 risk at least 90% of the time") and an auditor can check it against
 observed outcomes.
 
-**Recital 133** discusses the detection of "violations or
-non-conformities" by AI systems and the need to "regularly verify the
-results obtained." A point estimate does not surface non-conformity
-until after the fact. An interval that widens or narrows is itself a
-real-time signal that the model is moving into or out of a region
-where its predictions are trustworthy.
+A widening interval is itself a real-time signal that the model is
+moving into a region where its predictions cannot be trusted. A point
+estimate does not surface that drift until ground-truth labels arrive
+and the error rate is reconstructed after the fact.
 
 In short: a conformal interval converts "trust me, the score is 0.6"
 into "the score is 0.6, here is the range we expect to be in, here is


### PR DESCRIPTION
Recital 133 of the EU AI Act is about synthetic content watermarking under Article 50, not detection of non-conformities or accuracy verification. The conformal-prediction.md doc and v0.28.0 CHANGELOG entry both cited it incorrectly.

Verified the actual Recital 133 text via artificialintelligenceact.eu before this fix. The recital states: "A variety of AI systems can generate large quantities of synthetic content that becomes increasingly hard for humans to distinguish from human-generated and authentic content... it is appropriate to require providers of those systems to embed technical solutions that enable marking in a machine readable format and detection that the output has been generated or manipulated by an AI system."

That maps to Article 50 (transparency for synthetic content) and provider watermarking obligations, not to Article 15 accuracy/robustness or runtime detection of operational non-conformities.

### Fix

- `docs/conformal-prediction.md`: drop the Recital 133 paragraph. Article 15(1) anchor stands on its own. Replaced the recital framing with a tighter explanation of why a widening interval is itself the real-time signal.
- `CHANGELOG.md` v0.28.0 entry: drop the "and Recital 133 (detection of non-conformities)" clause from the conformal-prediction.md description.

### Why this is going in before tagging v0.28.0

v0.28.0 is merged to main but not yet tagged and not yet on PyPI. Landing this fix on main first means the tag points at the corrected content and PyPI never publishes the misattribution. Cleaner than v0.28.1 a few minutes later.

### Tests

771 passed, 12 skipped. No code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v0.28.0 Release Notes

* **Documentation**
  * Added plain-language explainer for conformal prediction and risk score intervals
  * Added public reference documenting evidence-sufficiency verdict logic, decision thresholds, and how auditors interpret compliance reports
  * Updated compliance documentation with clearer threshold definitions

* **Chores**
  * Version bumped to 0.28.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->