### PR TITLE
release(v0.29.0): chronology anchor and
  adjacent-work reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-05-24
+
+**Theme: chronology anchor for Vaara's load-bearing concepts and a
+neutral list of adjacent published work.** As runtime-evidence,
+hash-chained audit, and conformal-interval framings appear in
+recent pre-prints (Protocol-Driven Development, Subjective Logic
+runtime confidence updates, formal-methods runtime monitors), a
+reader comparing Vaara against newer proposals deserves a single
+file that anchors when each Vaara concept first shipped in a tagged
+public release and lists adjacent peer-reviewed and pre-print work
+without competitive framing. This release ships that file and adds a
+short related-work section to the conformal-prediction explainer.
+
+### Added
+- `PRIOR_ART.md`: per-concept chronology table mapping each
+  load-bearing Vaara concept to its first shipped version and a path
+  into the codebase or docs. Includes a related-work section listing
+  adjacent pre-prints (Protocol-Driven Development, Formal Methods
+  Meet LLMs, Subjective Logic runtime confidence updates,
+  mechanistic interpretability for EASA learning-assurance,
+  backchaining LoC mitigations from national security benchmarks)
+  and classical foundations (conformal prediction, Linear Temporal
+  Logic runtime verification). Inclusion is neutral attribution, not
+  ranking.
+- `PRIOR_ART.md` cross-link in the README "Where things live" table.
+
+### Changed
+- `docs/conformal-prediction.md`: appended a "Related
+  runtime-confidence work" section citing the Subjective Logic
+  safety-arguments pre-print (arXiv:2605.22530v1) as a complementary
+  research line, with a cross-link to `PRIOR_ART.md` for the broader
+  chronology and related-work list. The plain-language explanation
+  and the Article 15(1) mapping are unchanged.
+
+### Unchanged
+- Hash chain format, OVERT envelope schema, MCP proxy perimeter
+  semantics, CLI surface, HTTP API, release workflow. This release
+  ships documentation surfaces only. The compliance engine,
+  scorer, audit, OVERT, and policy paths are byte-identical to
+  v0.28.0.
+
+### Notes for deployers
+- The chronology table in `PRIOR_ART.md` is reconstructed from
+  `CHANGELOG.md` and the git tags. Both can be verified
+  independently against PyPI release history and the GitHub tag
+  list. Where a deployer or auditor wants a paper trail for "since
+  when has Vaara done X," `PRIOR_ART.md` is the file to cite.
+
 ## [0.28.0] - 2026-05-22
 
 **Theme: making the evidence-sufficiency rules and the conformal

--- a/PRIOR_ART.md
+++ b/PRIOR_ART.md
@@ -1,0 +1,143 @@
+# Prior art and related work
+
+This document anchors when each load-bearing Vaara concept first shipped
+in a tagged public release, and lists adjacent published work in the
+same lane. It exists so that a reader comparing Vaara against newer
+academic or industry proposals can check the published timeline rather
+than relying on marketing claims.
+
+The chronology is reconstructed from `CHANGELOG.md` and the git history
+of this repository. Dates are calendar dates of the tagged PyPI release.
+Version numbers and dates can be verified against
+[https://pypi.org/project/vaara/#history](https://pypi.org/project/vaara/#history)
+and the `vX.Y.Z` tags on
+[https://github.com/vaaraio/vaara/tags](https://github.com/vaaraio/vaara/tags).
+
+## When each Vaara concept first shipped
+
+| Concept | First shipped | Where to read it |
+|---|---|---|
+| Interception pipeline for agent tool calls | v0.1.0, 2026-04-10 | `src/vaara/pipeline.py`, `CHANGELOG.md` v0.1.0 |
+| Adaptive risk scoring with conformal interval on every score | v0.1.0, 2026-04-10 | `docs/formal_specification.md`, `docs/conformal-prediction.md` |
+| Hash-chained audit trail | v0.1.0, 2026-04-10 | `src/vaara/audit/`, `COMPLIANCE.md` |
+| Framework integrations (LangChain, CrewAI, OpenAI Agents) and MCP server surface | v0.3.0, 2026-04-18 | `src/vaara/integrations/` |
+| Signed audit-trail export and verification CLI | v0.4.1, 2026-04-20 | `src/vaara/audit/`, `docs/vaara-audit-cli.md` |
+| Sigstore-signed release workflow with PyPI trusted publishing and PEP 740 attestations | v0.4.3, 2026-04-21 | `.github/workflows/release.yml`, `docs/signing-keys.md` |
+| Opt-in XGBoost adversarial classifier with by-seed held-out benchmarks | v0.5.0, 2026-04-23 | `src/vaara/adversarial_classifier.py`, `bench/` |
+| Callable kernel HTTP surface (Vaara as the schema, not the plug-in) | v0.10.0, 2026-05-16 | `docs/openapi.yaml`, `src/vaara/integrations/http.py` |
+| Article 12 commit-prove receipt pair | v0.10.0, 2026-05-16 | `src/vaara/audit/`, `CHANGELOG.md` v0.10.0 |
+| `vaara-bench-v1` reproducible benchmark harness | v0.12.0, 2026-05-16 | `bench/` |
+| Hot policy reload without pipeline restart | v0.13.0, 2026-05-17 | `src/vaara/policy/`, `CHANGELOG.md` v0.13.0 |
+| Static HTML article-coverage dashboard | v0.13.0, 2026-05-17 | `src/vaara/compliance/dashboard.py` |
+| Pluggable signer with optional ML-DSA-65 (FIPS 204) post-quantum scheme | v0.14.0, 2026-05-17 | `src/vaara/audit/signer.py` |
+| External-scorer composition over the same HTTP interface | v0.14.0, 2026-05-17 | `src/vaara/policy/composition.py` |
+| TypeScript client (`@vaaraio/client`) for the HTTP surface | v0.15.0, 2026-05-17 | `clients/ts/` |
+| PDF auditor evidence export (per-article rollup) | v0.16.0, 2026-05-17 | `src/vaara/compliance/render.py` |
+| OVERT 1.0 reference verifier CLI (`vaara overt verify`) | v0.17.0, 2026-05-17 | `src/vaara/overt/`, `docs/openapi.yaml` |
+| Streaming-notification interception inside the audit and OVERT perimeter | v0.25.0, 2026-05-21 | `src/vaara/integrations/mcp_proxy.py` |
+| Per-article verdict drill-down: `verdict_inputs`, `verdict_reasons`, `contributing_events` | v0.26.0, 2026-05-21 | `src/vaara/compliance/engine.py`, `VERDICTS.md` |
+| SLSA build provenance attestation on every release | v0.26.0, 2026-05-21 | `.github/workflows/release.yml` |
+| Continuous fuzzing of the OVERT decoder, audit `from_dict`, and policy loader via ClusterFuzzLite | v0.27.0, 2026-05-22 | `fuzz/`, `.clusterfuzzlite/`, `.github/workflows/cflite_*.yml` |
+| `VERDICTS.md` per-article evidence sufficiency reference | v0.28.0, 2026-05-22 | `VERDICTS.md` |
+| `docs/conformal-prediction.md` plain-language explainer | v0.28.0, 2026-05-22 | `docs/conformal-prediction.md` |
+| This document (`PRIOR_ART.md`) | v0.29.0, 2026-05-24 | `PRIOR_ART.md` |
+
+The `CHANGELOG.md` entry for each version carries the substantive
+description and, where relevant, the failure mode that motivated the
+change.
+
+## Related published work
+
+The following peer-review and pre-print papers describe approaches in
+the same lane as Vaara (runtime evidence, hash-chained or signed audit
+trails, conformal calibration, behavioural-constraint monitoring,
+safety cases with runtime updates). They are listed here as related
+reading, not as competitors. Where the publication post-dates Vaara's
+shipped feature for the same idea, that is a chronological fact rather
+than a judgment of the work.
+
+### Runtime evidence and behavioural monitoring
+
+- **Protocol-Driven Development: Governing Generated Software Through
+  Invariants and Continuous Evidence.** arXiv:2605.12981v2, published
+  2026-05-15. Introduces an "Evidence Chain" of compliance for
+  generated implementations and a "Dynamic Evidence Ledger" for
+  deployed systems, with signed runtime observations appended by
+  verifiers. Conceptually adjacent to Vaara's hash-chained audit trail
+  with article-explicit evidence (shipped v0.1.0, 2026-04-10) and to
+  the per-article `verdict_inputs` and `contributing_events`
+  drill-down (shipped v0.26.0, 2026-05-21).
+- **Formal Methods Meet LLMs: Auditing, Monitoring, and Intervention
+  for Compliance of Advanced AI Systems.** arXiv:2605.16198v1,
+  published 2026-05-15. Proposes runtime monitors using Linear
+  Temporal Logic for product-specific behavioural constraints, with
+  intervening monitors that act at runtime to preempt predicted
+  violations. Adjacent to Vaara's policy-driven runtime decisions and
+  external-scorer composition (shipped v0.14.0, 2026-05-17).
+
+### Safety cases with runtime confidence updates
+
+- **A Subjective Logic-based method for runtime confidence updates in
+  safety arguments.** arXiv:2605.22530v1, published 2026-05-21.
+  Describes a method for continuously updating static safety cases
+  using runtime Safety Performance Indicators, propagating confidence
+  through a Subjective Logic assurance case. Adjacent to Vaara's
+  evidence-sufficiency framework shipped in `VERDICTS.md` (v0.28.0,
+  2026-05-22) and to the conformal interval that ships with every
+  Vaara risk score (v0.1.0, 2026-04-10).
+
+### Aviation learning-assurance
+
+- **Mechanistic Interpretability for Learning Assurance of a
+  Vision-Based Landing System.** arXiv:2605.20607v1, published
+  2026-05-20. Applies mechanistic interpretability to an EASA
+  learning-assurance scenario, including out-of-model-scope runtime
+  monitoring against the operational design domain. Vaara does not
+  currently target aviation directly, but EASA learning-assurance is
+  in the same harmonisation surface as the AI Act Article 6(1) /
+  Annex I product-safety route.
+
+### National security threat-modelling
+
+- **Backchaining Loss of Control Mitigations from Mission-Specific
+  Benchmarks in National Security.** arXiv:2605.21095v1, published
+  2026-05-20. Methodology for national security deployers to
+  back-chain affordance and permission constraints from
+  use-case-specific benchmarks. Adjacent in motivation to Vaara's
+  policy-driven decisions over agent tool calls, in a deployment
+  context Vaara does not currently target.
+
+### Classical foundations
+
+- **Conformal prediction.** Vovk, Gammerman, Shafer. *Algorithmic
+  Learning in a Random World* (Springer). Vaara implements
+  split-conformal prediction with a distribution-free coverage
+  guarantee, as documented in `docs/formal_specification.md` and
+  explained in plain language in `docs/conformal-prediction.md`.
+- **Linear Temporal Logic and runtime verification.** Pnueli (1977),
+  Bauer, Leucker, Schallhart (2011). Background for the runtime-monitor
+  literature cited above.
+
+## What this document is not
+
+This document is not a competitive matrix. It deliberately omits
+vendor comparisons, feature checklists against named peers, and any
+"first to ship" claims framed as authority rather than chronology.
+Inclusion of a paper here means the work is in the same lane and
+worth reading, not that it is positioned as inferior or superior to
+Vaara.
+
+For vendor positioning relative to commercial peers, see the
+discussion in `COMPLIANCE.md` and the framework integrations under
+`src/vaara/integrations/`.
+
+## How to keep this current
+
+When a tagged release adds a load-bearing concept (a new audit
+primitive, a new evidence shape, a new public surface, or a new
+formal property), add a row to the chronology table above with the
+version, date, and a path into the codebase or docs. When a relevant
+paper or peer specification appears in the wider literature, add it
+to the related-work section with a neutral one-paragraph summary and
+the publication date. The goal is a paper trail that a reader can
+verify against PyPI, the git tags, and the cited URLs.

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ See [COMPLIANCE.md](COMPLIANCE.md) "Position relative to open runtime-attestatio
 | [COMPLIANCE.md](COMPLIANCE.md) | EU AI Act (Art. 9, 11 to 15, 61) and DORA (Art. 10, 12, 13) mapping, eval numbers, PAIR calibration |
 | [VERDICTS.md](VERDICTS.md) | Per-article evidence sufficiency thresholds and decision tree |
 | [CHANGELOG.md](CHANGELOG.md) | Version-by-version feature evolution |
+| [PRIOR_ART.md](PRIOR_ART.md) | When each Vaara concept first shipped, and a neutral list of adjacent published work |
 | [docs/signing-keys.md](docs/signing-keys.md) | Release signing and verification |
 | [SECURITY.md](SECURITY.md) | Security policy and reporting |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution guidelines |

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/docs/conformal-prediction.md
+++ b/docs/conformal-prediction.md
@@ -52,10 +52,10 @@ makes the difference visible.
 
 ## Why this matters under the EU AI Act
 
-**Article 15(1)** requires high-risk AI systems to "be designed and
-developed in such a way that they achieve an appropriate level of
-accuracy, robustness and cybersecurity, and perform consistently in
-those respects throughout their lifecycle." The phrase "appropriate
+**Article 15(1)** requires that "high-risk AI systems shall be
+designed and developed in such a way that they achieve an appropriate
+level of accuracy, robustness, and cybersecurity, and that they
+perform consistently in those respects throughout their lifecycle." The phrase "appropriate
 level" is meaningless without a way to measure it. A point score
 cannot be measured against an accuracy target because it has no
 notion of how often it is wrong. A conformal interval is measurable: a

--- a/docs/conformal-prediction.md
+++ b/docs/conformal-prediction.md
@@ -98,3 +98,23 @@ staleness windows the engine applies to those records.
   Shafer) is a good academic anchor if you want the textbook proof.
   Vaara implements split-conformal prediction, the most operationally
   practical variant.
+
+## Related runtime-confidence work
+
+A different research line addresses the same underlying need (a
+static safety argument cannot keep up with what a deployed system
+actually does at runtime) by updating the confidence values inside
+a structured safety case as runtime evidence arrives.
+arXiv:2605.22530v1 (2026-05-21) describes a Subjective Logic
+formulation in which runtime Safety Performance Indicators are
+evaluated continuously and used to update targeted claims, with
+prompt confidence penalties when a violation occurs. The conformal
+interval Vaara emits is complementary to that approach: it does not
+update a safety case directly, but it gives a deployer a per-action
+numeric signal whose coverage guarantee holds without distributional
+assumptions, suitable as one of the inputs a Subjective Logic or
+similar assurance pipeline could consume.
+
+For the broader chronology of Vaara's runtime-evidence concepts and a
+neutral list of adjacent published work, see
+[`../PRIOR_ART.md`](../PRIOR_ART.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.28.0"
+version = "0.29.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.28.0"
+__version__ = "0.29.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
  ## Summary

  - Adds `PRIOR_ART.md`: per-concept chronology table mapping each load-bearing Vaara concept to its
  first shipped version and a path into the codebase or docs. Neutral list of adjacent published work
  (Protocol-Driven Development, Formal Methods Meet LLMs, Subjective Logic runtime confidence updates,
  EASA learning-assurance mechanistic interpretability, national security backchaining). Reconstructed
  from `CHANGELOG.md` and the git tags so a reader can verify any "since when" claim against PyPI release
   history and the GitHub tag list.
  - Appends a "Related runtime-confidence work" section to `docs/conformal-prediction.md` citing
  arXiv:2605.22530v1 (Subjective Logic runtime confidence updates in safety arguments, 2026-05-21) as a
  complementary research line, with a cross-link to `PRIOR_ART.md`.
  - Bumps version to 0.29.0 in `pyproject.toml`, `src/vaara/__init__.py`, and `clients/ts/package.json`.
  Cross-links `PRIOR_ART.md` from the README "Where things live" table.

  Documentation surfaces only. Hash chain format, OVERT envelope schema, MCP proxy semantics, CLI
  surface, HTTP API, and release workflow are byte-identical to v0.28.0.

  ## Test plan

  - [x] `pytest tests/` 771 passed, 12 skipped
  - [x] Public-prose audit on `PRIOR_ART.md`, `docs/conformal-prediction.md` addition, and CHANGELOG
  entry (no em-dashes, no semicolons, no consultant jargon)
  - [x] Version bumped consistently across `pyproject.toml`, `src/vaara/__init__.py`,
  `clients/ts/package.json`
  - [x] Chronology rows in `PRIOR_ART.md` spot-checked against `CHANGELOG.md` v0.1.0, v0.10.0, v0.13.0,
  v0.14.0, v0.15.0, v0.16.0, v0.17.0, v0.25.0, v0.26.0, v0.27.0, v0.28.0
  EOF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive reference guide documenting when each feature first shipped
  * Added catalog of adjacent published research aligned with core themes
  * Updated conformal prediction documentation with related runtime-confidence research
  * Enhanced README with navigation to new documentation resources

* **Chores**
  * Version bumped to 0.29.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->