### PR TITLE
docs(bench): punctuation polish in v0.37 bench doc

### DIFF
--- a/bench/vaara-bench-v0.37.md
+++ b/bench/vaara-bench-v0.37.md
@@ -64,7 +64,7 @@ Per-category cuts on this leg:
 
 The data_exfil pattern from v0.36 holds. Across all three attacker
 families now seen, DE is the hardest category. PE and TM generalise
-cleanly; DE generalises unevenly.
+cleanly. DE generalises unevenly.
 
 ## Carry-forward DE numbers
 


### PR DESCRIPTION
<!-- Keep this short. Detail belongs in the diff and the CHANGELOG. -->

## Summary

<!-- 1–3 bullets. What changes, why now. -->

-

## Test plan

<!-- Check off what you ran locally. Add new boxes for anything specific. -->

- [ ] `pytest -q` passes
- [ ] `scripts/lint_full.sh` passes (ruff + bandit + mypy + pytest)
- [ ] CHANGELOG.md updated if this changes the public API or shipped behaviour
- [ ] No secrets, audit DBs, or large binaries staged

## Risk / blast radius

<!-- One line. Examples: "test-only", "internal refactor, no API change",
     "audit DB schema bump (migration tested)", "CLI flag added", "breaking change". -->

-
