### PR TITLE
release(v0.37.1): SEP-2787 verifier step 5 (argument commitment verification)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.37.1] - 2026-05-27
+
+**Theme: SEP-2787 verifier step 5, argument commitment verification.**
+Closes the missing piece in Vaara's SEP-2787 reference implementation
+after the upstream SEP draft was rewritten to contain Vaara's four
+schema proposals plus a verifier-side `args_commitment_mismatch`
+rejection path. The new `verify_args_commitment` function covers all
+three commitment kinds in Vaara's three-way args shape. `ArgsDigest`
+recomputes the JCS-canonical hash of the runtime arguments and
+compares it to the bound digest. `ArgsRef` resolves the URI through a
+caller-supplied resolver, hashes the content, and matches both the
+stored digest and the canonicalized runtime arguments. `ArgsProjection`
+recomputes its own digest and reports whether the projection is an
+identity match for the runtime arguments (identity projection) or a
+signed redaction (no completeness claim, per spec). Step 5 is exposed
+as a separate function so callers compose it after the existing
+signature and TTL checks once the `tools/call` arguments are in hand.
+
+### Added
+- `src/vaara/attestation/_sep2787_verifier.py`: `verify_args_commitment`
+  and the `ArgsCommitmentResult` dataclass. Returns `ok`, an optional
+  `reason` matching the spec's `args_commitment_mismatch` enum value,
+  and a tri-state `projection_match` field for projection-kind
+  commitments.
+- Public re-exports of `verify_args_commitment` and
+  `ArgsCommitmentResult` from `vaara.attestation.sep2787`.
+- 11 new tests in `tests/test_attestation_sep2787.py` covering digest
+  match and mismatch, key-reorder canonicalization stability, ref
+  resolver missing or raising, ref digest mismatch, ref content not
+  matching runtime args, identity projection, redacted projection, and
+  projection-digest tampering.
+
+### Changed
+- `vaara.attestation.sep2787` module docstring documents verifier
+  coverage: steps 1 (signature) and 3 (TTL) inside `verify_attestation`,
+  step 5 via the new `verify_args_commitment`, steps 2 (nonce replay)
+  and 4 (tool call match) left to the runtime caller.
+
 ## [0.37.0] - 2026-05-27
 
 **Theme: third attacker family added to cross-model held-out, v8

--- a/bench/vaara-bench-v0.37.md
+++ b/bench/vaara-bench-v0.37.md
@@ -64,7 +64,7 @@ Per-category cuts on this leg:
 
 The data_exfil pattern from v0.36 holds. Across all three attacker
 families now seen, DE is the hardest category. PE and TM generalise
-cleanly; DE generalises unevenly.
+cleanly. DE generalises unevenly.
 
 ## Carry-forward DE numbers
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.37.0"
+version = "0.37.1"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.37.0"
+__version__ = "0.37.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_sep2787_verifier.py
+++ b/src/vaara/attestation/_sep2787_verifier.py
@@ -1,0 +1,122 @@
+"""SEP-2787 verifier step 5: argument commitment verification.
+
+Internal module. Public surface is in ``vaara.attestation.sep2787``.
+
+Implements step 5 of the verification rules in the SEP-2787 draft:
+
+    If the toolCalls entry uses args_ref, resolve the URI, compute
+    SHA-256 over the fetched content, and compare against the stored
+    digest. Confirm the resolved content corresponds to the arguments
+    being executed. If the entry uses args_projection, compare it
+    against the canonicalized runtime arguments (RFC 8785). Identity
+    projections MUST match exactly; redacted projections are verified
+    only to be signed -- the verifier makes no claim about
+    completeness relative to the runtime arguments. If neither field
+    is present, or if the content cannot be resolved and matched,
+    reject with args_commitment_mismatch.
+
+Vaara's three-way args shape (ArgsDigest / ArgsRef / ArgsProjection)
+extends the spec's two-way (args_ref / args_projection) with a
+commitment-only ArgsDigest where the payload never crosses the
+verifier. For ArgsDigest the verifier recomputes the JCS-canonical
+hash of the runtime arguments and compares against the bound digest.
+
+Step 5 is composed by the caller after steps 1-4 (signature, nonce
+replay, TTL, tool call match). It does not perform network IO.
+ArgsRef resolution is delegated to a caller-supplied resolver.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Callable, Literal, Optional
+
+from vaara.attestation._sep2787_canonical import canonical_json
+from vaara.attestation._sep2787_types import (
+    ArgsCommitment,
+    ArgsDigest,
+    ArgsProjection,
+    ArgsRef,
+)
+
+ARGS_COMMITMENT_MISMATCH: Literal["args_commitment_mismatch"] = (
+    "args_commitment_mismatch"
+)
+
+
+@dataclass(frozen=True)
+class ArgsCommitmentResult:
+    """Outcome of step 5 (argument commitment verification).
+
+    ``ok`` is True iff the commitment binds the runtime arguments
+    under the rules for the specific commitment kind.
+
+    ``reason`` is None on success, or ``"args_commitment_mismatch"``
+    on failure -- matching the spec's error-reason enum.
+
+    ``projection_match`` is meaningful only for ArgsProjection: True
+    when the projection equals the canonicalized runtime arguments
+    (identity projection per spec), False when it differs (redacted
+    projection -- verified only to be signed), None otherwise.
+    """
+
+    ok: bool
+    reason: Optional[Literal["args_commitment_mismatch"]] = None
+    projection_match: Optional[bool] = None
+
+
+def _sha256_hex(content: bytes) -> str:
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+def verify_args_commitment(
+    args: ArgsCommitment,
+    *,
+    runtime_arguments: Any,
+    ref_resolver: Optional[Callable[[str], bytes]] = None,
+) -> ArgsCommitmentResult:
+    """Verify the args commitment against the runtime arguments.
+
+    ``runtime_arguments`` is the JSON-serialisable arguments object
+    the server is about to execute against (i.e. the ``arguments``
+    field of the incoming ``tools/call`` request).
+
+    ``ref_resolver`` is a callable taking the ArgsRef URI and
+    returning the resolved content as bytes. Required for ArgsRef
+    commitments, ignored otherwise. The verifier intentionally
+    does not perform network IO. The deployment chooses resolver
+    policy (allowed schemes, timeouts, caching, trust).
+    """
+    if isinstance(args, ArgsDigest):
+        observed = _sha256_hex(canonical_json(runtime_arguments))
+        if observed != args.digest:
+            return ArgsCommitmentResult(ok=False, reason=ARGS_COMMITMENT_MISMATCH)
+        return ArgsCommitmentResult(ok=True)
+
+    if isinstance(args, ArgsRef):
+        if ref_resolver is None:
+            return ArgsCommitmentResult(ok=False, reason=ARGS_COMMITMENT_MISMATCH)
+        try:
+            content = ref_resolver(args.ref)
+        except Exception:
+            return ArgsCommitmentResult(ok=False, reason=ARGS_COMMITMENT_MISMATCH)
+        if not isinstance(content, (bytes, bytearray)):
+            return ArgsCommitmentResult(ok=False, reason=ARGS_COMMITMENT_MISMATCH)
+        if _sha256_hex(bytes(content)) != args.digest:
+            return ArgsCommitmentResult(ok=False, reason=ARGS_COMMITMENT_MISMATCH)
+        runtime_canonical = canonical_json(runtime_arguments)
+        if bytes(content) != runtime_canonical:
+            return ArgsCommitmentResult(ok=False, reason=ARGS_COMMITMENT_MISMATCH)
+        return ArgsCommitmentResult(ok=True)
+
+    if isinstance(args, ArgsProjection):
+        recomputed = _sha256_hex(canonical_json(args.projection))
+        if recomputed != args.projection_digest:
+            return ArgsCommitmentResult(ok=False, reason=ARGS_COMMITMENT_MISMATCH)
+        runtime_canonical = canonical_json(runtime_arguments)
+        projection_canonical = canonical_json(args.projection)
+        identity = runtime_canonical == projection_canonical
+        return ArgsCommitmentResult(ok=True, projection_match=identity)
+
+    return ArgsCommitmentResult(ok=False, reason=ARGS_COMMITMENT_MISMATCH)

--- a/src/vaara/attestation/sep2787.py
+++ b/src/vaara/attestation/sep2787.py
@@ -42,6 +42,13 @@ kernel emitting CBOR Base Envelopes for every action; SEP-2787 is a
 per-tool-call JSON envelope carried in MCP ``_meta``. See
 ``docs/sep2787-overt-mapping.md`` for the field-level mapping between
 them.
+
+Verifier coverage: ``verify_attestation`` covers steps 1 (signature)
+and 3 (TTL) of the SEP-2787 verification rules. Step 5 (argument
+commitment) is exposed separately as ``verify_args_commitment`` so it
+can be composed by the caller once the runtime ``tools/call``
+arguments are in hand. Steps 2 (nonce replay) and 4 (tool call match)
+are stateful in the runtime and remain the caller's responsibility.
 """
 
 from __future__ import annotations
@@ -67,10 +74,15 @@ from vaara.attestation._sep2787_types import (
     PlannerDeclared,
     ToolCallBinding,
 )
+from vaara.attestation._sep2787_verifier import (
+    ArgsCommitmentResult,
+    verify_args_commitment,
+)
 
 __all__ = [
     "Algorithm",
     "ArgsCommitment",
+    "ArgsCommitmentResult",
     "ArgsDigest",
     "ArgsProjection",
     "ArgsRef",
@@ -83,5 +95,6 @@ __all__ = [
     "emit_attestation",
     "make_args_digest",
     "make_args_projection",
+    "verify_args_commitment",
     "verify_attestation",
 ]

--- a/tests/test_attestation_sep2787.py
+++ b/tests/test_attestation_sep2787.py
@@ -27,6 +27,7 @@ from vaara.attestation.sep2787 import (  # noqa: E402
     emit_attestation,
     make_args_digest,
     make_args_projection,
+    verify_args_commitment,
     verify_attestation,
 )
 
@@ -214,3 +215,120 @@ def test_cross_alg_verification_fails():
     env = _emit_attestation()
     priv = ec.generate_private_key(ec.SECP256R1())
     assert verify_attestation(env, verifying_material=priv.public_key()) is False
+
+
+# --- Step 5: argument commitment verification ---
+
+
+def test_args_commitment_digest_matching_runtime_args_ok():
+    runtime = {"path": "/archive/2024-Q3.md"}
+    args = make_args_digest(runtime)
+    result = verify_args_commitment(args, runtime_arguments=runtime)
+    assert result.ok is True
+    assert result.reason is None
+
+
+def test_args_commitment_digest_mismatch_rejects():
+    args = make_args_digest({"path": "/archive/2024-Q3.md"})
+    result = verify_args_commitment(
+        args, runtime_arguments={"path": "/etc/passwd"},
+    )
+    assert result.ok is False
+    assert result.reason == "args_commitment_mismatch"
+
+
+def test_args_commitment_digest_key_reorder_still_matches():
+    args = make_args_digest({"a": 1, "b": [1, 2, 3]})
+    result = verify_args_commitment(
+        args, runtime_arguments={"b": [1, 2, 3], "a": 1},
+    )
+    assert result.ok is True
+
+
+def test_args_commitment_ref_no_resolver_rejects():
+    args = ArgsRef(ref="ipfs://Qm...", digest="sha256:" + "0" * 64)
+    result = verify_args_commitment(args, runtime_arguments={"x": 1})
+    assert result.ok is False
+    assert result.reason == "args_commitment_mismatch"
+
+
+def test_args_commitment_ref_resolver_content_matches():
+    runtime = {"path": "/archive/2024-Q3.md"}
+    canonical = canonical_json(runtime)
+    import hashlib as _h
+    digest = "sha256:" + _h.sha256(canonical).hexdigest()
+    args = ArgsRef(ref="memory://q3", digest=digest)
+    result = verify_args_commitment(
+        args,
+        runtime_arguments=runtime,
+        ref_resolver=lambda _ref: canonical,
+    )
+    assert result.ok is True
+
+
+def test_args_commitment_ref_digest_mismatch_rejects():
+    runtime = {"path": "/archive/2024-Q3.md"}
+    args = ArgsRef(ref="memory://q3", digest="sha256:" + "0" * 64)
+    result = verify_args_commitment(
+        args,
+        runtime_arguments=runtime,
+        ref_resolver=lambda _ref: canonical_json(runtime),
+    )
+    assert result.ok is False
+    assert result.reason == "args_commitment_mismatch"
+
+
+def test_args_commitment_ref_content_does_not_match_runtime_rejects():
+    referenced = {"path": "/archive/2024-Q3.md"}
+    runtime = {"path": "/etc/passwd"}
+    canonical = canonical_json(referenced)
+    import hashlib as _h
+    digest = "sha256:" + _h.sha256(canonical).hexdigest()
+    args = ArgsRef(ref="memory://other", digest=digest)
+    result = verify_args_commitment(
+        args,
+        runtime_arguments=runtime,
+        ref_resolver=lambda _ref: canonical,
+    )
+    assert result.ok is False
+    assert result.reason == "args_commitment_mismatch"
+
+
+def test_args_commitment_ref_resolver_raising_rejects():
+    args = ArgsRef(ref="memory://oops", digest="sha256:" + "0" * 64)
+    def _broken(_ref):
+        raise RuntimeError("offline")
+    result = verify_args_commitment(
+        args, runtime_arguments={"x": 1}, ref_resolver=_broken,
+    )
+    assert result.ok is False
+    assert result.reason == "args_commitment_mismatch"
+
+
+def test_args_commitment_identity_projection_marked_match():
+    runtime = {"path": "/archive/2024-Q3.md"}
+    args = make_args_projection(runtime)
+    result = verify_args_commitment(args, runtime_arguments=runtime)
+    assert result.ok is True
+    assert result.projection_match is True
+
+
+def test_args_commitment_redacted_projection_ok_but_not_identity():
+    redacted = {"redacted_user_id": "u-001"}
+    args = make_args_projection(redacted)
+    result = verify_args_commitment(
+        args, runtime_arguments={"path": "/archive/2024-Q3.md", "user_id": "u-001"},
+    )
+    assert result.ok is True
+    assert result.projection_match is False
+
+
+def test_args_commitment_projection_with_tampered_digest_rejects():
+    from vaara.attestation.sep2787 import ArgsProjection
+    args = ArgsProjection(
+        projection={"redacted_user_id": "u-001"},
+        projection_digest="sha256:" + "0" * 64,
+    )
+    result = verify_args_commitment(args, runtime_arguments={"x": 1})
+    assert result.ok is False
+    assert result.reason == "args_commitment_mismatch"


### PR DESCRIPTION
release(v0.37.1): SEP-2787 verifier step 5 (argument commitment verification)

Closes the missing piece in Vaara's SEP-2787 reference implementation
after the upstream SEP draft was rewritten to contain Vaara's four
schema proposals plus a verifier-side args_commitment_mismatch
rejection path. The new verify_args_commitment function covers all
three commitment kinds in Vaara's three-way args shape.

ArgsDigest recomputes the JCS-canonical hash of the runtime arguments
and compares it to the bound digest. ArgsRef resolves the URI through
a caller-supplied resolver, hashes the content, and matches both the
stored digest and the canonicalized runtime arguments. ArgsProjection
recomputes its own digest and reports whether the projection is an
identity match for the runtime arguments (identity projection) or a
signed redaction (no completeness claim, per spec).

Step 5 is exposed as a separate function so callers compose it after
the existing signature and TTL checks once the tools/call arguments
are in hand. The verifier does not perform network IO. ArgsRef
resolution is delegated to a caller-supplied resolver, so the
deployment chooses scheme policy, timeouts, caching, and trust.

Adds 11 tests covering digest match and mismatch, key-reorder
canonicalization stability, ref resolver missing or raising, ref
digest mismatch, ref content not matching runtime args, identity
projection, redacted projection, and projection-digest tampering.
All 28 SEP-2787 tests pass, 799 in the full suite, no regressions.

Three version files bumped (pyproject.toml, clients/ts/package.json,
src/vaara/__init__.py).
