### PR TITLE
fix(release-workflow): extract CHANGELOG entry as release notes body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,9 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Checkout (for CHANGELOG)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
       - name: Download distributions
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -89,6 +92,23 @@ jobs:
         with:
           inputs: ./dist/*.tar.gz ./dist/*.whl
 
+      - name: Extract release notes from CHANGELOG
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (in_section) exit
+              if ($0 ~ "^## \\[" ver "\\]") in_section = 1
+            }
+            in_section { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "::error::No CHANGELOG entry found for version $VERSION"
+            exit 1
+          fi
+          echo "Extracted $(wc -l < release-notes.md) lines for v${VERSION}"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
@@ -96,7 +116,7 @@ jobs:
             dist/*.tar.gz
             dist/*.whl
             dist/*.sigstore.json
-          generate_release_notes: true
+          body_path: release-notes.md
           fail_on_unmatched_files: true
 
   publish-npm:


### PR DESCRIPTION
## Summary

The github-release job in `.github/workflows/release.yml` was using
`generate_release_notes: true`, which produces an empty body
containing only the compare link when the PR-since-last-tag set is
small or unlabeled. Caught on the v0.39.2 ship: the GitHub Release
page had nothing but the compare link, requiring a manual
`gh release edit --notes-file ...` to populate.

## Fix

Three new / changed steps in the github-release job:

1. **Checkout the repo.** The job previously downloaded `dist/` only.
   It now checks out the source so the CHANGELOG is available.
2. **Extract release notes from CHANGELOG.** A small awk script pulls
   the `## [VERSION]` section from `CHANGELOG.md` based on
   `GITHUB_REF_NAME`. Fails loudly with `::error::` and exit 1 if no
   matching section is found, so a tag pushed without a CHANGELOG
   entry breaks the workflow rather than shipping empty notes.
3. **Switch softprops/action-gh-release to body_path.** Replaces
   `generate_release_notes: true` with `body_path: release-notes.md`.

## Smoke test

Extractor tested locally against the live CHANGELOG:

- `VERSION=0.39.2`: 65 lines extracted (matches the body we manually
  pushed via `gh release edit` for v0.39.2).
- `VERSION=9.99.99`: 0 lines extracted, triggering the loud error.

## Test plan

- [ ] CI passes on this PR
- [ ] Next release tag (whichever ships next) ends up with a populated
      GitHub Release page directly from the workflow, no manual
      `gh release edit` needed
- [ ] If a tag is pushed without a CHANGELOG entry, the workflow fails
      at the extract step rather than shipping empty notes
