### PR TITLE
chore(release): four-script release flow with manual publish fallback

### DIFF
--- a/scripts/RELEASE.md
+++ b/scripts/RELEASE.md
@@ -1,0 +1,107 @@
+# Release flow
+
+Four scripts under `scripts/`, run in order. Push remains gated; you
+keep the keystrokes that hit the network.
+
+## Pre-flight (you do this by hand)
+
+Per release, write three files in the repo root:
+
+- `.commit_msg_v<VERSION>_release.txt`: commit message body.
+- `.pr_body_v<VERSION>.md`: PR body, send-ready-prose audited.
+- `CHANGELOG.md`: add a `## [<VERSION>] - YYYY-MM-DD` entry.
+
+These stay local (gitignored by convention) and feed the scripts via
+`-F` / `--body-file` so you never paste prose into the terminal.
+
+## 1. Prepare the commit + tags + branch
+
+```
+scripts/release_prepare.sh <VERSION> [CO_TAG]
+```
+
+Example:
+
+```
+scripts/release_prepare.sh 0.39.2 sep2787-ref-v2
+```
+
+What runs:
+
+1. Verifies the three pre-flight files exist and the CHANGELOG entry is
+   present.
+2. Bumps `pyproject.toml`, `clients/ts/package.json`,
+   `src/vaara/__init__.py` to `<VERSION>`.
+3. `ruff check` on changed Python paths.
+4. Full `pytest` (skips `tests/adversarial`, deselects the pre-existing
+   SSRF distribution-shift test).
+5. Stages explicit paths only (no `git add -A`).
+6. Commits via `-F`.
+7. Creates annotated tags `v<VERSION>` and (if passed) `<CO_TAG>` at
+   HEAD.
+8. Creates branch `release/v<VERSION>` at HEAD.
+
+Stops before any push.
+
+## 2. Push the branch and open the PR
+
+```
+scripts/release_push_and_pr.sh <VERSION>
+```
+
+This pushes `release/v<VERSION>` and opens a PR against `main` using
+the commit subject as PR title and `.pr_body_v<VERSION>.md` as body.
+Prints the PR URL and the next-step command.
+
+## 3. After CI is green, merge and re-tag
+
+```
+scripts/release_merge_and_tag.sh <PR_NUMBER> <VERSION> [CO_TAG]
+```
+
+1. `gh pr checks --watch --required` blocks until all required checks
+   pass (or fails the script if a required check fails).
+2. `gh pr merge --squash --delete-branch`.
+3. `git checkout main && git pull --ff-only`.
+4. Re-creates `v<VERSION>` (and `<CO_TAG>` if passed) at the new merged
+   SHA. The pre-merge local tags pointed at the unmerged commit; squash
+   creates a new SHA so the tags need to move.
+5. Prints the gated `git push origin v<VERSION> <CO_TAG>` command for
+   you to paste.
+
+Tag push fires `.github/workflows/release.yml`: build with SLSA
+provenance, publish to PyPI via trusted publishing, sign with Sigstore,
+publish `@vaara/client` to npm with provenance, create the GitHub
+Release.
+
+## 4. Manual publish fallback (only when GH Actions is broken)
+
+```
+scripts/release_publish_manual.sh <VERSION>
+```
+
+For when the workflow itself cannot run (misconfig, OIDC trust
+failure, expired credential). NOT for transient infra noise; that is
+a wait-and-rerun situation, not a bypass.
+
+Requires:
+
+- `VAARA_PYPI_TOKEN` env var (PyPI API token starting with `pypi-`).
+- npm login state for `@vaara` scope (run `npm login` first).
+
+Limitations: ships PyPI wheels without Sigstore signatures / SLSA
+provenance, and ships npm without provenance. Those features require
+the GH OIDC flow. Manual publish trades them for being able to ship.
+Open an incident note explaining the bypass and restore the workflow
+before the next release.
+
+## Cross-repo follow-up
+
+The release scripts do not touch cross-repo work. After v0.39.2-style
+releases that ship a SEP-2787 reference impl, the follow-up is:
+
+- Regen `vaaraio/modelcontextprotocol#2789` v0 vectors against the new
+  envelope shape using `vaara.attestation.sep2787`.
+- Comment under `modelcontextprotocol/modelcontextprotocol#2787` with
+  cross-repo provenance: `vaaraio/vaara@<merged-sha>` and
+  `vaaraio/vaara#<pr-number>`.

--- a/scripts/release_merge_and_tag.sh
+++ b/scripts/release_merge_and_tag.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# After CI is green, squash-merge the PR and re-tag at the merged SHA.
+# Tag push remains gated.
+#
+# Usage: scripts/release_merge_and_tag.sh <PR_NUMBER> <VERSION> [CO_TAG]
+#   PR_NUMBER  the open release PR
+#   VERSION    e.g., 0.39.2
+#   CO_TAG     optional second annotated tag
+#
+# Why re-tag: squash-merge writes a NEW commit on main (different SHA
+# from the local pre-merge commit). The pre-merge local tags would
+# point at a commit that no longer exists on main. We move them to the
+# merged remote SHA.
+#
+# Why we do NOT sync local main: squash-merge diverges the histories
+# (local pre-merge commit and the remote squash commit share the prior
+# release as parent but have different SHAs). Syncing would require
+# `git reset --hard origin/main`, which is on the destructive-ops list
+# and needs explicit approval. Tagging against `origin/main` directly
+# avoids the issue. Reconcile local main yourself afterwards if you
+# care; the published tags are independent of local-main state.
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <PR_NUMBER> <VERSION> [CO_TAG]" >&2
+  exit 2
+fi
+
+PR_NUM="$1"
+VERSION="$2"
+CO_TAG="${3:-}"
+
+# 1. Wait for CI to land
+echo "Watching CI for PR #${PR_NUM}..."
+gh pr checks "$PR_NUM" --watch --required
+
+# 2. Squash-merge (matches v0.39.1 / v0.39.2 release pattern)
+gh pr merge "$PR_NUM" --squash --delete-branch
+
+# 3. Fetch the merged commit (no local main checkout, no reset)
+git fetch origin main
+MERGED_SHA=$(git rev-parse --short origin/main)
+echo "Merged commit on origin/main: $MERGED_SHA"
+
+# 4. Move tags to the merged SHA (point them at origin/main directly)
+if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+  git tag -d "v${VERSION}"
+fi
+git tag -a "v${VERSION}" origin/main -m "Vaara v${VERSION} (see CHANGELOG.md)"
+
+if [[ -n "$CO_TAG" ]]; then
+  if git rev-parse "$CO_TAG" >/dev/null 2>&1; then
+    git tag -d "$CO_TAG"
+  fi
+  git tag -a "$CO_TAG" origin/main -m "Pinned co-tag for v${VERSION} (see CHANGELOG.md)"
+fi
+
+# 5. Print the push command (gated)
+echo
+if [[ -n "$CO_TAG" ]]; then
+  echo "Tags ready at ${MERGED_SHA}. To publish (fires Release workflow):"
+  echo "  git push origin v${VERSION} ${CO_TAG}"
+else
+  echo "Tag ready at ${MERGED_SHA}. To publish (fires Release workflow):"
+  echo "  git push origin v${VERSION}"
+fi
+echo
+echo "If the Release workflow fails or is misconfigured, fallback:"
+echo "  scripts/release_publish_manual.sh ${VERSION}"
+echo "(Only when GH Actions confirmed broken, not for transient noise.)"

--- a/scripts/release_prepare.sh
+++ b/scripts/release_prepare.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Local prep for a Vaara release. Stops before any push.
+#
+# Usage: scripts/release_prepare.sh <VERSION> [CO_TAG]
+#   VERSION  e.g., 0.39.2
+#   CO_TAG   optional second annotated tag pinned to the same commit
+#            (e.g., sep2787-ref-v2)
+#
+# Expects:
+#   .commit_msg_v<VERSION>_release.txt  (commit message body)
+#   .pr_body_v<VERSION>.md              (PR body)
+#   CHANGELOG.md                        (entry for [<VERSION>])
+#
+# What it does:
+#   1. Pre-flight: required files exist, CHANGELOG entry present,
+#      working tree clean except for the staged release changes.
+#   2. Bumps version in pyproject.toml + clients/ts/package.json +
+#      src/vaara/__init__.py.
+#   3. ruff check on changed Python paths.
+#   4. pytest --no-header on the full suite (skips adversarial dir;
+#      deselects pre-existing known-failing test).
+#   5. Stages explicit paths (no `git add -A`).
+#   6. Commits via -F.
+#   7. Creates annotated tag v<VERSION>; if CO_TAG passed, also that.
+#   8. Creates branch release/v<VERSION> at HEAD.
+#
+# Push remains gated. Run scripts/release_push_and_pr.sh next.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <VERSION> [CO_TAG]" >&2
+  exit 2
+fi
+
+VERSION="$1"
+CO_TAG="${2:-}"
+
+COMMIT_MSG=".commit_msg_v${VERSION}_release.txt"
+PR_BODY=".pr_body_v${VERSION}.md"
+BRANCH="release/v${VERSION}"
+
+# 1. Pre-flight
+for f in "$COMMIT_MSG" "$PR_BODY" CHANGELOG.md pyproject.toml \
+         clients/ts/package.json src/vaara/__init__.py; do
+  [[ -f "$f" ]] || { echo "missing: $f" >&2; exit 1; }
+done
+
+if ! grep -qE "^## \[${VERSION}\]" CHANGELOG.md; then
+  echo "CHANGELOG.md missing entry: ## [${VERSION}]" >&2
+  exit 1
+fi
+
+if git rev-parse "v${VERSION}" >/dev/null 2>&1; then
+  echo "tag v${VERSION} already exists locally; delete first" >&2
+  exit 1
+fi
+
+if [[ -n "$CO_TAG" ]] && git rev-parse "$CO_TAG" >/dev/null 2>&1; then
+  echo "tag $CO_TAG already exists locally; delete first" >&2
+  exit 1
+fi
+
+if git show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+  echo "branch ${BRANCH} already exists; delete first" >&2
+  exit 1
+fi
+
+# 2. Bump versions (idempotent: only touches the version line)
+sed -i -E "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"$/version = \"${VERSION}\"/" pyproject.toml
+sed -i -E "s/^  \"version\": \"[0-9]+\.[0-9]+\.[0-9]+\",$/  \"version\": \"${VERSION}\",/" clients/ts/package.json
+sed -i -E "s/^__version__ = \"[0-9]+\.[0-9]+\.[0-9]+\"$/__version__ = \"${VERSION}\"/" src/vaara/__init__.py
+
+grep -E "^version = \"${VERSION}\"$" pyproject.toml >/dev/null
+grep -E "\"version\": \"${VERSION}\"" clients/ts/package.json >/dev/null
+grep -E "^__version__ = \"${VERSION}\"$" src/vaara/__init__.py >/dev/null
+
+# 3. Lint changed paths (best-effort; lint all of src + tests if no
+# precise change list)
+CHANGED=$(git diff --name-only HEAD -- '*.py' | tr '\n' ' ')
+if [[ -n "${CHANGED// }" ]]; then
+  .venv/bin/ruff check $CHANGED
+else
+  .venv/bin/ruff check src/vaara tests
+fi
+
+# 4. Tests (full suite, deselect pre-existing known failure)
+.venv/bin/python -m pytest -q --no-header \
+  --ignore=tests/adversarial \
+  --deselect tests/test_adversarial_classifier_integration.py::test_known_bad_metadata_ssrf_scores_high
+
+# 5. Stage explicit paths only
+git add CHANGELOG.md pyproject.toml clients/ts/package.json src/vaara/__init__.py
+# Re-add any other paths the caller has already staged
+git status --short
+
+# 6. Commit
+git commit -F "$COMMIT_MSG"
+
+# 7. Tags
+git tag -a "v${VERSION}" -m "Vaara v${VERSION} (see CHANGELOG.md)"
+if [[ -n "$CO_TAG" ]]; then
+  git tag -a "$CO_TAG" -m "Pinned co-tag for v${VERSION} (see CHANGELOG.md)"
+fi
+
+# 8. Release branch
+git checkout -b "$BRANCH"
+
+# Report
+HEAD_SHA=$(git rev-parse --short HEAD)
+echo
+echo "Prepared v${VERSION} at ${HEAD_SHA}."
+echo "Next: scripts/release_push_and_pr.sh ${VERSION}"

--- a/scripts/release_publish_manual.sh
+++ b/scripts/release_publish_manual.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Manual publish fallback for PyPI + npm when the GH Actions Release
+# workflow is broken (workflow misconfig, OIDC trust failure, lapsed
+# token). Use ONLY in that case.
+#
+# Per repo policy: transient GH Actions infra noise → wait + rerun the
+# workflow, do NOT bypass. This script exists for the case where the
+# workflow itself cannot run.
+#
+# Usage: scripts/release_publish_manual.sh <VERSION>
+#   VERSION  e.g., 0.39.2
+#
+# Requires:
+#   - tag v<VERSION> exists locally and points at a pushed commit on main
+#   - PyPI: VAARA_PYPI_TOKEN env var (API token starting with pypi-)
+#   - npm:  npm login state for @vaara scope (run `npm login` first)
+#
+# What it does:
+#   PyPI:
+#     1. Build sdist + wheel via python -m build
+#     2. twine check dist/*
+#     3. twine upload dist/* (no Sigstore signing here; Sigstore needs
+#        the GH OIDC flow. Manual publish ships without Sigstore.)
+#   npm:
+#     1. cd clients/ts; npm ci; npm run build; npm test
+#     2. npm publish --access public --no-provenance
+#        (Provenance also needs the GH OIDC flow.)
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <VERSION>" >&2
+  exit 2
+fi
+
+VERSION="$1"
+
+git rev-parse "v${VERSION}" >/dev/null 2>&1 || \
+  { echo "tag v${VERSION} does not exist locally" >&2; exit 1; }
+
+# Confirm intent (manual publish is a deliberate exception)
+echo "Manual publish for v${VERSION}. This bypasses the GH Actions"
+echo "Release workflow and ships WITHOUT Sigstore signatures / SLSA"
+echo "provenance / npm provenance. Use only when GH Actions itself is"
+echo "broken, not for transient infra noise."
+read -r -p "Confirm by typing the version (${VERSION}): " CONFIRM
+[[ "$CONFIRM" == "$VERSION" ]] || { echo "aborted" >&2; exit 1; }
+
+# Clean dist/
+rm -rf dist build *.egg-info
+
+# --- PyPI ---
+if [[ -z "${VAARA_PYPI_TOKEN:-}" ]]; then
+  echo "VAARA_PYPI_TOKEN not set; skipping PyPI publish."
+else
+  echo "Building Python distributions..."
+  .venv/bin/python -m pip install --quiet --upgrade build twine
+  .venv/bin/python -m build
+  .venv/bin/python -m twine check dist/*
+  echo "Uploading to PyPI..."
+  TWINE_USERNAME="__token__" \
+    TWINE_PASSWORD="$VAARA_PYPI_TOKEN" \
+    .venv/bin/python -m twine upload dist/*
+  echo "PyPI publish: done."
+fi
+
+# --- npm ---
+pushd clients/ts >/dev/null
+if ! npm whoami >/dev/null 2>&1; then
+  echo "Not logged in to npm. Run: npm login"
+  echo "Then re-run this script (PyPI step is idempotent on already-published versions)."
+  exit 1
+fi
+
+echo "Building npm client..."
+npm ci --no-audit --no-fund
+npm run build
+node --test test/*.test.mjs
+
+echo "Publishing @vaara/client@${VERSION} to npm..."
+npm publish --access public --no-provenance
+popd >/dev/null
+
+echo
+echo "Manual publish for v${VERSION}: done."
+echo "Follow-up:"
+echo "  - Verify: pip install vaara==${VERSION}; npm view @vaara/client@${VERSION}"
+echo "  - Open an incident note explaining why the GH Actions workflow"
+echo "    was bypassed (workflow misconfig, OIDC issue, etc.)."
+echo "  - Restore the workflow before the next release."

--- a/scripts/release_push_and_pr.sh
+++ b/scripts/release_push_and_pr.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Push the release branch and open the PR. Push requires your keystroke
+# (gated by your shell auth); this script bundles the commands you'd
+# otherwise paste.
+#
+# Usage: scripts/release_push_and_pr.sh <VERSION>
+#   VERSION  e.g., 0.39.2
+#
+# Expects scripts/release_prepare.sh has already run:
+#   - branch release/v<VERSION> exists locally
+#   - .pr_body_v<VERSION>.md exists
+#   - HEAD is the release commit
+#
+# What it does:
+#   1. git push -u origin release/v<VERSION>
+#   2. gh pr create --title <subject> --body-file .pr_body_v<VERSION>.md
+#                   --base main --head release/v<VERSION>
+#   3. Prints the PR URL and the next-step command.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <VERSION>" >&2
+  exit 2
+fi
+
+VERSION="$1"
+BRANCH="release/v${VERSION}"
+PR_BODY=".pr_body_v${VERSION}.md"
+
+[[ -f "$PR_BODY" ]] || { echo "missing: $PR_BODY" >&2; exit 1; }
+[[ "$(git branch --show-current)" == "$BRANCH" ]] || \
+  { echo "not on $BRANCH (currently $(git branch --show-current))" >&2; exit 1; }
+
+# Derive PR title from the commit subject line so the PR matches the
+# commit history one-to-one.
+SUBJECT=$(git log -1 --pretty=%s)
+
+# 1. Push the branch
+git push -u origin "$BRANCH"
+
+# 2. Open the PR
+PR_URL=$(gh pr create \
+  --title "$SUBJECT" \
+  --body-file "$PR_BODY" \
+  --base main \
+  --head "$BRANCH")
+
+echo
+echo "PR opened: $PR_URL"
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+echo "Next: scripts/release_merge_and_tag.sh ${PR_NUM} ${VERSION} [CO_TAG]"


### PR DESCRIPTION
## Summary

Four scripts under `scripts/` plus a runbook at `scripts/RELEASE.md`.
Lifts the release pattern actually used in v0.39.1 (#150) and v0.39.2
(#151) so the next dozen releases don't get pasted by hand.

## Scripts

- `scripts/release_prepare.sh <VERSION> [CO_TAG]`: verifies the
  pre-flight files exist (`.commit_msg_v<VERSION>_release.txt`,
  `.pr_body_v<VERSION>.md`, CHANGELOG entry), bumps the three version
  files, runs ruff + full pytest (deselects the pre-existing SSRF
  test), stages explicit paths only, commits via `-F`, creates both
  annotated tags, creates `release/v<VERSION>` branch. Stops before
  push.
- `scripts/release_push_and_pr.sh <VERSION>`: pushes the release
  branch (your keystroke), opens the PR using the commit subject as
  PR title and `.pr_body_v<VERSION>.md` as body.
- `scripts/release_merge_and_tag.sh <PR_NUMBER> <VERSION> [CO_TAG]`:
  `gh pr checks --watch --required`, squash-merge, fetch the merged
  commit, re-tag at `origin/main` (sidesteps squash-merge divergence
  without `git reset --hard`), print the gated tag-push command.
- `scripts/release_publish_manual.sh <VERSION>`: PyPI via twine + npm
  publish `--no-provenance` fallback when the GH Actions Release
  workflow itself is broken. Behind a typed-version confirmation.
  Use only when the workflow cannot run, not for transient infra
  noise (wait + rerun the workflow in that case).

## Gated keystrokes preserved

The release flow keeps three gated keystrokes: branch push, tag push,
and manual PyPI upload. Everything else is one invocation per stage.

## Tagging strategy

The re-tag step uses `git tag -a v<VERSION> origin/main` rather than
checking out main and tagging HEAD. Squash-merge writes a new commit
on remote main that does not match the pre-merge local SHA; tagging
against `origin/main` directly avoids needing a `git reset --hard`
(which is on the destructive-ops list) to sync local main first.

## Test plan

- [ ] CI passes on this PR
- [ ] Next release (v0.40 or later) uses `scripts/release_prepare.sh`
      end-to-end and the pasted-command count drops from ~12 to ~3
      (branch push, tag push, optional local-main reconciliation)
