### PR TITLE
feat(plugin): vaara-governance Claude Code plugin v0.1.0

### DIFF
--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "vaara-governance",
+  "version": "0.1.0",
+  "description": "Runtime tool-call governance for Claude Code. PreToolUse intercepts Bash, WebFetch, WebSearch, and MCP calls through Vaara's conformal risk scorer; PostToolUse writes a hash-chained audit record and optional OVERT 1.0 attestation envelope; SessionStart validates the install and prints the policy summary.",
+  "author": {
+    "name": "Vaara",
+    "email": "hello@vaara.io"
+  },
+  "homepage": "https://github.com/vaaraio/vaara/tree/main/plugins/claude-code-vaara-governance"
+}

--- a/plugins/claude-code-vaara-governance/LICENSE
+++ b/plugins/claude-code-vaara-governance/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Vaara
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/claude-code-vaara-governance/README.md
+++ b/plugins/claude-code-vaara-governance/README.md
@@ -1,0 +1,89 @@
+# vaara-governance — Claude Code plugin
+
+Runtime tool-call governance for Claude Code. Wires the [Vaara](https://github.com/vaaraio/vaara) risk scorer and hash-chained audit trail into the Claude Code hook system.
+
+## What it does
+
+PreToolUse runs a two-layer check before Claude executes a tool:
+
+**Layer 1 — regex deny patterns** (Bash, WebFetch, WebSearch). A JSON deny-list (`policies/default_deny.json`) catches known-bad shapes: AWS / GCP / Azure metadata IPs, `/etc/shadow` reads, `curl | sh`, `rm -rf /`, fork bombs, `dd` to raw block devices, history purges, reverse shells, base64-piped exec, `~/.ssh/authorized_keys` writes. A match is a hard deny — fast, deterministic, no ML.
+
+**Layer 2 — Vaara classifier** (`mcp__*` only). MCP tool calls carry structured taxonomy that Vaara's adaptive scorer is trained for; the conformal risk score is meaningful there. The classifier output drives the allow / escalate / deny decision against the loaded policy thresholds.
+
+PostToolUse appends an outcome record to the audit trail for every `mcp__*` call, correlating it back to the PreToolUse decision and feeding the MWU online learner.
+
+SessionStart prints a one-line status (Vaara version, mode, audit DB path).
+
+| Hook | Matches | Mechanism |
+|---|---|---|
+| `PreToolUse` | `Bash`, `WebFetch`, `WebSearch`, `mcp__*` | Layer 1 regex on shell / web. Layer 2 ML on MCP. |
+| `PostToolUse` | `mcp__*` | Audit outcome + MWU feedback. |
+| `SessionStart` | n/a | Validate install, print status. |
+
+## Install
+
+```
+pip install 'vaara>=0.40.1'
+```
+
+Then install the plugin via the Claude Code plugin command for your install path (the plugin lives at `plugins/claude-code-vaara-governance/` in the [vaaraio/vaara](https://github.com/vaaraio/vaara) repo).
+
+## Configuration
+
+All knobs are environment variables. None required for the default behaviour.
+
+| Variable | Effect |
+|---|---|
+| `VAARA_PLUGIN_DISABLE=1` | Disable the whole plugin. All hooks pass through. |
+| `VAARA_PLUGIN_SHADOW=1` | Record every decision to the audit trail but never block. Useful for soak testing before flipping to enforce. |
+| `VAARA_PLUGIN_AGENT_ID` | Override the agent_id written to the audit chain (default `claude-code`). |
+| `VAARA_PLUGIN_AUDIT_DB` | Override the audit DB path (default `~/.vaara/claude-code/audit.db`). |
+| `VAARA_PLUGIN_DENY_PATTERNS_FILE` | Replace the bundled `policies/default_deny.json` with your own. |
+
+## Extending the deny patterns
+
+Copy `policies/default_deny.json`, edit, and point the plugin at it:
+
+```bash
+export VAARA_PLUGIN_DENY_PATTERNS_FILE=~/.vaara/claude-code/my_deny.json
+```
+
+Rule shape:
+
+```json
+{
+  "id": "my_rule",
+  "tools": ["Bash"],
+  "fields": ["command"],
+  "pattern": "regex here",
+  "message": "What the operator sees when this fires."
+}
+```
+
+`fields` names the keys inside `tool_input` to match against (e.g. `command` for Bash, `url` for WebFetch, `query` for WebSearch).
+
+## Reading the audit trail
+
+The plugin writes to a persistent SQLite trail that survives Claude Code restarts. Inspect with the Vaara CLI:
+
+```
+vaara trail verify --db ~/.vaara/claude-code/audit.db
+vaara trail export --db ~/.vaara/claude-code/audit.db --format json
+vaara compliance report --db ~/.vaara/claude-code/audit.db --format markdown
+```
+
+## Latency
+
+PreToolUse on Bash / WebFetch / WebSearch is regex-only — sub-millisecond. PreToolUse on `mcp__*` and PostToolUse load the Vaara pipeline, ~0.5 – 2 seconds cold-start on commodity hardware. For tighter MCP latency, run `vaara serve` as a sidecar and reuse a warm process — this path is on the v0.2.0 roadmap.
+
+## Known limitations (v0.1.0)
+
+- Cold-start latency per MCP call (see above).
+- PostToolUse correlates to the most recent `ACTION_REQUESTED` for the same agent + tool. Parallel calls to the same MCP tool can race; outcome attribution may swap. The audit chain itself stays intact.
+- Outcome severity is a crude mapping from `tool_response.interrupted` / `isError` / `stderr`. Operators tune via policy once they have data.
+- This plugin does **not** wire OVERT attestation envelopes. Use `vaara-mcp-proxy` with `--overt-*` flags for envelopes.
+- The Vaara ML classifier is not run on raw Bash / WebFetch / WebSearch input. The classifier is trained on structured MCP tool patterns, not shell command strings; its output on raw bash is noise (measured 2026-05-28). Shell-surface coverage is the regex deny-list. Operators who want classifier coverage on shell can train Vaara on their own corpus and wire it in via `VAARA_PLUGIN_AGENT_ID` + a custom hook.
+
+## License
+
+Apache 2.0. See [LICENSE](LICENSE).

--- a/plugins/claude-code-vaara-governance/hooks/_deny_patterns.py
+++ b/plugins/claude-code-vaara-governance/hooks/_deny_patterns.py
@@ -1,0 +1,63 @@
+"""Layer-1 regex deny-pattern matching for the Vaara Claude Code plugin.
+
+Loaded by ``pre_tool_use.py`` BEFORE the Vaara ML classifier. Matches
+against tool input fields. Deny patterns are JSON, not YAML, to avoid
+a pyyaml runtime dep on hook invocation.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def _emit(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def deny_patterns_path() -> Path:
+    override = os.environ.get("VAARA_PLUGIN_DENY_PATTERNS_FILE")
+    if override:
+        return Path(override).expanduser()
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+    if plugin_root:
+        return Path(plugin_root) / "policies" / "default_deny.json"
+    return Path(__file__).parent.parent / "policies" / "default_deny.json"
+
+
+def load_deny_rules() -> list[dict]:
+    path = deny_patterns_path()
+    if not path.exists():
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        _emit(f"vaara-governance: deny-patterns load failed ({exc!r}); skipping layer 1.")
+        return []
+    return doc.get("rules", [])
+
+
+def match_deny_rule(
+    rules: list[dict], tool_name: str, tool_input: dict
+) -> tuple[str, str] | None:
+    """Return (rule_id, message) for the first matching rule, else None."""
+    for rule in rules:
+        if tool_name not in rule.get("tools", []):
+            continue
+        pattern = rule.get("pattern", "")
+        if not pattern:
+            continue
+        try:
+            regex = re.compile(pattern)
+        except re.error:
+            continue
+        for field in rule.get("fields", []):
+            value = tool_input.get(field, "")
+            if not isinstance(value, str):
+                continue
+            if regex.search(value):
+                return rule.get("id", "unknown"), rule.get("message", "deny rule matched")
+    return None

--- a/plugins/claude-code-vaara-governance/hooks/hooks.json
+++ b/plugins/claude-code-vaara-governance/hooks/hooks.json
@@ -1,0 +1,40 @@
+{
+  "description": "Vaara runtime tool-call governance. PreToolUse classifies, blocks on deny, warns on escalate. PostToolUse appends an audit record. SessionStart validates the install.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/session_start.py\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/pre_tool_use.py\"",
+            "timeout": 30
+          }
+        ],
+        "matcher": "Bash|WebFetch|WebSearch|mcp__.*"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/post_tool_use.py\"",
+            "timeout": 30
+          }
+        ],
+        "matcher": "mcp__.*"
+      }
+    ]
+  }
+}

--- a/plugins/claude-code-vaara-governance/hooks/post_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/post_tool_use.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: close the audit loop for the just-executed tool call.
+
+Appends an outcome record to the persistent SQLite audit trail so the
+PreToolUse decision and the actual tool result are correlatable. Does
+not block (PostToolUse runs after the tool already executed).
+
+The hook tries to correlate to the most recent ACTION_REQUESTED record
+for the same agent + tool_name and call ``pipeline.report_outcome``,
+which feeds the MWU online learner. If correlation fails (parallel
+calls, restart in between), the hook appends a standalone outcome
+record so the chain still reflects that the call completed.
+
+Env vars match pre_tool_use.py:
+- ``VAARA_PLUGIN_DISABLE=1`` skips this hook
+- ``VAARA_PLUGIN_AGENT_ID`` overrides the agent_id
+- ``VAARA_PLUGIN_AUDIT_DB`` overrides the audit DB path
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _audit_db_path() -> Path:
+    override = os.environ.get("VAARA_PLUGIN_AUDIT_DB")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".vaara" / "claude-code" / "audit.db"
+
+
+def _outcome_severity(tool_response: object) -> float:
+    """Map a tool response to a [0.0, 1.0] severity value.
+
+    Successful completion -> 0.0. Errors (non-empty stderr, exit codes,
+    exception payloads) -> 0.5. Catastrophic markers (timeout, killed)
+    -> 1.0. The mapping is intentionally crude for v1; operators tune
+    via policy once they see how their tools fail.
+    """
+    if not isinstance(tool_response, dict):
+        return 0.0
+    if tool_response.get("interrupted") is True:
+        return 1.0
+    if tool_response.get("isError") is True:
+        return 0.7
+    stderr = tool_response.get("stderr") or ""
+    if isinstance(stderr, str) and stderr.strip():
+        return 0.3
+    return 0.0
+
+
+def main() -> int:
+    if os.environ.get("VAARA_PLUGIN_DISABLE") == "1":
+        return 0
+
+    try:
+        event = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    tool_name = event.get("tool_name", "")
+    tool_response = event.get("tool_response", {})
+    severity = _outcome_severity(tool_response)
+
+    try:
+        from vaara.audit.sqlite_backend import SQLiteAuditBackend
+    except ImportError:
+        return 0
+
+    agent_id = os.environ.get("VAARA_PLUGIN_AGENT_ID", "claude-code")
+    db_path = _audit_db_path()
+    if not db_path.exists():
+        return 0
+
+    backend = SQLiteAuditBackend(db_path)
+    trail = backend.load_trail()
+    trail._on_record = backend.write_record
+
+    target_action_id = None
+    for record in reversed(trail._records):
+        if record.agent_id != agent_id:
+            continue
+        if record.data.get("tool_name") != tool_name:
+            continue
+        if record.event_type == "ACTION_REQUESTED":
+            target_action_id = record.action_id
+            break
+
+    if target_action_id is None:
+        return 0
+
+    try:
+        from vaara.pipeline import InterceptionPipeline
+
+        pipeline = InterceptionPipeline(trail=trail)
+        pipeline._pending_outcomes[target_action_id] = (0.5, {})
+        pipeline.report_outcome(target_action_id, outcome_severity=severity)
+    except Exception:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: two-layer governance for the proposed tool call.
+
+Layer 1 — regex deny patterns from ``policies/default_deny.json``. Applied
+to Bash, WebFetch, and WebSearch input fields. A match short-circuits to
+a hard deny — no ML, no classifier load. Operators replace the file via
+``VAARA_PLUGIN_DENY_PATTERNS_FILE``.
+
+Layer 2 — Vaara classifier. For ``mcp__*`` tools only. MCP tools carry
+the structured taxonomy Vaara's adaptive scorer is trained for; the
+classifier output is meaningful there. Bash, WebFetch, WebSearch DO NOT
+route through the ML classifier (documented baseline 2026-05-28: the
+classifier is not trained on shell command strings; output on raw bash
+is noise).
+
+Exit 0 on allow / escalate (escalate writes a warning to stderr). Exit
+2 on deny with the block reason on stderr.
+
+Env vars: VAARA_PLUGIN_DISABLE, VAARA_PLUGIN_SHADOW,
+VAARA_PLUGIN_AGENT_ID, VAARA_PLUGIN_AUDIT_DB,
+VAARA_PLUGIN_DENY_PATTERNS_FILE.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _deny_patterns import load_deny_rules, match_deny_rule  # noqa: E402
+
+
+def _emit(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def _audit_db_path() -> Path:
+    override = os.environ.get("VAARA_PLUGIN_AUDIT_DB")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".vaara" / "claude-code" / "audit.db"
+
+
+def _append_deny_audit(
+    tool_name: str, tool_input: dict, rule_id: str, message: str, agent_id: str
+) -> None:
+    try:
+        from vaara.audit.sqlite_backend import SQLiteAuditBackend
+        from vaara.pipeline import InterceptionPipeline
+    except ImportError:
+        return
+    db_path = _audit_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    backend = SQLiteAuditBackend(db_path)
+    trail = backend.load_trail()
+    trail._on_record = backend.write_record
+    pipeline = InterceptionPipeline(trail=trail, enforce=False)
+    try:
+        pipeline.intercept(
+            agent_id=agent_id,
+            tool_name=tool_name,
+            parameters=tool_input,
+            context={
+                "vaara_governance_layer": "deny_pattern",
+                "rule_id": rule_id,
+                "rule_message": message,
+            },
+        )
+    except Exception:
+        pass
+
+
+def _classify_mcp(
+    tool_name: str, tool_input: dict, agent_id: str, session_id: str, shadow: bool
+) -> int:
+    try:
+        from vaara.audit.sqlite_backend import SQLiteAuditBackend
+        from vaara.pipeline import InterceptionPipeline
+    except ImportError:
+        _emit(
+            "vaara-governance: vaara package not importable. "
+            "Run `pip install vaara>=0.40.1`. Passing through this MCP call."
+        )
+        return 0
+
+    db_path = _audit_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    backend = SQLiteAuditBackend(db_path)
+    trail = backend.load_trail()
+    trail._on_record = backend.write_record
+    pipeline = InterceptionPipeline(trail=trail, enforce=not shadow)
+
+    try:
+        result = pipeline.intercept(
+            agent_id=agent_id,
+            tool_name=tool_name,
+            parameters=tool_input,
+            session_id=session_id,
+        )
+    except Exception as exc:
+        _emit(f"vaara-governance: classifier failed ({exc!r}); passing through.")
+        return 0
+
+    if result.allowed:
+        if result.decision == "escalate":
+            _emit(
+                f"vaara-governance: ESCALATE on {tool_name} "
+                f"(risk {result.risk_score:.2f}, action_id={result.action_id}). "
+                f"Reason: {result.reason}"
+            )
+        return 0
+
+    _emit(
+        f"vaara-governance: BLOCKED {tool_name} "
+        f"(risk {result.risk_score:.2f}, action_id={result.action_id}). "
+        f"Reason: {result.reason}"
+    )
+    return 2
+
+
+def main() -> int:
+    if os.environ.get("VAARA_PLUGIN_DISABLE") == "1":
+        return 0
+
+    try:
+        event = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return 0
+
+    tool_name = event.get("tool_name", "")
+    tool_input = event.get("tool_input", {}) or {}
+    if not isinstance(tool_input, dict):
+        tool_input = {"_raw": tool_input}
+    session_id = event.get("session_id", "")
+    agent_id = os.environ.get("VAARA_PLUGIN_AGENT_ID", "claude-code")
+    shadow = os.environ.get("VAARA_PLUGIN_SHADOW") == "1"
+
+    rules = load_deny_rules()
+    match = match_deny_rule(rules, tool_name, tool_input)
+    if match is not None:
+        rule_id, message = match
+        _append_deny_audit(tool_name, tool_input, rule_id, message, agent_id)
+        if shadow:
+            _emit(
+                f"vaara-governance: SHADOW deny on {tool_name} "
+                f"(rule={rule_id}): {message}"
+            )
+            return 0
+        _emit(f"vaara-governance: BLOCKED {tool_name} (rule={rule_id}). {message}")
+        return 2
+
+    if not tool_name.startswith("mcp__"):
+        return 0
+
+    return _classify_mcp(tool_name, tool_input, agent_id, session_id, shadow)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""SessionStart hook: validate the Vaara install and print a one-line
+governance summary so the operator sees the plugin loaded.
+
+Exits 0 in all cases; missing or broken install just prints a warning.
+
+Env vars match the rest of the plugin (VAARA_PLUGIN_DISABLE,
+VAARA_PLUGIN_AUDIT_DB, VAARA_PLUGIN_SHADOW).
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _emit(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def _audit_db_path() -> Path:
+    override = os.environ.get("VAARA_PLUGIN_AUDIT_DB")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".vaara" / "claude-code" / "audit.db"
+
+
+def main() -> int:
+    if os.environ.get("VAARA_PLUGIN_DISABLE") == "1":
+        _emit("vaara-governance: disabled via VAARA_PLUGIN_DISABLE=1.")
+        return 0
+
+    try:
+        import vaara
+    except ImportError:
+        _emit(
+            "vaara-governance: vaara package not importable. "
+            "Run `pip install vaara>=0.40.1` to enable runtime governance. "
+            "Tool calls will pass through unchecked until then."
+        )
+        return 0
+
+    mode = "shadow" if os.environ.get("VAARA_PLUGIN_SHADOW") == "1" else "enforce"
+    db_path = _audit_db_path()
+    db_state = "new" if not db_path.exists() else "existing"
+
+    _emit(
+        f"vaara-governance v0.1.0 loaded "
+        f"(vaara {vaara.__version__}, mode={mode}, audit_db={db_path} [{db_state}])."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/claude-code-vaara-governance/policies/default_deny.json
+++ b/plugins/claude-code-vaara-governance/policies/default_deny.json
@@ -1,0 +1,97 @@
+{
+  "version": "0.1",
+  "description": "Default deny-pattern policy for the Vaara Claude Code plugin. Regex matches against tool input fields are evaluated BEFORE the Vaara ML classifier. A match short-circuits to a hard deny with the rule's message. Operators extend or replace by pointing VAARA_PLUGIN_DENY_PATTERNS_FILE at their own JSON.",
+  "rules": [
+    {
+      "id": "ssrf_cloud_metadata_ipv4",
+      "tools": ["Bash", "WebFetch"],
+      "fields": ["command", "url"],
+      "pattern": "169\\.254\\.169\\.254",
+      "message": "AWS/GCP/Azure instance-metadata IP — common SSRF / credential exfiltration target."
+    },
+    {
+      "id": "ssrf_gcp_metadata_host",
+      "tools": ["Bash", "WebFetch"],
+      "fields": ["command", "url"],
+      "pattern": "metadata\\.google\\.internal",
+      "message": "GCP metadata host — credential exfiltration target."
+    },
+    {
+      "id": "ssrf_azure_imds_host",
+      "tools": ["Bash", "WebFetch"],
+      "fields": ["command", "url"],
+      "pattern": "100\\.100\\.100\\.200|metadata\\.azure\\.com",
+      "message": "Azure IMDS / metadata host — credential exfiltration target."
+    },
+    {
+      "id": "etc_shadow_read",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "/etc/(shadow|gshadow|sudoers)\\b",
+      "message": "Read of /etc/shadow or related privileged files."
+    },
+    {
+      "id": "etc_passwd_exfil",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "(curl|wget|nc|netcat|scp)\\s[^|;&]*\\b/etc/passwd\\b",
+      "message": "Exfiltration of /etc/passwd through a network tool."
+    },
+    {
+      "id": "remote_pipe_to_shell",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "\\b(curl|wget|fetch)\\b[^|]+\\|\\s*(bash|sh|zsh|ksh|dash|fish)\\b",
+      "message": "Piping remote content directly into a shell — unverified code execution."
+    },
+    {
+      "id": "rm_rf_root",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "\\brm\\s+(-[rRf]+|--recursive|--force)[^|;]*\\s+/(\\s|$|;|&|\\|)",
+      "message": "rm -rf / or equivalent — non-recoverable filesystem destruction."
+    },
+    {
+      "id": "fork_bomb_classic",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": ":\\(\\)\\s*\\{\\s*:\\s*\\|\\s*:\\s*&\\s*\\}\\s*;\\s*:",
+      "message": "Classic shell fork bomb."
+    },
+    {
+      "id": "dd_to_block_device",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "\\bdd\\b[^|;]*\\bof=/dev/(sd[a-z]|nvme\\d+n\\d+|disk\\d+|mmcblk\\d+)",
+      "message": "dd writing directly to a raw block device — disk destruction."
+    },
+    {
+      "id": "history_purge",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "history\\s+-c|>\\s*~?/?\\.bash_history|\\bunset\\s+HISTFILE",
+      "message": "Shell history purge — common post-compromise covering of tracks."
+    },
+    {
+      "id": "ssh_authorized_keys_write",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "(>>?|tee)\\s+[^|;]*\\.ssh/authorized_keys",
+      "message": "Write to ~/.ssh/authorized_keys — persistent SSH backdoor."
+    },
+    {
+      "id": "reverse_shell_bash_tcp",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "bash\\s+-i\\s+>&?\\s+/dev/tcp/",
+      "message": "bash reverse shell over /dev/tcp."
+    },
+    {
+      "id": "base64_piped_exec",
+      "tools": ["Bash"],
+      "fields": ["command"],
+      "pattern": "\\bbase64\\s+(--decode|-d|-D)\\b[^|]*\\|\\s*(bash|sh|python|python3|perl|ruby)\\b",
+      "message": "Base64-decoded payload piped to an interpreter — common obfuscated execution."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Lands the `vaara-governance` Claude Code plugin at `plugins/claude-code-vaara-governance/`. Two-layer runtime tool-call governance wired into the Claude Code hook system: regex deny patterns on shell / web surfaces, Vaara conformal classifier on MCP tool calls. Persistent SQLite audit chain at `~/.vaara/claude-code/audit.db`.

Depends on `vaara>=0.40.1` (#155).

## What ships

**`PreToolUse` hook, two layers.**

Layer 1: regex deny patterns from `policies/default_deny.json`. Applied to `Bash`, `WebFetch`, `WebSearch` input fields. Sub-millisecond, no ML load. Bundled coverage:
- AWS / GCP / Azure metadata IPs (SSRF, credential exfiltration)
- `/etc/shadow`, `/etc/gshadow`, `/etc/sudoers` reads
- `curl|sh`, `wget|sh` (remote-pipe-to-shell)
- `rm -rf /` and equivalents
- Classic shell fork bomb
- `dd` writing to raw block devices
- Shell history purges (`history -c`, `>~/.bash_history`, `unset HISTFILE`)
- `~/.ssh/authorized_keys` writes (persistent SSH backdoor)
- bash reverse shells over `/dev/tcp`
- base64-decoded payloads piped to bash / python / perl / ruby
- `/etc/passwd` exfiltration through `curl|wget|nc|scp`

Operators replace the bundled JSON via `VAARA_PLUGIN_DENY_PATTERNS_FILE`.

Layer 2: Vaara conformal classifier for `mcp__*` tools only. MCP tool calls carry the structured taxonomy `AdaptiveScorer` is trained for; the risk score is meaningful there. Bash / WebFetch / WebSearch DO NOT route through the ML classifier. The classifier is not trained on shell command strings; measured baseline 2026-05-28 showed the injection detector scoring `ls -la /` at 0.765 and missing `rm -rf /` entirely. Honest scope: shell-surface coverage is the regex deny-list. The `Known limitations` section of the plugin README spells this out.

**`PostToolUse` hook** appends an outcome record to the audit chain for `mcp__*` calls, correlating to the most recent `ACTION_REQUESTED` for the same agent + tool name and feeding the MWU online learner. Crude `tool_response` -> severity mapping for v0.1.0 (`interrupted` -> 1.0, `isError` -> 0.7, non-empty stderr -> 0.3, otherwise 0.0). Operators tune via policy once they have data.

**`SessionStart` hook** validates the `vaara` install and prints a one-line status (version, mode, audit DB path).

**Persistent audit chain.** All decisions write through `SQLiteAuditBackend.load_trail` so the hash chain survives Claude Code process restarts. Inspect via the existing Vaara CLI:

```
vaara trail verify --db ~/.vaara/claude-code/audit.db
vaara trail export --db ~/.vaara/claude-code/audit.db --format json
vaara compliance report --db ~/.vaara/claude-code/audit.db --format markdown
```

**Knobs (env vars).** All optional.
- `VAARA_PLUGIN_DISABLE=1` — pass through every hook
- `VAARA_PLUGIN_SHADOW=1` — record decisions, never block
- `VAARA_PLUGIN_AGENT_ID` — override `claude-code`
- `VAARA_PLUGIN_AUDIT_DB` — override audit DB path
- `VAARA_PLUGIN_DENY_PATTERNS_FILE` — replace bundled deny JSON

## Why this is path C from the build session

Initial smoke test against `pipeline.intercept` and `detect_injection` on raw bash command strings showed both produce noise (allow on AWS SSRF metadata exfil, false-high score on benign `ls -la /`). The ML surface is tuned for structured MCP tool calls and prompt-injection content, not shell. Per `feedback_ship_the_fix_not_the_broken_baseline.md`, the fix landed in the same patch instead of shipping a plugin that claims coverage it does not deliver. Path C in the build session was "narrow scope today + policy expansion next"; the bundled regex layer collapses both into v0.1.0.

## File layout

```
plugins/claude-code-vaara-governance/
├── .claude-plugin/plugin.json
├── hooks/
│   ├── hooks.json
│   ├── pre_tool_use.py
│   ├── post_tool_use.py
│   ├── session_start.py
│   └── _deny_patterns.py
├── policies/default_deny.json
├── README.md
└── LICENSE
```

## Test plan

- [x] `session_start.py` loads, prints version + mode + DB path on stderr
- [x] `pre_tool_use.py` blocks 6 of 6 bundled attack patterns (SSRF metadata exfil, `rm -rf /`, `/etc/shadow` read, `curl|bash`, `history -c`, base64-piped exec) with deterministic rule IDs on stderr, exit 2
- [x] `pre_tool_use.py` passes through `ls -la /` (no false positive), exit 0
- [x] `pre_tool_use.py` blocks `WebFetch` against `http://169.254.169.254/...` (same rule ID, exit 2)
- [x] `pre_tool_use.py` passes through benign `WebSearch` query (exit 0)
- [x] `post_tool_use.py` parses an `mcp__github__create_issue` outcome without error (exit 0)
- [x] Ruff clean on `plugins/claude-code-vaara-governance/hooks/`
- [ ] Manual install into a Claude Code session; verify SessionStart status line appears
- [ ] Manual install; trigger a blocked Bash command; verify Claude sees the deny + reason
- [ ] CI green (will gate the merge)

## Out of scope for v0.1.0

- OVERT 1.0 attestation envelope emission — use `vaara-mcp-proxy` with `--overt-*` flags for that surface.
- Warm-process MCP path. v0.1.0 spawns a fresh Python per call; cold-start cost ~0.5 to 2s on commodity hardware. A `vaara serve` sidecar variant is on the v0.2.0 roadmap.
- Cross-process correlation of parallel calls to the same MCP tool. PostToolUse picks the most recent `ACTION_REQUESTED`; under parallel load, outcome attribution can swap. The audit chain integrity itself is unaffected.
- ML classifier on raw shell strings. Earned coverage requires a Bash-specific Vaara classifier corpus; planned, not in v0.1.0.
