### PR TITLE
fix(plugin): align plugin metadata + audit-trail commands with shipped CLI

### DIFF
--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaara-governance",
   "version": "0.1.0",
-  "description": "Runtime tool-call governance for Claude Code. PreToolUse intercepts Bash, WebFetch, WebSearch, and MCP calls through Vaara's conformal risk scorer; PostToolUse writes a hash-chained audit record and optional OVERT 1.0 attestation envelope; SessionStart validates the install and prints the policy summary.",
+  "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record. SessionStart validates the install and prints version, mode, and audit DB path.",
   "author": {
     "name": "Vaara",
     "email": "hello@vaara.io"

--- a/plugins/claude-code-vaara-governance/README.md
+++ b/plugins/claude-code-vaara-governance/README.md
@@ -67,10 +67,11 @@ Rule shape:
 The plugin writes to a persistent SQLite trail that survives Claude Code restarts. Inspect with the Vaara CLI:
 
 ```
-vaara trail verify --db ~/.vaara/claude-code/audit.db
-vaara trail export --db ~/.vaara/claude-code/audit.db --format json
-vaara compliance report --db ~/.vaara/claude-code/audit.db --format markdown
+vaara compliance report --db ~/.vaara/claude-code/audit.db --format md
+vaara compliance dashboard --db ~/.vaara/claude-code/audit.db --out ~/audit-dashboard.html
 ```
+
+For a signed, regulator-handoff bundle, export the trail with `vaara trail export --trail PATH --out PATH --key PATH`, then verify the zip with `vaara trail verify --zip PATH`.
 
 ## Latency
 


### PR DESCRIPTION
## Summary

Two plugin documentation fixes flagged during the v0.40.1 wrap audit:

- **plugin.json description**: drops the "optional OVERT 1.0 attestation envelope" claim. No hook in v0.1.0 emits OVERT envelopes (verified via `grep -n "overt\|OVERT" plugins/claude-code-vaara-governance/hooks/*.py` — zero hits). Replaces with what the hooks actually do.
- **plugin README**: replaces broken audit-trail CLI commands. `vaara trail verify --db PATH` does not exist — that subcommand takes `--zip PATH` for signed regulator-handoff bundles, not SQLite DBs. Same applies to `vaara trail export --db`. The audit-DB-shaped commands actually shipped are `vaara compliance report --db PATH --format md` and `vaara compliance dashboard --db PATH --out PATH`. Trail export/verify guidance moved to the regulator-handoff paragraph with correct argument shape.

No code change. No version bump (plugin metadata + README only).

## Test plan

- [x] Plugin description matches what hooks actually do (manual verification against `pre_tool_use.py`, `post_tool_use.py`, `session_start.py`)
- [x] Every CLI command in plugin README verified against `src/vaara/cli.py` argparse definitions
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated plugin metadata to reflect governance check mechanisms and audit logging details.
  * Updated audit trail documentation with new Vaara CLI command examples for compliance reporting and regulator handoff workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->