### PR TITLE
release(v0.40.2): vaara-mcp-server packaging + fan-out latency bench

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "vaara",
+  "description": "Vaara runtime tool-call governance plugins for Claude Code",
+  "owner": {
+    "name": "Vaara",
+    "email": "hello@vaara.io"
+  },
+  "plugins": [
+    {
+      "name": "vaara-governance",
+      "description": "Runtime tool-call governance for Claude Code. Layer-1 regex deny on Bash/WebFetch/WebSearch. Layer-2 conformal risk classifier on mcp__* tools. Hash-chained SQLite audit trail at ~/.vaara/claude-code/audit.db.",
+      "author": {
+        "name": "Henri Sirkkavaara",
+        "email": "hello@vaara.io"
+      },
+      "category": "security",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/vaaraio/vaara.git",
+        "path": "plugins/claude-code-vaara-governance",
+        "ref": "main"
+      },
+      "homepage": "https://vaara.io"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.40.2] - 2026-05-28
+
+**Theme: vaara-mcp-server packaging + fan-out latency numbers.**
+
+### Added
+- `vaara-mcp-server` console script in `[project.scripts]`, wired to
+  the existing `vaara.integrations.mcp_server:main` entry point. The
+  standalone MCP server has shipped in the package for several
+  releases but only ran via `python -m vaara.integrations.mcp_server`.
+  It now installs as a console script alongside `vaara-mcp-proxy` and
+  exposes the `vaara_check`, `vaara_intercept`, and
+  `vaara_report_outcome` tools plus the `vaara://status` and
+  `vaara://compliance` resources to any MCP host.
+- `bench/latency_fanout.py` and `bench/v040_fanout.json`. Measures
+  Vaara's per-call overhead on the v0.40 streamable-HTTP transport
+  across N upstream slots. Result: 1.2 ms mean, 1.4 ms p99, flat from
+  N=1 to N=8. Closes the honest-scope caveat from the v0.40 PR body.
+  The upstream subprocess is mocked at the `UpstreamMCPClient` boundary
+  so the number isolates added governance cost (HTTP parse, tenant and
+  upstream header resolution, `Pipeline.intercept`, dispatch).
+- `server-vaara-server.json` for a second MCP Registry listing under
+  `io.github.vaaraio/vaara-server`, alongside the existing
+  `io.github.vaaraio/vaara` proxy entry. Two separate registry slots
+  for two separate MCP servers: the proxy that wraps upstream MCP
+  servers, and the standalone server that exposes Vaara governance as
+  MCP tools.
+- `.claude-plugin/marketplace.json` at the repo root. Registers a local
+  Claude Code plugin marketplace so `claude plugin install
+  vaara-governance@vaara` works after `claude plugin marketplace add
+  /path/to/vaara`. Same file doubles as the seed for a future
+  submission to `anthropics/claude-plugins-official`.
+
+### Changed
+- `server.json` version bumped to 0.40.2 to track the PyPI package.
+
 ## [0.40.1] - 2026-05-28
 
 **Theme: registry-prep + README trim.**

--- a/bench/latency_fanout.py
+++ b/bench/latency_fanout.py
@@ -1,0 +1,193 @@
+"""Fan-out HTTP-transport latency micro-benchmark for vaara-mcp-proxy.
+
+Measures per-call overhead Vaara adds to a `tools/call` routed through the
+v0.40 streamable-HTTP transport across N upstream slots. Answers "what
+does fan-out routing cost on top of the single-upstream baseline" and
+gives publishable p50/p95/p99 numbers for the v0.40 PR-body scope note.
+
+Honest scope: the upstream subprocess is mocked at the `UpstreamMCPClient`
+boundary, so the measurement isolates Vaara's added cost (HTTP parse,
+tenant + upstream header resolution, `Pipeline.intercept`, dispatch). It
+does NOT include real stdio JSON-RPC roundtrip to a live MCP server,
+which depends on the upstream's own runtime and is out of scope for a
+governance-overhead number.
+
+Run::
+
+    python bench/latency_fanout.py                       # default: N=[1,2,4,8], 2000 calls each
+    python bench/latency_fanout.py --calls 5000
+    python bench/latency_fanout.py --upstreams 1,2,4,8,16
+    python bench/latency_fanout.py --json bench/v040_fanout.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import statistics
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from vaara.integrations import mcp_proxy  # noqa: E402
+from vaara.integrations.mcp_proxy import VaaraMCPProxy  # noqa: E402
+from vaara.pipeline import InterceptionPipeline  # noqa: E402
+
+
+@dataclass
+class FanoutStats:
+    n_upstreams: int
+    n_calls: int
+    mean_ms: float
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    p999_ms: float
+    min_ms: float
+    max_ms: float
+    throughput_per_sec: float
+
+
+def _percentile(sorted_samples: list[float], p: float) -> float:
+    if not sorted_samples:
+        return 0.0
+    k = (len(sorted_samples) - 1) * p
+    lo = int(k)
+    hi = min(lo + 1, len(sorted_samples) - 1)
+    frac = k - lo
+    return sorted_samples[lo] + (sorted_samples[hi] - sorted_samples[lo]) * frac
+
+
+def _summarize(n_upstreams: int, samples_ms: list[float]) -> FanoutStats:
+    s = sorted(samples_ms)
+    total_s = sum(samples_ms) / 1000.0
+    return FanoutStats(
+        n_upstreams=n_upstreams,
+        n_calls=len(samples_ms),
+        mean_ms=round(statistics.fmean(samples_ms), 4),
+        p50_ms=round(_percentile(s, 0.50), 4),
+        p95_ms=round(_percentile(s, 0.95), 4),
+        p99_ms=round(_percentile(s, 0.99), 4),
+        p999_ms=round(_percentile(s, 0.999), 4),
+        min_ms=round(s[0], 4),
+        max_ms=round(s[-1], 4),
+        throughput_per_sec=round(len(samples_ms) / total_s, 1) if total_s > 0 else 0.0,
+    )
+
+
+def _make_app(n_upstreams: int, pipeline: InterceptionPipeline):
+    """Build a FastAPI app with N mocked upstreams. Returns (app, slot_names)."""
+    # The mock returns a fixed tools/list response so the proxy's own
+    # response-handling path executes end-to-end without a real subprocess.
+    def make_client(*_a, **_kw):
+        c = MagicMock()
+        c.request.return_value = {
+            "jsonrpc": "2.0", "id": 1, "result": {"tools": []},
+        }
+        return c
+
+    original_cls = mcp_proxy.UpstreamMCPClient
+    mcp_proxy.UpstreamMCPClient = MagicMock(side_effect=make_client)
+    try:
+        if n_upstreams == 1:
+            proxy = VaaraMCPProxy(upstream_command=["mock"], pipeline=pipeline)
+            slot_names = ["default"]
+        else:
+            upstreams = {f"u{i}": [f"mock-{i}"] for i in range(n_upstreams)}
+            proxy = VaaraMCPProxy(upstreams=upstreams, pipeline=pipeline)
+            slot_names = sorted(upstreams.keys())
+
+        # Replicate run_http()'s FastAPI build without uvicorn.run().
+        import unittest.mock as um
+        captured: dict = {}
+        with um.patch("uvicorn.run") as run_mock:
+            def fake_run(app, **_kw):
+                captured["app"] = app
+            run_mock.side_effect = fake_run
+            proxy.run_http(host="127.0.0.1", port=0)
+        return captured["app"], slot_names
+    finally:
+        mcp_proxy.UpstreamMCPClient = original_cls
+
+
+def bench_fanout(n_upstreams: int, n_calls: int, n_warmup: int) -> FanoutStats:
+    pipeline = InterceptionPipeline()
+    app, slot_names = _make_app(n_upstreams, pipeline)
+    client = TestClient(app)
+    # Single-upstream keeps v0.39 silent-default contract — no header.
+    # Multi-upstream requires explicit X-Vaara-Upstream per v0.40 4XX rule.
+    rng = random.Random(0xC0FFEE)
+
+    def call_once(i: int) -> float:
+        headers = {"X-Vaara-Tenant": f"t{i & 0x3}"}
+        if n_upstreams > 1:
+            headers["X-Vaara-Upstream"] = rng.choice(slot_names)
+        body = {
+            "jsonrpc": "2.0",
+            "id": i,
+            "method": "tools/call",
+            "params": {
+                "name": "data.read",
+                "arguments": {"path": "s3://bucket/key"},
+            },
+        }
+        t0 = time.perf_counter_ns()
+        client.post("/mcp", json=body, headers=headers)
+        return (time.perf_counter_ns() - t0) / 1_000_000.0
+
+    for i in range(n_warmup):
+        call_once(i)
+
+    samples_ms = [call_once(i) for i in range(n_calls)]
+    return _summarize(n_upstreams, samples_ms)
+
+
+def _print_markdown_table(rows: list[FanoutStats]) -> None:
+    print()
+    print("| N upstreams | mean (ms) | p50 (ms) | p95 (ms) | p99 (ms) | p99.9 (ms) | throughput/s |")
+    print("|-------------|-----------|----------|----------|----------|------------|--------------|")
+    for r in rows:
+        print(
+            f"| {r.n_upstreams:>11} | {r.mean_ms:>9.3f} | {r.p50_ms:>8.3f} | "
+            f"{r.p95_ms:>8.3f} | {r.p99_ms:>8.3f} | {r.p999_ms:>10.3f} | "
+            f"{r.throughput_per_sec:>12,.0f} |"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--calls", type=int, default=2000,
+                        help="calls per N-upstream configuration (default: 2000)")
+    parser.add_argument("--warmup", type=int, default=200,
+                        help="warmup calls per configuration (default: 200)")
+    parser.add_argument("--upstreams", type=str, default="1,2,4,8",
+                        help="comma-separated N values (default: 1,2,4,8)")
+    parser.add_argument("--json", type=str, default=None,
+                        help="dump machine-readable results to PATH")
+    args = parser.parse_args()
+
+    n_values = [int(x) for x in args.upstreams.split(",") if x.strip()]
+    rows: list[FanoutStats] = []
+    for n in n_values:
+        print(f"[bench] N={n} upstreams, {args.calls} calls (+{args.warmup} warmup)...", flush=True)
+        rows.append(bench_fanout(n, args.calls, args.warmup))
+
+    _print_markdown_table(rows)
+
+    if args.json:
+        out = Path(args.json)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps({"results": [asdict(r) for r in rows]}, indent=2))
+        print(f"\n[bench] wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/v040_fanout.json
+++ b/bench/v040_fanout.json
@@ -1,0 +1,52 @@
+{
+  "results": [
+    {
+      "n_upstreams": 1,
+      "n_calls": 2000,
+      "mean_ms": 1.1949,
+      "p50_ms": 1.1819,
+      "p95_ms": 1.3223,
+      "p99_ms": 1.4093,
+      "p999_ms": 2.0578,
+      "min_ms": 0.99,
+      "max_ms": 19.1454,
+      "throughput_per_sec": 836.9
+    },
+    {
+      "n_upstreams": 2,
+      "n_calls": 2000,
+      "mean_ms": 1.1978,
+      "p50_ms": 1.1799,
+      "p95_ms": 1.3358,
+      "p99_ms": 1.4287,
+      "p999_ms": 2.4195,
+      "min_ms": 0.9972,
+      "max_ms": 29.0318,
+      "throughput_per_sec": 834.9
+    },
+    {
+      "n_upstreams": 4,
+      "n_calls": 2000,
+      "mean_ms": 1.1962,
+      "p50_ms": 1.1728,
+      "p95_ms": 1.3196,
+      "p99_ms": 1.4174,
+      "p999_ms": 2.5463,
+      "min_ms": 0.9952,
+      "max_ms": 26.3158,
+      "throughput_per_sec": 836.0
+    },
+    {
+      "n_upstreams": 8,
+      "n_calls": 2000,
+      "mean_ms": 1.1906,
+      "p50_ms": 1.1734,
+      "p95_ms": 1.3217,
+      "p99_ms": 1.3961,
+      "p999_ms": 2.1214,
+      "min_ms": 0.986,
+      "max_ms": 29.3558,
+      "throughput_per_sec": 839.9
+    }
+  ]
+}

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.40.1"
+version = "0.40.2"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"
@@ -59,6 +59,7 @@ rebuff = ["rebuff>=0.1"]
 vaara = "vaara.cli:main"
 vaara-audit = "vaara.audit_cli:main"
 vaara-mcp-proxy = "vaara.integrations.mcp_proxy:main"
+vaara-mcp-server = "vaara.integrations.mcp_server:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.vaaraio/vaara-server",
+  "title": "Vaara MCP Server",
+  "description": "Vaara governance exposed as a standalone MCP server. Provides vaara_check, vaara_intercept, and vaara_report_outcome tools plus vaara://status and vaara://compliance resources, so any MCP host can score and audit its own tool calls without running the Vaara proxy.",
+  "websiteUrl": "https://vaara.io",
+  "repository": {
+    "url": "https://github.com/vaaraio/vaara",
+    "source": "github"
+  },
+  "version": "0.40.2",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "vaara",
+      "version": "0.40.2",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeArguments": [
+        {
+          "type": "named",
+          "name": "--from",
+          "value": "vaara",
+          "description": "PyPI package providing the vaara-mcp-server entry point"
+        },
+        {
+          "type": "positional",
+          "value": "vaara-mcp-server"
+        }
+      ],
+      "environmentVariables": [
+        {
+          "name": "VAARA_DB",
+          "description": "Path to the SQLite audit DB. Defaults to vaara_audit.db in the working directory.",
+          "isRequired": false
+        },
+        {
+          "name": "VAARA_API_KEY",
+          "description": "Optional shared secret. When set, every tool call must include _api_key in its arguments. Leave unset for single-tenant stdio deployments where process isolation is enough.",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.40.1",
+  "version": "0.40.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.40.1",
+      "version": "0.40.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.40.1"
+__version__ = "0.40.2"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## Summary

- `vaara-mcp-server` console script entry in `[project.scripts]`. The standalone MCP server (`vaara_check`, `vaara_intercept`, `vaara_report_outcome` tools plus `vaara://status` and `vaara://compliance` resources) now installs as a console script alongside `vaara-mcp-proxy`.
- Fan-out latency micro-bench: 1.2 ms mean, 1.4 ms p99, flat from N=1 to N=8 upstream slots. Closes the honest-scope caveat from #154.
- Second MCP Registry slot at `io.github.vaaraio/vaara-server`, alongside the existing `io.github.vaaraio/vaara` proxy entry. Two separate slots for two separate MCP servers.
- Local Claude Code plugin marketplace at `.claude-plugin/marketplace.json` so `claude plugin install vaara-governance@vaara` works after `claude plugin marketplace add /path/to/vaara`. Also seeds a future submission to `anthropics/claude-plugins-official`.

## Honest scope

The fan-out bench mocks the upstream MCP subprocess at the `UpstreamMCPClient` boundary so the number isolates added governance cost (HTTP parse, tenant and upstream header resolution, `Pipeline.intercept`, dispatch). It does not include the stdio JSON-RPC roundtrip to a live upstream, which depends on the upstream's own runtime.

## Test plan

- [ ] CI green across full Python matrix
- [ ] CodeQL clean
- [ ] CodeRabbit clean
- [ ] After merge + Release workflow: `pip install vaara==0.40.2` resolves
- [ ] `which vaara-mcp-server` returns the installed path
- [ ] `@vaara/client@0.40.2` resolves on npm after manual publish
- [ ] Registry submission lands under `io.github.vaaraio/vaara-server` (new slot) and `io.github.vaaraio/vaara` version bumped to 0.40.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v0.40.2

* **New Features**
  * Added `vaara-mcp-server` console script for standalone MCP server deployment.
  * Registered vaara-governance plugin in marketplace metadata.
  * Added new MCP server manifest for enhanced server discovery and configuration.

* **Chores**
  * Version bumped to 0.40.2 across package manager and metadata files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->