### PR TITLE
fix(release-prep): pin plugin marketplace ref + bench input guards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         "source": "git-subdir",
         "url": "https://github.com/vaaraio/vaara.git",
         "path": "plugins/claude-code-vaara-governance",
-        "ref": "main"
+        "ref": "v0.40.2"
       },
       "homepage": "https://vaara.io"
     }

--- a/bench/latency_fanout.py
+++ b/bench/latency_fanout.py
@@ -140,8 +140,13 @@ def bench_fanout(n_upstreams: int, n_calls: int, n_warmup: int) -> FanoutStats:
             },
         }
         t0 = time.perf_counter_ns()
-        client.post("/mcp", json=body, headers=headers)
-        return (time.perf_counter_ns() - t0) / 1_000_000.0
+        resp = client.post("/mcp", json=body, headers=headers)
+        elapsed = (time.perf_counter_ns() - t0) / 1_000_000.0
+        resp.raise_for_status()
+        payload = resp.json()
+        if isinstance(payload, dict) and payload.get("error") is not None:
+            raise RuntimeError(f"benchmark request failed: {payload['error']}")
+        return elapsed
 
     for i in range(n_warmup):
         call_once(i)
@@ -173,6 +178,11 @@ def main() -> None:
     parser.add_argument("--json", type=str, default=None,
                         help="dump machine-readable results to PATH")
     args = parser.parse_args()
+
+    if args.calls <= 0:
+        parser.error("--calls must be > 0")
+    if args.warmup < 0:
+        parser.error("--warmup must be >= 0")
 
     n_values = [int(x) for x in args.upstreams.split(",") if x.strip()]
     rows: list[FanoutStats] = []


### PR DESCRIPTION
## Summary

CodeRabbit fold on PR #158, must land before the v0.40.2 tag pushes.

- **Major:** `.claude-plugin/marketplace.json` was pinned to `"ref": "main"`, making `claude plugin install vaara-governance@vaara` resolve to whatever main HEAD is at install time. Pinned to `v0.40.2` so installs are reproducible against a known-good snapshot.
- **Minor:** `bench/latency_fanout.py` argparse rejects `--calls <= 0` and `--warmup < 0`. `call_once` raises on non-200 or JSON-RPC error responses so failed requests do not silently count as latency samples.

## Why this blocks the tag

The marketplace.json that ships in the v0.40.2 tag tells installers to fetch from `ref: v0.40.2`. Tagging before this fix would tag a commit whose marketplace.json still says `ref: main`. That is self-inconsistent, and the supply-chain finding ships into the release.

## Honest scope

The published bench numbers in `bench/v040_fanout.json` were generated against an `UpstreamMCPClient` mock that always returns 200, so the headline (1.2 ms mean, 1.4 ms p99, flat from N=1 to N=8) is unaffected by the missing `raise_for_status()`. The guard matters once the bench runs against a live upstream subprocess.

## Test plan

- [ ] CI green (full matrix + CodeQL + CodeRabbit)
- [ ] After merge: tag v0.40.2 on the post-fix commit, push tag, Release workflow publishes to PyPI + GH Release
- [ ] Verify `claude plugin install vaara-governance@vaara` after `claude plugin marketplace add` resolves the v0.40.2 ref (no `main` drift)
