### PR TITLE
release(v0.40.3): registry completion + supply-chain cleanup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         "source": "git-subdir",
         "url": "https://github.com/vaaraio/vaara.git",
         "path": "plugins/claude-code-vaara-governance",
-        "ref": "v0.40.2"
+        "ref": "v0.40.3"
       },
       "homepage": "https://vaara.io"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.40.3] - 2026-05-28
+
+**Theme: registry completion + supply-chain cleanup.**
+
+### Added
+- `mcp-name: io.github.vaaraio/vaara-server` ownership marker in
+  `README.md`, alongside the existing `mcp-name:
+  io.github.vaaraio/vaara` marker. Required by the MCP Registry to
+  verify that the PyPI `vaara` package owns both the proxy and the
+  standalone-server slots before publishing to either. v0.40.2 added
+  the `server-vaara-server.json` manifest but the marker was missing,
+  so the second-slot registry submission could not complete. This
+  release ships the marker so the second slot publishes cleanly.
+
+### Changed
+- `server.json` and `server-vaara-server.json` version fields bumped
+  to 0.40.3.
+- `.claude-plugin/marketplace.json` `ref` bumped from `v0.40.2` to
+  `v0.40.3`. Closes the self-reference loop where v0.40.2's
+  marketplace.json pinned to its own pre-fix tag.
+
 ## [0.40.2] - 2026-05-28
 
 **Theme: vaara-mcp-server packaging + fan-out latency numbers.**

--- a/README.md
+++ b/README.md
@@ -259,3 +259,4 @@ Acknowledgements:
 Apache 2.0. See [LICENSE](LICENSE).
 
 <!-- mcp-name: io.github.vaaraio/vaara -->
+<!-- mcp-name: io.github.vaaraio/vaara-server -->

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.40.2",
+  "version": "0.40.3",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.40.2"
+version = "0.40.3"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -2,19 +2,19 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vaaraio/vaara-server",
   "title": "Vaara MCP Server",
-  "description": "Vaara governance exposed as a standalone MCP server. Provides vaara_check, vaara_intercept, and vaara_report_outcome tools plus vaara://status and vaara://compliance resources, so any MCP host can score and audit its own tool calls without running the Vaara proxy.",
+  "description": "Vaara governance as standalone MCP server. Risk scoring, intercept, hash-chained audit.",
   "websiteUrl": "https://vaara.io",
   "repository": {
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.40.2",
+  "version": "0.40.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.40.2",
+      "version": "0.40.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.40.2",
+  "version": "0.40.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.40.2",
+      "version": "0.40.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.40.2"
+__version__ = "0.40.3"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## Summary

Registry-completion release. v0.40.2 shipped `server-vaara-server.json` but the second-slot registry submission failed ownership verification. The published PyPI README only carried the proxy marker. v0.40.3 adds the second marker so the submission completes.

- **README:** `<!-- mcp-name: io.github.vaaraio/vaara-server -->` alongside the existing proxy marker. Required by MCP Registry ownership verification on the PyPI `vaara` package.
- **marketplace.json:** `ref` bumped `v0.40.2` to `v0.40.3`. Closes the self-reference where v0.40.2's marketplace.json had pinned to its own pre-fix tag.
- Version bumps: `pyproject.toml`, `clients/ts/package.json`, `src/vaara/__init__.py`, `server.json`, `server-vaara-server.json` to 0.40.3.

## Why this is a separate release

PyPI does not allow republishing a version. The README marker has to ship in a new wheel for the registry's ownership check to see it. Bundled with the marketplace.json `ref` cleanup so the v0.40.3 tag is the single point that closes both supply-chain items from the v0.40.2 release.

## Test plan

- [ ] CI green
- [ ] After merge + tag + Release workflow: `pip install vaara==0.40.3` resolves
- [ ] `grep "mcp-name: io.github.vaaraio/vaara-server" $(pip show vaara | awk '/Location/{print $2}')/vaara-*.dist-info/METADATA` confirms marker shipped
- [ ] `mcp-publisher publish` for both `server.json` and `server-vaara-server.json` returns 200
- [ ] `curl https://registry.modelcontextprotocol.io/v0/servers/io.github.vaaraio/vaara-server` resolves with version 0.40.3
