### PR TITLE
fix(plugin): create audit DB on session start

### DIFF
--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -42,7 +42,15 @@ def main() -> int:
 
     mode = "shadow" if os.environ.get("VAARA_PLUGIN_SHADOW") == "1" else "enforce"
     db_path = _audit_db_path()
-    db_state = "new" if not db_path.exists() else "existing"
+    existed = db_path.exists()
+    try:
+        from vaara.audit.sqlite_backend import SQLiteAuditBackend
+
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        SQLiteAuditBackend(db_path)
+        db_state = "existing" if existed else "created"
+    except Exception as exc:
+        db_state = f"unavailable ({exc!r})"
 
     _emit(
         f"vaara-governance v0.1.0 loaded "


### PR DESCRIPTION
## Summary
- SessionStart previously printed `[new]` based on `db_path.exists()` without ever creating the file, so the documented default audit DB path stayed empty for any session that produced no `mcp__*` calls or deny-pattern hits.
- SessionStart now does `mkdir -p` on the parent and opens `SQLiteAuditBackend(db_path)`, which runs the schema DDL and persists the file. Label reads `[created]` on first run, `[existing]` on subsequent runs, `[unavailable (...)]` if the import or open fails.
- Pre/Post hooks already `mkdir + open`; this brings SessionStart in line with the rest of the plugin.

## Test plan
- [x] `python3 -m py_compile` and `ruff check` clean on the modified hook.
- [x] Manual: `echo '{}' | python3 hooks/session_start.py` materialises the DB at `VAARA_PLUGIN_AUDIT_DB` and prints `[created]`.
- [ ] Manual re-run prints `[existing]`.
- [ ] 5 required status checks green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audit database status reporting during session initialization to verify actual database availability rather than relying solely on file existence checks. Enhanced status messages now reflect successful initialization (`created` or `existing`) or report unavailability with specific error details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->