### PR TITLE
release(v0.40.4): policy mode presets + plugin shakedown fix delivery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         "source": "git-subdir",
         "url": "https://github.com/vaaraio/vaara.git",
         "path": "plugins/claude-code-vaara-governance",
-        "ref": "v0.40.3"
+        "ref": "v0.40.4"
       },
       "homepage": "https://vaara.io"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.40.4] - 2026-05-28
+
+**Theme: policy mode presets + plugin shakedown fix delivery.**
+
+### Added
+- `vaara mode` CLI subcommand with three actions:
+  - `vaara mode list` prints the four built-in preset operating points
+    (`eco`, `balanced`, `performance`, `strict`) with their thresholds
+    and one-line descriptions.
+  - `vaara mode show NAME` prints thresholds, description, and watt
+    profile for a single preset.
+  - `vaara mode emit NAME [--format json|yaml] [--output PATH]` emits
+    a minimal valid Vaara policy document for the chosen preset,
+    ready for the deployer to add action classes, sequences, and
+    escalation routes. Output round-trips through
+    `vaara.policy.from_dict`, `from_json`, and `from_yaml`.
+- New `vaara.policy.modes` module exposing `Mode`, `available_modes`,
+  `get_mode`, `to_policy_dict`, `emit_json`, and `emit_yaml`. Presets
+  are shaped like CPU power profiles: `eco` (0.40 / 0.60) cuts agent
+  loops short on borderline risk, `balanced` (0.55 / 0.85) is the
+  default, `performance` (0.70 / 0.92) is for high-throughput
+  pipelines with tight action-class overrides, `strict` (0.30 / 0.55)
+  escalates on doubt for incident response and audit prep.
+
+### Changed
+- `.claude-plugin/marketplace.json` `ref` bumped from `v0.40.3` to
+  `v0.40.4`. Delivers the session_start audit-DB-creation fix from
+  PR #161 to marketplace users.
+- `plugins/claude-code-vaara-governance/.claude-plugin/plugin.json`
+  bumped from `0.1.0` to `0.1.1`. Picks up the session_start fix.
+- `server.json` and `server-vaara-server.json` version fields bumped
+  to 0.40.4.
+
 ## [0.40.3] - 2026-05-28
 
 **Theme: registry completion + supply-chain cleanup.**

--- a/README.md
+++ b/README.md
@@ -150,6 +150,25 @@ const r = await vaara.score({ tool_name: "tx.transfer", agent_id: "agent-007", b
 if (r.decision === "deny") throw new Error("blocked");
 ```
 
+## Policy modes
+
+Four preset operating points for the risk thresholds, shaped like CPU power profiles:
+
+- `eco` (escalate 0.40, deny 0.60). Tight deny threshold cuts agent loops short on borderline risk. Pair with regex-first gating to short-circuit before any model forward pass.
+- `balanced` (0.55, 0.85). Vaara's default behaviour.
+- `performance` (0.70, 0.92). Looser thresholds let more through. For high-throughput pipelines where the deployer keeps tight action-class overrides on the few classes that matter.
+- `strict` (0.30, 0.55). Escalate-on-doubt. For incident response, audit prep, or production lockdown windows.
+
+Each mode emits a minimal valid Vaara policy document with `thresholds.default` set, ready for the deployer to fill in action classes, sequences, and escalation routes.
+
+```bash
+vaara mode list
+vaara mode show balanced
+vaara mode emit strict --format yaml --output policy.yaml
+```
+
+The emitted document round-trips through `vaara.policy.from_dict`, `from_json`, and `from_yaml` like any other policy artifact.
+
 ## MCP proxy (Vaara as a transparent governance layer)
 
 `vaara.integrations.mcp_proxy.VaaraMCPProxy` sits between an MCP client (Claude Code, Cursor, any MCP-capable host) and an upstream MCP server. Every `tools/call` from the client routes through Vaara's interception pipeline before reaching the upstream. Allowed calls forward transparently and report the upstream outcome back to the scorer. Blocked calls return an MCP `isError: true` response with the block reason. The initialization handshake and `notifications/*` forward unchanged. `tools/list`, `resources/list`, `resources/read`, `prompts/list`, and `prompts/get` route through the operator perimeter before reaching the client or upstream.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.40.3",
+  "version": "0.40.4",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record. SessionStart validates the install and prints version, mode, and audit DB path.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.40.3"
+version = "0.40.4"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.40.3",
+  "version": "0.40.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.40.3",
+      "version": "0.40.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.40.3",
+  "version": "0.40.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.40.3",
+      "version": "0.40.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.40.3"
+__version__ = "0.40.4"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -63,6 +63,17 @@ Subcommands:
         process. The new thresholds and sequence patterns take effect
         on the next ``evaluate()``; in-flight calls keep the old ones.
 
+    vaara mode list
+        List the built-in policy mode presets (eco, balanced, performance,
+        strict) with their thresholds and one-line descriptions.
+
+    vaara mode show NAME
+        Print thresholds, description, and watt profile for a single mode.
+
+    vaara mode emit NAME [--format json|yaml] [--output PATH]
+        Emit a mode as a minimal, valid Vaara policy document. Round-trips
+        through ``vaara.policy.from_dict`` / ``from_json`` / ``from_yaml``.
+
     vaara version
         Print the installed Vaara version.
 
@@ -1131,6 +1142,52 @@ def _cmd_policy_reload(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_mode_list(_args: argparse.Namespace) -> int:
+    from vaara.policy.modes import _BY_NAME, available_modes
+
+    for name in available_modes():
+        m = _BY_NAME[name]
+        print(
+            f"{name:12s} escalate={m.escalate:.2f} deny={m.deny:.2f}  "
+            f"{m.description}"
+        )
+    return 0
+
+
+def _cmd_mode_show(args: argparse.Namespace) -> int:
+    from vaara.policy.modes import get_mode
+
+    try:
+        m = get_mode(args.name)
+    except KeyError as e:
+        print(f"vaara mode show: {e}", file=sys.stderr)
+        return 2
+    print(f"mode:        {m.name}")
+    print(f"escalate:    {m.escalate}")
+    print(f"deny:        {m.deny}")
+    print(f"description: {m.description}")
+    print(f"watts:       {m.watt_profile}")
+    return 0
+
+
+def _cmd_mode_emit(args: argparse.Namespace) -> int:
+    from vaara.policy.modes import emit_json, emit_yaml
+
+    try:
+        text = emit_yaml(args.name) if args.format == "yaml" else emit_json(args.name)
+    except KeyError as e:
+        print(f"vaara mode emit: {e}", file=sys.stderr)
+        return 2
+    except ImportError as e:
+        print(f"vaara mode emit: {e}", file=sys.stderr)
+        return 1
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="vaara", description="Vaara AI Agent Execution Layer")
     sub = p.add_subparsers(dest="cmd", required=True)
@@ -1595,6 +1652,48 @@ def build_parser() -> argparse.ArgumentParser:
         help="HTTP request timeout in seconds (default 10)",
     )
     preload.set_defaults(func=_cmd_policy_reload)
+
+    pmode = sub.add_parser(
+        "mode",
+        help=(
+            "Preset policy threshold bundles "
+            "(eco / balanced / performance / strict)"
+        ),
+    )
+    msub = pmode.add_subparsers(dest="mode_cmd", required=True)
+
+    pml = msub.add_parser(
+        "list",
+        help="List available modes with thresholds and descriptions",
+    )
+    pml.set_defaults(func=_cmd_mode_list)
+
+    pms = msub.add_parser(
+        "show",
+        help="Show a mode's thresholds, description, and watt profile",
+    )
+    pms.add_argument(
+        "name", help="Mode name (eco, balanced, performance, strict)",
+    )
+    pms.set_defaults(func=_cmd_mode_show)
+
+    pme = msub.add_parser(
+        "emit",
+        help=(
+            "Emit a mode as a valid Vaara policy document "
+            "(JSON by default, YAML with --format yaml)"
+        ),
+    )
+    pme.add_argument("name", help="Mode name")
+    pme.add_argument(
+        "--format", choices=["json", "yaml"], default="json",
+        help="Output format (default: json)",
+    )
+    pme.add_argument(
+        "--output", "-o", default=None,
+        help="Output path (default: stdout)",
+    )
+    pme.set_defaults(func=_cmd_mode_emit)
 
     return p
 

--- a/src/vaara/policy/modes.py
+++ b/src/vaara/policy/modes.py
@@ -1,0 +1,149 @@
+"""Vaara policy modes — preset threshold bundles.
+
+Each mode is a preset operating point for the risk thresholds Vaara uses to
+decide allow / escalate / deny. Modes do not change Vaara's primitives; they
+bundle a default-threshold choice that maps to a concrete cost / risk / latency
+profile, in the spirit of a CPU/GPU power profile.
+
+Four built-in modes:
+
+- eco: tight deny threshold catches borderline risk early, cutting agent loops
+  short. Pairs with regex-first gating (sub-millisecond) to short-circuit
+  before any model forward pass. Lowest watts per call.
+- balanced: Vaara's default operating point (0.55 / 0.85). Current behaviour
+  when no mode is selected.
+- performance: loose thresholds let more through. For high-throughput internal
+  pipelines where the deployer keeps tight action-class overrides on the few
+  classes that matter (financial, infrastructure).
+- strict: lowest deny threshold, escalate-on-doubt. For incident response,
+  regulator audit prep, or production lockdown windows.
+
+A mode emits a minimal valid Policy document — ``thresholds.default`` tuned
+per mode, ``action_classes`` / ``sequences`` / ``escalation`` left for the
+deployer to add. The emitted document round-trips through
+``vaara.policy.from_dict`` / ``from_json`` / ``from_yaml`` like any other
+policy artifact.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from vaara.policy.schema import SCHEMA_VERSION
+
+
+@dataclass(frozen=True)
+class Mode:
+    """A preset operating point for Vaara risk thresholds."""
+    name: str
+    escalate: float
+    deny: float
+    description: str
+    watt_profile: str
+
+
+_MODES: tuple[Mode, ...] = (
+    Mode(
+        name="eco",
+        escalate=0.40,
+        deny=0.60,
+        description=(
+            "Tight deny threshold; cuts agent loops short on borderline risk. "
+            "Pair with regex-first gating to short-circuit before any model pass."
+        ),
+        watt_profile=(
+            "Lowest. Fewer downstream LLM calls per blocked tool invocation; "
+            "more requests resolved at the regex gate."
+        ),
+    ),
+    Mode(
+        name="balanced",
+        escalate=0.55,
+        deny=0.85,
+        description="Default operating point. Current Vaara behaviour.",
+        watt_profile="Baseline. No optimization either direction.",
+    ),
+    Mode(
+        name="performance",
+        escalate=0.70,
+        deny=0.92,
+        description=(
+            "Loose thresholds; lets more through. For high-throughput "
+            "pipelines where the deployer keeps tight action-class overrides "
+            "on the few classes that matter."
+        ),
+        watt_profile=(
+            "Higher per call. Fewer early denials means more downstream tool "
+            "calls and more LLM round trips."
+        ),
+    ),
+    Mode(
+        name="strict",
+        escalate=0.30,
+        deny=0.55,
+        description=(
+            "Escalate-on-doubt. For incident response, audit prep, or "
+            "production lockdown windows."
+        ),
+        watt_profile=(
+            "Mixed. More escalations (cheap, human-bound) but rarely runs "
+            "the full scorer ensemble before a verdict."
+        ),
+    ),
+)
+
+_BY_NAME: Mapping[str, Mode] = {m.name: m for m in _MODES}
+
+
+def available_modes() -> tuple[str, ...]:
+    """Return the names of the built-in modes in canonical order."""
+    return tuple(m.name for m in _MODES)
+
+
+def get_mode(name: str) -> Mode:
+    """Return the Mode by name. Raises KeyError on unknown name."""
+    try:
+        return _BY_NAME[name]
+    except KeyError as e:
+        valid = ", ".join(repr(n) for n in available_modes())
+        raise KeyError(
+            f"unknown mode {name!r}, expected one of [{valid}]"
+        ) from e
+
+
+def to_policy_dict(mode: Mode) -> dict:
+    """Return a minimal Vaara policy dict for ``mode``.
+
+    Round-trips through ``vaara.policy.from_dict``. Action classes, sequences,
+    and escalation routes are left empty for the deployer to fill in.
+    """
+    return {
+        "version": SCHEMA_VERSION,
+        "domains": ["eu_ai_act"],
+        "action_classes": {},
+        "thresholds": {
+            "default": {"escalate": mode.escalate, "deny": mode.deny},
+        },
+    }
+
+
+def emit_json(name: str, *, indent: int = 2) -> str:
+    """Emit a mode's policy as a JSON string with a trailing newline."""
+    return json.dumps(to_policy_dict(get_mode(name)), indent=indent) + "\n"
+
+
+def emit_yaml(name: str) -> str:
+    """Emit a mode's policy as YAML. Requires ``vaara[yaml]``."""
+    try:
+        import yaml  # type: ignore[import-untyped]
+    except ImportError as e:
+        raise ImportError(
+            "emit_yaml requires the [yaml] extra. "
+            "Install with: pip install 'vaara[yaml]'"
+        ) from e
+    return yaml.safe_dump(
+        to_policy_dict(get_mode(name)),
+        sort_keys=False,
+    )

--- a/tests/test_policy_modes.py
+++ b/tests/test_policy_modes.py
@@ -1,0 +1,167 @@
+"""Tests for `vaara.policy.modes` preset bundles and the `vaara mode` CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vaara.cli import main
+from vaara.policy import from_dict, from_json, from_yaml
+from vaara.policy.modes import (
+    Mode,
+    available_modes,
+    emit_json,
+    emit_yaml,
+    get_mode,
+    to_policy_dict,
+)
+
+
+CANONICAL_NAMES = ("eco", "balanced", "performance", "strict")
+
+
+class TestModeRegistry:
+    def test_available_modes_canonical_order(self) -> None:
+        assert available_modes() == CANONICAL_NAMES
+
+    @pytest.mark.parametrize("name", CANONICAL_NAMES)
+    def test_get_mode_returns_dataclass(self, name: str) -> None:
+        m = get_mode(name)
+        assert isinstance(m, Mode)
+        assert m.name == name
+        assert 0.0 <= m.escalate < m.deny <= 1.0
+        assert m.description
+        assert m.watt_profile
+
+    def test_get_mode_unknown_raises_key_error(self) -> None:
+        with pytest.raises(KeyError) as exc:
+            get_mode("turbo")
+        msg = str(exc.value)
+        for name in CANONICAL_NAMES:
+            assert repr(name) in msg
+
+
+class TestPolicyRoundTrip:
+    @pytest.mark.parametrize("name", CANONICAL_NAMES)
+    def test_to_policy_dict_round_trips_through_from_dict(
+        self, name: str,
+    ) -> None:
+        m = get_mode(name)
+        data = to_policy_dict(m)
+        policy = from_dict(data)
+        assert policy.thresholds_default.escalate == m.escalate
+        assert policy.thresholds_default.deny == m.deny
+
+    @pytest.mark.parametrize("name", CANONICAL_NAMES)
+    def test_emit_json_round_trips_through_from_json(
+        self, name: str, tmp_path: Path,
+    ) -> None:
+        text = emit_json(name)
+        assert text.endswith("\n")
+        # Indented for human readers.
+        assert "  " in text
+        # Round-trip through the loader.
+        path = tmp_path / f"{name}.json"
+        path.write_text(text, encoding="utf-8")
+        policy = from_json(path)
+        m = get_mode(name)
+        assert policy.thresholds_default.escalate == m.escalate
+        assert policy.thresholds_default.deny == m.deny
+
+    @pytest.mark.parametrize("name", CANONICAL_NAMES)
+    def test_emit_yaml_round_trips_through_from_yaml(
+        self, name: str, tmp_path: Path,
+    ) -> None:
+        pytest.importorskip("yaml")
+        text = emit_yaml(name)
+        path = tmp_path / f"{name}.yaml"
+        path.write_text(text, encoding="utf-8")
+        policy = from_yaml(path)
+        m = get_mode(name)
+        assert policy.thresholds_default.escalate == m.escalate
+        assert policy.thresholds_default.deny == m.deny
+
+    def test_emit_yaml_without_extra_raises_import_error(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args, **kwargs):
+            if name == "yaml":
+                raise ImportError("simulated missing extra")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        with pytest.raises(ImportError) as exc:
+            emit_yaml("balanced")
+        assert "vaara[yaml]" in str(exc.value)
+
+
+class TestModeCLI:
+    def test_mode_list_prints_all_modes(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main(["mode", "list"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        for name in CANONICAL_NAMES:
+            assert name in out
+
+    def test_mode_show_prints_thresholds(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main(["mode", "show", "balanced"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "mode:" in out
+        assert "0.55" in out
+        assert "0.85" in out
+
+    def test_mode_show_unknown_exits_nonzero(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main(["mode", "show", "turbo"])
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "turbo" in err
+
+    def test_mode_emit_json_to_stdout_round_trips(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main(["mode", "emit", "eco"])
+        out = capsys.readouterr().out
+        assert rc == 0
+        data = json.loads(out)
+        policy = from_dict(data)
+        assert policy.thresholds_default.escalate == 0.40
+        assert policy.thresholds_default.deny == 0.60
+
+    def test_mode_emit_yaml_to_file(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        pytest.importorskip("yaml")
+        out_path = tmp_path / "strict.yaml"
+        rc = main([
+            "mode", "emit", "strict",
+            "--format", "yaml",
+            "--output", str(out_path),
+        ])
+        assert rc == 0
+        # stdout stays clean when writing to file.
+        assert capsys.readouterr().out == ""
+        policy = from_yaml(out_path)
+        m = get_mode("strict")
+        assert policy.thresholds_default.escalate == m.escalate
+        assert policy.thresholds_default.deny == m.deny
+
+    def test_mode_emit_unknown_exits_nonzero(
+        self, capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = main(["mode", "emit", "turbo"])
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "turbo" in err


### PR DESCRIPTION
## Summary

Patch release. Two threads bundled.

### Policy mode presets

New `vaara mode` CLI subcommand with three actions, plus the matching `vaara.policy.modes` module:

- `vaara mode list` prints the four built-in preset operating points (`eco`, `balanced`, `performance`, `strict`) with their thresholds and one-line descriptions.
- `vaara mode show NAME` prints thresholds, description, and watt profile for a single preset.
- `vaara mode emit NAME [--format json|yaml] [--output PATH]` emits a minimal valid Vaara policy document for the chosen preset, ready for the deployer to add action classes, sequences, and escalation routes.

Preset operating points are shaped like CPU power profiles:

| Mode | escalate | deny | When |
|---|---|---|---|
| `eco` | 0.40 | 0.60 | Cuts agent loops short on borderline risk. Pair with regex-first gating to short-circuit before any model forward pass. |
| `balanced` | 0.55 | 0.85 | Default operating point. Current Vaara behaviour. |
| `performance` | 0.70 | 0.92 | High-throughput pipelines where the deployer keeps tight action-class overrides on the few classes that matter. |
| `strict` | 0.30 | 0.55 | Escalate-on-doubt. For incident response, audit prep, or production lockdown windows. |

Emitted documents round-trip through `vaara.policy.from_dict`, `from_json`, and `from_yaml` like any other policy artifact.

### Plugin shakedown fix delivery

- `plugins/claude-code-vaara-governance/.claude-plugin/plugin.json` bumped `0.1.0` to `0.1.1`, picking up the SessionStart audit-DB creation fix from #161.
- `.claude-plugin/marketplace.json` `ref` bumped `v0.40.3` to `v0.40.4` so marketplace users receive the plugin update.

## Test plan

- [x] `pytest tests/test_policy_modes.py` 25 passed
- [x] `ruff check src/vaara/policy/modes.py src/vaara/cli.py tests/test_policy_modes.py` clean
- [x] `vaara mode list / show balanced / emit eco / emit strict --format yaml --output policy.yaml` smoke
- [ ] CI green
- [ ] Release workflow PyPI + GitHub Release on tag push
- [ ] `mcp-publisher publish` for both registry slots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four built-in policy mode presets (`eco`, `balanced`, `performance`, `strict`) with configurable risk thresholds.
  * Added `vaara mode` CLI commands: `list` (display all modes), `show` (view mode details), and `emit` (export modes as Vaara policies in JSON or YAML format).

* **Documentation**
  * Updated documentation with a "Policy modes" section explaining preset modes and CLI usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->