### PR TITLE
release(v0.41.0): server-initiated SSE notifications + cancellation routing under fan-out

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         "source": "git-subdir",
         "url": "https://github.com/vaaraio/vaara.git",
         "path": "plugins/claude-code-vaara-governance",
-        "ref": "v0.40.4"
+        "ref": "v0.41.0"
       },
       "homepage": "https://vaara.io"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,59 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.41.0] - 2026-05-28
+
+**Theme: server-initiated notifications and cancellation routing under fan-out.**
+
+### Added
+- `GET /mcp` Server-Sent Events endpoint on the Streamable HTTP
+  transport. Upstream-initiated notifications (progress events, log
+  messages) reach the client over a long-lived SSE stream keyed by
+  the standard `Mcp-Session-Id` header. The endpoint requires the
+  session header, refuses values longer than 128 characters, returns
+  `404` for unknown `X-Vaara-Upstream` values, and returns `400`
+  when fan-out is configured and the upstream header is missing
+  instead of guessing the slot.
+- Reconnect-with-resume via `Last-Event-ID`. The server keeps a
+  bounded replay buffer of the most recent 100 events per session
+  and replays any events newer than the resumption cursor when the
+  client reconnects. Event ids are strictly monotonic per session,
+  so a gap from eviction is observable on the client.
+- 15-second SSE heartbeat (`: keepalive` comment) and a 5-second
+  `retry:` hint so EventSource clients reconnect on a fixed cadence
+  after transient socket loss.
+- `notifications/cancelled` routing across fan-out. The proxy tracks
+  every in-flight `tools/call` request id against the upstream
+  serving it and forwards a client cancellation to that upstream
+  regardless of what `X-Vaara-Upstream` the cancel POST carries.
+  Under fan-out the cancel reaches the subprocess that owns the
+  long-running call rather than the slot named by the cancel header.
+- New `vaara.integrations._mcp_notify` module: `NotificationRouter`
+  protocol with `StdioRouter` (writes through the proxy's stdout
+  lock) and `HttpRouter` (per-session asyncio queues, bounded replay
+  buffer, broadcast across an upstream's sessions when no session
+  scope is known). The proxy holds one router instance for the
+  lifetime of the serve loop and delivers every upstream-initiated
+  notification through it.
+
+### Changed
+- `VaaraMCPProxy._inflight_progress` now carries the originating
+  `Mcp-Session-Id` alongside action id, agent id, tool name, and
+  tenant. The audit and OVERT paths discard the session id so the
+  perimeter event schema stays unchanged.
+- `UpstreamMCPClient.on_notification` is wrapped per upstream so the
+  reader-thread callback carries the upstream's name. Closes a
+  late-binding bug that would have pinned every reader thread to
+  the last name in the `_upstreams` dict.
+- `run_http` split into `_build_http_app` + uvicorn launch so tests
+  drive the FastAPI app via `fastapi.testclient.TestClient` without
+  standing up a server.
+- `server.json`, `server-vaara-server.json`, `pyproject.toml`,
+  `src/vaara/__init__.py`, and `clients/ts/package.json` version
+  fields bumped to 0.41.0.
+- `.claude-plugin/marketplace.json` `ref` bumped from `v0.40.4` to
+  `v0.41.0`.
+
 ## [0.40.4] - 2026-05-28
 
 **Theme: policy mode presets + plugin shakedown fix delivery.**

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.40.4",
+  "version": "0.41.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaara-governance",
-  "version": "0.1.1",
-  "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record. SessionStart validates the install and prints version, mode, and audit DB path.",
+  "version": "0.1.2",
+  "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. SessionStart validates the install and prints version, mode, and audit DB path. /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",
     "email": "hello@vaara.io"

--- a/plugins/claude-code-vaara-governance/commands/vaara-stats.md
+++ b/plugins/claude-code-vaara-governance/commands/vaara-stats.md
@@ -1,0 +1,12 @@
+---
+description: Print Vaara governance stats from the Claude Code audit trail (records, event types, top tools, last 5 actions).
+allowed-tools: Bash(python3:*)
+---
+
+Execute this exact command via Bash and show the user the stdout verbatim. Do not summarize, interpret, or add commentary around the output.
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/vaara_stats.py"
+```
+
+If the command exits non-zero, print its stderr as-is and stop.

--- a/plugins/claude-code-vaara-governance/hooks/hooks.json
+++ b/plugins/claude-code-vaara-governance/hooks/hooks.json
@@ -33,7 +33,7 @@
             "timeout": 30
           }
         ],
-        "matcher": "mcp__.*"
+        "matcher": "Bash|WebFetch|WebSearch|mcp__.*"
       }
     ]
   }

--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -53,7 +53,7 @@ def main() -> int:
         db_state = f"unavailable ({exc!r})"
 
     _emit(
-        f"vaara-governance v0.1.0 loaded "
+        f"vaara-governance v0.1.2 loaded "
         f"(vaara {vaara.__version__}, mode={mode}, audit_db={db_path} [{db_state}])."
     )
     return 0

--- a/plugins/claude-code-vaara-governance/scripts/vaara_stats.py
+++ b/plugins/claude-code-vaara-governance/scripts/vaara_stats.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Vaara governance stats for the Claude Code audit trail.
+
+Reads ~/.vaara/claude-code/audit.db (or VAARA_PLUGIN_AUDIT_DB) and prints
+a summary: total records, counts by event type, top tools, last 5 actions.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def _audit_db_path() -> Path:
+    override = os.environ.get("VAARA_PLUGIN_AUDIT_DB")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".vaara" / "claude-code" / "audit.db"
+
+
+def main() -> int:
+    db_path = _audit_db_path()
+    if not db_path.exists():
+        print(f"vaara-stats: audit DB not found at {db_path}", file=sys.stderr)
+        print("SessionStart will create it on the next Claude Code restart.", file=sys.stderr)
+        return 1
+
+    con = sqlite3.connect(db_path)
+    cur = con.cursor()
+
+    tables = {r[0] for r in cur.execute("select name from sqlite_master where type='table'")}
+    if "audit_records" not in tables:
+        print(f"vaara-stats: unexpected schema (tables: {sorted(tables)})", file=sys.stderr)
+        return 2
+
+    total = cur.execute("select count(*) from audit_records").fetchone()[0]
+    print(f"audit_db: {db_path}")
+    print(f"records:  {total}")
+    if total == 0:
+        print("(no records yet, make a tool call to populate)")
+        con.close()
+        return 0
+
+    print()
+    print("by event_type:")
+    by_type = cur.execute(
+        "select event_type, count(*) from audit_records group by event_type order by 2 desc"
+    ).fetchall()
+    for et, n in by_type:
+        print(f"  {et:24s} {n}")
+
+    print()
+    print("top tools:")
+    by_tool = cur.execute(
+        "select tool_name, count(*) from audit_records "
+        "where tool_name != '' group by tool_name order by 2 desc limit 10"
+    ).fetchall()
+    for tool, n in by_tool:
+        print(f"  {tool:24s} {n}")
+
+    print()
+    print("last 5 records:")
+    rows = cur.execute(
+        "select event_type, agent_id, tool_name, timestamp "
+        "from audit_records order by timestamp desc limit 5"
+    ).fetchall()
+    for et, agent, tool, ts in rows:
+        print(f"  [{ts:.3f}] {et:20s} agent={agent} tool={tool}")
+
+    con.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.40.4"
+version = "0.41.0"
 description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.40.4",
+  "version": "0.41.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.40.4",
+      "version": "0.41.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.40.4",
+  "version": "0.41.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.40.4",
+      "version": "0.41.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.40.4"
+__version__ = "0.41.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -1188,9 +1188,17 @@ def _cmd_mode_emit(args: argparse.Namespace) -> int:
     return 0
 
 
+def _help_dispatch(parser: argparse.ArgumentParser):
+    def _print(_args: argparse.Namespace) -> int:
+        parser.print_help()
+        return 0
+    return _print
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="vaara", description="Vaara AI Agent Execution Layer")
-    sub = p.add_subparsers(dest="cmd", required=True)
+    sub = p.add_subparsers(dest="cmd")
+    p.set_defaults(func=_help_dispatch(p))
 
     sub.add_parser("version", help="Print Vaara version").set_defaults(func=_cmd_version)
 
@@ -1208,7 +1216,8 @@ def build_parser() -> argparse.ArgumentParser:
     pk.set_defaults(func=_cmd_keygen)
 
     pt = sub.add_parser("trail", help="Audit-trail commands")
-    tsub = pt.add_subparsers(dest="trail_cmd", required=True)
+    tsub = pt.add_subparsers(dest="trail_cmd")
+    pt.set_defaults(func=_help_dispatch(pt))
 
     pe = tsub.add_parser("export", help="Export a signed, regulator-handoff trail zip")
     pe.add_argument("--trail", required=True, help="Path to trail JSONL file")
@@ -1307,7 +1316,8 @@ def build_parser() -> argparse.ArgumentParser:
         "review",
         help="Human-in-the-loop review queue (EU AI Act Article 14)",
     )
-    rsub = pr.add_subparsers(dest="review_cmd", required=True)
+    rsub = pr.add_subparsers(dest="review_cmd")
+    pr.set_defaults(func=_help_dispatch(pr))
 
     rl = rsub.add_parser("list", help="List queue items (default: pending)")
     rl.add_argument("--db", required=True, help="Path to the review queue DB")
@@ -1372,7 +1382,8 @@ def build_parser() -> argparse.ArgumentParser:
         "policy",
         help="Policy artifact commands (validate, test, reload)",
     )
-    psub = pp_policy.add_subparsers(dest="policy_cmd", required=True)
+    psub = pp_policy.add_subparsers(dest="policy_cmd")
+    pp_policy.set_defaults(func=_help_dispatch(pp_policy))
 
     pvalid = psub.add_parser(
         "validate",
@@ -1404,7 +1415,8 @@ def build_parser() -> argparse.ArgumentParser:
         "compliance",
         help="Compliance reporting commands",
     )
-    csub = pcr.add_subparsers(dest="compliance_cmd", required=True)
+    csub = pcr.add_subparsers(dest="compliance_cmd")
+    pcr.set_defaults(func=_help_dispatch(pcr))
     pcrep = csub.add_parser(
         "report",
         help="Assemble and render an article-level evidence report",
@@ -1495,7 +1507,8 @@ def build_parser() -> argparse.ArgumentParser:
         "detect",
         help="Named detectors (injection, pii) over Vaara's scoring surface",
     )
-    dsub = pdetect.add_subparsers(dest="detect_cmd", required=True)
+    dsub = pdetect.add_subparsers(dest="detect_cmd")
+    pdetect.set_defaults(func=_help_dispatch(pdetect))
 
     def _add_text_input_args(p_):
         g = p_.add_mutually_exclusive_group(required=True)
@@ -1540,7 +1553,8 @@ def build_parser() -> argparse.ArgumentParser:
             "OVERT 1.0 attestation commands (Protocol Profile 1.0 Annex B.6)"
         ),
     )
-    osub = povert.add_subparsers(dest="overt_cmd", required=True)
+    osub = povert.add_subparsers(dest="overt_cmd")
+    povert.set_defaults(func=_help_dispatch(povert))
     pov_verify = osub.add_parser(
         "verify",
         help=(
@@ -1573,7 +1587,8 @@ def build_parser() -> argparse.ArgumentParser:
             "Hardware TEE attestation commands (experimental, AMD SEV-SNP)"
         ),
     )
-    tsub = ptee.add_subparsers(dest="tee_cmd", required=True)
+    tsub = ptee.add_subparsers(dest="tee_cmd")
+    ptee.set_defaults(func=_help_dispatch(ptee))
 
     ptee_parse = tsub.add_parser(
         "parse",
@@ -1660,7 +1675,8 @@ def build_parser() -> argparse.ArgumentParser:
             "(eco / balanced / performance / strict)"
         ),
     )
-    msub = pmode.add_subparsers(dest="mode_cmd", required=True)
+    msub = pmode.add_subparsers(dest="mode_cmd")
+    pmode.set_defaults(func=_help_dispatch(pmode))
 
     pml = msub.add_parser(
         "list",

--- a/src/vaara/integrations/_mcp_notify.py
+++ b/src/vaara/integrations/_mcp_notify.py
@@ -1,0 +1,184 @@
+"""Transport-aware notification routing for the Vaara MCP proxy.
+
+Upstream MCP servers can push notifications back to the client mid-call
+(progress events, log messages, sampling requests). The stdio transport
+writes those notifications to its single stdout. The Streamable HTTP
+transport has zero-to-many SSE subscribers keyed by ``Mcp-Session-Id``,
+and a notification must be delivered to the session that owns the
+originating tools/call (matched via progressToken at call time) or
+broadcast across sessions when no session scope is known.
+
+``NotificationRouter`` is the small surface the proxy uses regardless of
+transport. ``HttpRouter`` holds per-session queues plus a bounded replay
+buffer indexed by monotonically increasing event IDs so a reconnecting
+client can resume with ``Last-Event-ID``. Events evicted from the bounded
+buffer before reconnect are not recoverable: the caller sees a gap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import threading
+from collections import deque
+from typing import Deque, Optional, Protocol
+
+from vaara.integrations._mcp_upstream import strict_json_dumps
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_REPLAY_BUFFER = 100
+
+
+class NotificationRouter(Protocol):
+    def deliver(
+        self,
+        message: dict,
+        *,
+        session_id: Optional[str] = None,
+        upstream: str = "default",
+    ) -> None:
+        ...
+
+
+class StdioRouter:
+    """Stdio: serialise to stdout under a shared lock; session_id ignored."""
+
+    def __init__(self, stdout_lock: threading.Lock) -> None:
+        self._lock = stdout_lock
+
+    def deliver(
+        self,
+        message: dict,
+        *,
+        session_id: Optional[str] = None,
+        upstream: str = "default",
+    ) -> None:
+        with self._lock:
+            sys.stdout.write(strict_json_dumps(message) + "\n")
+            sys.stdout.flush()
+
+
+class _SessionState:
+    """One subscribed HTTP client connected via GET /mcp.
+
+    Mutation crosses threads: the upstream reader thread enqueues from a
+    sync context while the SSE handler drains from inside FastAPI's event
+    loop, so ``call_soon_threadsafe`` lands queue puts on the right loop.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        upstream: str,
+        tenant: str,
+        loop: asyncio.AbstractEventLoop,
+        replay_buffer_size: int,
+    ) -> None:
+        self.session_id = session_id
+        self.upstream = upstream
+        self.tenant = tenant
+        self._loop = loop
+        self._queue: asyncio.Queue[Optional[tuple[int, dict]]] = asyncio.Queue()
+        self._buffer: Deque[tuple[int, dict]] = deque(maxlen=replay_buffer_size)
+        self._next_id = 1
+        self._lock = threading.Lock()
+        self._closed = False
+
+    def enqueue(self, message: dict) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            event_id = self._next_id
+            self._next_id += 1
+            entry = (event_id, message)
+            self._buffer.append(entry)
+        try:
+            self._loop.call_soon_threadsafe(self._queue.put_nowait, entry)
+        except RuntimeError:
+            logger.debug("session %s loop closed during enqueue", self.session_id)
+
+    async def drain(self) -> Optional[tuple[int, dict]]:
+        """Yield the next event, or None when the session has been closed."""
+        return await self._queue.get()
+
+    def replay_since(self, last_event_id: int) -> list[tuple[int, dict]]:
+        with self._lock:
+            return [entry for entry in self._buffer if entry[0] > last_event_id]
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+        try:
+            self._loop.call_soon_threadsafe(self._queue.put_nowait, None)
+        except RuntimeError:
+            pass
+
+
+class HttpRouter:
+    """Per-session SSE notification delivery for Streamable HTTP transport.
+
+    ``deliver`` with a session_id targets exactly that session; without one
+    (log notifications carry no progressToken) it broadcasts across every
+    registered session on the matching upstream.
+    """
+
+    def __init__(self, replay_buffer_size: int = _DEFAULT_REPLAY_BUFFER) -> None:
+        self._sessions: dict[str, _SessionState] = {}
+        self._lock = threading.Lock()
+        self._replay_buffer_size = replay_buffer_size
+
+    def register_session(
+        self,
+        session_id: str,
+        upstream: str,
+        tenant: str,
+        loop: asyncio.AbstractEventLoop,
+    ) -> _SessionState:
+        state = _SessionState(
+            session_id=session_id,
+            upstream=upstream,
+            tenant=tenant,
+            loop=loop,
+            replay_buffer_size=self._replay_buffer_size,
+        )
+        with self._lock:
+            prior = self._sessions.get(session_id)
+            self._sessions[session_id] = state
+        # Close the prior state outside the lock so its sentinel put doesn't
+        # land while another thread holds the router lock. The prior SSE
+        # handler unblocks on its next drain() and runs its finally cleanup.
+        if prior is not None:
+            prior.close()
+        return state
+
+    def unregister_session(self, session_id: str) -> None:
+        with self._lock:
+            state = self._sessions.pop(session_id, None)
+        if state is not None:
+            state.close()
+
+    def deliver(
+        self,
+        message: dict,
+        *,
+        session_id: Optional[str] = None,
+        upstream: str = "default",
+    ) -> None:
+        with self._lock:
+            if session_id is not None:
+                state = self._sessions.get(session_id)
+                targets = [state] if state is not None else []
+            else:
+                targets = [
+                    s for s in self._sessions.values() if s.upstream == upstream
+                ]
+        for state in targets:
+            state.enqueue(message)
+
+    def session_count(self) -> int:
+        with self._lock:
+            return len(self._sessions)

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -38,6 +38,11 @@ from typing import Any, Optional
 from vaara import __version__ as _VAARA_VERSION
 from vaara.audit.sqlite_backend import SQLiteAuditBackend
 from vaara.audit.trail import AuditTrail
+from vaara.integrations._mcp_notify import (
+    HttpRouter,
+    NotificationRouter,
+    StdioRouter,
+)
 from vaara.integrations._mcp_overt import (
     OVERTConfigError,
     OVERTReceiptEmitter,
@@ -70,6 +75,14 @@ _REQUEST_UPSTREAM: contextvars.ContextVar[str] = contextvars.ContextVar(
 )
 _REQUEST_TENANT: contextvars.ContextVar[str] = contextvars.ContextVar(
     "vaara_mcp_tenant", default="",
+)
+# v0.41 GET-SSE: HTTP transport sets this per inbound POST /mcp call so the
+# tools/call handler can capture the originating session in the inflight
+# map. The upstream reader thread later uses that captured session_id to
+# route notifications/progress through the HTTP router to the right SSE
+# subscriber. Empty default keeps stdio transport unaffected.
+_REQUEST_SESSION: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "vaara_mcp_session", default="",
 )
 
 def _safe_log(value: Any, max_len: int = 200) -> str:
@@ -111,6 +124,7 @@ class VaaraMCPProxy:
         prompt_denylist: Optional[set[str]] = None,
         overt_emitter: Optional[OVERTReceiptEmitter] = None,
         upstreams: Optional[dict[str, list[str]]] = None,
+        router: Optional[NotificationRouter] = None,
     ) -> None:
         if pipeline is not None:
             self._pipeline = pipeline
@@ -140,14 +154,29 @@ class VaaraMCPProxy:
         )
         self._stdout_lock = threading.Lock()
         self._overt = overt_emitter
-        # progressToken -> (action_id, agent_id, tool_name, tenant_id). Populated
-        # when a tools/call enters interception with params._meta.progressToken
-        # set, consulted by the upstream-notification handler so progress events
-        # arriving mid-call carry the originating action_id into the audit
-        # record and into the OVERT envelope's non_content_metadata. The tenant
-        # is captured at tools/call time because the upstream reader thread that
-        # delivers later notifications does not inherit the request ContextVars.
-        self._inflight_progress: dict[Any, tuple[str, str, str, str]] = {}
+        # Notification router. stdio default writes through the shared stdout
+        # lock; HTTP transport swaps in HttpRouter in run_http(). The router is
+        # the only surface allowed to deliver upstream-initiated notifications
+        # to clients; tools/call response replies still go through
+        # _write_to_client / JSONResponse on their own paths.
+        self._router: NotificationRouter = router or StdioRouter(self._stdout_lock)
+        # progressToken -> (action_id, agent_id, tool_name, tenant_id, session_id).
+        # Populated when a tools/call enters interception with
+        # params._meta.progressToken set, consulted by the upstream-notification
+        # handler so progress events arriving mid-call carry the originating
+        # action_id into the audit record and into the OVERT envelope's
+        # non_content_metadata. The tenant and session_id are captured at
+        # tools/call time because the upstream reader thread that delivers
+        # later notifications does not inherit the request ContextVars.
+        self._inflight_progress: dict[Any, tuple[str, str, str, str, str]] = {}
+        # request_id -> upstream_name for every tools/call still running.
+        # Used to route notifications/cancelled to the upstream actually
+        # serving the matching request, regardless of which header the
+        # cancellation POST carries. Without this, cancellations under
+        # fan-out would land on the upstream named by X-Vaara-Upstream
+        # on the cancel POST, which the client has no reason to set
+        # correctly. Request-id ownership is the only stable identifier.
+        self._inflight_requests: dict[Any, str] = {}
         self._inflight_lock = threading.Lock()
         # v0.40 fan-out: hold N upstream MCP servers in a name -> client map.
         # The single-upstream legacy entry point (positional ``upstream_command``)
@@ -176,10 +205,16 @@ class VaaraMCPProxy:
             # deterministic across restarts. Alias the slot rather than
             # cloning the command so we never spawn a duplicate subprocess.
             default_alias_target = sorted(upstream_map)[0]
+        # Wrap on_notification per upstream so the reader thread's callback
+        # carries the upstream's name. Default-arg ``n=name`` binds the loop
+        # variable at lambda creation, avoiding the late-binding bug that
+        # would otherwise pin every upstream to the last name in the dict.
         self._upstreams: dict[str, UpstreamMCPClient] = {
             name: UpstreamMCPClient(
                 command=command,
-                on_notification=self._on_upstream_notification,
+                on_notification=(
+                    lambda msg, n=name: self._on_upstream_notification(n, msg)
+                ),
             )
             for name, command in upstream_map.items()
         }
@@ -216,7 +251,7 @@ class VaaraMCPProxy:
 
         Test fixtures and embedders that previously assigned
         ``proxy._upstream = MagicMock()`` keep working under the v0.40
-        fan-out shape — the assignment lands in the "default" slot and the
+        fan-out shape: the assignment lands in the "default" slot and the
         property reads it back.
         """
         self._upstreams["default"] = client
@@ -255,26 +290,25 @@ class VaaraMCPProxy:
             # Notifications (no id) forward silently per JSON-RPC 2.0 §4.1.
             if isinstance(request, dict) and "id" not in request:
                 try:
-                    self._upstream.notify(request)
+                    self._handle_client_notification(request)
                 except ProxyError:
                     logger.exception("Failed to forward notification")
                 continue
             self._write_to_client(self._handle_request(request))
 
-    def run_http(self, host: str, port: int, log_level: str = "info") -> None:
-        """Run the proxy on Streamable HTTP (MCP 2026 transport).
+    def _build_http_app(self):
+        """Construct the FastAPI app that backs the Streamable HTTP transport.
 
-        POST /mcp accepts one JSON-RPC message and returns one JSON
-        response. Notifications (no ``id``) return 202 Accepted and are
-        forwarded to the upstream without a reply. Multi-tenant /
-        fan-out scope is read per request from the
-        ``X-Vaara-Tenant`` and ``X-Vaara-Upstream`` headers and pushed
-        into the per-request ContextVars before dispatch.
+        Split out from ``run_http`` so tests can drive the endpoints via
+        ``fastapi.testclient.TestClient`` without standing up uvicorn. As a
+        side effect, swaps the proxy's notification router to ``HttpRouter``
+        so upstream-initiated notifications fan out to SSE subscribers
+        instead of stdout.
         """
         try:
-            import uvicorn
+            import asyncio
             from fastapi import FastAPI, Header, HTTPException, Response
-            from fastapi.responses import JSONResponse
+            from fastapi.responses import JSONResponse, StreamingResponse
         except ImportError as exc:
             raise RuntimeError(
                 "vaara-mcp-proxy --transport http requires the 'server' "
@@ -287,6 +321,13 @@ class VaaraMCPProxy:
             )
 
         proxy = self
+        # Replace the default StdioRouter with an HTTP-aware fan-out router.
+        # Mutation here is safe: it happens once at HTTP startup, before any
+        # request arrives, so the upstream reader threads consistently see
+        # the HTTP router for the lifetime of the serve loop. The StdioRouter
+        # instance is dropped.
+        http_router = HttpRouter()
+        proxy._router = http_router
 
         app = FastAPI(
             title="Vaara MCP Proxy",
@@ -311,6 +352,7 @@ class VaaraMCPProxy:
             request: _StarletteRequest,
             x_vaara_tenant: Optional[str] = Header(default=None, alias="X-Vaara-Tenant"),
             x_vaara_upstream: Optional[str] = Header(default=None, alias="X-Vaara-Upstream"),
+            mcp_session_id: Optional[str] = Header(default=None, alias="Mcp-Session-Id"),
         ) -> Response:
             # 1 MiB cap on a single MCP JSON-RPC message. Real tool calls and
             # responses fit comfortably; anything larger is either a misuse or
@@ -397,12 +439,26 @@ class VaaraMCPProxy:
                     },
                 )
 
+            session_value = (mcp_session_id or "").strip()
+            # Cap session id length to keep the inflight-progress and HttpRouter
+            # session-map keys bounded against a malicious client that submits
+            # an absurdly long header. 128 chars is comfortably wider than any
+            # realistic cryptographically-random session id.
+            if len(session_value) > 128:
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": {
+                        "code": "session_id_too_long",
+                        "message": "Mcp-Session-Id must be 128 characters or fewer",
+                    }},
+                )
             upstream_token = _REQUEST_UPSTREAM.set(upstream_name)
             tenant_token = _REQUEST_TENANT.set((x_vaara_tenant or "").strip())
+            session_token = _REQUEST_SESSION.set(session_value)
             try:
                 if isinstance(payload, dict) and "id" not in payload:
                     try:
-                        proxy._upstream.notify(payload)
+                        proxy._handle_client_notification(payload)
                     except ProxyError:
                         logger.exception("Failed to forward HTTP notification")
                     return Response(status_code=202)
@@ -411,12 +467,184 @@ class VaaraMCPProxy:
             finally:
                 _REQUEST_UPSTREAM.reset(upstream_token)
                 _REQUEST_TENANT.reset(tenant_token)
+                _REQUEST_SESSION.reset(session_token)
 
+        @app.get("/mcp")
+        async def mcp_sse_endpoint(
+            request: _StarletteRequest,
+            x_vaara_tenant: Optional[str] = Header(default=None, alias="X-Vaara-Tenant"),
+            x_vaara_upstream: Optional[str] = Header(default=None, alias="X-Vaara-Upstream"),
+            mcp_session_id: Optional[str] = Header(default=None, alias="Mcp-Session-Id"),
+            last_event_id: Optional[str] = Header(default=None, alias="Last-Event-ID"),
+        ) -> StreamingResponse:
+            session_value = (mcp_session_id or "").strip()
+            if not session_value:
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": {
+                        "code": "session_id_required",
+                        "message": "Mcp-Session-Id header is required for GET /mcp",
+                    }},
+                )
+            if len(session_value) > 128:
+                raise HTTPException(
+                    status_code=400,
+                    detail={"error": {
+                        "code": "session_id_too_long",
+                        "message": "Mcp-Session-Id must be 128 characters or fewer",
+                    }},
+                )
+            header_name = (x_vaara_upstream or "").strip()
+            real_slots = sorted(n for n in proxy._upstreams if n != "default")
+            ambiguous_fanout = len(real_slots) > 1
+            if not header_name:
+                if ambiguous_fanout:
+                    raise HTTPException(
+                        status_code=400,
+                        detail={"error": {
+                            "code": "upstream_required",
+                            "message": (
+                                "X-Vaara-Upstream header is required when "
+                                "the proxy serves more than one upstream. "
+                                f"Available upstreams: {real_slots!r}"
+                            ),
+                        }},
+                    )
+                upstream_name = "default"
+            else:
+                upstream_name = header_name
+            if upstream_name not in proxy._upstreams:
+                raise HTTPException(
+                    status_code=404,
+                    detail={"error": {
+                        "code": "unknown_upstream",
+                        "message": (
+                            f"No upstream named {upstream_name!r}; "
+                            f"configured: {sorted(proxy._upstreams)!r}"
+                        ),
+                    }},
+                )
+            # Last-Event-ID is the SSE resumption cursor. Non-integer values
+            # are tolerated and treated as 0 (full replay window) rather than
+            # rejected, matching the EventSource spec's lenient parsing.
+            resume_after = 0
+            if last_event_id is not None:
+                try:
+                    resume_after = max(int(last_event_id.strip()), 0)
+                except ValueError:
+                    resume_after = 0
+            loop = asyncio.get_running_loop()
+            state = http_router.register_session(
+                session_id=session_value,
+                upstream=upstream_name,
+                tenant=(x_vaara_tenant or "").strip(),
+                loop=loop,
+            )
+
+            async def event_stream():
+                # enqueue populates both the buffer (for replay) and the queue
+                # (for live drain), so an event that lands between
+                # register_session and the first replay_since call would arrive
+                # on both paths. Tracking the highest yielded id and filtering
+                # the drain stream by it keeps each event on the wire exactly
+                # once.
+                last_yielded = resume_after
+                try:
+                    # Initial retry hint (5s) so EventSource clients reconnect
+                    # at a predictable cadence on transient disconnect.
+                    yield b"retry: 5000\n\n"
+                    for event_id, payload in state.replay_since(resume_after):
+                        yield (
+                            f"id: {event_id}\n"
+                            f"data: {strict_json_dumps(payload)}\n\n"
+                        ).encode("utf-8")
+                        last_yielded = max(last_yielded, event_id)
+                    while True:
+                        try:
+                            entry = await asyncio.wait_for(state.drain(), timeout=15.0)
+                        except asyncio.TimeoutError:
+                            # Heartbeat. A failing yield here surfaces a dead
+                            # socket and lets the finally block tear the
+                            # session down.
+                            yield b": keepalive\n\n"
+                            continue
+                        if entry is None:
+                            break
+                        event_id, payload = entry
+                        if event_id <= last_yielded:
+                            continue
+                        yield (
+                            f"id: {event_id}\n"
+                            f"data: {strict_json_dumps(payload)}\n\n"
+                        ).encode("utf-8")
+                        last_yielded = event_id
+                finally:
+                    http_router.unregister_session(session_value)
+
+            return StreamingResponse(
+                event_stream(),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            )
+
+        return app
+
+    def run_http(self, host: str, port: int, log_level: str = "info") -> None:
+        """Run the proxy on Streamable HTTP (MCP 2026 transport).
+
+        POST /mcp accepts one JSON-RPC message and returns one JSON response.
+        GET /mcp opens a server-sent-events stream for upstream-initiated
+        notifications scoped to the ``Mcp-Session-Id`` header. Notifications
+        (no ``id``) return 202 Accepted and are forwarded to the upstream
+        without a reply, with ``notifications/cancelled`` routed to the
+        upstream that owns the named request id. Multi-tenant / fan-out scope
+        is read per request from the ``X-Vaara-Tenant`` and
+        ``X-Vaara-Upstream`` headers and pushed into the per-request
+        ContextVars before dispatch.
+        """
+        try:
+            import uvicorn
+        except ImportError as exc:
+            raise RuntimeError(
+                "vaara-mcp-proxy --transport http requires the 'server' "
+                "extra. Install with: pip install 'vaara[server]'"
+            ) from exc
+        app = self._build_http_app()
         logger.info(
             "Vaara MCP proxy starting on http://%s:%d (%s, upstreams=%s)",
             host, port, self.PROXY_NAME, sorted(self._upstreams.keys()),
         )
         uvicorn.run(app, host=host, port=port, log_level=log_level)
+
+    def _handle_client_notification(self, payload: dict) -> None:
+        """Route a client-originated JSON-RPC notification to the right upstream.
+
+        Most notifications follow the per-request ContextVar set by the HTTP
+        transport from ``X-Vaara-Upstream`` (or stdio's default of "default").
+        ``notifications/cancelled`` overrides that with the upstream actually
+        serving the named ``requestId``, so under fan-out the cancel reaches
+        the upstream subprocess that owns the long-running tools/call rather
+        than whatever slot the cancel POST's header guessed at.
+        """
+        target_upstream: Optional[str] = None
+        if (
+            isinstance(payload, dict)
+            and payload.get("method") == "notifications/cancelled"
+        ):
+            params = payload.get("params")
+            if isinstance(params, dict):
+                req_id = params.get("requestId")
+                if req_id is not None:
+                    with self._inflight_lock:
+                        target_upstream = self._inflight_requests.get(req_id)
+        if target_upstream is not None and target_upstream in self._upstreams:
+            token = _REQUEST_UPSTREAM.set(target_upstream)
+            try:
+                self._upstream.notify(payload)
+            finally:
+                _REQUEST_UPSTREAM.reset(token)
+        else:
+            self._upstream.notify(payload)
 
     def _handle_request(self, request: Any) -> dict:
         if not isinstance(request, dict):
@@ -590,20 +818,27 @@ class VaaraMCPProxy:
                     "isError": True,
                 },
             }
-        if progress_token is not None:
-            with self._inflight_lock:
+        request_id = request.get("id")
+        upstream_name = _REQUEST_UPSTREAM.get()
+        with self._inflight_lock:
+            if progress_token is not None:
                 self._inflight_progress[progress_token] = (
                     str(getattr(result, "action_id", None) or ""),
                     agent_id,
                     tool_name,
                     _REQUEST_TENANT.get(),
+                    _REQUEST_SESSION.get(),
                 )
+            if request_id is not None:
+                self._inflight_requests[request_id] = upstream_name
         try:
             upstream_response = self._upstream.request(request)
         finally:
-            if progress_token is not None:
-                with self._inflight_lock:
+            with self._inflight_lock:
+                if progress_token is not None:
                     self._inflight_progress.pop(progress_token, None)
+                if request_id is not None:
+                    self._inflight_requests.pop(request_id, None)
         outcome_severity = self._severity_from_response(upstream_response)
         try:
             self._pipeline.report_outcome(
@@ -850,7 +1085,7 @@ class VaaraMCPProxy:
             return 1.0
         return 0.0
 
-    def _on_upstream_notification(self, message: dict) -> None:
+    def _on_upstream_notification(self, upstream_name: str, message: dict) -> None:
         """Audit + OVERT-emit upstream-originated notifications, then forward.
 
         Streaming surfaces (notifications/progress, notifications/message) flow
@@ -858,9 +1093,10 @@ class VaaraMCPProxy:
         them inside the audit boundary: each notification is recorded as a
         perimeter-style audit event (no scorer) and, when OVERT is configured,
         emits its own Base Envelope. Progress events correlate to the
-        originating tools/call via params.progressToken when present. The
-        notification is then forwarded to the client unchanged — auditing is
-        observational, never blocking.
+        originating tools/call via params.progressToken when present. Routing
+        to the destination client goes through the transport-aware
+        ``NotificationRouter``: stdio writes to the proxy stdout, HTTP fans
+        out to the SSE session registered for the originating tools/call.
         """
         method = message.get("method") if isinstance(message, dict) else None
         try:
@@ -870,7 +1106,24 @@ class VaaraMCPProxy:
                 self._audit_message_notification(message)
         except Exception:
             logger.exception("Streaming-notification audit failed for %s", method)
-        self._write_to_client(message)
+        # Resolve the session that originated this notification, if any. Only
+        # progress notifications carry a progressToken; log notifications and
+        # any other server-pushed message broadcast across the sessions
+        # subscribed to this upstream (HttpRouter handles broadcast when
+        # session_id is None; StdioRouter ignores both args).
+        session_id: Optional[str] = None
+        if method == "notifications/progress":
+            params = message.get("params") if isinstance(message, dict) else None
+            if isinstance(params, dict):
+                token = params.get("progressToken")
+                if isinstance(token, (str, int)):
+                    with self._inflight_lock:
+                        entry = self._inflight_progress.get(token)
+                    if entry is not None:
+                        captured_session = entry[4]
+                        if captured_session:
+                            session_id = captured_session
+        self._router.deliver(message, session_id=session_id, upstream=upstream_name)
 
     @staticmethod
     def _progress_token(params: dict) -> Any:
@@ -902,7 +1155,10 @@ class VaaraMCPProxy:
             with self._inflight_lock:
                 entry = self._inflight_progress.get(token)
             if entry is not None:
-                parent_action_id, agent_id, parent_tool, captured_tenant = entry
+                # Session id is captured for routing in _on_upstream_notification;
+                # the audit/OVERT path discards it intentionally so the perimeter
+                # record schema stays unchanged.
+                parent_action_id, agent_id, parent_tool, captured_tenant, _ = entry
         self._record_perimeter_audit(
             agent_id=agent_id,
             tool_name="mcp.notification.progress",

--- a/tests/test_integrations_mcp_proxy.py
+++ b/tests/test_integrations_mcp_proxy.py
@@ -451,7 +451,7 @@ def test_uninterpreted_method_still_forwards_verbatim(monkeypatch):
 
 def test_progress_notification_records_perimeter_audit(monkeypatch):
     p, pipeline = _make_proxy(monkeypatch)
-    p._on_upstream_notification({
+    p._on_upstream_notification("default", {
         "jsonrpc": "2.0", "method": "notifications/progress",
         "params": {"progressToken": "tok-1", "progress": 25, "total": 100},
     })
@@ -474,7 +474,7 @@ def test_progress_notification_correlates_to_inflight_tools_call(monkeypatch):
             # works on the long-running call. The reader thread would invoke
             # this callback from a separate thread in production; calling it
             # synchronously here verifies the correlation logic.
-            p._on_upstream_notification({
+            p._on_upstream_notification("default", {
                 "jsonrpc": "2.0", "method": "notifications/progress",
                 "params": {"progressToken": "tok-stream", "progress": 50, "total": 100},
             })
@@ -491,7 +491,7 @@ def test_progress_notification_correlates_to_inflight_tools_call(monkeypatch):
             "_meta": {"progressToken": "tok-stream"},
         },
     })
-    assert progress_seen == [{"tok-stream": ("parent-act-9", "mcp-proxy-client", "long_tool", "")}]
+    assert progress_seen == [{"tok-stream": ("parent-act-9", "mcp-proxy-client", "long_tool", "", "")}]
     # Map is cleaned up after the call returns.
     assert p._inflight_progress == {}
     # Audit was called for the progress event with the parent correlation.
@@ -506,18 +506,21 @@ def test_progress_notification_correlates_to_inflight_tools_call(monkeypatch):
 def test_progress_notification_forwards_to_client(monkeypatch):
     p, _ = _make_proxy(monkeypatch)
     forwarded: list[dict] = []
-    monkeypatch.setattr(p, "_write_to_client", forwarded.append)
+    monkeypatch.setattr(
+        p._router, "deliver",
+        lambda message, *, session_id=None, upstream="default": forwarded.append(message),
+    )
     msg = {
         "jsonrpc": "2.0", "method": "notifications/progress",
         "params": {"progressToken": "tok-2", "progress": 1, "total": 1},
     }
-    p._on_upstream_notification(msg)
+    p._on_upstream_notification("default", msg)
     assert forwarded == [msg]
 
 
 def test_message_notification_records_perimeter_audit(monkeypatch):
     p, pipeline = _make_proxy(monkeypatch)
-    p._on_upstream_notification({
+    p._on_upstream_notification("default", {
         "jsonrpc": "2.0", "method": "notifications/message",
         "params": {"level": "info", "logger": "upstream", "data": "working"},
     })
@@ -530,12 +533,15 @@ def test_message_notification_records_perimeter_audit(monkeypatch):
 def test_non_governed_notification_still_forwards_without_audit(monkeypatch):
     p, pipeline = _make_proxy(monkeypatch)
     forwarded: list[dict] = []
-    monkeypatch.setattr(p, "_write_to_client", forwarded.append)
+    monkeypatch.setattr(
+        p._router, "deliver",
+        lambda message, *, session_id=None, upstream="default": forwarded.append(message),
+    )
     msg = {
         "jsonrpc": "2.0", "method": "notifications/resources/list_changed",
         "params": {},
     }
-    p._on_upstream_notification(msg)
+    p._on_upstream_notification("default", msg)
     assert forwarded == [msg]
     pipeline.registry.classify.assert_not_called()
 
@@ -544,12 +550,15 @@ def test_audit_failure_in_notification_does_not_break_forwarding(monkeypatch):
     p, pipeline = _make_proxy(monkeypatch)
     pipeline.registry.classify.side_effect = RuntimeError("audit blew up")
     forwarded: list[dict] = []
-    monkeypatch.setattr(p, "_write_to_client", forwarded.append)
+    monkeypatch.setattr(
+        p._router, "deliver",
+        lambda message, *, session_id=None, upstream="default": forwarded.append(message),
+    )
     msg = {
         "jsonrpc": "2.0", "method": "notifications/message",
         "params": {"level": "error"},
     }
-    p._on_upstream_notification(msg)
+    p._on_upstream_notification("default", msg)
     # Forward still happens — audit failure must not block streaming.
     assert forwarded == [msg]
 
@@ -600,3 +609,117 @@ def test_upstream_request_raises_proxy_error_when_reader_exits_without_response(
     with pytest.raises(up.ProxyError, match="closed before responding"):
         client.request({"jsonrpc": "2.0", "id": 1, "method": "ping"})
     client.close()
+
+
+# --- cancellation routing across fan-out (v0.41) ----------------------------
+
+def _make_fanout_proxy(monkeypatch):
+    """Build a proxy with two named upstreams, each backed by its own MagicMock.
+
+    The default ``UpstreamMCPClient`` patch returns the same mock instance for
+    every call, which conflates upstreams in fan-out tests. ``side_effect``
+    with a factory produces a fresh mock per construction so each slot has a
+    distinct ``notify`` call record.
+    """
+    from vaara.integrations import mcp_proxy
+
+    monkeypatch.setattr(
+        mcp_proxy, "UpstreamMCPClient",
+        MagicMock(side_effect=lambda **kw: MagicMock()),
+    )
+    pipeline = MagicMock()
+    p = mcp_proxy.VaaraMCPProxy(
+        upstreams={"alpha": ["echo", "alpha"], "beta": ["echo", "beta"]},
+        pipeline=pipeline,
+    )
+    return p, pipeline
+
+
+def test_cancellation_routes_to_upstream_that_owns_the_request_id(monkeypatch):
+    p, _ = _make_fanout_proxy(monkeypatch)
+    with p._inflight_lock:
+        p._inflight_requests[42] = "alpha"
+    p._handle_client_notification({
+        "jsonrpc": "2.0", "method": "notifications/cancelled",
+        "params": {"requestId": 42},
+    })
+    p._upstreams["alpha"].notify.assert_called_once()
+    p._upstreams["beta"].notify.assert_not_called()
+
+
+def test_cancellation_with_unknown_request_id_uses_contextvar_routing(monkeypatch):
+    p, _ = _make_fanout_proxy(monkeypatch)
+    from vaara.integrations.mcp_proxy import _REQUEST_UPSTREAM
+    token = _REQUEST_UPSTREAM.set("beta")
+    try:
+        p._handle_client_notification({
+            "jsonrpc": "2.0", "method": "notifications/cancelled",
+            "params": {"requestId": 9999},
+        })
+    finally:
+        _REQUEST_UPSTREAM.reset(token)
+    p._upstreams["beta"].notify.assert_called_once()
+    p._upstreams["alpha"].notify.assert_not_called()
+
+
+def test_non_cancellation_notification_follows_contextvar(monkeypatch):
+    p, _ = _make_fanout_proxy(monkeypatch)
+    # Even if the inflight map points to alpha, a non-cancellation
+    # notification must follow the per-request ContextVar instead.
+    with p._inflight_lock:
+        p._inflight_requests[7] = "alpha"
+    from vaara.integrations.mcp_proxy import _REQUEST_UPSTREAM
+    token = _REQUEST_UPSTREAM.set("beta")
+    try:
+        p._handle_client_notification({
+            "jsonrpc": "2.0", "method": "notifications/roots/list_changed",
+            "params": {},
+        })
+    finally:
+        _REQUEST_UPSTREAM.reset(token)
+    p._upstreams["beta"].notify.assert_called_once()
+    p._upstreams["alpha"].notify.assert_not_called()
+
+
+def test_inflight_requests_populated_during_tools_call_then_cleared(monkeypatch):
+    p, pipeline = _make_fanout_proxy(monkeypatch)
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="a-1")
+    from vaara.integrations.mcp_proxy import _REQUEST_UPSTREAM
+    captured: list[dict] = []
+
+    def upstream_request(req):
+        # Snapshot the map mid-call; should show the request_id binding.
+        with p._inflight_lock:
+            captured.append(dict(p._inflight_requests))
+        return {"jsonrpc": "2.0", "id": req["id"], "result": {}}
+
+    token = _REQUEST_UPSTREAM.set("alpha")
+    try:
+        p._upstreams["alpha"].request.side_effect = upstream_request
+        p._handle_tools_call({
+            "jsonrpc": "2.0", "id": 77, "method": "tools/call",
+            "params": {"name": "t", "arguments": {}},
+        })
+    finally:
+        _REQUEST_UPSTREAM.reset(token)
+    assert captured == [{77: "alpha"}]
+    # Cleared after the call returns.
+    assert p._inflight_requests == {}
+
+
+def test_inflight_requests_cleared_when_tools_call_raises(monkeypatch):
+    p, pipeline = _make_fanout_proxy(monkeypatch)
+    pipeline.intercept.return_value = _StubInterceptResult(allowed=True, action_id="a-1")
+    from vaara.integrations._mcp_upstream import ProxyError
+    from vaara.integrations.mcp_proxy import _REQUEST_UPSTREAM
+    p._upstreams["alpha"].request.side_effect = ProxyError("boom")
+    token = _REQUEST_UPSTREAM.set("alpha")
+    try:
+        with pytest.raises(ProxyError):
+            p._handle_tools_call({
+                "jsonrpc": "2.0", "id": 88, "method": "tools/call",
+                "params": {"name": "t", "arguments": {}},
+            })
+    finally:
+        _REQUEST_UPSTREAM.reset(token)
+    assert p._inflight_requests == {}

--- a/tests/test_integrations_mcp_proxy_overt.py
+++ b/tests/test_integrations_mcp_proxy_overt.py
@@ -238,7 +238,7 @@ def test_progress_notification_emits_envelope_with_parent_correlation(monkeypatc
 
     def upstream_request(req):
         if req["method"] == "tools/call":
-            p._on_upstream_notification({
+            p._on_upstream_notification("default", {
                 "jsonrpc": "2.0", "method": "notifications/progress",
                 "params": {"progressToken": "tok-z", "progress": 10, "total": 20},
             })
@@ -270,7 +270,7 @@ def test_progress_notification_emits_envelope_with_parent_correlation(monkeypatc
 
 def test_message_notification_emits_envelope(monkeypatch, emitter):
     p, _ = _make_proxy(monkeypatch, emitter=emitter)
-    p._on_upstream_notification({
+    p._on_upstream_notification("default", {
         "jsonrpc": "2.0", "method": "notifications/message",
         "params": {"level": "warning", "logger": "upstream", "data": "slow"},
     })
@@ -291,7 +291,7 @@ def test_orphan_progress_without_inflight_call_still_emits(monkeypatch, emitter)
     can spot the dangling event rather than having it disappear.
     """
     p, _ = _make_proxy(monkeypatch, emitter=emitter)
-    p._on_upstream_notification({
+    p._on_upstream_notification("default", {
         "jsonrpc": "2.0", "method": "notifications/progress",
         "params": {"progressToken": "orphan", "progress": 5},
     })

--- a/tests/test_integrations_mcp_proxy_sse.py
+++ b/tests/test_integrations_mcp_proxy_sse.py
@@ -1,0 +1,104 @@
+"""Tests for the Streamable HTTP transport's GET /mcp SSE endpoint (v0.41).
+
+Exercises validation, basic event delivery, and Last-Event-ID resume against
+the FastAPI app produced by ``VaaraMCPProxy._build_http_app`` without
+standing up uvicorn. The streaming behaviour is driven through
+``TestClient.stream`` so each test can assert against the SSE frames as
+they arrive.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+starlette = pytest.importorskip("starlette")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _build_proxy(monkeypatch, upstreams=None):
+    from vaara.integrations import mcp_proxy
+
+    monkeypatch.setattr(
+        mcp_proxy, "UpstreamMCPClient",
+        MagicMock(side_effect=lambda **kw: MagicMock()),
+    )
+    pipeline = MagicMock()
+    if upstreams is None:
+        p = mcp_proxy.VaaraMCPProxy(upstream_command=["echo"], pipeline=pipeline)
+    else:
+        p = mcp_proxy.VaaraMCPProxy(upstreams=upstreams, pipeline=pipeline)
+    return p, pipeline
+
+
+def test_get_mcp_requires_session_id_header(monkeypatch):
+    p, _ = _build_proxy(monkeypatch)
+    app = p._build_http_app()
+    client = TestClient(app)
+    r = client.get("/mcp")
+    assert r.status_code == 400
+    body = r.json()
+    assert body["detail"]["error"]["code"] == "session_id_required"
+
+
+def test_get_mcp_rejects_oversized_session_id(monkeypatch):
+    p, _ = _build_proxy(monkeypatch)
+    app = p._build_http_app()
+    client = TestClient(app)
+    r = client.get("/mcp", headers={"Mcp-Session-Id": "x" * 129})
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"]["code"] == "session_id_too_long"
+
+
+def test_get_mcp_404_on_unknown_upstream(monkeypatch):
+    p, _ = _build_proxy(
+        monkeypatch, upstreams={"alpha": ["echo"], "beta": ["echo"]},
+    )
+    app = p._build_http_app()
+    client = TestClient(app)
+    r = client.get(
+        "/mcp",
+        headers={"Mcp-Session-Id": "s1", "X-Vaara-Upstream": "ghost"},
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"]["error"]["code"] == "unknown_upstream"
+
+
+def test_get_mcp_400_on_ambiguous_fanout_without_upstream(monkeypatch):
+    p, _ = _build_proxy(
+        monkeypatch, upstreams={"alpha": ["echo"], "beta": ["echo"]},
+    )
+    app = p._build_http_app()
+    client = TestClient(app)
+    r = client.get("/mcp", headers={"Mcp-Session-Id": "s1"})
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"]["code"] == "upstream_required"
+
+
+def test_post_mcp_rejects_oversized_session_id(monkeypatch):
+    p, _ = _build_proxy(monkeypatch)
+    app = p._build_http_app()
+    client = TestClient(app)
+    r = client.post(
+        "/mcp",
+        content=b'{"jsonrpc":"2.0","method":"ping"}',
+        headers={
+            "Content-Type": "application/json",
+            "Mcp-Session-Id": "x" * 200,
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"]["code"] == "session_id_too_long"
+
+
+def test_health_endpoint_works_after_app_build(monkeypatch):
+    p, _ = _build_proxy(monkeypatch)
+    app = p._build_http_app()
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert "default" in body["upstreams"]

--- a/tests/test_mcp_notify.py
+++ b/tests/test_mcp_notify.py
@@ -1,0 +1,184 @@
+"""Tests for vaara.integrations._mcp_notify.
+
+Covers the transport-aware notification routing surfaces introduced for
+v0.41 GET-SSE: per-session enqueue, broadcast on missing session id,
+bounded replay buffer eviction, and the close-sentinel drain contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import sys
+import threading
+
+from vaara.integrations._mcp_notify import (
+    HttpRouter,
+    StdioRouter,
+    _SessionState,
+)
+
+
+def _new_loop() -> asyncio.AbstractEventLoop:
+    """Create a fresh loop for tests that only need it as a target for
+    ``call_soon_threadsafe`` from the enqueue path. No running required."""
+    return asyncio.new_event_loop()
+
+
+def test_stdio_router_writes_json_line_to_stdout(monkeypatch):
+    captured = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", captured)
+    router = StdioRouter(threading.Lock())
+    router.deliver({"jsonrpc": "2.0", "method": "notifications/x"})
+    line = captured.getvalue().strip()
+    assert json.loads(line) == {"jsonrpc": "2.0", "method": "notifications/x"}
+
+
+def test_http_router_register_and_unregister(monkeypatch):
+    router = HttpRouter(replay_buffer_size=10)
+    loop = _new_loop()
+    try:
+        router.register_session("sess-a", upstream="alpha", tenant="t1", loop=loop)
+        assert router.session_count() == 1
+        router.unregister_session("sess-a")
+        assert router.session_count() == 0
+    finally:
+        loop.close()
+
+
+def test_http_router_deliver_targets_named_session():
+    router = HttpRouter(replay_buffer_size=10)
+    loop = _new_loop()
+    try:
+        state_a = router.register_session("sess-a", "alpha", "", loop)
+        state_b = router.register_session("sess-b", "alpha", "", loop)
+        msg = {"jsonrpc": "2.0", "method": "notifications/progress"}
+        router.deliver(msg, session_id="sess-a", upstream="alpha")
+        # Buffer reflects the enqueue side-effect even without draining.
+        assert state_a.replay_since(0) == [(1, msg)]
+        assert state_b.replay_since(0) == []
+    finally:
+        loop.close()
+
+
+def test_http_router_deliver_without_session_broadcasts_on_upstream():
+    router = HttpRouter(replay_buffer_size=10)
+    loop = _new_loop()
+    try:
+        state_alpha = router.register_session("sess-a", "alpha", "", loop)
+        state_beta = router.register_session("sess-b", "beta", "", loop)
+        msg = {"jsonrpc": "2.0", "method": "notifications/message"}
+        router.deliver(msg, session_id=None, upstream="alpha")
+        assert state_alpha.replay_since(0) == [(1, msg)]
+        # beta upstream subscriber must not receive the alpha-scoped message.
+        assert state_beta.replay_since(0) == []
+    finally:
+        loop.close()
+
+
+def test_http_router_deliver_to_unknown_session_is_noop():
+    router = HttpRouter(replay_buffer_size=10)
+    loop = _new_loop()
+    try:
+        state = router.register_session("sess-a", "alpha", "", loop)
+        router.deliver({"foo": 1}, session_id="ghost", upstream="alpha")
+        assert state.replay_since(0) == []
+    finally:
+        loop.close()
+
+
+def test_session_state_replay_buffer_is_bounded():
+    loop = _new_loop()
+    try:
+        state = _SessionState("s", "alpha", "", loop, replay_buffer_size=3)
+        for i in range(5):
+            state.enqueue({"n": i})
+        replayed = state.replay_since(0)
+        # Only the last 3 events remain. Event IDs reflect monotonic
+        # assignment; the first two are gone but their IDs were 1, 2.
+        assert [eid for eid, _ in replayed] == [3, 4, 5]
+        assert [payload["n"] for _, payload in replayed] == [2, 3, 4]
+    finally:
+        loop.close()
+
+
+def test_session_state_replay_since_filters_by_cursor():
+    loop = _new_loop()
+    try:
+        state = _SessionState("s", "alpha", "", loop, replay_buffer_size=10)
+        for i in range(5):
+            state.enqueue({"n": i})
+        # Resume after seeing event id 3. Replay only events 4 and 5.
+        replayed = state.replay_since(3)
+        assert [eid for eid, _ in replayed] == [4, 5]
+    finally:
+        loop.close()
+
+
+def test_session_state_close_is_idempotent():
+    loop = _new_loop()
+    try:
+        state = _SessionState("s", "alpha", "", loop, replay_buffer_size=10)
+        state.close()
+        # Second close must not raise and must not double-post a sentinel.
+        state.close()
+    finally:
+        loop.close()
+
+
+def test_session_state_enqueue_after_close_is_ignored():
+    loop = _new_loop()
+    try:
+        state = _SessionState("s", "alpha", "", loop, replay_buffer_size=10)
+        state.close()
+        state.enqueue({"after_close": True})
+        assert state.replay_since(0) == []
+    finally:
+        loop.close()
+
+
+def test_drain_yields_events_then_sentinel_on_close():
+    """drain() returns enqueued events, then None once close() runs.
+
+    Exercised inside an actual running loop: enqueue schedules puts via
+    ``call_soon_threadsafe``, so the queue mutation must happen inside the
+    loop's execution.
+    """
+    async def run() -> list:
+        loop = asyncio.get_running_loop()
+        state = _SessionState("s", "alpha", "", loop, replay_buffer_size=10)
+        state.enqueue({"n": 1})
+        state.enqueue({"n": 2})
+        # Schedule close after the queued events are pulled.
+        out: list = []
+        for _ in range(2):
+            entry = await state.drain()
+            out.append(entry)
+        state.close()
+        sentinel = await state.drain()
+        out.append(sentinel)
+        return out
+
+    result = asyncio.run(run())
+    assert result == [(1, {"n": 1}), (2, {"n": 2}), None]
+
+
+def test_http_router_re_registration_replaces_session():
+    """A second register_session under the same id swaps the state.
+
+    The new state has a fresh buffer; the old state is closed via the
+    sentinel path so any drain awaiting on it would unblock.
+    """
+    router = HttpRouter(replay_buffer_size=10)
+    loop = _new_loop()
+    try:
+        old = router.register_session("sess-a", "alpha", "", loop)
+        old.enqueue({"old": True})
+        new = router.register_session("sess-a", "alpha", "", loop)
+        assert new is not old
+        new.enqueue({"new": True})
+        assert old.replay_since(0) == [(1, {"old": True})]
+        assert new.replay_since(0) == [(1, {"new": True})]
+    finally:
+        loop.close()


### PR DESCRIPTION
## Summary

- `GET /mcp` Server-Sent Events endpoint on the Streamable HTTP transport. Upstream-initiated notifications (progress, log) reach the client over a long-lived SSE stream keyed by `Mcp-Session-Id`. Reconnect-with-resume via `Last-Event-ID` against a 100-event bounded replay buffer. 15s heartbeat, 5s retry hint.
- `notifications/cancelled` routes to the upstream serving the named `requestId` rather than the slot named by the cancel header. New in-flight request-id map tracks ownership across fan-out.
- New `vaara.integrations._mcp_notify` module: `NotificationRouter` protocol with `StdioRouter` and `HttpRouter`. `UpstreamMCPClient.on_notification` wrapped per upstream to fix a late-binding bug that would have pinned every reader thread to the last name in `_upstreams`.
- `run_http` split into `_build_http_app` + uvicorn launch so tests drive the FastAPI app via `TestClient` without standing up a server.

## Release bundle

- Five-surface version bump to 0.41.0: `pyproject.toml`, `src/vaara/__init__.py`, `clients/ts/package.json`, `server.json`, `server-vaara-server.json`.
- `.claude-plugin/marketplace.json` `ref` bumped from `v0.40.4` to `v0.41.0`.
- Plugin already on 0.1.2 from earlier on the branch (widened audit matcher + `/vaara-stats`).

## Deferred

- `vaara mcp-proxy` / `vaara mcp-server` CLI consolidation: build plan flagged "skip if going straight to substance". Console scripts `vaara-mcp-proxy` and `vaara-mcp-server` stay in place.
- Classifier hot-reload + `POST /v1/scorer/reload`: rolled to v0.42.

## Test plan

- [ ] CI green on the 5 required status checks
- [ ] `tests/test_mcp_notify.py` and `tests/test_integrations_mcp_proxy_sse.py` green locally and in CI
- [ ] No regression on `tests/test_integrations_mcp_proxy.py` (cancellation routing and per-upstream notification callback touch this surface)
- [ ] `vaara-mcp-proxy --transport http` smoke against a real MCP host before tag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.41.0

* **New Features**
  * Added MCP server-sent notifications via HTTP GET endpoint with session resumption support.
  * New `vaara-stats` command to view governance audit trail summary (record counts, tool usage, recent events).
  * Enhanced governance audit tracking for Bash, Web, and MCP calls.

* **Bug Fixes**
  * Fixed CLI help dispatch when subcommands are omitted.
  * Improved cancellation routing across multi-upstream scenarios.

* **Chores**
  * Updated all package versions to 0.41.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->