### PR TITLE
chore(bench): v0.41 fan-out latency numbers

### DIFF
--- a/bench/v041_fanout.json
+++ b/bench/v041_fanout.json
@@ -1,0 +1,52 @@
+{
+  "results": [
+    {
+      "n_upstreams": 1,
+      "n_calls": 2000,
+      "mean_ms": 1.2189,
+      "p50_ms": 1.2102,
+      "p95_ms": 1.347,
+      "p99_ms": 1.4347,
+      "p999_ms": 2.7184,
+      "min_ms": 1.0079,
+      "max_ms": 17.9851,
+      "throughput_per_sec": 820.4
+    },
+    {
+      "n_upstreams": 2,
+      "n_calls": 2000,
+      "mean_ms": 1.2227,
+      "p50_ms": 1.2133,
+      "p95_ms": 1.359,
+      "p99_ms": 1.4472,
+      "p999_ms": 1.5789,
+      "min_ms": 1.0114,
+      "max_ms": 32.0135,
+      "throughput_per_sec": 817.9
+    },
+    {
+      "n_upstreams": 4,
+      "n_calls": 2000,
+      "mean_ms": 1.2224,
+      "p50_ms": 1.2136,
+      "p95_ms": 1.3598,
+      "p99_ms": 1.456,
+      "p999_ms": 1.6194,
+      "min_ms": 1.0038,
+      "max_ms": 27.2556,
+      "throughput_per_sec": 818.1
+    },
+    {
+      "n_upstreams": 8,
+      "n_calls": 2000,
+      "mean_ms": 1.2103,
+      "p50_ms": 1.2063,
+      "p95_ms": 1.3658,
+      "p99_ms": 1.4426,
+      "p999_ms": 1.5853,
+      "min_ms": 1.0003,
+      "max_ms": 15.0092,
+      "throughput_per_sec": 826.2
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Re-ran `bench/latency_fanout.py` against v0.41.0. Mean and p99 stay flat within micro-bench noise vs the v0.40.2 baseline across N=1, 2, 4, 8 upstream slots.

| N | mean (ms) | p99 (ms) |
| 1 | 1.219     | 1.435    |
| 2 | 1.223     | 1.447    |
| 4 | 1.222     | 1.456    |
| 8 | 1.210     | 1.443    |

v0.40.2 baseline at N=1: 1.195 ms mean / 1.409 ms p99. Roughly 25 microseconds drift across the N slots, consistent with the per-request session-id contextvar set/reset and the `_inflight_requests` dict put/pop added in v0.41 for cancellation routing across fan-out.

File: `bench/v041_fanout.json`.

## Why a follow-up

The bench should have ridden in PR #165 next to the substance, matching the v0.40.2 pattern (`bench/v040_fanout.json` shipped with PR #158). It was run as post-merge validation instead. This PR closes the gap so the v0.41 numbers exist in the tree.

## Test plan

- [ ] CI green on the 5 required status checks
- [ ] No other tracked files touched (`bench/v041_fanout.json` is the only addition)
