### PR TITLE
fix(attest): correct single-upstream fingerprint keying before tagging v0.43.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         "source": "git-subdir",
         "url": "https://github.com/vaaraio/vaara.git",
         "path": "plugins/claude-code-vaara-governance",
-        "ref": "v0.41.0"
+        "ref": "v0.43.0"
       },
       "homepage": "https://vaara.io"
     }

--- a/src/vaara/integrations/_mcp_attest.py
+++ b/src/vaara/integrations/_mcp_attest.py
@@ -296,6 +296,14 @@ def build_attest_emitter(
                 f"--attest-signing-key is not a usable PEM private key: {exc}"
             ) from exc
         if isinstance(key, EllipticCurvePrivateKey):
+            # ES256 emits a fixed 32-byte r||s; a non-P-256 curve would be
+            # mislabeled and then silently fail to sign (emit_attestation
+            # swallows errors), so reject it up front with a clear message.
+            if key.curve.name != "secp256r1":
+                raise AttestConfigError(
+                    "--attest-signing-key EC key must use the P-256 (secp256r1) "
+                    f"curve for ES256; got {key.curve.name!r}."
+                )
             alg: str = "ES256"
         elif isinstance(key, RSAPrivateKey):
             alg = "RS256"

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -1393,7 +1393,9 @@ def main(argv: Optional[list[str]] = None) -> None:
             "github=github-mcp-server` or `--upstream npx`).",
         )
 
-    attest_emitter = _build_attest_emitter_from_args(args, upstreams=upstreams)
+    attest_emitter = _build_attest_emitter_from_args(
+        args, upstreams=_attest_upstreams_for_slots(upstreams),
+    )
 
     legacy_single = (
         list(next(iter(upstreams.values()))) if len(upstreams) == 1 else None
@@ -1465,6 +1467,23 @@ def _parse_upstream_specs(
     if legacy_args and first_name is not None:
         upstreams[first_name].extend(legacy_args)
     return upstreams
+
+
+def _attest_upstreams_for_slots(
+    upstreams: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    """Key the attestation fingerprint table the way the proxy slots upstreams.
+
+    A single upstream (named ``NAME=CMD`` or bare ``CMD``) collapses into the
+    ``"default"`` slot inside ``VaaraMCPProxy``, and ``_REQUEST_UPSTREAM``
+    resolves to ``"default"`` at runtime. The emitter must be keyed the same
+    way, or ``fingerprint_for("default")`` misses the precomputed cmd-hash and
+    emits a ``cmd:sha256:unknown-default`` placeholder. Multi-upstream fan-out
+    keeps the operator-supplied slot names.
+    """
+    if len(upstreams) == 1:
+        return {"default": list(next(iter(upstreams.values())))}
+    return dict(upstreams)
 
 
 def _build_attest_emitter_from_args(

--- a/tests/test_integrations_mcp_proxy.py
+++ b/tests/test_integrations_mcp_proxy.py
@@ -723,3 +723,24 @@ def test_inflight_requests_cleared_when_tools_call_raises(monkeypatch):
     finally:
         _REQUEST_UPSTREAM.reset(token)
     assert p._inflight_requests == {}
+
+
+# ---------------------------------------------------------------------------
+# Attestation emitter slot-keying (pure; runs without the attestation extra)
+# ---------------------------------------------------------------------------
+
+def test_attest_upstreams_named_single_collapses_to_default():
+    # A named single upstream (--upstream github=CMD) collapses to the
+    # "default" slot inside the proxy, so the attestation fingerprint table
+    # must be keyed "default" too. Regression for the placeholder-fingerprint
+    # bug on the documented NAME=CMD single-upstream form.
+    from vaara.integrations.mcp_proxy import _attest_upstreams_for_slots
+    assert _attest_upstreams_for_slots(
+        {"github": ["github-mcp-server", "stdio"]}
+    ) == {"default": ["github-mcp-server", "stdio"]}
+
+
+def test_attest_upstreams_multi_preserves_names():
+    from vaara.integrations.mcp_proxy import _attest_upstreams_for_slots
+    upstreams = {"github": ["gh-srv"], "fs": ["fs-srv"]}
+    assert _attest_upstreams_for_slots(upstreams) == upstreams

--- a/tests/test_integrations_mcp_proxy_attest.py
+++ b/tests/test_integrations_mcp_proxy_attest.py
@@ -320,6 +320,66 @@ def test_manifest_fingerprint_idempotent(monkeypatch, emitter):
 
 
 # ---------------------------------------------------------------------------
+# Key validation
+# ---------------------------------------------------------------------------
+
+def test_build_attest_emitter_rejects_non_p256_ec_key(tmp_path):
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from vaara.integrations._mcp_attest import AttestConfigError, build_attest_emitter
+    key = ec.generate_private_key(ec.SECP384R1())
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_path = tmp_path / "p384.pem"
+    key_path.write_bytes(pem)
+    with pytest.raises(AttestConfigError, match="secp256r1"):
+        build_attest_emitter(
+            signing_key_path=key_path,
+            receipts_dir=tmp_path / "r",
+            upstream_commands={"default": ["echo"]},
+        )
+
+
+def test_build_attest_emitter_accepts_p256_ec_key(tmp_path):
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from vaara.integrations._mcp_attest import build_attest_emitter
+    key = ec.generate_private_key(ec.SECP256R1())
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_path = tmp_path / "p256.pem"
+    key_path.write_bytes(pem)
+    emitter = build_attest_emitter(
+        signing_key_path=key_path,
+        receipts_dir=tmp_path / "r",
+        upstream_commands={"default": ["echo"]},
+    )
+    assert emitter.fingerprint_for("default").startswith("cmd:sha256:")
+
+
+def test_named_single_upstream_fingerprints_under_default(attest_key, attest_receipts_dir):
+    # End-to-end of the slot-keying fix: an emitter built the way main() now
+    # builds it for a named single upstream returns a real cmd-hash under
+    # "default", never the unknown-* placeholder.
+    from vaara.integrations._mcp_attest import build_attest_emitter
+    from vaara.integrations.mcp_proxy import _attest_upstreams_for_slots
+    emitter = build_attest_emitter(
+        signing_key_path=attest_key,
+        receipts_dir=attest_receipts_dir,
+        upstream_commands=_attest_upstreams_for_slots({"github": ["github-mcp-server"]}),
+    )
+    fp = emitter.fingerprint_for("default")
+    assert fp.startswith("cmd:sha256:")
+    assert "unknown" not in fp
+
+
+# ---------------------------------------------------------------------------
 # Config error handling
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What this is

v0.43.0 merged to `main` in #168 but was never tagged, so PyPI, the GH Release, and the registry slots never fired. Before finishing the tag I found two correctness bugs in the merged attestation code, plus a stale plugin marketplace ref. This lands the fixes so the published v0.43.0 is correct from the first tag, rather than shipping a broken artifact and chasing it with a v0.43.1.

## Fixes

**Single-upstream fingerprint keying.** A named single upstream (`--upstream NAME=CMD`) collapses into the `"default"` slot inside `VaaraMCPProxy`, and `_REQUEST_UPSTREAM` resolves to `"default"` at runtime. The attestation emitter was keyed on the operator-supplied name, so `fingerprint_for("default")` missed the precomputed command hash and emitted a `cmd:sha256:unknown-default` placeholder for the documented `NAME=CMD` form. `_attest_upstreams_for_slots` now keys the emitter the way the proxy slots upstreams. Multi-upstream fan-out keeps the operator names.

**Reject non-P-256 EC signing keys.** ES256 emits a fixed 32-byte `r||s`, so a non-secp256r1 curve would be mislabeled `ES256` and then silently fail to sign (the emit path swallows signing errors). The key loader now rejects it up front with a clear `AttestConfigError`.

## Chore

**Marketplace ref.** `.claude-plugin/marketplace.json` had been stale at `v0.41.0` across v0.42.0 and v0.43.0, pinning plugin installs two releases back. Bumped to `v0.43.0`.

## Tests

5 new tests: slot-keying (named-single collapses to default, multi preserved), curve validation (P-384 rejected, P-256 accepted), and an end-to-end fingerprint check. Affected suites: 61 passed, ruff clean.
