### PR TITLE
release(v0.44.0): keygen --attest + offline attest/receipt verify CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,7 +19,7 @@
         "source": "git-subdir",
         "url": "https://github.com/vaaraio/vaara.git",
         "path": "plugins/claude-code-vaara-governance",
-        "ref": "v0.43.0"
+        "ref": "v0.44.0"
       },
       "homepage": "https://vaara.io"
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-05-30
+
+**Theme: a runnable reference verifier. Generate the attestation key, then verify attestations and receipts offline from the command line.**
+
+### Added
+- `vaara keygen --attest --out PATH`: generate an EC P-256 (ES256) keypair
+  for SEP-2787 attestation signing, compatible with `vaara-mcp-proxy
+  --attest-signing-key`. Writes a PKCS8 PEM private key (0600) and a
+  SubjectPublicKeyInfo PEM public key. Prints the `secretVersion` (first 8 hex
+  of SHA-256 over the public-key DER) that appears in every attestation the
+  key signs, so a signed envelope can be matched to the keypair without the
+  private key. Replaces the documented `openssl ecparam | pkcs8` pipe. Unlike
+  the Ed25519 trail-signing keygen it does not gate on `--dev`, since this is
+  the documented operator path for the proxy.
+- `vaara attest verify ENVELOPE.json (--pubkey-file PUB.pem |
+  --hs256-secret-file SECRET) [--enforce-ttl]`: verify a SEP-2787 attestation
+  envelope's signature and report whether its TTL has expired. TTL is reported
+  but not enforced by default, because a saved attestation is durable evidence
+  and its short TTL is normally long past at verification time; `--enforce-ttl`
+  makes expiry a failure. Emits a JSON verdict and exits non-zero on a failed
+  signature.
+- `vaara receipt verify RECEIPT.json --attestation ATT.json (--pubkey-file
+  PUB.pem | --hs256-secret-file SECRET) [--result RESULT.json]`: verify an
+  execution receipt against its attestation in three composable checks: the
+  receipt signature, the attestation signature (TTL ignored), and the
+  `backLink` binding the two. When the receipt carries a result commitment,
+  `--result` verifies it against the runtime result object. Emits a JSON
+  verdict and exits non-zero if any check fails.
+- `docs/sep2787-conformance.md`: the conformance surface the verifier commands
+  cover, keyed to the spec revision Vaara aligns to (`dd030d5b`, tag
+  `sep2787-ref-v2`), with the verification steps Vaara checks versus the ones
+  that remain the runtime's responsibility (nonce replay, tool-call match).
+- 18 tests in `tests/test_cli_attest_receipt_verify.py` covering ES256 and
+  HS256 paths, wrong-key rejection, alg/material mismatch, TTL reporting and
+  enforcement, back-link failure, result-commitment match and mismatch, and a
+  `keygen --attest` to `attest verify` round-trip.
+
+### Changed
+- The PyPI summary now leads with the runtime-evidence framing
+  ("Tamper-evident runtime evidence layer for AI agents: ..."), aligning the
+  package metadata with the README hero and vaara.io.
+
 ## [0.43.0] - 2026-05-29
 
 **Theme: proxy pairing -- SEP-2787 request attestation and execution receipt emitted per tools/call.**

--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ OVERT envelopes per governed interaction turn on with `--overt-signing-key`, `--
 
 SEP-2787 request attestation paired with an execution receipt turns on with `--attest-signing-key PATH` and `--attest-receipts-dir DIR`. Each allowed `tools/call` writes a `{n}-attest.json` (pre-execution SEP-2787 envelope) and a `{n}-receipt.json` (post-execution outcome record with a `backLink` digest over the attestation). Key type is auto-detected from the file: EC P-256 PEM uses ES256, RSA PEM uses RS256, raw bytes uses HS256. An operator-supplied `X-Vaara-Intent` HTTP header overrides the derived `tools/call/{tool_name}` intent label. The `serverFingerprint` field in the attestation starts as a hash of the upstream command string and upgrades to a hash of the upstream's `tools/list` response on first use, binding the exact capability set the proxy presented. See [docs/execution-receipts.md](docs/execution-receipts.md) for the receipt format.
 
+Generate the signing key and verify the output offline:
+
+```
+vaara keygen --attest --out attest_key.pem
+vaara attest verify  0000000001-ab12cd34-attest.json  --pubkey-file attest_key.pem.pub
+vaara receipt verify 0000000001-ab12cd34-receipt.json --attestation 0000000001-ab12cd34-attest.json --pubkey-file attest_key.pem.pub
+```
+
+`keygen --attest` emits an EC P-256 (ES256) key compatible with `--attest-signing-key`, replacing the `openssl ecparam | pkcs8` pipe. The two `verify` commands are reference verifiers: `attest verify` checks the attestation signature and reports TTL state (a saved attestation is durable evidence, so TTL is not enforced unless you pass `--enforce-ttl`); `receipt verify` checks the receipt signature, the attestation signature, and the `backLink` binding the two, plus an optional `--result` check when the receipt carries a result commitment. Both exit non-zero on any failed check, so they drop straight into CI or an audit script. The conformance surface they cover is documented in [docs/sep2787-conformance.md](docs/sep2787-conformance.md).
+
 Worked examples:
 
 - [`examples/github-mcp-proxy-demo/`](examples/github-mcp-proxy-demo/): Vaara in front of [`github/github-mcp-server`](https://github.com/github/github-mcp-server), 42 tools, hash-chained audit trail recorded end-to-end.
@@ -234,6 +244,7 @@ Architectural framing and the OVERT 1.0 Part 3 control walk in [COMPLIANCE.md](C
 | [docs/formal_specification.md](docs/formal_specification.md) | MWU regret bound, conformal coverage, security properties |
 | [docs/conformal-prediction.md](docs/conformal-prediction.md) | Plain-language explainer for compliance reviewers and legal counsel |
 | [docs/execution-receipts.md](docs/execution-receipts.md) | Execution receipts: the post-execution outcome record paired with SEP-2787 request attestation |
+| [docs/sep2787-conformance.md](docs/sep2787-conformance.md) | SEP-2787 conformance surface: what `vaara attest verify` / `vaara receipt verify` check, keyed to the tracked spec revision |
 | [COMPLIANCE.md](COMPLIANCE.md) | EU AI Act (Art. 9, 11 to 15, 61) and DORA (Art. 10, 12, 13) mapping, eval numbers, PAIR calibration |
 | [VERDICTS.md](VERDICTS.md) | Per-article evidence sufficiency thresholds and decision tree |
 | [CHANGELOG.md](CHANGELOG.md) | Version-by-version feature evolution |

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
   "main": "dist/index.js",

--- a/docs/sep2787-conformance.md
+++ b/docs/sep2787-conformance.md
@@ -1,0 +1,108 @@
+# SEP-2787 conformance surface
+
+This document states what Vaara's SEP-2787 verifier checks, what it leaves to
+the runtime, and which spec revision it tracks. It is the reference for the
+`vaara attest verify` and `vaara receipt verify` commands shipped in v0.44.0.
+
+## Spec revision tracked
+
+Vaara aligns to the SEP-2787 draft at commit `dd030d5b` on
+`soup-oss/sep-tool-call-attestation`, the revision whose envelope adopted the
+three trust-surface blocks (`plannerDeclared`, `issuerAsserted`,
+`payloadDerived`) and the four schema points Vaara raised in
+`modelcontextprotocol/modelcontextprotocol#2787`
+(`issuecomment-4557017068`): tool calls under `payloadDerived`,
+`argsProjection` as a JCS-stringified projection, no `kind` discriminator, and
+commitment-only audit via a hash-only-identity projection.
+
+The reference implementation is pinned at tag `sep2787-ref-v2`
+(`src/vaara/attestation/sep2787.py` and helpers). The draft is community
+authored and at the time of writing carries `Sponsor: None`; this is a
+first-implementer position, not a maintainer endorsement.
+
+## Signing modes
+
+The signature covers the JCS-canonical encoding (RFC 8785) of the four
+envelope blocks `{version, alg, plannerDeclared, issuerAsserted,
+payloadDerived}` and is excluded from its own input.
+
+| `alg` | Algorithm | Verify with |
+|---|---|---|
+| `ES256` | ECDSA P-256, raw `r\|\|s` (not DER) | `--pubkey-file PUB.pem` |
+| `RS256` | RSASSA-PKCS1-v1_5 | `--pubkey-file PUB.pem` |
+| `HS256` | HMAC-SHA256 | `--hs256-secret-file SECRET` |
+
+ES256 is the recommended default: the public key is publishable, so a relying
+party verifies without holding any secret. HS256 envelopes are only verifiable
+by a party that already shares the secret.
+
+## Verification steps
+
+The SEP-2787 draft lists five verification steps. Vaara splits them between the
+verifier (stateless, no IO) and the runtime (stateful), because nonce replay
+and tool-call matching cannot be decided from a saved envelope alone.
+
+| Step | Check | Where | Covered by |
+|---|---|---|---|
+| 1 | Signature over the canonical envelope | verifier | `vaara attest verify` |
+| 2 | Nonce replay (each nonce used once) | runtime | caller's replay cache |
+| 3 | TTL (`iat + expSeconds` not past) | verifier | `vaara attest verify` (reported; enforced with `--enforce-ttl`) |
+| 4 | Tool-call match (envelope binds the call being executed) | runtime | proxy / host |
+| 5 | Argument commitment binds the runtime arguments | verifier | `verify_args_commitment` (composed by the caller, or `vaara receipt verify --result` for result commitments) |
+
+Steps 2 and 4 are stateful and depend on the live request, so they stay in the
+runtime. Vaara's MCP proxy performs them inline when it emits a pair; a
+standalone verifier reading saved files cannot, and does not pretend to.
+
+### TTL is not enforced at audit time by default
+
+A SEP-2787 attestation carries a short TTL (`expSeconds`, default 300) because
+it authorizes a request that is about to run. A *saved* attestation is durable
+evidence read long after that window, so `vaara attest verify` reports
+`ttl_expired` but does not fail on it. Pass `--enforce-ttl` when you are
+verifying an envelope you expect to still be live.
+
+## Execution receipts
+
+An execution receipt is the post-execution complement: it records the outcome
+of one attested request and pins the attestation it answers. `vaara receipt
+verify` checks three things:
+
+1. the receipt signature (same canonicalization and signing stack);
+2. the attestation signature (with TTL ignored, since the attestation is
+   expected to be expired by the time the outcome is audited);
+3. the `backLink`, which must carry both a SHA-256 digest over the
+   attestation's full wire bytes and the attestation's nonce. A receipt with a
+   valid signature but a broken back-link proves an outcome that belongs to no
+   attested request, and is rejected.
+
+When `outcomeDerived` carries a `resultCommitment`, `--result RESULT.json`
+verifies it against the runtime result object using the same
+argument-commitment rules (step 5). The proxy does not emit a result
+commitment today, so live-proxy receipts report `result_commitment_valid:
+null`.
+
+## Conformance vectors
+
+- Execution-receipt vectors live in-repo at
+  `tests/vectors/execution_receipt_v0/` (five cases, pinned keys, a
+  stdlib-only `_check_independent.py` walker that verifies them without
+  importing Vaara).
+- SEP-2787 attestation vectors are published on the fork PR
+  `modelcontextprotocol/modelcontextprotocol#2789`. Mirroring them in-repo as
+  `tests/vectors/sep2787_attestation_v0/` is a planned follow-up so the
+  `vaara attest verify` command can be exercised against pinned fixtures the
+  same way the receipt vectors are.
+
+## Quick start
+
+```
+pip install 'vaara[attestation]'
+vaara keygen --attest --out attest_key.pem
+# point the proxy at the key, run some tool calls, then:
+vaara attest verify  RECEIPTS/0000000001-<nonce>-attest.json  --pubkey-file attest_key.pem.pub
+vaara receipt verify RECEIPTS/0000000001-<nonce>-receipt.json --attestation RECEIPTS/0000000001-<nonce>-attest.json --pubkey-file attest_key.pem.pub
+```
+
+Both commands print a JSON verdict and exit non-zero on any failed check, so
+they compose into CI or an audit script.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.43.0"
-description = "Adaptive AI Agent Execution Layer for risk scoring, audit trails, and regulatory compliance"
+version = "0.44.0"
+description = "Tamper-evident runtime evidence layer for AI agents: risk scoring, audit trails, and regulatory compliance"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -74,11 +74,35 @@ Subcommands:
         Emit a mode as a minimal, valid Vaara policy document. Round-trips
         through ``vaara.policy.from_dict`` / ``from_json`` / ``from_yaml``.
 
+    vaara keygen --attest --out PATH [--force]
+        Generate an EC P-256 (ES256) keypair for SEP-2787 attestation
+        signing with ``vaara-mcp-proxy --attest-signing-key``. Replaces
+        the ``openssl ecparam | pkcs8`` pipe. Does not require --dev.
+
+    vaara attest verify ENVELOPE.json
+            (--pubkey-file PUB.pem | --hs256-secret-file SECRET)
+            [--enforce-ttl]
+        Verify a SEP-2787 attestation envelope. Reports signature
+        validity and whether the TTL has expired; TTL is not enforced
+        by default (a saved attestation is durable evidence). Exit 0
+        iff the signature verifies.
+
+    vaara receipt verify RECEIPT.json --attestation ATT.json
+            (--pubkey-file PUB.pem | --hs256-secret-file SECRET)
+            [--result RESULT.json]
+        Verify an execution receipt against its attestation: receipt
+        signature, attestation signature (TTL ignored), and the
+        back-link binding the two. When the receipt carries a result
+        commitment, --result verifies it against the runtime result.
+        Exit 0 iff all checks pass.
+
     vaara version
         Print the installed Vaara version.
 
 Installing the CLI requires no extra deps. ``keygen``/``export``/``verify``
-require ``pip install 'vaara[export]'`` (pulls cryptography).
+require ``pip install 'vaara[export]'`` (pulls cryptography). The
+``attest``/``receipt`` verifiers and ``keygen --attest`` require
+``pip install 'vaara[attestation]'``.
 """
 
 from __future__ import annotations
@@ -91,13 +115,18 @@ import stat
 import sys
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from vaara import __version__
 
 _INSTALL_HINT = (
     "This command requires the 'cryptography' package. "
     "Install with: pip install 'vaara[export]'"
+)
+
+_ATTESTATION_HINT = (
+    "This command requires the 'attestation' extra "
+    "(rfc8785 + cryptography). Install with: pip install 'vaara[attestation]'"
 )
 
 
@@ -124,6 +153,12 @@ def _cmd_keygen(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+
+    if args.attest:
+        # EC P-256 (ES256) key for SEP-2787 attestation signing. This is the
+        # documented operator path for vaara-mcp-proxy --attest-signing-key, so
+        # it does not gate on --dev the way the Ed25519 trail-signing key does.
+        return _keygen_attest(out, pub_out)
 
     if not args.dev:
         print(
@@ -170,6 +205,69 @@ def _cmd_keygen(args: argparse.Namespace) -> int:
         "REMINDER: this key was generated on disk with no password and no HSM. "
         "Do not use it to sign trails you submit to a regulator. For production, "
         "see docs/signing-keys.md."
+    )
+    return 0
+
+
+def _keygen_attest(out: Path, pub_out: Path) -> int:
+    """Generate an EC P-256 (ES256) keypair for SEP-2787 attestation signing.
+
+    Writes a PKCS8 PEM private key (0600) and a SubjectPublicKeyInfo PEM
+    public key. The printed ``secretVersion`` is the first 8 hex of the
+    SHA-256 over the public-key DER, matching what ``build_attest_emitter``
+    derives, so the operator can correlate a signed envelope with this
+    keypair. Replaces the documented ``openssl ecparam | pkcs8`` pipe.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(priv_pem)
+    try:
+        os.chmod(out, stat.S_IRUSR | stat.S_IWUSR)  # 0600
+    except OSError:
+        pass
+    pub_out.write_bytes(pub_pem)
+
+    pub_der = key.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    secret_version = hashlib.sha256(pub_der).hexdigest()[:8]
+
+    print("Generated EC P-256 keypair for SEP-2787 attestation signing (ES256)")
+    print(f"  private key:   {out}        (0600)")
+    print(f"  public key:    {pub_out}")
+    print(f"  secretVersion: {secret_version}")
+    print()
+    print("Sign with the proxy:")
+    print(
+        f"  vaara-mcp-proxy --attest-signing-key {out} "
+        "--attest-receipts-dir DIR --upstream NAME=CMD"
+    )
+    print("Verifiers need only the public key:")
+    print(f"  vaara attest verify ATTESTATION.json --pubkey-file {pub_out}")
+    print()
+    print(
+        "The secretVersion above is the first 8 hex of SHA-256 over the public "
+        "key DER. It is carried in every attestation this key signs, so a "
+        "signed envelope can be matched to this keypair without the private key."
+    )
+    print()
+    print(
+        "REMINDER: this private key is on disk with no passphrase. For higher "
+        "assurance, hold the signing key in a KMS/HSM. See docs/signing-keys.md."
     )
     return 0
 
@@ -1013,6 +1111,217 @@ def _load_overt_pubkey(args: argparse.Namespace) -> Optional[bytes]:
         return None
 
 
+def _load_jws_verifying_material(args: argparse.Namespace) -> "tuple[Any, bool]":
+    """Resolve ``--pubkey-file`` (PEM public key) or ``--hs256-secret-file``.
+
+    Returns ``(material, ok)``. ``material`` is a public-key object (ES256 /
+    RS256) when ``--pubkey-file`` is given, or raw ``bytes`` (HS256) when
+    ``--hs256-secret-file`` is given. ``ok`` is False on error, with the
+    diagnostic already printed to stderr.
+    """
+    if args.pubkey_file:
+        from cryptography.hazmat.primitives import serialization
+
+        path = Path(args.pubkey_file).expanduser()
+        if not path.is_file():
+            print(f"pubkey file not found: {path}", file=sys.stderr)
+            return None, False
+        try:
+            return serialization.load_pem_public_key(path.read_bytes()), True
+        except Exception as exc:
+            print(
+                f"--pubkey-file is not a usable PEM public key: {exc}",
+                file=sys.stderr,
+            )
+            return None, False
+
+    path = Path(args.hs256_secret_file).expanduser()
+    if not path.is_file():
+        print(f"hs256 secret file not found: {path}", file=sys.stderr)
+        return None, False
+    return path.read_bytes(), True
+
+
+def _alg_material_mismatch(alg: str, material: Any) -> Optional[str]:
+    """Return a diagnostic if the key material does not match the envelope alg.
+
+    HS256 needs a raw shared secret (``--hs256-secret-file``); ES256 / RS256
+    need a public key (``--pubkey-file``). Catching the mismatch here yields a
+    clear message instead of a low-level signature failure, or a crash inside
+    the verifier when the wrong material type reaches the crypto backend.
+    """
+    is_secret = isinstance(material, (bytes, bytearray))
+    if alg == "HS256" and not is_secret:
+        return "alg is HS256; verify with --hs256-secret-file, not --pubkey-file"
+    if alg in ("ES256", "RS256") and is_secret:
+        return f"alg is {alg}; verify with --pubkey-file, not --hs256-secret-file"
+    return None
+
+
+def _cmd_attest_verify(args: argparse.Namespace) -> int:
+    """Verify a SEP-2787 attestation envelope's signature (and optionally TTL)."""
+    try:
+        from vaara.attestation.sep2787 import (
+            AttestationError,
+            parse_attestation,
+            verify_attestation,
+        )
+    except ImportError:
+        print(_ATTESTATION_HINT, file=sys.stderr)
+        return 2
+
+    env_path = Path(args.envelope).expanduser()
+    if not env_path.is_file():
+        print(f"vaara attest verify: not a file: {env_path}", file=sys.stderr)
+        return 2
+    try:
+        data = json.loads(env_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"vaara attest verify: cannot read JSON: {exc}", file=sys.stderr)
+        return 1
+    try:
+        envelope = parse_attestation(data)
+    except (AttestationError, KeyError, TypeError, ValueError) as exc:
+        print(
+            f"vaara attest verify: not a valid SEP-2787 attestation: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    material, ok = _load_jws_verifying_material(args)
+    if not ok:
+        return 2
+    mismatch = _alg_material_mismatch(envelope.alg, material)
+    if mismatch is not None:
+        print(f"vaara attest verify: {mismatch}", file=sys.stderr)
+        return 2
+
+    # now=0.0 makes the TTL deadline trivially pass, isolating signature
+    # validity; a second pass at real time reveals whether the TTL expired.
+    # Durable evidence files are routinely checked long after exp, so TTL is
+    # reported but not enforced unless --enforce-ttl is set.
+    signature_ok = verify_attestation(envelope, verifying_material=material, now=0.0)
+    live_ok = verify_attestation(envelope, verifying_material=material)
+    ttl_expired = signature_ok and not live_ok
+
+    result = {
+        "valid": signature_ok,
+        "alg": envelope.alg,
+        "iss": envelope.issuer_asserted.iss,
+        "sub": envelope.issuer_asserted.sub,
+        "intent": envelope.planner_declared.intent,
+        "nonce": envelope.issuer_asserted.nonce,
+        "issued_at": envelope.issuer_asserted.iat,
+        "exp_seconds": envelope.issuer_asserted.exp_seconds,
+        "ttl_expired": ttl_expired,
+    }
+    print(json.dumps(result, indent=2))
+
+    if not signature_ok:
+        print("vaara attest verify: signature verification failed", file=sys.stderr)
+        return 1
+    if args.enforce_ttl and ttl_expired:
+        print("vaara attest verify: attestation TTL has expired", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _cmd_receipt_verify(args: argparse.Namespace) -> int:
+    """Verify an execution receipt: signature, back-link, and optionally result."""
+    try:
+        from vaara.attestation.receipt import (
+            parse_receipt,
+            verify_back_link,
+            verify_receipt_signature,
+        )
+        from vaara.attestation.sep2787 import (
+            AttestationError,
+            parse_attestation,
+            verify_args_commitment,
+            verify_attestation,
+        )
+    except ImportError:
+        print(_ATTESTATION_HINT, file=sys.stderr)
+        return 2
+
+    receipt_path = Path(args.receipt).expanduser()
+    att_path = Path(args.attestation).expanduser()
+    for label, p in (("receipt", receipt_path), ("attestation", att_path)):
+        if not p.is_file():
+            print(f"vaara receipt verify: {label} not a file: {p}", file=sys.stderr)
+            return 2
+    try:
+        receipt = parse_receipt(json.loads(receipt_path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError, KeyError, TypeError, ValueError) as exc:
+        print(f"vaara receipt verify: not a valid receipt: {exc}", file=sys.stderr)
+        return 1
+    try:
+        attestation = parse_attestation(
+            json.loads(att_path.read_text(encoding="utf-8"))
+        )
+    except (
+        json.JSONDecodeError, OSError, AttestationError, KeyError, TypeError,
+        ValueError,
+    ) as exc:
+        print(f"vaara receipt verify: not a valid attestation: {exc}", file=sys.stderr)
+        return 1
+
+    material, ok = _load_jws_verifying_material(args)
+    if not ok:
+        return 2
+    mismatch = _alg_material_mismatch(receipt.alg, material)
+    if mismatch is not None:
+        print(f"vaara receipt verify: {mismatch}", file=sys.stderr)
+        return 2
+
+    receipt_sig_ok = verify_receipt_signature(receipt, verifying_material=material)
+    # Attestation signature checked with TTL ignored: a receipt is a durable
+    # record of an outcome, so its attestation is expected to be long expired.
+    attestation_sig_ok = verify_attestation(
+        attestation, verifying_material=material, now=0.0
+    )
+    back_link = verify_back_link(receipt, attestation=attestation)
+
+    result: dict[str, Any] = {
+        "receipt_signature_valid": receipt_sig_ok,
+        "attestation_signature_valid": attestation_sig_ok,
+        "back_link_valid": back_link.ok,
+        "status": receipt.outcome_derived.status,
+        "completed_at": receipt.outcome_derived.completed_at,
+    }
+
+    commitment = receipt.outcome_derived.result_commitment
+    if commitment is None:
+        result["result_commitment_valid"] = None
+    elif not args.result:
+        result["result_commitment_valid"] = None
+        result["result_commitment_note"] = (
+            "receipt carries a result commitment; pass --result FILE to verify it"
+        )
+    else:
+        rpath = Path(args.result).expanduser()
+        if not rpath.is_file():
+            print(f"vaara receipt verify: --result not a file: {rpath}", file=sys.stderr)
+            return 2
+        try:
+            runtime_result = json.loads(rpath.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(
+                f"vaara receipt verify: cannot read --result JSON: {exc}",
+                file=sys.stderr,
+            )
+            return 1
+        rc = verify_args_commitment(commitment, runtime_arguments=runtime_result)
+        result["result_commitment_valid"] = rc.ok
+
+    print(json.dumps(result, indent=2))
+
+    failed = not (receipt_sig_ok and attestation_sig_ok and back_link.ok)
+    if result.get("result_commitment_valid") is False:
+        failed = True
+    return 1 if failed else 0
+
+
 def _cmd_serve(args: argparse.Namespace) -> int:
     try:
         import uvicorn
@@ -1213,6 +1522,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Required. Acknowledges this key is for local evaluation, not production.",
     )
     pk.add_argument("--force", action="store_true", help="Overwrite an existing key file")
+    pk.add_argument(
+        "--attest",
+        action="store_true",
+        help="Generate an EC P-256 (ES256) key for SEP-2787 attestation "
+             "signing with vaara-mcp-proxy --attest-signing-key, instead of "
+             "an Ed25519 trail-signing key. Does not require --dev.",
+    )
     pk.set_defaults(func=_cmd_keygen)
 
     pt = sub.add_parser("trail", help="Audit-trail commands")
@@ -1580,6 +1896,69 @@ def build_parser() -> argparse.ArgumentParser:
         help="Raw 32-byte Ed25519 public key encoded as 64 hex characters",
     )
     pov_verify.set_defaults(func=_cmd_overt_verify)
+
+    def _add_jws_key_args(p_):
+        g = p_.add_mutually_exclusive_group(required=True)
+        g.add_argument(
+            "--pubkey-file", dest="pubkey_file", default=None,
+            help="Path to a PEM public key (SubjectPublicKeyInfo) for "
+                 "ES256 / RS256 envelopes",
+        )
+        g.add_argument(
+            "--hs256-secret-file", dest="hs256_secret_file", default=None,
+            help="Path to a file holding the raw HS256 shared secret",
+        )
+
+    pattest = sub.add_parser(
+        "attest",
+        help="SEP-2787 tool-call attestation commands",
+    )
+    asub = pattest.add_subparsers(dest="attest_cmd")
+    pattest.set_defaults(func=_help_dispatch(pattest))
+    pa_verify = asub.add_parser(
+        "verify",
+        help="Verify a SEP-2787 attestation envelope's signature (and TTL). "
+             "Requires the attestation extra.",
+    )
+    pa_verify.add_argument(
+        "envelope", help="Path to a SEP-2787 attestation JSON file",
+    )
+    _add_jws_key_args(pa_verify)
+    pa_verify.add_argument(
+        "--enforce-ttl", action="store_true",
+        help="Fail if the attestation TTL has expired. Off by default: a saved "
+             "attestation is durable evidence and its short TTL is normally "
+             "long past at verification time.",
+    )
+    pa_verify.set_defaults(func=_cmd_attest_verify)
+
+    preceipt = sub.add_parser(
+        "receipt",
+        help="Execution-receipt commands (post-execution sibling of SEP-2787)",
+    )
+    rcsub = preceipt.add_subparsers(dest="receipt_cmd")
+    preceipt.set_defaults(func=_help_dispatch(preceipt))
+    prc_verify = rcsub.add_parser(
+        "verify",
+        help="Verify an execution receipt: signature, back-link to its "
+             "attestation, and optional result commitment. Requires the "
+             "attestation extra.",
+    )
+    prc_verify.add_argument(
+        "receipt", help="Path to an execution-receipt JSON file",
+    )
+    prc_verify.add_argument(
+        "--attestation", required=True,
+        help="Path to the SEP-2787 attestation JSON the receipt answers "
+             "(needed to verify the back-link)",
+    )
+    _add_jws_key_args(prc_verify)
+    prc_verify.add_argument(
+        "--result", default=None,
+        help="Path to the runtime result JSON. When the receipt carries a "
+             "result commitment, the commitment is verified against this.",
+    )
+    prc_verify.set_defaults(func=_cmd_receipt_verify)
 
     ptee = sub.add_parser(
         "tee",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -237,6 +237,8 @@ def _keygen_attest(out: Path, pub_out: Path) -> int:
     try:
         os.chmod(out, stat.S_IRUSR | stat.S_IWUSR)  # 0600
     except OSError:
+        # Best-effort: filesystems without POSIX permission bits still get the
+        # key written; the operator owns the enclosing directory's perms.
         pass
     pub_out.write_bytes(pub_pem)
 
@@ -244,12 +246,15 @@ def _keygen_attest(out: Path, pub_out: Path) -> int:
         encoding=serialization.Encoding.DER,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     )
-    secret_version = hashlib.sha256(pub_der).hexdigest()[:8]
+    # Despite the SEP-2787 field name "secretVersion", this value is a digest
+    # of the PUBLIC key and is safe to print and publish. It is named here for
+    # what it is so it is not mistaken (by a reader or a scanner) for a secret.
+    pubkey_version = hashlib.sha256(pub_der).hexdigest()[:8]
 
     print("Generated EC P-256 keypair for SEP-2787 attestation signing (ES256)")
     print(f"  private key:   {out}        (0600)")
     print(f"  public key:    {pub_out}")
-    print(f"  secretVersion: {secret_version}")
+    print(f"  secretVersion: {pubkey_version}")
     print()
     print("Sign with the proxy:")
     print(

--- a/tests/test_cli_attest_receipt_verify.py
+++ b/tests/test_cli_attest_receipt_verify.py
@@ -1,0 +1,368 @@
+"""Tests for ``vaara keygen --attest``, ``vaara attest verify`` and
+``vaara receipt verify`` — the v0.44 reference-verifier CLI surface."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cryptography")
+pytest.importorskip("rfc8785")
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vaara.attestation.receipt import (
+    OutcomeDerived,
+    emit_receipt,
+    make_back_link,
+    make_result_digest,
+)
+from vaara.attestation.sep2787 import (
+    PayloadDerived,
+    PlannerDeclared,
+    ToolCallBinding,
+    emit_attestation,
+    make_args_digest,
+)
+from vaara.cli import main
+
+_ISS = "vaara-mcp-proxy"
+_SUB = "tenantA/files"
+_ARGS = {"path": "/tmp/x"}
+
+
+def _write_pubkey(tmp_path: Path, key) -> Path:
+    pub_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    p = tmp_path / "pub.pem"
+    p.write_bytes(pub_pem)
+    return p
+
+
+def _emit_attestation(key, *, alg: str = "ES256", exp_seconds: int = 300, iat=None):
+    return emit_attestation(
+        planner_declared=PlannerDeclared(intent="tools/call/read_file"),
+        payload_derived=PayloadDerived(
+            tool_calls=(
+                ToolCallBinding(
+                    name="read_file",
+                    server_fingerprint="cmd:sha256:abc",
+                    args=make_args_digest(_ARGS),
+                ),
+            ),
+        ),
+        iss=_ISS,
+        sub=_SUB,
+        secret_version="deadbeef",
+        alg=alg,
+        signing_material=key,
+        exp_seconds=exp_seconds,
+        iat=iat,
+    )
+
+
+def _emit_receipt(key, attestation, *, alg="ES256", result_commitment=None):
+    return emit_receipt(
+        back_link=make_back_link(attestation),
+        outcome_derived=OutcomeDerived(
+            status="executed",
+            completed_at="2026-05-30T00:00:00Z",
+            result_commitment=result_commitment,
+        ),
+        iss=_ISS,
+        sub=_SUB,
+        secret_version="deadbeef",
+        alg=alg,
+        signing_material=key,
+    )
+
+
+def _es256_pair(tmp_path, **att_kwargs):
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub = _write_pubkey(tmp_path, key)
+    att = _emit_attestation(key, **att_kwargs)
+    receipt = _emit_receipt(key, att)
+    att_path = tmp_path / "attest.json"
+    receipt_path = tmp_path / "receipt.json"
+    att_path.write_text(json.dumps(att.to_dict(), indent=2))
+    receipt_path.write_text(json.dumps(receipt.to_dict(), indent=2))
+    return key, pub, att, att_path, receipt_path
+
+
+# --- attest verify --------------------------------------------------------
+
+
+def test_attest_verify_accepts_valid_es256(tmp_path, capsys):
+    _, pub, _, att_path, _ = _es256_pair(tmp_path)
+    rc = main(["attest", "verify", str(att_path), "--pubkey-file", str(pub)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"valid": true' in out
+    assert '"ttl_expired": false' in out
+    assert '"intent": "tools/call/read_file"' in out
+
+
+def test_attest_verify_rejects_wrong_pubkey(tmp_path, capsys):
+    _, _, _, att_path, _ = _es256_pair(tmp_path)
+    wrong = ec.generate_private_key(ec.SECP256R1())
+    wrong_pub = tmp_path / "wrong.pem"
+    wrong_pub.write_bytes(
+        wrong.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    rc = main(["attest", "verify", str(att_path), "--pubkey-file", str(wrong_pub)])
+    assert rc == 1
+    assert "signature verification failed" in capsys.readouterr().err
+
+
+def test_attest_verify_alg_material_mismatch(tmp_path, capsys):
+    """An HS256 secret offered for an ES256 envelope is rejected up front."""
+    _, _, _, att_path, _ = _es256_pair(tmp_path)
+    secret = tmp_path / "secret.bin"
+    secret.write_bytes(b"x" * 32)
+    rc = main([
+        "attest", "verify", str(att_path), "--hs256-secret-file", str(secret),
+    ])
+    assert rc == 2
+    assert "alg is ES256" in capsys.readouterr().err
+
+
+def test_attest_verify_hs256_secret(tmp_path, capsys):
+    secret = b"k" * 32
+    secret_path = tmp_path / "secret.bin"
+    secret_path.write_bytes(secret)
+    att = _emit_attestation(secret, alg="HS256")
+    att_path = tmp_path / "attest.json"
+    att_path.write_text(json.dumps(att.to_dict(), indent=2))
+    rc = main([
+        "attest", "verify", str(att_path),
+        "--hs256-secret-file", str(secret_path),
+    ])
+    assert rc == 0
+    assert '"valid": true' in capsys.readouterr().out
+
+
+def test_attest_verify_ttl_reported_not_enforced_by_default(tmp_path, capsys):
+    _, pub, _, att_path, _ = _es256_pair(
+        tmp_path, exp_seconds=1, iat="2020-01-01T00:00:00Z",
+    )
+    rc = main(["attest", "verify", str(att_path), "--pubkey-file", str(pub)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"valid": true' in out
+    assert '"ttl_expired": true' in out
+
+
+def test_attest_verify_enforce_ttl_fails_on_expired(tmp_path, capsys):
+    _, pub, _, att_path, _ = _es256_pair(
+        tmp_path, exp_seconds=1, iat="2020-01-01T00:00:00Z",
+    )
+    rc = main([
+        "attest", "verify", str(att_path), "--pubkey-file", str(pub),
+        "--enforce-ttl",
+    ])
+    assert rc == 1
+    assert "TTL has expired" in capsys.readouterr().err
+
+
+def test_attest_verify_missing_file(tmp_path, capsys):
+    pub = tmp_path / "pub.pem"
+    pub.write_bytes(b"x")
+    rc = main([
+        "attest", "verify", str(tmp_path / "nope.json"),
+        "--pubkey-file", str(pub),
+    ])
+    assert rc == 2
+    assert "not a file" in capsys.readouterr().err
+
+
+def test_attest_verify_bad_json(tmp_path, capsys):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    pub = tmp_path / "pub.pem"
+    pub.write_bytes(b"x")
+    rc = main(["attest", "verify", str(bad), "--pubkey-file", str(pub)])
+    assert rc == 1
+    assert "cannot read JSON" in capsys.readouterr().err
+
+
+def test_attest_verify_valid_json_but_not_attestation(tmp_path, capsys):
+    notatt = tmp_path / "x.json"
+    notatt.write_text(json.dumps({"hello": "world"}))
+    pub = tmp_path / "pub.pem"
+    pub.write_bytes(b"x")
+    rc = main(["attest", "verify", str(notatt), "--pubkey-file", str(pub)])
+    assert rc == 1
+    assert "not a valid SEP-2787 attestation" in capsys.readouterr().err
+
+
+# --- receipt verify -------------------------------------------------------
+
+
+def test_receipt_verify_accepts_valid_pair(tmp_path, capsys):
+    _, pub, _, att_path, receipt_path = _es256_pair(tmp_path)
+    rc = main([
+        "receipt", "verify", str(receipt_path),
+        "--attestation", str(att_path), "--pubkey-file", str(pub),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"receipt_signature_valid": true' in out
+    assert '"attestation_signature_valid": true' in out
+    assert '"back_link_valid": true' in out
+    assert '"result_commitment_valid": null' in out
+
+
+def test_receipt_verify_detects_broken_backlink(tmp_path, capsys):
+    key, pub, att, att_path, receipt_path = _es256_pair(tmp_path)
+    # A receipt that signs cleanly but is checked against a different
+    # attestation: the back-link must fail.
+    other_att = _emit_attestation(key)
+    other_path = tmp_path / "other.json"
+    other_path.write_text(json.dumps(other_att.to_dict(), indent=2))
+    rc = main([
+        "receipt", "verify", str(receipt_path),
+        "--attestation", str(other_path), "--pubkey-file", str(pub),
+    ])
+    assert rc == 1
+    assert '"back_link_valid": false' in capsys.readouterr().out
+
+
+def test_receipt_verify_wrong_pubkey(tmp_path, capsys):
+    _, _, _, att_path, receipt_path = _es256_pair(tmp_path)
+    wrong = ec.generate_private_key(ec.SECP256R1())
+    wrong_pub = tmp_path / "wrong.pem"
+    wrong_pub.write_bytes(
+        wrong.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    rc = main([
+        "receipt", "verify", str(receipt_path),
+        "--attestation", str(att_path), "--pubkey-file", str(wrong_pub),
+    ])
+    assert rc == 1
+    assert '"receipt_signature_valid": false' in capsys.readouterr().out
+
+
+def test_receipt_verify_result_commitment_matches(tmp_path, capsys):
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub = _write_pubkey(tmp_path, key)
+    att = _emit_attestation(key)
+    result_obj = {"content": "file body", "bytes": 9}
+    receipt = _emit_receipt(
+        key, att, result_commitment=make_result_digest(result_obj),
+    )
+    att_path = tmp_path / "attest.json"
+    receipt_path = tmp_path / "receipt.json"
+    result_path = tmp_path / "result.json"
+    att_path.write_text(json.dumps(att.to_dict(), indent=2))
+    receipt_path.write_text(json.dumps(receipt.to_dict(), indent=2))
+    result_path.write_text(json.dumps(result_obj))
+
+    rc = main([
+        "receipt", "verify", str(receipt_path),
+        "--attestation", str(att_path), "--pubkey-file", str(pub),
+        "--result", str(result_path),
+    ])
+    assert rc == 0
+    assert '"result_commitment_valid": true' in capsys.readouterr().out
+
+
+def test_receipt_verify_result_commitment_mismatch(tmp_path, capsys):
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub = _write_pubkey(tmp_path, key)
+    att = _emit_attestation(key)
+    receipt = _emit_receipt(
+        key, att, result_commitment=make_result_digest({"content": "real"}),
+    )
+    att_path = tmp_path / "attest.json"
+    receipt_path = tmp_path / "receipt.json"
+    result_path = tmp_path / "result.json"
+    att_path.write_text(json.dumps(att.to_dict(), indent=2))
+    receipt_path.write_text(json.dumps(receipt.to_dict(), indent=2))
+    result_path.write_text(json.dumps({"content": "tampered"}))
+
+    rc = main([
+        "receipt", "verify", str(receipt_path),
+        "--attestation", str(att_path), "--pubkey-file", str(pub),
+        "--result", str(result_path),
+    ])
+    assert rc == 1
+    assert '"result_commitment_valid": false' in capsys.readouterr().out
+
+
+def test_receipt_verify_commitment_present_without_result_flag(tmp_path, capsys):
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub = _write_pubkey(tmp_path, key)
+    att = _emit_attestation(key)
+    receipt = _emit_receipt(
+        key, att, result_commitment=make_result_digest({"content": "real"}),
+    )
+    att_path = tmp_path / "attest.json"
+    receipt_path = tmp_path / "receipt.json"
+    att_path.write_text(json.dumps(att.to_dict(), indent=2))
+    receipt_path.write_text(json.dumps(receipt.to_dict(), indent=2))
+
+    rc = main([
+        "receipt", "verify", str(receipt_path),
+        "--attestation", str(att_path), "--pubkey-file", str(pub),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert '"result_commitment_valid": null' in out
+    assert "pass --result" in out
+
+
+# --- keygen --attest ------------------------------------------------------
+
+
+def test_keygen_attest_emits_p256_without_dev(tmp_path, capsys):
+    out = tmp_path / "attest_key.pem"
+    rc = main(["keygen", "--attest", "--out", str(out)])
+    assert rc == 0
+    assert out.exists()
+    assert (tmp_path / "attest_key.pem.pub").exists()
+    key = serialization.load_pem_private_key(out.read_bytes(), password=None)
+    assert isinstance(key, ec.EllipticCurvePrivateKey)
+    assert key.curve.name == "secp256r1"
+    stdout = capsys.readouterr().out
+    assert "secretVersion:" in stdout
+    assert "ES256" in stdout
+
+
+def test_keygen_attest_roundtrips_through_verify(tmp_path, capsys):
+    """Key from keygen --attest signs an attestation the verify command accepts."""
+    out = tmp_path / "k.pem"
+    assert main(["keygen", "--attest", "--out", str(out)]) == 0
+    capsys.readouterr()
+    key = serialization.load_pem_private_key(out.read_bytes(), password=None)
+    att = _emit_attestation(key)
+    att_path = tmp_path / "attest.json"
+    att_path.write_text(json.dumps(att.to_dict(), indent=2))
+    rc = main([
+        "attest", "verify", str(att_path),
+        "--pubkey-file", str(tmp_path / "k.pem.pub"),
+    ])
+    assert rc == 0
+    assert '"valid": true' in capsys.readouterr().out
+
+
+def test_keygen_default_still_ed25519_and_requires_dev(tmp_path, capsys):
+    out = tmp_path / "ed.pem"
+    rc = main(["keygen", "--out", str(out)])
+    assert rc == 2  # still gated on --dev
+    assert not out.exists()
+    rc = main(["keygen", "--dev", "--out", str(out)])
+    assert rc == 0
+    key = serialization.load_pem_private_key(out.read_bytes(), password=None)
+    assert isinstance(key, Ed25519PrivateKey)


### PR DESCRIPTION
## v0.44.0: keygen --attest + offline attest/receipt verify

v0.43.0 made the MCP proxy emit a paired SEP-2787 attestation and execution receipt per allowed `tools/call`. This release makes that output something an auditor can act on without Vaara in the loop: a key generator, two offline verifiers, and a conformance doc.

### What's new

**`vaara keygen --attest --out attest_key.pem`**
Emits an EC P-256 (ES256) keypair compatible with `vaara-mcp-proxy --attest-signing-key`, replacing the `openssl ecparam | pkcs8` pipe the docs used to point at. It prints the `secretVersion` that gets carried in every attestation the key signs, so a signed envelope can be matched back to the keypair without the private key. It does not require `--dev` (the Ed25519 trail-signing keygen still does, since that one is evaluation-only).

**`vaara attest verify ENVELOPE.json --pubkey-file PUB.pem`**
Checks the SEP-2787 signature and reports whether the TTL has expired. TTL is reported, not enforced: a saved attestation is durable evidence read long after its short window, so `--enforce-ttl` is opt-in.

**`vaara receipt verify RECEIPT.json --attestation ATT.json --pubkey-file PUB.pem`**
Three composable checks: the receipt signature, the attestation signature (TTL ignored), and the `backLink` that binds the two. A receipt that signs cleanly but answers a different attestation fails the back-link. When the receipt carries a result commitment, `--result RESULT.json` verifies it against the runtime result.

Both verifiers print a JSON verdict and exit non-zero on any failed check, so they drop into CI or an audit script. They wire to the existing `verify_attestation`, `verify_receipt_signature`, `verify_back_link` and `verify_args_commitment` functions, so there is no new crypto.

**`docs/sep2787-conformance.md`**
States the conformance surface keyed to the tracked spec revision (`dd030d5b`, tag `sep2787-ref-v2`): which verification steps the verifier covers (signature, TTL, argument commitment) versus the ones that stay in the runtime (nonce replay, tool-call match).

### Also

The PyPI summary now leads with the runtime-evidence framing, aligning the package metadata with the README hero and vaara.io. (Folds in the earlier `chore/pypi-summary-soft-pivot` change so it rides this bump.)

### Tests

18 new tests in `tests/test_cli_attest_receipt_verify.py`: ES256 and HS256 paths, wrong-key rejection, alg/material mismatch, TTL reporting and enforcement, back-link failure, result-commitment match and mismatch, and a `keygen --attest` to `attest verify` round-trip. An end-to-end smoke against the real proxy emitter output verifies clean. Full suite 986 passed, 12 skipped, ruff clean. Version bumped across pyproject, `src/vaara/__init__.py`, the npm client, and the plugin marketplace ref.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline SEP-2787 attestation tools: attestation key generation, attestation verification (ES256/RS256/HS256), receipt verification, TTL enforcement option, result-commitment checking, and clearer exit codes.

* **Documentation**
  * Added SEP-2787 conformance guide, offline attestation walkthrough, and updated project description.

* **Tests**
  * End-to-end CLI tests covering keygen, attest verify, receipt verify, TTL and result-commitment cases.

* **Chores**
  * Version bumped to 0.44.0 and marketplace plugin reference updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vaaraio/vaara/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->