### PR TITLE
chore(registry): bump MCP server manifests to 0.44.0

### DIFF
--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.43.0",
+  "version": "0.44.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.43.0",
+  "version": "0.44.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Both MCP-registry manifests were left at 0.43.0 by the v0.44.0 release PR. Bumps top-level + packages[].version to 0.44.0 so the registry slots match PyPI/GH.