### PR TITLE
fix(proxy): egress opt-in hardening + notification offload + audit backend close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   `--allow-private-upstream-hosts` flag now leaves the
   `VAARA_MCP_ALLOW_PRIVATE_UPSTREAM` env opt-in live instead of silently
   shadowing it with a `False`.
+- Egress opt-in narrowed to the private classes only. The opt-in previously
+  bypassed the whole floor, so trusting internal hosts also re-opened
+  `0.0.0.0`, multicast, and reserved ranges. The never-routable classes
+  (cloud-metadata, unspecified, reserved, multicast) are now refused regardless
+  of the opt-in; only loopback, link-local, and private (RFC1918 and IPv6 ULA)
+  are relaxed by it.
 
 ### Fixed
 - HTTP transport no longer serialises concurrent requests. The POST `/mcp`
@@ -43,7 +49,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   slow upstream stalled every other POST, SSE drain, and `/health` (real
   concurrency 1). It now runs on a worker thread via `asyncio.to_thread`, with
   the per-request ContextVars preserved across the hop through
-  `contextvars.copy_context()`.
+  `contextvars.copy_context()`. The JSON-RPC notification branch is offloaded
+  the same way, so a slow upstream `notify()` no longer parks the event loop
+  either.
+- `vaara trail receipt`, `compliance dashboard`, and `compliance report` leaked
+  the SQLite audit connection: each opened `SQLiteAuditBackend` and never closed
+  it, locking the DB file under in-process invocation. All three are now
+  context-managed.
 - SSE reconnect race that dropped notifications for the live session. On
   reconnect under the same `Mcp-Session-Id`, the old stream's teardown
   unregistered the NEW session. `unregister_session` is now identity-checked and

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.45.0",
+  "version": "0.45.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.45.0",
+      "version": "0.45.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -679,12 +679,12 @@ def _cmd_trail_receipt(args: argparse.Namespace) -> int:
         print(f"audit DB not found: {db_path}", file=sys.stderr)
         return 2
 
-    backend = SQLiteAuditBackend(str(db_path))
-    try:
-        trail = backend.load_trail()
-    except Exception as exc:
-        print(f"failed to load audit trail: {exc}", file=sys.stderr)
-        return 2
+    with SQLiteAuditBackend(str(db_path)) as backend:
+        try:
+            trail = backend.load_trail()
+        except Exception as exc:
+            print(f"failed to load audit trail: {exc}", file=sys.stderr)
+            return 2
 
     receipt = extract_receipt(trail, args.action_id)
     if receipt is None:
@@ -719,12 +719,12 @@ def _cmd_compliance_dashboard(args: argparse.Namespace) -> int:
         print(f"vaara compliance dashboard: not a file: {db_path}", file=sys.stderr)
         return 2
 
-    backend = SQLiteAuditBackend(str(db_path))
-    try:
-        trail = backend.load_trail()
-    except Exception as exc:
-        print(f"failed to load audit trail: {exc}", file=sys.stderr)
-        return 2
+    with SQLiteAuditBackend(str(db_path)) as backend:
+        try:
+            trail = backend.load_trail()
+        except Exception as exc:
+            print(f"failed to load audit trail: {exc}", file=sys.stderr)
+            return 2
 
     engine = create_default_engine()
     report = engine.assess(
@@ -757,12 +757,12 @@ def _cmd_compliance_report(args: argparse.Namespace) -> int:
         print(f"audit DB not found: {db_path}", file=sys.stderr)
         return 2
 
-    backend = SQLiteAuditBackend(str(db_path))
-    try:
-        trail = backend.load_trail()
-    except Exception as exc:
-        print(f"failed to load audit trail: {exc}", file=sys.stderr)
-        return 2
+    with SQLiteAuditBackend(str(db_path)) as backend:
+        try:
+            trail = backend.load_trail()
+        except Exception as exc:
+            print(f"failed to load audit trail: {exc}", file=sys.stderr)
+            return 2
 
     engine = create_default_engine()
     report = engine.assess(

--- a/src/vaara/integrations/_egress_guard.py
+++ b/src/vaara/integrations/_egress_guard.py
@@ -65,25 +65,24 @@ def _is_metadata(ip: ipaddress._BaseAddress) -> bool:
     return ip == _METADATA_V4 or ip == _METADATA_V6
 
 
-def _ip_is_blocked(ip: ipaddress._BaseAddress) -> bool:
-    """True iff this resolved address must never be reached by default.
+def _ip_is_blocked(ip: ipaddress._BaseAddress, *, allow_private: bool = False) -> bool:
+    """True iff this resolved address must not be reached.
 
-    Covers the metadata addresses plus loopback, link-local (IPv4 169.254/16
-    and IPv6 fe80::/10), private (RFC1918 and ULA fc00::/7), unspecified,
-    reserved, and multicast.
+    The metadata addresses, the unspecified address (0.0.0.0 / ::), reserved
+    ranges, and multicast are never reachable. Loopback, link-local (IPv4
+    169.254/16 and IPv6 fe80::/10), and private (RFC1918 and ULA fc00::/7) are
+    reachable only when ``allow_private`` is set. That flag trusts internal
+    hosts, not the never-routable classes, so opting in does not re-open
+    0.0.0.0, multicast, or reserved space.
     """
     mapped = getattr(ip, "ipv4_mapped", None)
     if mapped is not None:  # ::ffff:a.b.c.d judged on the embedded v4 address
         ip = mapped
-    return (
-        _is_metadata(ip)
-        or ip.is_loopback
-        or ip.is_link_local
-        or ip.is_private
-        or ip.is_unspecified
-        or ip.is_reserved
-        or ip.is_multicast
-    )
+    if _is_metadata(ip) or ip.is_unspecified or ip.is_reserved or ip.is_multicast:
+        return True
+    if not allow_private and (ip.is_loopback or ip.is_link_local or ip.is_private):
+        return True
+    return False
 
 
 def _coerce_dotless_host(host: str) -> Optional[ipaddress._BaseAddress]:
@@ -126,7 +125,7 @@ def assert_url_egress_allowed(url: str, *, allow_private: bool = False) -> None:
             raise EgressBlocked(
                 f"upstream URL targets the cloud-metadata address: {url!r}",
             )
-        if not allow_private and _ip_is_blocked(dotless):
+        if _ip_is_blocked(dotless, allow_private=allow_private):
             raise EgressBlocked(f"upstream URL resolves to a blocked address: {url!r}")
         return
 
@@ -139,7 +138,7 @@ def assert_url_egress_allowed(url: str, *, allow_private: bool = False) -> None:
             raise EgressBlocked(
                 f"upstream URL targets the cloud-metadata address: {url!r}",
             )
-        if not allow_private and _ip_is_blocked(literal):
+        if _ip_is_blocked(literal, allow_private=allow_private):
             raise EgressBlocked(f"upstream URL resolves to a blocked address: {url!r}")
         return
 
@@ -153,7 +152,7 @@ def assert_url_egress_allowed(url: str, *, allow_private: bool = False) -> None:
             raise EgressBlocked(
                 f"upstream host {host!r} resolves to the cloud-metadata address",
             )
-        if not allow_private and _ip_is_blocked(ip):
+        if _ip_is_blocked(ip, allow_private=allow_private):
             raise EgressBlocked(
                 f"upstream host {host!r} resolves to a blocked address {ip}",
             )
@@ -178,7 +177,7 @@ def pick_egress_ip(host: str, port: Optional[int], *, allow_private: bool = Fals
     if dotless is not None:
         if dotless == _METADATA_V4:
             raise EgressBlocked(f"upstream host targets the cloud-metadata address: {host!r}")
-        if not allow_private and _ip_is_blocked(dotless):
+        if _ip_is_blocked(dotless, allow_private=allow_private):
             raise EgressBlocked(f"upstream host resolves to a blocked address: {host!r}")
         return str(dotless)
 
@@ -189,7 +188,7 @@ def pick_egress_ip(host: str, port: Optional[int], *, allow_private: bool = Fals
     if literal is not None:
         if _is_metadata(literal):
             raise EgressBlocked(f"upstream host targets the cloud-metadata address: {host!r}")
-        if not allow_private and _ip_is_blocked(literal):
+        if _ip_is_blocked(literal, allow_private=allow_private):
             raise EgressBlocked(f"upstream host resolves to a blocked address: {host!r}")
         return str(literal)
 
@@ -203,7 +202,7 @@ def pick_egress_ip(host: str, port: Optional[int], *, allow_private: bool = Fals
         ip = ipaddress.ip_address(addr)
         if _is_metadata(ip):
             raise EgressBlocked(f"upstream host {host!r} resolves to the cloud-metadata address")
-        if not allow_private and _ip_is_blocked(ip):
+        if _ip_is_blocked(ip, allow_private=allow_private):
             raise EgressBlocked(f"upstream host {host!r} resolves to a blocked address {ip}")
         if chosen is None:
             chosen = addr

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -605,8 +605,15 @@ class VaaraMCPProxy:
             intent_token = _REQUEST_INTENT.set((x_vaara_intent or "").strip())
             try:
                 if isinstance(payload, dict) and "id" not in payload:
+                    # _handle_client_notification forwards to the upstream via a
+                    # blocking sync notify(); offload it on the same copied
+                    # context as the request path so a slow upstream notify does
+                    # not park the event loop and serialise other HTTP traffic.
+                    nctx = contextvars.copy_context()
                     try:
-                        proxy._handle_client_notification(payload)
+                        await asyncio.to_thread(
+                            nctx.run, proxy._handle_client_notification, payload,
+                        )
                     except ProxyError:
                         logger.exception("Failed to forward HTTP notification")
                     return Response(status_code=202)

--- a/tests/test_mcp_egress_guard.py
+++ b/tests/test_mcp_egress_guard.py
@@ -75,6 +75,23 @@ def test_private_allowed_with_opt_in(url):
     assert_url_egress_allowed(url, allow_private=True)
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://0.0.0.0/mcp",  # unspecified
+        "http://[::]/mcp",  # unspecified IPv6
+        "http://224.0.0.1/mcp",  # multicast
+        "http://[ff02::1]/mcp",  # multicast IPv6
+        "http://240.0.0.1/mcp",  # reserved
+    ],
+)
+def test_never_routable_refused_even_with_opt_in(url):
+    # allow_private trusts internal hosts, not the never-routable classes.
+    # Opting in must not re-open 0.0.0.0, multicast, or reserved space.
+    with pytest.raises(EgressBlocked):
+        assert_url_egress_allowed(url, allow_private=True)
+
+
 def test_public_host_allowed():
     # Literal public IP so the floor passes without a live DNS lookup.
     assert_url_egress_allowed("https://8.8.8.8/mcp")


### PR DESCRIPTION
Three #173-review findings fixed before cutting v0.45.1: egress allow_private no longer re-opens 0.0.0.0/multicast/reserved (only loopback/link-local/private are gated); HTTP notification branch offloaded to a worker thread; SQLiteAuditBackend context-managed at all three CLI call sites. 1072 passed, ruff clean.