### PR TITLE
fix(release): wire NODE_AUTH_TOKEN on npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,3 +151,5 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Enables CI npm auto-publish, paired with NPM_PUBLISH_ENABLED=true. Without the token env the job 401s.