### PR TITLE
v0.48.0: external time anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-05-31
+
+**Theme: external time anchoring. The audit chain head can now be timestamped by
+a third-party authority, so the chain's existence is provable against an external
+clock even if the signing key is later compromised. This is the anti-backdating
+property the server-side signed execution-record SEP relies on.**
+
+### Added
+- External time anchoring for the audit hash chain (`vaara.audit.timeanchor`, new
+  `timeanchor` extra). `AuditTrail.anchor_head(client)` takes the current chain
+  head (already a SHA-256 digest) and obtains an RFC 3161 trusted timestamp over
+  it from an external Time-Stamp Authority. RFC 3161 underpins eIDAS qualified
+  electronic timestamps, so a qualified TSA makes this regulator-grade evidence
+  under EU AI Act Article 12. The token is verified on receipt and kept as a
+  `TimeAnchor`; verification is offline (`verify_anchor`,
+  `verify_anchor_over_records`) and binds the anchor to a specific record, so a
+  rewritten chain or a token over a different digest is rejected. The HTTP round
+  trip uses the standard library; only the ASN.1 and signature checks need the
+  extra. See `docs/sep/sep-server-execution-record.md`.
+
+### Changed
+- Public framing leads with EU AI Act runtime evidence and data sovereignty (runs
+  in your own environment, no SaaS, no telemetry) across the README, package
+  descriptions, MCP manifests, and vaara.io. The tamper-evident receipt stays the
+  mechanism, not the headline.
+
 ## [0.47.0] - 2026-05-31
 
 **Theme: tenant isolation across the evidence path. The reference server can no

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
   <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
 </p>
 
-Vaara is an open-source runtime evidence layer for AI agents. It sits in front of an agent's tool calls, decides whether each one is allowed, and writes a tamper-evident record of what happened. When you have to prove what an agent actually did, to an auditor, a regulator, or a customer, that record is the proof. Runs in your own environment. No SaaS, no telemetry.
+Vaara is the open-source runtime evidence layer for AI agents under the EU AI Act. It sits in front of an agent's tool calls, gates each one against your policy, and writes a tamper-evident record an outside party can verify. When a regulator, an auditor, or a public-sector buyer needs proof of what your agent actually did and why, that record is the answer. Runs entirely in your own environment. No SaaS, no telemetry.
 
-The original driver is EU AI Act compliance, but the same trail answers any "show me exactly what the agent did, and why" question.
+EU AI Act Article 12 record-keeping is the driver. The same trail answers any "show me exactly what the agent did" demand: procurement validation, incident reconstruction, SOC 2 evidence.
 
+- Article-level EU AI Act evidence report, honest about the gaps instead of rubber-stamping them.
+- Hash-chained, tamper-evident audit trail an outside party can verify without trusting your stack, with the chain head anchorable to an external trusted timestamp (RFC 3161 / eIDAS).
 - Gate every agent tool call against your own policy: allow, block, or escalate.
-- Hash-chained, tamper-evident audit trail an outside party can verify without trusting your stack.
-- Article-level EU AI Act evidence report, honest about gaps instead of rubber-stamping them.
 
 ## How it works
 
@@ -31,6 +31,21 @@ Every tool call an agent makes passes through Vaara before it runs:
 3. **Record.** The call, the score, the decision, and the real-world outcome are written to a hash-chained audit trail. An outside auditor can verify the chain is intact without trusting your stack or your word.
 
 The scoring blends five expert signals and keeps adapting as outcomes come back, and each risk score carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. Those are the properties an auditor can check independently; the math is in [Benchmarks](#benchmarks) and [docs/formal_specification.md](docs/formal_specification.md).
+
+### External time anchor
+
+The hash chain proves order and integrity but not *when* it existed: every timestamp comes from your own clock, so a compromised signing key could in principle be used to forge a backdated chain. Vaara can anchor the current chain head to an external RFC 3161 Time-Stamp Authority, the standard behind eIDAS qualified electronic timestamps. The authority signs the chain head and the time, so the chain's existence is provable against a clock you do not control. Verification is offline.
+
+```bash
+pip install 'vaara[timeanchor]'
+```
+
+```python
+from vaara.audit.timeanchor import RFC3161TimeAnchorClient
+
+# Periodically, or after a batch of high-risk actions:
+trail.anchor_head(RFC3161TimeAnchorClient("https://freetsa.org/tsr"))
+```
 
 ## Install
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@vaara/client",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "mcpName": "io.github.vaaraio/vaara",
-  "description": "TypeScript client for the Vaara HTTP API. Conformal risk scoring, hash-chained audit, policy reload, named detectors.",
+  "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/docs/sep/sep-server-execution-record.md
+++ b/docs/sep/sep-server-execution-record.md
@@ -1,0 +1,583 @@
+# SEP-XXXX: Server-Side Signed Execution Record for MCP Tool Calls
+
+> **Note**: SEP number is a placeholder (`XXXX`) until a PR is opened against
+> `modelcontextprotocol/modelcontextprotocol`. On PR creation, rename the file
+> to `XXXX-server-side-signed-execution-record.md` and update the header and
+> the `PR` field below.
+
+- **Status**: Draft
+- **Type**: Standards Track (Extensions Track)
+- **Created**: 2026-05-31
+- **Author(s)**: vaaraio (@vaaraio)
+- **Sponsor**: None (seeking sponsor)
+- **PR**: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/XXXX
+- **Requires**: SEP-2787 (Tool call attestation)
+- **Related**: SEP-2817 (AI Invocation Audit Context in Request `_meta`), SEP-414 (request `_meta`)
+- **Replaces**: None
+- **Discussions-To**: https://github.com/modelcontextprotocol/modelcontextprotocol/discussions/2704
+
+## Abstract
+
+This SEP defines two server-authoritative, cryptographically signed records
+for MCP tool calls: a **decision record** emitted by the governing server or
+proxy before the side effect runs, and an **outcome record** emitted after
+execution completes. The decision record binds what was requested, the policy
+decision (allow, block, or escalate), and the risk basis for that decision. The
+outcome record binds the execution status (`executed`, `refused`, or `errored`),
+a commitment over the result, and timing. The two are paired through a
+`backLink` and bound to the originating request, so a verifier can reconstruct
+what the agent was permitted to do, why, and what it actually did.
+
+These records are signed by the server or proxy that governs execution
+(`issuerAsserted` / `receiptAsserted`), which is a different trust surface from
+the client-asserted attestation of the call in SEP-2787 and the client-asserted
+input audit context in SEP-2817. The records use RFC 8785 (JCS) canonical JSON,
+a detached signature that does not cover itself, and are offline-verifiable by a
+standard-library checker. The wire schema is the shape already shipping in the
+Vaara MCP proxy (`vaara.attestation.receipt`), which also provides an
+independent verifier and JCS conformance vectors.
+
+## Motivation
+
+EU AI Act Article 12 obliges providers and deployers of high-risk AI systems to
+keep automatic records of events ("logs") over the system's lifetime, including
+records adequate to identify situations that may cause the system to present a
+risk and to support post-market monitoring under Article 72. For an
+agentic MCP deployment, the regulator's question is not only "what did the
+client claim it wanted to do" but "what did the governing system decide, on what
+basis, and what did the tool call actually do." That is a statement the server
+or governance layer must make, because it is the party that holds the decision
+logic and observes the result.
+
+SEP-2787 standardizes a signed attestation of a tool **call**: it binds the
+agent identity, tool name, intent, and an argument commitment into a verifiable
+envelope. SEP-2817 standardizes optional, explicitly non-authoritative,
+**client-asserted** input audit context (`invocationReason`, `model`,
+`userIntent`, `turnId`). Both describe the input side: what was claimed, by the
+party making the call. Neither carries the governing system's decision or the
+recorded outcome. SEP-2817 says so directly: "server-side decision records,
+stable tool-call identity, agent/session correlation, and taxonomies are left to
+follow-up SEPs," and Discussion #2704 frames the server-authoritative record as
+the deferred half. This SEP is that follow-up.
+
+Client-asserted records alone cannot satisfy Article 12 for a deployment where
+the server enforces policy. A client can claim its intent and its arguments; it
+cannot credibly attest that the call was allowed, why it was allowed or blocked,
+or what the tool returned, because it does not own that logic and is not a
+neutral observer of its own behavior. A regulator auditing an incident needs a
+record signed by the enforcement point, paired to the request it answers, that
+survives the client. Without a standard for that record, every governance vendor
+invents an incompatible one, and cross-implementation verification (the point of
+a conformance test) is impossible.
+
+The records are also the natural place to satisfy the rest of the Article 12 and
+Article 14 surface that input audit does not reach: the allow/block/escalate
+decision (human-oversight evidence under Article 14), the risk basis that drove
+it (risk-management evidence under Article 9), and the post-execution outcome
+that feeds post-market monitoring (Article 72). A shipping implementation already
+emits all of these as audit events; this SEP standardizes the signed wire shape
+so they are portable and independently verifiable.
+
+## Specification
+
+### Terminology
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in RFC 2119 and RFC 8174.
+
+- **Governing server**: the MCP server, or a proxy in front of it, that decides
+  whether a tool call runs and observes the result. It is the issuer of both
+  records defined here.
+- **Decision record**: a signed envelope emitted before the side effect,
+  carrying the policy decision and its risk basis.
+- **Outcome record**: a signed envelope emitted after execution, carrying the
+  execution status and a result commitment.
+- **Request attestation**: the SEP-2787 envelope describing the tool call. It is
+  the anchor both records point back to.
+
+### Trust boundary
+
+This SEP is server-authoritative. Both records are signed under the governing
+server's key and place their bound claims in an issuer block
+(`issuerAsserted` for the decision record, `receiptAsserted` for the outcome
+record), mirroring the SEP-2787 trust-surface split. The records make claims
+about the **decision** and the **execution**, which only the enforcement point
+can make.
+
+This is distinct from SEP-2787, where the issuer attests the **call** (identity,
+tool, args) and the planner declares intent, and from SEP-2817, where the client
+asserts input context that is explicitly not authorization evidence. A verifier
+MUST treat the three as separate surfaces: a SEP-2787 attestation and a SEP-2817
+`_meta` block describe what was asked for; the records in this SEP describe what
+the governing system did about it. A server MUST NOT copy client-asserted
+SEP-2817 fields into the signed decision or outcome record in a way that implies
+the server vouches for their truth; it MAY reference them by `turnId` for
+correlation (see Pairing).
+
+### Canonicalization and signature
+
+Both records use RFC 8785 (JCS) canonical JSON. The signature is computed over
+the JCS-canonical encoding of the record's blocks **excluding** the `signature`
+field, and the `signature` field carries the result; it does not cover itself.
+This is identical to the SEP-2787 and the shipped Vaara execution-receipt scheme,
+so a verifier that already handles SEP-2787 signatures handles these records with
+no new cryptographic code.
+
+- The `alg` field MUST be one of `ES256`, `RS256`, or `HS256`. Production
+  deployments crossing a trust boundary SHOULD use an asymmetric algorithm
+  (`ES256` or `RS256`) so verifiers need only the public key.
+- IEEE-754 floats MUST NOT appear anywhere in a canonicalized body. Numeric
+  values that are not integers MUST be encoded as scaled integers or decimal
+  strings. This removes the most common source of cross-stack signature drift
+  and matches the Vaara JCS discipline.
+- All digests are encoded as the string `sha256:<lowercase-hex>`.
+- All timestamps are RFC 3339 / ISO 8601 UTC strings with second precision and a
+  trailing `Z` (for example `2026-05-31T09:30:00Z`).
+
+### Argument and result commitments
+
+Both records reuse the SEP-2787 commitment shapes verbatim. A commitment is one
+of:
+
+- **`ArgsRef`**: a content-addressed reference, `{ "ref": "<uri>", "digest":
+  "sha256:<hex>", "canonicalization": "jcs" }`. The verifier MAY fetch `ref` and
+  check the digest.
+- **`ArgsProjection`**: a reviewed projection, `{ "projection": "<jcs-string>",
+  "projectionDigest": "sha256:<hex>" }`, where `projection` is the JCS-canonical
+  encoding of the projection object as a UTF-8 string and `projectionDigest` is
+  the sha256 over those bytes.
+
+Commitment-only audit, where the payload never leaves the server, is expressed as
+a hash-only-identity `ArgsProjection` whose `projection` is the JCS encoding of
+`{ "digest": "sha256:<hex>" }` and whose embedded digest binds the underlying
+value. This is the shipped `make_args_digest` behavior and is the RECOMMENDED
+default for the outcome record's `resultCommitment` so that results, which may
+contain personal data, are committed to without being copied into the record.
+
+### Decision record
+
+A decision record MUST be emitted by the governing server before the tool call's
+side effect runs, for every governed call. It is a JSON object with the
+following top-level fields.
+
+| Field            | Type     | Required | Description                                                                 |
+| ---------------- | -------- | -------- | --------------------------------------------------------------------------- |
+| `version`        | integer  | yes      | Record schema version. `1` for this SEP.                                    |
+| `alg`            | string   | yes      | `ES256`, `RS256`, or `HS256`.                                               |
+| `backLink`       | object   | yes      | Join to the SEP-2787 attestation (see below).                               |
+| `decisionDerived`| object   | yes      | The decision and its risk basis (see below).                                |
+| `issuerAsserted` | object   | yes      | The governing server's issuer block (see below).                            |
+| `signature`      | string   | yes      | Detached signature over the JCS body excluding `signature`.                 |
+
+**`backLink`** joins the decision to the request attestation it governs:
+
+| Field              | Type   | Required | Description                                                                          |
+| ------------------ | ------ | -------- | ------------------------------------------------------------------------------------ |
+| `attestationDigest`| string | yes      | `sha256:<hex>` over the JCS-canonical full SEP-2787 attestation wire bytes, signature included. Pins the exact attestation instance. |
+| `attestationNonce` | string | yes      | Echoes the attestation's `issuerAsserted.nonce` for fast correlation.                |
+
+If no SEP-2787 attestation exists for the call (the deployment does not run
+2787), the server MUST instead bind the request by setting `attestationDigest` to
+`sha256:<hex>` over the JCS-canonical encoding of the request envelope it
+observed (the `tools/call` params plus `_meta`), and set `attestationNonce` to a
+server-chosen per-call nonce. The binding is to the request **instance**, not
+only its content.
+
+**`decisionDerived`** carries the decision and the basis for it:
+
+| Field             | Type    | Required | Description                                                                                      |
+| ----------------- | ------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `decision`        | string  | yes      | One of `allow`, `block`, `escalate`.                                                              |
+| `reason`          | string  | no       | Short human-readable basis for the decision.                                                      |
+| `riskScore`       | string  | no       | The risk estimate that drove the decision, as a decimal string (floats are prohibited on the wire). |
+| `thresholdAllow`  | string  | no       | The allow threshold in force at decision time, as a decimal string.                              |
+| `thresholdBlock`  | string  | no       | The block threshold in force at decision time, as a decimal string.                              |
+| `policyId`        | string  | no       | Identifier or digest of the policy/ruleset version that produced the decision.                   |
+| `decidedAt`       | string  | yes      | ISO 8601 UTC timestamp of the decision.                                                          |
+
+A `decision` of `escalate` means the call was held for human oversight; the
+outcome record for that call will report `refused` if the human declined, or a
+later decision record MAY supersede it (see Pairing).
+
+**`issuerAsserted`** is the governing server's signed block:
+
+| Field          | Type    | Required | Description                                                            |
+| -------------- | ------- | -------- | --------------------------------------------------------------------- |
+| `iss`          | string  | yes      | Issuer identity (the governing server or proxy).                      |
+| `sub`          | string  | yes      | Subject the decision is about (tenant, agent, or upstream identity).  |
+| `iat`          | string  | yes      | ISO 8601 UTC issuance time.                                           |
+| `nonce`        | string  | yes      | Unique per record.                                                    |
+| `secretVersion`| string  | yes      | Key/secret version identifier for rotation and dispatch.              |
+| `alg`          | string  | yes      | MUST equal the top-level `alg`.                                       |
+
+### Outcome record
+
+An outcome record MUST be emitted by the governing server after the governed call
+completes (or is refused), and MUST be paired to a decision record for the same
+call. It is a JSON object with the following top-level fields. This is the shape
+already shipping as `vaara.attestation.receipt.ExecutionReceipt`.
+
+| Field            | Type     | Required | Description                                                          |
+| ---------------- | -------- | -------- | ------------------------------------------------------------------- |
+| `version`        | integer  | yes      | Record schema version. `1`.                                         |
+| `alg`            | string   | yes      | `ES256`, `RS256`, or `HS256`.                                       |
+| `backLink`       | object   | yes      | Same shape as the decision record's `backLink`; pins the request.   |
+| `outcomeDerived` | object   | yes      | Execution status, timing, and result commitment (see below).        |
+| `receiptAsserted`| object   | yes      | The governing server's issuer block (same shape as `issuerAsserted`, minus `expSeconds`; an outcome record is a durable record, not a capability, so it carries no `exp` and verifiers enforce no TTL). |
+| `signature`      | string   | yes      | Detached signature over the JCS body excluding `signature`.         |
+
+**`outcomeDerived`** carries what happened:
+
+| Field              | Type   | Required | Description                                                                          |
+| ------------------ | ------ | -------- | ------------------------------------------------------------------------------------ |
+| `status`           | string | yes      | One of `executed`, `refused`, `errored`.                                             |
+| `completedAt`      | string | yes      | ISO 8601 UTC completion (or refusal) time.                                           |
+| `resultCommitment` | object | no       | An `ArgsRef` or `ArgsProjection` over the result (executed) or error object (errored). Absent for `refused`, which has no result. RECOMMENDED to use the commitment-only hash-only-identity projection so result payloads, which may contain personal data, are not copied into the record. |
+
+### Pairing
+
+A decision record and an outcome record describe the same governed call when
+both carry the same `backLink` (`attestationDigest` and `attestationNonce`
+equal). A verifier that has both, plus the SEP-2787 attestation, can confirm the
+full chain: the attestation pins the call; the decision record pins the policy
+verdict and risk basis for that call; the outcome record pins what the call did.
+This is instance-binding, not only content-binding: two byte-identical calls
+produce two attestations with distinct nonces and therefore distinct
+`attestationDigest` values, so a decision or outcome record cannot be replayed
+against a different instance of the same call.
+
+For correlation with client-asserted input context (SEP-2817), a server MAY
+include the SEP-2817 `turnId` as an additional, clearly client-asserted field
+inside `decisionDerived` under the key `clientTurnId`. This is correlation only;
+its presence in the signed body means the server records that the client claimed
+this `turnId`, not that the server vouches for it.
+
+A superseding decision (for example, a human resolving an `escalate`) is recorded
+as a new decision record with the same `backLink` and a later `decidedAt`. The
+record with the latest `decidedAt` for a given `backLink` is the effective
+decision; earlier ones are retained as history. Verifiers MUST NOT treat
+multiple decision records for one `backLink` as a conflict.
+
+### Transport
+
+The records are signed JSON objects and are transport-agnostic. A server MAY
+return the outcome record in the `tools/call` response `_meta` under the reserved
+key `io.modelcontextprotocol/executionRecord`, MAY return the decision record
+under `io.modelcontextprotocol/decisionRecord`, and MAY persist either to an
+out-of-band audit store. When a record is too large to carry inline (a large
+`ArgsRef` chain), the server SHOULD return an `ArgsRef` pointing to the stored
+record. This SEP does not require any change to existing MCP message formats; the
+records ride in `_meta`, consistent with SEP-414, SEP-2787, and SEP-2817.
+
+### JSON examples
+
+Decision record (allow, with risk basis):
+
+```json
+{
+  "version": 1,
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:8f1e2c0a9b7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f",
+    "attestationNonce": "qWZ3kP1nB8tR0aL"
+  },
+  "decisionDerived": {
+    "decision": "allow",
+    "reason": "risk below allow threshold",
+    "riskScore": "0.21",
+    "thresholdAllow": "0.40",
+    "thresholdBlock": "0.70",
+    "policyId": "sha256:3c9d4b8a",
+    "decidedAt": "2026-05-31T09:30:00Z",
+    "clientTurnId": "turn-7f3a"
+  },
+  "issuerAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-31T09:30:00Z",
+    "iss": "vaara-proxy://acme-eu",
+    "nonce": "Yb7Qd2mK9sV",
+    "secretVersion": "2026-05",
+    "sub": "tenant:acme/agent:billing-bot"
+  },
+  "signature": "3045022100ab12"
+}
+```
+
+Outcome record (executed, result committed by digest only):
+
+```json
+{
+  "version": 1,
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:8f1e2c0a9b7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f",
+    "attestationNonce": "qWZ3kP1nB8tR0aL"
+  },
+  "outcomeDerived": {
+    "status": "executed",
+    "completedAt": "2026-05-31T09:30:02Z",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c\"}",
+      "projectionDigest": "sha256:aa11bb22cc33dd44ee55ff66aa77bb88cc99dd00ee11ff22aa33bb44cc55dd66"
+    }
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-31T09:30:02Z",
+    "iss": "vaara-proxy://acme-eu",
+    "nonce": "Zc8Re3nL0tW",
+    "secretVersion": "2026-05",
+    "sub": "tenant:acme/agent:billing-bot"
+  },
+  "signature": "3046022100cd34"
+}
+```
+
+Outcome record (refused, no result):
+
+```json
+{
+  "version": 1,
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:8f1e2c0a9b7d6e5f4a3b2c1d0e9f8a7b6c5d4e3f2a1b0c9d8e7f6a5b4c3d2e1f",
+    "attestationNonce": "qWZ3kP1nB8tR0aL"
+  },
+  "outcomeDerived": {
+    "status": "refused",
+    "completedAt": "2026-05-31T09:30:01Z"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-31T09:30:01Z",
+    "iss": "vaara-proxy://acme-eu",
+    "nonce": "Wd9Sf4oM1uX",
+    "secretVersion": "2026-05",
+    "sub": "tenant:acme/agent:billing-bot"
+  },
+  "signature": "3045022100ef56"
+}
+```
+
+### Verification algorithm
+
+A verifier holding a decision record, an outcome record, the SEP-2787
+attestation, and the governing server's public key (or shared secret for HS256)
+MUST perform, and a conforming implementation MUST pass, the following checks:
+
+1. For each record, recompute the JCS-canonical encoding of the body with the
+   `signature` field removed, and verify `signature` under the issuer key for the
+   record's `alg`. Reject on mismatch.
+2. Recompute `attestationDigest` from the SEP-2787 attestation wire bytes and
+   confirm both records' `backLink.attestationDigest` and
+   `backLink.attestationNonce` match it. Reject on mismatch.
+3. Confirm the two records share the same `backLink` (they describe the same
+   call).
+4. If `resultCommitment` is present and the verifier has the result payload,
+   recompute the commitment digest from the runtime result and confirm it
+   matches. Reject on mismatch.
+5. Confirm `decisionDerived.decision` is one of `allow`, `block`, `escalate` and
+   `outcomeDerived.status` is one of `executed`, `refused`, `errored`.
+
+## Rationale
+
+**Two records, not one.** The decision and the outcome are made at different
+times by the same party and answer different regulatory questions (Article 9 and
+14 risk and oversight evidence versus Article 72 post-market outcome evidence). A
+single combined record would force the server to delay signing until after
+execution, losing the pre-side-effect commitment that proves the verdict was
+fixed before the action ran. Splitting them, paired by `backLink`, preserves the
+commit-before-execute property that is the whole point of an enforcement record.
+
+**Instance-binding over content-binding.** Earlier drafts in the #2704 / #2817
+discussion considered binding records to the content hash of the call alone. That
+lets a record be replayed against any byte-identical call. Binding to the
+SEP-2787 attestation digest (signature included) pins the exact attestation
+instance, so distinct calls with identical content still produce distinct
+bindings. This was the resolved position in discussion; the agent-guard author
+conceded the instance-binding point on 2026-05-30, and this SEP adopts it as
+normative.
+
+**Reusing the SEP-2787 stack.** The outcome record is the post-execution sibling
+of the SEP-2787 attestation and deliberately reuses its canonicalization, signing
+algorithms, commitment shapes, and issuer-block layout. A verifier that handles
+SEP-2787 handles these records with no new cryptographic code, and the decision
+record adds only one new block (`decisionDerived`).
+
+**Why server-authoritative.** A client cannot credibly attest a decision it did
+not make or an outcome it is not a neutral observer of. SEP-2787 and SEP-2817
+cover the input side precisely because they are client or issuer claims about the
+call. The enforcement record has to come from the enforcement point, which is why
+this is a separate SEP rather than an extension of either.
+
+**Alternatives considered.** Carrying the decision inside the SEP-2787
+`issuerAsserted` block was rejected because SEP-2787 attests the call, not the
+verdict, and overloading it would blur the trust surface that SEP made explicit.
+Adopting AlgoVoi's content-addressed `action_ref` as the primary binding field
+was rejected: a content-addressed receipt id is a useful secondary index but is
+content-binding, and using it as the primary join reintroduces the replay
+problem instance-binding solves. The `action_ref` style is reconcilable as an
+optional `ArgsRef`-shaped pointer, not as the default join.
+
+## Backward Compatibility
+
+This SEP introduces no breaking changes. Both records are new, optional `_meta`
+payloads under reserved keys; servers that do not emit them and clients that do
+not consume them are unaffected. The schema reuses the SEP-2787 commitment and
+issuer-block shapes, so an existing SEP-2787 verifier extends to these records by
+adding the `decisionDerived` block and the `outcomeDerived.status` enum, with no
+change to the canonicalization or signature code. The records do not alter any
+existing MCP request or response method.
+
+## Security Implications
+
+**Signing-key compromise and post-hoc backdating.** A signed record proves the
+holder of the key bound those values, but a compromised key lets an adversary
+mint records with any `decidedAt` / `completedAt` they choose, including
+backdated ones, to fabricate a clean history. A signature alone cannot defeat
+this. The defense is an **external time anchor**: periodically anchoring the head
+of the append-only audit chain that carries these records to an independent,
+trusted timestamp (an RFC 3161 timestamp token, or an eIDAS qualified electronic
+timestamp) so that records signed after a compromise cannot be inserted before
+the last anchored head without detection. The Vaara reference implementation
+binds each record into a hash chain today (chain version 2, with tenant identity
+bound into the chained hash), and the external-anchor mechanism is the next
+shipped step (Vaara v0.48). A conforming deployment under EU AI Act retention
+obligations SHOULD anchor the chain head externally at a cadence proportionate to
+its risk.
+
+**Replay.** Instance-binding through the SEP-2787 attestation digest (signature
+included) plus the per-record `nonce` means a record cannot be replayed against a
+different call instance. Verifiers MUST reject a record whose `backLink` does not
+match the attestation under verification.
+
+**Instance versus content binding.** As above, binding is to the attestation
+instance, not only the call content. Implementations MUST NOT substitute a bare
+content hash of the arguments for the `attestationDigest`, because that
+reintroduces replay across byte-identical calls.
+
+**Personal data minimization.** Tool arguments and results can contain personal
+data. The RECOMMENDED default for both `decisionDerived` (which never copies the
+arguments, only a risk basis and decision) and `outcomeDerived.resultCommitment`
+(commitment-only hash-only-identity projection) is that the record commits to a
+digest of the value without copying the value. Where a reviewed projection is
+needed for audit, servers SHOULD redact to the minimum fields necessary and
+commit to the projection, never the raw payload. This keeps the signed,
+long-retained record free of personal data while preserving the ability to prove,
+given the original value out of band, that it is the one the record committed to.
+This aligns with GDPR data minimization and storage limitation alongside the
+Article 12 retention obligation.
+
+**Issuer identity and key distribution.** Verifiers must obtain the governing
+server's public key out of band; embedding a public key in the record is a
+convenience for local verification only and is not trust-establishing. The
+`secretVersion` field supports key rotation; verifiers dispatch on it.
+
+**Denial of service.** Record emission MUST NOT block legitimate traffic; a
+governing server that cannot sign SHOULD fail closed on the **decision** (do not
+allow an ungoverned call) but record the signing failure, and MAY degrade outcome
+recording to a logged error rather than dropping the call's result. The reference
+implementation emits records on a best-effort path that never blocks the proxied
+call and counts emission failures for operator alerting.
+
+## Prior Art Reconciled
+
+- **SEP-2787 (Tool call attestation, author soup-oss, Extensions Track, open).**
+  Attests the tool **call**: planner-declared intent, issuer-asserted identity,
+  payload-derived tool bindings and argument commitment. This SEP is its
+  post-decision and post-execution counterpart and reuses its canonicalization,
+  signing, commitment shapes, and trust-surface layout. The `backLink` pins a
+  SEP-2787 attestation. The split between what was asked (2787) and what was
+  decided and done (this SEP) is deliberate and preserves 2787's trust surface.
+
+- **SEP-2817 (AI Invocation Audit Context in Request `_meta`, author hangum,
+  Standards Track, draft seeking sponsor).** Standardizes optional,
+  client-asserted input audit context (`invocationReason`, `model`, `userIntent`,
+  `turnId`) and states explicitly that these fields are not authorization
+  evidence and that server-side decision records are left to a follow-up SEP.
+  This is that follow-up. Correlation with 2817 is by optionally recording the
+  client-asserted `turnId` as `clientTurnId`, clearly marked as a client claim.
+
+- **agent-guard (XuebinMa, Rust).** Models a `Guard` producing an `AuditRecord`
+  and an `ExecutionProof`. The two-record decision/outcome split here covers the
+  same ground as `AuditRecord` plus `ExecutionProof`, with the binding made
+  explicit and instance-scoped through the SEP-2787 attestation digest rather
+  than left to a content hash. The instance-binding position was conceded by the
+  agent-guard author in discussion on 2026-05-30 and is adopted here as
+  normative.
+
+- **AlgoVoi / chopmob-cloud `action_ref` and `draft-hopley-x402-compliance-receipt`.**
+  Defines a content-addressed receipt identifier `action_ref = sha256(JCS(...))`.
+  This SEP does not adopt `action_ref` as the default join field, because a
+  content-addressed id is content-binding and reintroduces cross-instance replay
+  when used as the primary binding. A content-addressed pointer is reconcilable
+  as an optional `ArgsRef`-shaped reference (the `ref` carries such an id and the
+  `digest` pins it), not as the normative pairing key, which remains the
+  instance-scoped `backLink`.
+
+## Reference Implementation
+
+The wire schema in this SEP is the shape shipping in the Vaara MCP proxy
+(v0.47; the receipt library landed in v0.42). Relevant modules:
+
+- `vaara/attestation/_receipt_types.py`: the `ExecutionReceipt` envelope
+  (`version`, `alg`, `backLink`, `outcomeDerived`, `receiptAsserted`,
+  `signature`), `OutcomeDerived` with `status` constrained to `executed` /
+  `refused` / `errored`, and `BackLink` (`attestationDigest`,
+  `attestationNonce`). This is the outcome record of this SEP, byte for byte.
+- `vaara/attestation/_receipt_emit.py`: builds, JCS-canonicalizes (signing input
+  excludes `signature`), and signs the outcome record; verifies the signature.
+- `vaara/attestation/_receipt_verifier.py`: `make_back_link` / `verify_back_link`
+  and `attestation_digest` (sha256 over the JCS-canonical full SEP-2787 wire
+  bytes, signature included): the instance-binding join.
+- `vaara/attestation/_sep2787_types.py` and `_sep2787_canonical.py`: the shared
+  commitment shapes (`ArgsRef`, `ArgsProjection`, `make_args_digest`), the
+  issuer-block layout, RFC 8785 canonicalization with float rejection, and the
+  signing stack (`ES256` / `RS256` / `HS256`) reused unchanged.
+- `vaara/integrations/_mcp_attest.py` and `mcp_proxy.py`: the proxy emits the
+  SEP-2787 attestation before the call and the paired outcome record after it,
+  on a best-effort path that never blocks proxied traffic.
+- `vaara/audit/trail.py`: the append-only, hash-chained audit trail the records
+  are written into; chain version 2 binds `tenant_id` and `chain_version` into
+  the chained hash so a record cannot be silently re-attributed to another
+  tenant. The external time anchor over the chain head (Security Implications) is
+  the next shipped step (v0.48).
+
+**Implementation gap (decision record).** The pre-execution **decision** is today
+emitted as an audit event and as a SHA-256 commit-outcome receipt pair
+(`vaara/audit/receipts.py`: `CommitPayload` with `decision`, `risk_score`,
+`threshold_allow`, `threshold_deny`, `decided_at`, and `OutcomePayload`), but as
+a hash-chained pair rather than as a signed envelope in the SEP-2787 issuer-block
+shape. The `decisionDerived` block in this SEP standardizes that content as a
+signed envelope and is the part of the reference implementation that lands
+alongside this SEP. The field mapping is direct: `decision` to `decision`,
+`risk_score` to `riskScore`, `threshold_allow` to `thresholdAllow`,
+`threshold_deny` to `thresholdBlock`, `decided_at` to `decidedAt`.
+
+## Test Vectors
+
+The Vaara conformance vectors for the SEP-2787 canonicalization and signature
+(`modelcontextprotocol/modelcontextprotocol#2789`) cover the JCS encoding, float
+rejection, and the detached-signature scheme that both records in this SEP reuse.
+A standard-library-only checker (no Vaara import; `cryptography` for the
+asymmetric case) verifies a signed export offline, mirroring the
+`scripts/verify_vaara_trail.py` approach. For Standards Track finalization, this
+SEP will add:
+
+- JCS canonical vectors for the `decisionDerived` block and the
+  `outcomeDerived.status` enum, in the same vector format as #2789.
+- A paired decision-plus-outcome fixture with its SEP-2787 attestation, exercising
+  the full verification algorithm above, including a replay-rejection case
+  (mismatched `backLink`) and a superseding-decision case (two decision records,
+  same `backLink`, distinct `decidedAt`).
+- A `sep-XXXX.yaml` traceability file mapping each MUST / MUST NOT and
+  SHOULD / SHOULD NOT in the Specification to a conformance check ID, as required
+  for Standards Track SEPs reaching Final.
+
+## Acknowledgments
+
+This proposal builds directly on SEP-2787 (soup-oss) and SEP-2817 (hangum), and
+on the server-authoritative record direction set out in Discussion #2704. The
+instance-binding versus content-binding discussion with the agent-guard author
+(XuebinMa) shaped the normative pairing rule.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.47.0"
-description = "Tamper-evident runtime evidence layer for AI agents: conformal risk scoring, hash-chained audit trails, and signed attestation plus execution receipts per MCP tool call"
+version = "0.48.0"
+description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 readme = "README.md"
@@ -45,6 +45,7 @@ ml = ["xgboost>=2.0", "scikit-learn>=1.3", "joblib>=1.3", "numpy>=1.24", "senten
 yaml = ["pyyaml>=6.0"]
 server = ["fastapi>=0.110", "uvicorn>=0.27"]
 attestation = ["cbor2>=5.4", "cryptography>=41.0", "rfc8785>=0.1.4"]
+timeanchor = ["asn1crypto>=1.5", "cryptography>=41.0"]
 pq = ["dilithium-py>=1.4.0"]
 pdf = ["reportlab>=4.0"]
 bedrock = ["boto3>=1.34"]

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -2,19 +2,19 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vaaraio/vaara-server",
   "title": "Vaara MCP Server",
-  "description": "Vaara governance as standalone MCP server. Risk scoring, intercept, hash-chained audit.",
+  "description": "EU AI Act runtime evidence as a standalone MCP server. Policy gating, intercept, hash-chained tamper-evident audit with external time anchoring.",
   "websiteUrl": "https://vaara.io",
   "repository": {
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.47.0",
+  "version": "0.48.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -2,19 +2,19 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vaaraio/vaara",
   "title": "Vaara",
-  "description": "Runtime governance proxy for MCP servers. Risk scoring, hash-chained audit, per-tenant policy.",
+  "description": "EU AI Act runtime evidence proxy for MCP servers. Policy-gated tool calls, hash-chained tamper-evident audit with external time anchoring, per-tenant isolation.",
   "websiteUrl": "https://vaara.io",
   "repository": {
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.47.0",
+  "version": "0.48.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/audit/timeanchor.py
+++ b/src/vaara/audit/timeanchor.py
@@ -1,0 +1,428 @@
+"""External time anchoring for the audit hash chain (v0.48).
+
+The hash chain proves order and integrity, but not *when* it existed: every
+timestamp comes from the runtime's own clock and is signed on export by the
+runtime's own key. If that key is later compromised, an attacker who also
+controls the clock can forge a backdated alternate chain that nothing internal
+to Vaara can distinguish from the original.
+
+An external time anchor closes that gap. At intervals Vaara takes the current
+chain head (the last record's ``record_hash``, itself a SHA-256 digest) and
+obtains a trusted timestamp over it from an authority it does not control. The
+authority signs ``(digest, time)``, proving the chain head existed no later
+than the attested time. A forger who later steals the signing key still cannot
+date records before a genuine anchor without forging the authority's signature,
+which lives outside Vaara's trust boundary.
+
+The default authority is an RFC 3161 Time-Stamp Authority. RFC 3161 underpins
+eIDAS qualified electronic timestamps, recognised EU-wide, so a qualified TSA
+makes this regulator-grade evidence under EU AI Act Article 12. Verification is
+offline. This is the anti-backdating mechanism cited by the server-side signed
+execution-record SEP (``docs/sep/sep-server-execution-record.md``); the
+execution records sit inside the chain, so anchoring the head anchors them.
+
+Optional dependencies (the ``timeanchor`` extra): ``asn1crypto`` and
+``cryptography``. The TSA HTTP round trip uses the standard library.
+"""
+
+from __future__ import annotations
+
+import secrets
+import urllib.request
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+try:  # optional: the 'timeanchor' extra
+    from asn1crypto import algos, cms, core, tsp  # type: ignore
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec, padding
+    from cryptography.x509 import load_der_x509_certificate
+
+    _HAS_DEPS = True
+except ImportError:  # pragma: no cover - exercised via the install-hint path
+    _HAS_DEPS = False
+
+_INSTALL_HINT = (
+    "External time anchoring requires the 'timeanchor' extra. "
+    "Install with: pip install 'vaara[timeanchor]' "
+    "(provides asn1crypto and cryptography)."
+)
+
+# Message-imprint hash algorithms we accept. The chain head is a SHA-256
+# digest, so sha256 is the natural default.
+_DIGEST_LEN = {"sha256": 32, "sha384": 48, "sha512": 64}
+
+
+class TimeAnchorError(Exception):
+    """Anchoring or anchor verification failed."""
+
+
+def _require_deps() -> None:
+    if not _HAS_DEPS:
+        raise TimeAnchorError(_INSTALL_HINT)
+
+
+@dataclass
+class TimeAnchor:
+    """A trusted-timestamp anchor over one chain-head digest.
+
+    ``chain_position`` is the index of the anchored record in the trail and
+    ``chain_head_hash`` is that record's ``record_hash`` (hex). ``token_b64``
+    is the base64 DER of the RFC 3161 ``TimeStampToken`` and is the actual
+    evidence, verified offline. ``anchored_time`` is the attested time parsed
+    from the token for display; the verifier re-derives it from the token.
+    """
+
+    chain_position: int
+    chain_head_hash: str
+    backend: str
+    tsa_url: str
+    hash_algorithm: str
+    token_b64: str
+    anchored_time: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "TimeAnchor":
+        fields = {
+            "chain_position", "chain_head_hash", "backend", "tsa_url",
+            "hash_algorithm", "token_b64", "anchored_time",
+        }
+        return cls(**{k: d[k] for k in fields})
+
+
+def build_timestamp_request(
+    digest: bytes,
+    *,
+    hash_algorithm: str = "sha256",
+    nonce: Optional[int] = None,
+    cert_req: bool = True,
+) -> bytes:
+    """Build a DER-encoded RFC 3161 ``TimeStampReq`` over ``digest``."""
+    _require_deps()
+    expected = _DIGEST_LEN.get(hash_algorithm)
+    if expected is None:
+        raise TimeAnchorError(f"unsupported hash algorithm: {hash_algorithm!r}")
+    if len(digest) != expected:
+        raise TimeAnchorError(
+            f"digest length {len(digest)} does not match {hash_algorithm} "
+            f"({expected} bytes)"
+        )
+    req = tsp.TimeStampReq({
+        "version": 1,
+        "message_imprint": tsp.MessageImprint({
+            "hash_algorithm": algos.DigestAlgorithm({"algorithm": hash_algorithm}),
+            "hashed_message": digest,
+        }),
+        "nonce": nonce if nonce is not None else secrets.randbits(64),
+        "cert_req": cert_req,
+    })
+    return req.dump()
+
+
+def extract_token_from_response(der: bytes) -> bytes:
+    """Pull the DER ``TimeStampToken`` out of a ``TimeStampResp``.
+
+    Raises if the TSA did not grant the request.
+    """
+    _require_deps()
+    try:
+        resp = tsp.TimeStampResp.load(der)
+    except Exception as exc:  # malformed reply from an untrusted endpoint
+        raise TimeAnchorError(f"could not parse TimeStampResp: {exc}") from exc
+    status = resp["status"]["status"].native
+    if status not in ("granted", "granted_with_mods"):
+        try:
+            fail = resp["status"]["fail_info"].native
+        except (KeyError, ValueError):
+            fail = None  # fail_info is optional and may be absent
+        raise TimeAnchorError(
+            f"TSA refused the request: status={status} fail_info={fail}"
+        )
+    token = resp["time_stamp_token"]
+    if token is None or token.native is None:
+        raise TimeAnchorError("TSA reply granted but carried no time_stamp_token")
+    return token.dump()
+
+
+def _hash_for(name: str) -> Any:
+    # Instantiate the concrete hash directly so type checkers do not see an
+    # attempt to construct the abstract HashAlgorithm base.
+    if name == "sha256":
+        return hashes.SHA256()
+    if name == "sha384":
+        return hashes.SHA384()
+    if name == "sha512":
+        return hashes.SHA512()
+    raise TimeAnchorError(f"unsupported digest algorithm in token: {name!r}")
+
+
+def _signer_cert(signed_data: Any) -> Any:
+    """Return the cryptography certificate that signed ``signed_data``.
+
+    Matches the SignerInfo ``sid`` (issuer + serial) against the embedded
+    certificate set, falling back to the sole certificate when only one is
+    present (the common TSA case).
+    """
+    certs = [c for c in signed_data["certificates"] if c.name == "certificate"]
+    if not certs:
+        raise TimeAnchorError("token carries no signer certificate")
+    sid = signed_data["signer_infos"][0]["sid"]
+    if sid.name == "issuer_and_serial_number":
+        want_serial = sid.chosen["serial_number"].native
+        want_issuer = sid.chosen["issuer"]
+        for choice in certs:
+            tbs = choice.chosen["tbs_certificate"]
+            if tbs["serial_number"].native == want_serial and tbs["issuer"] == want_issuer:
+                return load_der_x509_certificate(choice.chosen.dump())
+        raise TimeAnchorError("no embedded certificate matches the signer id")
+    if len(certs) == 1:
+        return load_der_x509_certificate(certs[0].chosen.dump())
+    raise TimeAnchorError("cannot disambiguate signer certificate by key id")
+
+
+def _verify_cms_signature(signed_data: Any, signer_cert: Any) -> None:
+    """Verify the TSA's signature over the SignedAttributes."""
+    signer_info = signed_data["signer_infos"][0]
+    signed_attrs = signer_info["signed_attrs"]
+    if not signed_attrs or signed_attrs.native is None:
+        raise TimeAnchorError("token has no signed attributes")
+
+    # The signature covers the SignedAttributes encoded as an explicit SET OF
+    # (tag 0x31), not the [0] IMPLICIT tag used inside the SignerInfo
+    # (RFC 5652 section 5.4). untag() drops the implicit tag for re-encoding.
+    signed_attrs_der = signed_attrs.untag().dump()
+
+    digest_alg = signer_info["digest_algorithm"]["algorithm"].native
+    sig = signer_info["signature"].native
+    sig_alg = signer_info["signature_algorithm"]["algorithm"].native
+    pub = signer_cert.public_key()
+    try:
+        if sig_alg in ("rsassa_pkcs1v15", "sha256_rsa", "sha384_rsa", "sha512_rsa", "rsa"):
+            pub.verify(sig, signed_attrs_der, padding.PKCS1v15(), _hash_for(digest_alg))
+        elif sig_alg in ("ecdsa", "sha256_ecdsa", "sha384_ecdsa", "sha512_ecdsa"):
+            pub.verify(sig, signed_attrs_der, ec.ECDSA(_hash_for(digest_alg)))
+        else:
+            raise TimeAnchorError(f"unsupported TSA signature algorithm: {sig_alg!r}")
+    except InvalidSignature as exc:
+        raise TimeAnchorError(
+            "TSA signature did not verify (token forged or corrupt)"
+        ) from exc
+
+
+def verify_timestamp_token(
+    token_der: bytes,
+    expected_digest: bytes,
+    *,
+    hash_algorithm: str = "sha256",
+) -> datetime:
+    """Verify an RFC 3161 token and return the attested UTC time.
+
+    Checks, in order: the token is CMS SignedData wrapping a TSTInfo; the
+    TSTInfo message imprint equals ``(hash_algorithm, expected_digest)``; the
+    SignedAttributes message-digest equals the hash of the TSTInfo content; and
+    the TSA's signature over the SignedAttributes verifies under the embedded
+    signer certificate. Raises :class:`TimeAnchorError` on any failure.
+
+    Trust note: this proves the token is internally consistent and signed by
+    the certificate it carries. Establishing that the certificate is a trusted
+    (e.g. eIDAS-qualified) TSA is the deployer's policy; pin the TSA
+    certificate out of band to enforce that.
+    """
+    _require_deps()
+    try:
+        content_info = cms.ContentInfo.load(token_der)
+    except Exception as exc:
+        raise TimeAnchorError(f"could not parse TimeStampToken: {exc}") from exc
+    if content_info["content_type"].native != "signed_data":
+        raise TimeAnchorError("token is not CMS SignedData")
+    signed_data = content_info["content"]
+
+    encap = signed_data["encap_content_info"]
+    if encap["content_type"].native != "tst_info":
+        raise TimeAnchorError("token does not encapsulate a TSTInfo")
+    econtent = encap["content"]
+    if econtent is None:
+        raise TimeAnchorError("token has no eContent")
+    # Read the exact eContent octets. asn1crypto may auto-parse the tst_info
+    # spec, so cast to a plain OctetString to recover the raw bytes the
+    # message_digest attribute was computed over (re-encoding could differ).
+    tst_bytes = econtent.cast(core.OctetString).native
+    tst_info = tsp.TSTInfo.load(tst_bytes)
+
+    imprint = tst_info["message_imprint"]
+    token_alg = imprint["hash_algorithm"]["algorithm"].native
+    token_digest = imprint["hashed_message"].native
+    if token_alg != hash_algorithm:
+        raise TimeAnchorError(
+            f"token imprint algorithm {token_alg!r} != expected {hash_algorithm!r}"
+        )
+    if token_digest != expected_digest:
+        raise TimeAnchorError(
+            "token does not attest the expected digest "
+            "(it timestamped a different value)"
+        )
+
+    # The SignedAttributes message-digest must equal the hash of the TSTInfo
+    # eContent, or the signature would cover something other than this token.
+    signer_info = signed_data["signer_infos"][0]
+    digest_alg = signer_info["digest_algorithm"]["algorithm"].native
+    md_attr = None
+    for attr in signer_info["signed_attrs"]:
+        if attr["type"].native == "message_digest":
+            md_attr = attr["values"][0].native
+            break
+    if md_attr is None:
+        raise TimeAnchorError("token signed attributes lack a message_digest")
+    h = hashes.Hash(_hash_for(digest_alg))
+    h.update(bytes(tst_bytes))
+    if h.finalize() != md_attr:
+        raise TimeAnchorError("signed message_digest does not match the TSTInfo content")
+
+    _verify_cms_signature(signed_data, _signer_cert(signed_data))
+
+    gen_time = tst_info["gen_time"].native
+    if gen_time.tzinfo is None:
+        gen_time = gen_time.replace(tzinfo=timezone.utc)
+    return gen_time.astimezone(timezone.utc)
+
+
+# A transport takes (url, der_request, timeout) and returns the der response.
+# Injectable so tests and offline deployments can supply a local TSA.
+Transport = Callable[[str, bytes, float], bytes]
+
+
+def _urllib_transport(url: str, der_request: bytes, timeout: float) -> bytes:
+    req = urllib.request.Request(
+        url,
+        data=der_request,
+        headers={
+            "Content-Type": "application/timestamp-query",
+            "Accept": "application/timestamp-reply",
+        },
+        method="POST",
+    )
+    # URL is operator-supplied TSA configuration, not attacker-controlled.
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return resp.read()
+
+
+class RFC3161TimeAnchorClient:
+    """Anchors chain-head digests to an RFC 3161 Time-Stamp Authority."""
+
+    backend = "rfc3161"
+
+    def __init__(
+        self,
+        tsa_url: str,
+        *,
+        hash_algorithm: str = "sha256",
+        timeout: float = 10.0,
+        transport: Optional[Transport] = None,
+    ) -> None:
+        _require_deps()
+        if hash_algorithm not in _DIGEST_LEN:
+            raise TimeAnchorError(f"unsupported hash algorithm: {hash_algorithm!r}")
+        self.tsa_url = tsa_url
+        self.hash_algorithm = hash_algorithm
+        self.timeout = timeout
+        self._transport = transport or _urllib_transport
+
+    def anchor(self, chain_position: int, chain_head_hash: str) -> TimeAnchor:
+        """Obtain a trusted timestamp over a chain-head digest.
+
+        ``chain_head_hash`` is the record's ``record_hash`` (a SHA-256 hex
+        digest), anchored directly as the message imprint so the TSA attests
+        this exact chain head existed at the returned time.
+        """
+        import base64
+        digest = _digest_bytes(chain_head_hash, self.hash_algorithm)
+        request = build_timestamp_request(digest, hash_algorithm=self.hash_algorithm)
+        try:
+            response = self._transport(self.tsa_url, request, self.timeout)
+        except Exception as exc:  # network, TLS, HTTP error
+            raise TimeAnchorError(
+                f"TSA request to {self.tsa_url} failed: {exc}"
+            ) from exc
+        token_der = extract_token_from_response(response)
+        attested = verify_timestamp_token(
+            token_der, digest, hash_algorithm=self.hash_algorithm
+        )
+        return TimeAnchor(
+            chain_position=chain_position,
+            chain_head_hash=chain_head_hash,
+            backend=self.backend,
+            tsa_url=self.tsa_url,
+            hash_algorithm=self.hash_algorithm,
+            token_b64=base64.b64encode(token_der).decode("ascii"),
+            anchored_time=attested.isoformat(),
+        )
+
+
+def _digest_bytes(chain_head_hash: str, hash_algorithm: str) -> bytes:
+    try:
+        digest = bytes.fromhex(chain_head_hash)
+    except ValueError as exc:
+        raise TimeAnchorError(
+            f"chain_head_hash is not hex: {chain_head_hash!r}"
+        ) from exc
+    if len(digest) != _DIGEST_LEN[hash_algorithm]:
+        raise TimeAnchorError(
+            f"chain_head_hash is {len(digest)} bytes, not a {hash_algorithm} digest"
+        )
+    return digest
+
+
+def verify_anchor(anchor: TimeAnchor) -> datetime:
+    """Verify an anchor's token attests its own ``chain_head_hash``.
+
+    Returns the attested UTC time. Does not check the hash belongs to a given
+    chain; use :func:`verify_anchor_over_records` for that.
+    """
+    _require_deps()
+    import base64
+    try:
+        token_der = base64.b64decode(anchor.token_b64)
+    except Exception as exc:
+        raise TimeAnchorError(f"anchor token_b64 is not valid base64: {exc}") from exc
+    digest = _digest_bytes(anchor.chain_head_hash, anchor.hash_algorithm)
+    return verify_timestamp_token(token_der, digest, hash_algorithm=anchor.hash_algorithm)
+
+
+def verify_anchor_over_records(anchor: TimeAnchor, record_hashes: list[str]) -> datetime:
+    """Verify an anchor binds to an actual record in a chain.
+
+    ``record_hashes`` is the ordered list of ``record_hash`` values from the
+    trail. Confirms the record at ``anchor.chain_position`` has exactly
+    ``anchor.chain_head_hash``, then verifies the token over it. This proves
+    the chain (and every execution record up to that position) existed at the
+    attested time. Returns the attested UTC time.
+    """
+    pos = anchor.chain_position
+    if pos < 0 or pos >= len(record_hashes):
+        raise TimeAnchorError(
+            f"anchor chain_position {pos} is outside the trail "
+            f"(len={len(record_hashes)})"
+        )
+    if record_hashes[pos] != anchor.chain_head_hash:
+        raise TimeAnchorError(
+            f"anchor chain_position {pos} does not match the trail "
+            "(anchor refers to a different or rewritten chain)"
+        )
+    return verify_anchor(anchor)
+
+
+__all__ = [
+    "TimeAnchor",
+    "TimeAnchorError",
+    "RFC3161TimeAnchorClient",
+    "build_timestamp_request",
+    "extract_token_from_response",
+    "verify_timestamp_token",
+    "verify_anchor",
+    "verify_anchor_over_records",
+]

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -554,10 +554,21 @@ class AuditTrail:
         # tenant's scope. A dedicated lock keeps the map coherent without
         # widening the hash-chain lock or risking re-entrancy with _append.
         self._tenant_map_lock = threading.Lock()
+        # v0.48 external time anchors over chain-head digests. Opt-in: stays
+        # empty until anchor_head() is called. Each entry binds a chain
+        # position + head hash to a third-party trusted timestamp, so the
+        # chain's existence is provable against an external clock even if the
+        # signing key is later compromised. See vaara.audit.timeanchor.
+        self._anchors: list = []
 
     @property
     def size(self) -> int:
         return len(self._records)
+
+    @property
+    def anchors(self) -> list:
+        """External time anchors recorded over this trail's chain heads."""
+        return list(self._anchors)
 
     @property
     def persistence_failures(self) -> int:
@@ -1135,6 +1146,31 @@ class AuditTrail:
             for record in snapshot:
                 f.write(strict_json_dumps(record.to_dict()) + "\n")
         return len(snapshot)
+
+    def anchor_head(self, client: Any) -> Any:
+        """Anchor the current chain head to an external time authority.
+
+        ``client`` is a time-anchor backend such as
+        ``vaara.audit.timeanchor.RFC3161TimeAnchorClient``. Reads the latest
+        record's hash under the lock, obtains a trusted timestamp over it, and
+        appends the resulting ``TimeAnchor`` to this trail's anchor list. The
+        anchor proves the chain head existed no later than the attested time,
+        attested by a party outside Vaara's trust boundary, which is what
+        defeats post-hoc backdating after a signing-key compromise.
+
+        Raises ``ValueError`` if the trail is empty (nothing to anchor) and
+        ``TimeAnchorError`` if the authority cannot be reached or its token
+        does not verify. The anchor is appended only after the token verifies.
+        """
+        with self._lock:
+            if not self._records:
+                raise ValueError("cannot anchor an empty trail")
+            position = len(self._records) - 1
+            head_hash = self._records[-1].record_hash
+        anchor = client.anchor(position, head_hash)
+        with self._lock:
+            self._anchors.append(anchor)
+        return anchor
 
     # ── Internal ──────────────────────────────────────────────────
 

--- a/tests/test_sqlite_backend.py
+++ b/tests/test_sqlite_backend.py
@@ -293,11 +293,8 @@ class TestSchemaUpgrade:
         )
         conn.close()
 
-        backend = SQLiteAuditBackend(db_path)  # migrates 3 -> 4
-        try:
+        with SQLiteAuditBackend(db_path) as backend:  # migrates 3 -> 4
             reloaded = backend.load_trail(strict=True)  # raises if chain broke
-        finally:
-            backend.close()
         self._assert_current(db_path)
         assert reloaded.verify_chain() is None
         loaded = reloaded._records[0]

--- a/tests/test_timeanchor.py
+++ b/tests/test_timeanchor.py
@@ -1,0 +1,255 @@
+"""External time anchor (v0.48): RFC 3161 trusted-timestamp verification.
+
+These tests stand up a self-contained in-process TSA (an EC key plus a
+self-signed certificate) and issue real RFC 3161 tokens, so the full
+build-request / parse-response / verify-token path is exercised with no
+network. The verifier is the security-critical surface; the negative tests
+prove it rejects a token over the wrong digest and a tampered token.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+
+import pytest
+
+pytest.importorskip("asn1crypto")
+pytest.importorskip("cryptography")
+
+from asn1crypto import algos, cms, tsp  # noqa: E402
+from asn1crypto import x509 as asn1_x509  # noqa: E402
+from cryptography import x509  # noqa: E402
+from cryptography.hazmat.primitives import hashes, serialization  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import ec  # noqa: E402
+from cryptography.x509.oid import NameOID  # noqa: E402
+
+from vaara.audit.timeanchor import (  # noqa: E402
+    RFC3161TimeAnchorClient,
+    TimeAnchor,
+    TimeAnchorError,
+    verify_anchor,
+    verify_anchor_over_records,
+    verify_timestamp_token,
+)
+
+_GEN_TIME = datetime.datetime(2026, 5, 31, 9, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+def _make_tsa():
+    """Return (private_key, cert_der) for an in-process test TSA."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Vaara Test TSA")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2020, 1, 1))
+        .not_valid_after(datetime.datetime(2035, 1, 1))
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert.public_bytes(serialization.Encoding.DER)
+
+
+def _issue_token(digest, key, cert_der, *, hash_algorithm="sha256", gen_time=_GEN_TIME):
+    """Build a valid RFC 3161 TimeStampToken over ``digest``."""
+    cert_asn1 = asn1_x509.Certificate.load(cert_der)
+    tst = tsp.TSTInfo({
+        "version": 1,
+        "policy": "1.3.6.1.4.1.99999.1",
+        "message_imprint": tsp.MessageImprint({
+            "hash_algorithm": algos.DigestAlgorithm({"algorithm": hash_algorithm}),
+            "hashed_message": digest,
+        }),
+        "serial_number": 1,
+        "gen_time": gen_time,
+    })
+    tst_der = tst.dump()
+    attrs = cms.CMSAttributes([
+        cms.CMSAttribute({"type": "content_type", "values": ["tst_info"]}),
+        cms.CMSAttribute({
+            "type": "message_digest",
+            "values": [hashlib.sha256(tst_der).digest()],
+        }),
+    ])
+    signature = key.sign(attrs.dump(), ec.ECDSA(hashes.SHA256()))
+    signer_info = cms.SignerInfo({
+        "version": "v1",
+        "sid": cms.SignerIdentifier({
+            "issuer_and_serial_number": cms.IssuerAndSerialNumber({
+                "issuer": cert_asn1.issuer,
+                "serial_number": cert_asn1.serial_number,
+            }),
+        }),
+        "digest_algorithm": algos.DigestAlgorithm({"algorithm": "sha256"}),
+        "signed_attrs": attrs,
+        "signature_algorithm": algos.SignedDigestAlgorithm({"algorithm": "sha256_ecdsa"}),
+        "signature": signature,
+    })
+    signed_data = cms.SignedData({
+        "version": "v3",
+        "digest_algorithms": [algos.DigestAlgorithm({"algorithm": "sha256"})],
+        "encap_content_info": cms.EncapsulatedContentInfo({
+            "content_type": "tst_info",
+            "content": tst,  # pass the object; asn1crypto octet-wraps + encodes
+        }),
+        "certificates": [cms.CertificateChoices({"certificate": cert_asn1})],
+        "signer_infos": [signer_info],
+    })
+    return cms.ContentInfo({"content_type": "signed_data", "content": signed_data}).dump()
+
+
+def _make_response(token_der, status="granted"):
+    """Wrap a token in an RFC 3161 TimeStampResp (no token on refusal)."""
+    body = {"status": tsp.PKIStatusInfo({"status": status})}
+    if token_der:
+        body["time_stamp_token"] = cms.ContentInfo.load(token_der)
+    return tsp.TimeStampResp(body).dump()
+
+
+def _head_hash():
+    """A plausible chain-head record_hash (a real SHA-256 hex digest)."""
+    return hashlib.sha256(b"chain head").hexdigest()
+
+
+def test_verify_token_roundtrip():
+    key, cert = _make_tsa()
+    digest = bytes.fromhex(_head_hash())
+    token = _issue_token(digest, key, cert)
+    attested = verify_timestamp_token(token, digest)
+    assert attested == _GEN_TIME
+
+
+def test_verify_rejects_wrong_digest():
+    key, cert = _make_tsa()
+    token = _issue_token(bytes.fromhex(_head_hash()), key, cert)
+    other = hashlib.sha256(b"a different chain head").digest()
+    with pytest.raises(TimeAnchorError, match="different value"):
+        verify_timestamp_token(token, other)
+
+
+def test_verify_rejects_tampered_token():
+    key, cert = _make_tsa()
+    digest = bytes.fromhex(_head_hash())
+    token = bytearray(_issue_token(digest, key, cert))
+    token[-1] ^= 0xFF  # flip a byte in the signature region
+    with pytest.raises(TimeAnchorError):
+        verify_timestamp_token(bytes(token), digest)
+
+
+def test_client_anchor_with_local_tsa():
+    """End to end: build request, local TSA issues, client verifies."""
+    key, cert = _make_tsa()
+
+    def transport(url, der_request, timeout):
+        req = tsp.TimeStampReq.load(der_request)
+        digest = req["message_imprint"]["hashed_message"].native
+        return _make_response(_issue_token(digest, key, cert))
+
+    client = RFC3161TimeAnchorClient("https://tsa.example/tsr", transport=transport)
+    head = _head_hash()
+    anchor = client.anchor(chain_position=41, chain_head_hash=head)
+    assert isinstance(anchor, TimeAnchor)
+    assert anchor.chain_position == 41
+    assert anchor.chain_head_hash == head
+    assert anchor.backend == "rfc3161"
+    # The stored token re-verifies on its own.
+    assert verify_anchor(anchor) == _GEN_TIME
+
+
+def test_client_raises_on_tsa_refusal():
+    key, cert = _make_tsa()
+
+    def transport(url, der_request, timeout):
+        # A refusal carries a status but the client must not accept the token.
+        token = _issue_token(bytes.fromhex(_head_hash()), key, cert)
+        return _make_response(token, status="rejection")
+
+    client = RFC3161TimeAnchorClient("https://tsa.example/tsr", transport=transport)
+    with pytest.raises(TimeAnchorError, match="refused"):
+        client.anchor(0, _head_hash())
+
+
+def _local_tsa_client():
+    key, cert = _make_tsa()
+
+    def transport(url, der_request, timeout):
+        req = tsp.TimeStampReq.load(der_request)
+        digest = req["message_imprint"]["hashed_message"].native
+        return _make_response(_issue_token(digest, key, cert))
+
+    return RFC3161TimeAnchorClient("https://tsa.example/tsr", transport=transport)
+
+
+def test_anchor_head_binds_live_trail():
+    from vaara.audit.trail import AuditTrail
+    from vaara.taxonomy.actions import (
+        ActionCategory,
+        ActionRequest,
+        ActionType,
+        BlastRadius,
+        Reversibility,
+    )
+
+    trail = AuditTrail()
+    trail.record_action_requested(ActionRequest(
+        action_type=ActionType(
+            name="t", category=ActionCategory.DATA,
+            reversibility=Reversibility.FULLY, blast_radius=BlastRadius.LOCAL,
+        ),
+        tool_name="t", agent_id="agent", parameters={},
+    ))
+
+    anchor = trail.anchor_head(_local_tsa_client())
+    assert anchor.chain_position == trail.size - 1
+    assert len(trail.anchors) == 1
+    # The anchor binds to the actual chain head and re-verifies offline.
+    record_hashes = [r.record_hash for r in trail._records]
+    assert verify_anchor_over_records(anchor, record_hashes) == _GEN_TIME
+
+
+def test_anchor_head_rejects_empty_trail():
+    from vaara.audit.trail import AuditTrail
+
+    with pytest.raises(ValueError, match="empty trail"):
+        AuditTrail().anchor_head(_local_tsa_client())
+
+
+def test_verify_anchor_over_records_binds_to_chain():
+    key, cert = _make_tsa()
+    head = _head_hash()
+    token = _issue_token(bytes.fromhex(head), key, cert)
+    import base64
+    anchor = TimeAnchor(
+        chain_position=2,
+        chain_head_hash=head,
+        backend="rfc3161",
+        tsa_url="https://tsa.example/tsr",
+        hash_algorithm="sha256",
+        token_b64=base64.b64encode(token).decode("ascii"),
+        anchored_time=_GEN_TIME.isoformat(),
+    )
+    record_hashes = ["aa" * 32, "bb" * 32, head]  # head sits at position 2
+    assert verify_anchor_over_records(anchor, record_hashes) == _GEN_TIME
+
+
+def test_verify_anchor_over_records_rejects_rewritten_chain():
+    key, cert = _make_tsa()
+    head = _head_hash()
+    token = _issue_token(bytes.fromhex(head), key, cert)
+    import base64
+    anchor = TimeAnchor(
+        chain_position=2,
+        chain_head_hash=head,
+        backend="rfc3161",
+        tsa_url="https://tsa.example/tsr",
+        hash_algorithm="sha256",
+        token_b64=base64.b64encode(token).decode("ascii"),
+        anchored_time=_GEN_TIME.isoformat(),
+    )
+    # A rewritten chain has a different hash at the anchored position.
+    rewritten = ["aa" * 32, "bb" * 32, "cc" * 32]
+    with pytest.raises(TimeAnchorError, match="does not match the trail"):
+        verify_anchor_over_records(anchor, rewritten)

--- a/tests/test_v040_tenant.py
+++ b/tests/test_v040_tenant.py
@@ -327,9 +327,8 @@ def test_v2_records_roundtrip_through_sqlite(tmp_path):
     from vaara.audit.sqlite_backend import SQLiteAuditBackend
 
     db = tmp_path / "audit.db"
-    backend = SQLiteAuditBackend(db)
-    trail = AuditTrail(on_record=backend.write_record)
-    try:
+    with SQLiteAuditBackend(db) as backend:
+        trail = AuditTrail(on_record=backend.write_record)
         for tid in ("tenant-a", "tenant-b", ""):
             trail.record_action_requested(
                 ActionRequest(
@@ -337,14 +336,9 @@ def test_v2_records_roundtrip_through_sqlite(tmp_path):
                     agent_id="agent", parameters={}, tenant_id=tid,
                 )
             )
-    finally:
-        backend.close()
 
-    reopened = SQLiteAuditBackend(db)
-    try:
+    with SQLiteAuditBackend(db) as reopened:
         reloaded = reopened.load_trail(strict=True)  # raises if chain broken
-    finally:
-        reopened.close()
     assert len(reloaded._records) == 3
     assert [r.chain_version for r in reloaded._records] == [2, 2, 2]
     assert [r.tenant_id for r in reloaded._records] == ["tenant-a", "tenant-b", ""]


### PR DESCRIPTION
# v0.48.0: external time anchor + EU-wedge reframe

## What this is

The audit hash chain proves order and integrity, but not *when* it existed. Every timestamp comes from the runtime's own clock and is signed on export by the runtime's own key, so a later signing-key compromise lets an attacker forge a backdated chain that nothing internal can distinguish from the original.

This adds an external time anchor that closes that gap. `AuditTrail.anchor_head(client)` takes the current chain head (already a SHA-256 digest) and obtains an RFC 3161 trusted timestamp over it from an authority the runtime does not control. RFC 3161 is the basis for eIDAS qualified electronic timestamps, so a qualified TSA makes this regulator-grade evidence under EU AI Act Article 12.

This is the anti-backdating mechanism the server-side signed execution-record SEP relies on (draft included at `docs/sep/sep-server-execution-record.md`).

## Design

- `vaara.audit.timeanchor`: `RFC3161TimeAnchorClient` (build request, parse response, verify token), `TimeAnchor`, and offline verifiers `verify_anchor` / `verify_anchor_over_records`.
- The verifier checks the token is CMS SignedData over a TSTInfo, the message imprint equals the expected digest, the signed message-digest matches the eContent, and the TSA signature verifies under the embedded certificate. Negative tests cover a wrong-digest token, a tampered token, and a refused request.
- `verify_anchor_over_records` binds an anchor to a specific record in a trail, so a rewritten chain or a token over a different value is rejected.
- HTTP uses the standard library. Only the ASN.1 and signature checks need the new optional `timeanchor` extra (`asn1crypto` + `cryptography`); core install stays dependency-free.

## Public framing

Leads back to EU AI Act runtime evidence and data sovereignty (runs in your own environment, no SaaS, no telemetry) across the README, package descriptions, MCP manifests, and vaara.io. The tamper-evident receipt stays the mechanism, not the headline.

## Also

Lands the three CodeQL "use a `with` statement" advisories from the v0.47 audit tests (the fix never reached the remote before #179 squash-merged).

## Verification

1096 passed / 12 skipped, ruff clean, mypy clean on the new module. New `tests/test_timeanchor.py` stands up a self-contained in-process TSA, so the full request / response / verify path runs with no network.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v0.48.0

* **New Features**
  * External time anchoring via RFC 3161 timestamps for audit trails with offline verification capability
  * Optional installation extra for time anchoring dependencies
  * Server execution record specifications with cryptographic signatures for MCP tool calls

* **Documentation**
  * Updated project positioning emphasizing EU AI Act runtime evidence layer
  * Time anchoring documentation with usage examples

* **Chores**
  * Version bumped to 0.48.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->