### PR TITLE
chore: bump @vaara/client to 0.49.0

### DIFF
--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM registry.suse.com/bci/python:3.12
+
+LABEL org.opencontainers.image.title="Vaara MCP Governance Server"
+LABEL org.opencontainers.image.description="Runtime evidence layer for AI agents — policy-gated tool calls, tamper-evident audit trails, EU AI Act Article 12 compliant"
+LABEL org.opencontainers.image.source="https://github.com/vaaraio/vaara"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir "vaara[server,attestation,timeanchor]"
+
+# Non-root user
+RUN useradd -r -u 1000 -g users vaara
+USER vaara
+
+EXPOSE 8000
+
+ENV VAARA_HOST=0.0.0.0
+ENV VAARA_PORT=8000
+
+CMD ["vaara-mcp-server", "--host", "0.0.0.0", "--port", "8000"]

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: vaara
+description: Runtime evidence layer for AI agents on SUSE Rancher. Policy-gated MCP tool calls with tamper-evident audit trails and EU AI Act Article 12 compliance.
+type: application
+version: 0.49.0
+appVersion: "0.49.0"
+home: https://vaara.io
+sources:
+  - https://github.com/vaaraio/vaara
+maintainers:
+  - name: Vaara
+    email: hello@vaara.io
+keywords:
+  - ai-governance
+  - mcp
+  - audit
+  - eu-ai-act
+  - security

--- a/deploy/helm/vaara/templates/_helpers.tpl
+++ b/deploy/helm/vaara/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+{{- define "vaara.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "vaara.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ include "vaara.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "vaara.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "vaara.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vaara.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/vaara/templates/deployment.yaml
+++ b/deploy/helm/vaara/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "vaara.fullname" . }}
+  labels:
+    {{- include "vaara.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "vaara.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "vaara.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "vaara.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: vaara
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          env:
+            - name: VAARA_HOST
+              value: "0.0.0.0"
+            - name: VAARA_PORT
+              value: "{{ .Values.service.port }}"
+            - name: VAARA_LOG_LEVEL
+              value: {{ .Values.vaara.logLevel | quote }}
+            - name: VAARA_TENANT_ID
+              value: {{ .Values.vaara.tenantId | quote }}
+            {{- if .Values.vaara.signingKeySecret }}
+            - name: VAARA_SIGNING_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.vaara.signingKeySecret }}
+                  key: VAARA_SIGNING_KEY
+            {{- end }}
+          {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "vaara.fullname" . }}
+      {{- end }}

--- a/deploy/helm/vaara/templates/pvc.yaml
+++ b/deploy/helm/vaara/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "vaara.fullname" . }}
+  labels:
+    {{- include "vaara.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/vaara/templates/service.yaml
+++ b/deploy/helm/vaara/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vaara.fullname" . }}
+  labels:
+    {{- include "vaara.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "vaara.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/vaara/templates/serviceaccount.yaml
+++ b/deploy/helm/vaara/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vaara.serviceAccountName" . }}
+  labels:
+    {{- include "vaara.labels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/vaara/values.yaml
+++ b/deploy/helm/vaara/values.yaml
@@ -1,0 +1,59 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/vaaraio/vaara
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 8000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: vaara.local
+      paths:
+        - path: /
+          pathType: Prefix
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+persistence:
+  enabled: true
+  storageClass: ""
+  size: 1Gi
+  mountPath: /data
+
+vaara:
+  logLevel: INFO
+  # Tenant configuration
+  tenantId: "default"
+  # Policy directory (mount a ConfigMap here)
+  policyDir: ""
+  # Signing key secret name (must contain VAARA_SIGNING_KEY)
+  signingKeySecret: ""
+
+serviceAccount:
+  create: true
+  name: ""
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL


### PR DESCRIPTION
Fixes npm publish: TS client version missed in the v0.49.0 release commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped TypeScript client package version to 0.49.0.

* **New Features**
  * Added Docker container image support for deploying the MCP Governance Server.
  * Added Helm chart with Kubernetes templates, enabling deployments to Kubernetes clusters with configurable storage, security contexts, and service accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->