### PR TITLE
v0.50.0: verifiable evidence plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   rather than counted. The standalone verifier
   (`scripts/verify_vaara_trail.py`) verifies threshold exports with only the
   `cryptography` package. See `docs/design/threshold-signing-spec.md`.
+- **Chain-anchored key-lifecycle markers** (the second half of threshold
+  signing). `AuditTrail.record_key_lifecycle(action, fingerprint, ...)` records
+  custodian rotation, revocation, and addition as ordinary audit records, so
+  they inherit the v0.47 hash chain and the v0.48 external time anchor. A
+  `revoked` marker anchored before a compromise window pins the revocation in
+  time: a compromised key can re-sign but cannot re-anchor past chain heads.
+  `verify_signed` now returns any lifecycle records found
+  (`VerifyResult.key_lifecycle`), and the standalone verifier prints them, so a
+  reviewer sees the custodian set's history inline with the evidence. New
+  `EventType.KEY_LIFECYCLE` maps to EU AI Act Articles 15(1) and 12(1).
 
 ### Fixed
 - `scripts/verify_vaara_trail.py` hash-chain re-check now binds `tenant_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   verification routes through the unchanged `verify_receipt_signature` stack. No
   new crypto, no re-canonicalization. The `@context` is vendored
   (`load_receipt_context`), so verification needs no network.
+- **Article 12 one-command regulator export.** `vaara trail export-article12`
+  (and `vaara.audit.article12_export.export_article12`) writes a signed
+  evidence zip plus a generated, human-readable report that maps the trail to
+  the EU AI Act Article 12 / 26(5) record-keeping obligations: a cover from
+  operator `--system-meta`, an obligation table driven by the event types
+  present and the chain's `regulatory_articles` tags, an event inventory, an
+  integrity statement, and verify instructions a regulator runs without a
+  Vaara install. It composes the existing signed export (single-signer or
+  k-of-n threshold), it does not duplicate it. The report is built from the
+  signed trail bytes and bound to them by the manifest `trail_sha256`; it is a
+  derived view, not a second signed surface, and the package says so. `--period`
+  is a report lens that narrows the summary counts only; the signed trail stays
+  whole. `--format md|html`. See `docs/design/article12-export-spec.md`.
 
 ### Fixed
 - `scripts/verify_vaara_trail.py` hash-chain re-check now binds `tenant_id`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- `vaara.audit.export.export_signed_threshold` and the `vaara trail
+  export-threshold` CLI: k-of-n threshold signing for audit exports. n
+  custodians each hold an independent Ed25519 key; the export carries one
+  detached signature per available custodian and verification requires at
+  least `threshold_k` valid signatures from the authorized set. No single
+  key-holder can issue or forge a trail. `threshold_k`, `signers_n`, and the
+  authorized fingerprint set are written inside the signed manifest, so the
+  quorum cannot be downgraded without invalidating every member signature.
+  Each stored public key is bound to its manifest fingerprint, so a
+  substituted key is rejected and an unauthorized extra signature is ignored
+  rather than counted. The standalone verifier
+  (`scripts/verify_vaara_trail.py`) verifies threshold exports with only the
+  `cryptography` package. See `docs/design/threshold-signing-spec.md`.
+
+### Fixed
+- `scripts/verify_vaara_trail.py` hash-chain re-check now binds `tenant_id`
+  and `chain_version` for chain v2 records (v0.47+), matching the in-package
+  verifier. The standalone script previously failed every v0.47+ trail.
+
 ## [0.49.0] - 2026-05-31
 
 **Theme: decision records. The evidence chain now covers the full call lifecycle:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-06-01
+
+**Theme: the verifiable evidence plane. Trail exports can be threshold-signed so
+no single custodian can issue or forge them, and custodian changes are pinned in
+the chain. Execution receipts serialize losslessly as W3C Verifiable Credentials
+for interoperability without a second trust surface. One command turns a trail
+into a signed, self-explaining EU AI Act Article 12 regulator package.**
+
 ### Added
 - `vaara.audit.export.export_signed_threshold` and the `vaara trail
   export-threshold` CLI: k-of-n threshold signing for audit exports. n

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   (`VerifyResult.key_lifecycle`), and the standalone verifier prints them, so a
   reviewer sees the custodian set's history inline with the evidence. New
   `EventType.KEY_LIFECYCLE` maps to EU AI Act Articles 15(1) and 12(1).
+- **W3C Verifiable Credential serialization for execution receipts (opt-in).**
+  `vaara.attestation.receipt.receipt_to_vc` / `receipt_from_vc` present an
+  `ExecutionReceipt` as a VCDM 2.0 credential and recover it losslessly
+  (`receipt_from_vc(receipt_to_vc(r)) == r`). The VC is a view, not a second
+  trust surface: `credentialSubject` carries the native receipt blocks verbatim,
+  `proof.proofValue` carries the existing SEP-2787 detached signature, and
+  verification routes through the unchanged `verify_receipt_signature` stack. No
+  new crypto, no re-canonicalization. The `@context` is vendored
+  (`load_receipt_context`), so verification needs no network.
 
 ### Fixed
 - `scripts/verify_vaara_trail.py` hash-chain re-check now binds `tenant_id`

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/design/article12-export-spec.md
+++ b/docs/design/article12-export-spec.md
@@ -1,0 +1,137 @@
+# Design spec: Article-12 one-command regulator export
+
+Status: draft for v0.5. Priority 2 of 3. Companion to
+`docs/signing-keys.md` and the existing export surfaces.
+
+## Goal
+
+One command turns a live trail into a regulator-facing Article-12
+record-keeping package: the signed evidence plus a human-readable report
+that maps the trail to the AI Act Article 12 logging obligations. The
+institutional-anchoring artifact (SFS / SR 315), not a new evidence format.
+
+Today an operator hands a regulator `signed.zip` (trail + manifest +
+signature) and has to explain, out of band, how it satisfies Article 12.
+This makes the package self-explaining.
+
+## What already exists (reuse, do not rebuild)
+
+- `vaara trail export` -> `export_signed()`: signed zip (trail.jsonl,
+  manifest.json, trail.sig, pubkey).
+- `vaara trail export-incident` -> `incident_export.py`: Article 73
+  serious-incident report from a trail.
+- `vaara trail export-prov` -> `prov_export.py`: W3C PROV-JSON lineage.
+- `vaara trail prune` (retention): Article 12(2) deletion.
+- `AuditRecord.regulatory_articles`: per-record article tags already
+  carried in the chain.
+
+The Article-12 export composes these, it does not duplicate them.
+
+## Scope of Article 12
+
+Article 12 (record-keeping) requires high-risk AI systems to
+automatically record events ("logs") over their lifetime, to a degree
+appropriate to the intended purpose, enabling: traceability, post-market
+monitoring, and the Article 26(5) deployer-side monitoring duty. The
+export answers "show me your Article 12 logs and prove they are intact"
+in one artifact.
+
+## Command
+
+```
+vaara trail export-article12 \
+  --trail trail.jsonl \
+  --key signer.pem \
+  --out art12_package.zip \
+  [--system-meta system.json] \
+  [--period 2026-01-01:2026-06-30] \
+  [--format md|html]
+```
+
+`--system-meta` is a small operator-supplied JSON (system name, provider,
+intended purpose, deployer, AI Act risk classification) that the report's
+cover section needs and the trail does not carry. Optional; absent fields
+render as "not provided" rather than failing.
+
+## Package contents (zip)
+
+Everything `export_signed` writes, plus:
+
+```
+trail.jsonl              # unchanged signed evidence
+manifest.json            # unchanged
+trail.sig                # unchanged
+signer_pubkey.pem        # unchanged
+article12_report.md      # NEW: the human-readable mapping (or .html)
+article12_summary.json   # NEW: machine-readable version of the report
+verify_instructions.txt  # NEW: how the regulator checks the package
+```
+
+The report and summary are inside the signed set: the manifest's
+`trail_sha256` covers `trail.jsonl`; the report is generated *from* that
+trail, and `article12_summary.json` records the trail sha256 it was built
+over, so a regulator can confirm the report describes the signed trail and
+not a different one.
+
+## Report contents (`article12_report.md`)
+
+Generated, deterministic, from the trail + system-meta:
+
+1. **Cover** — system identity from `--system-meta`, export timestamp,
+   Vaara version, signer fingerprint, reporting period.
+2. **Record-keeping summary** — total records, time span, chain-intact
+   status, retention configuration if present.
+3. **Article 12 obligation mapping** — a table: each Article 12 / 26(5)
+   obligation against how the trail evidences it (event types present,
+   counts, example record ids). Driven by `regulatory_articles` tags plus
+   a static obligation checklist.
+4. **Event inventory** — event-type histogram, per-type counts, first/last
+   timestamps.
+5. **Integrity statement** — the hash-chain + (if present) external time
+   anchor status, with the trust-model one-liner: a valid signature proves
+   integrity and provenance of these logs, not the truth of every recorded
+   assertion. Links to `docs/signing-keys.md` and the trust model.
+6. **How to verify** — the exact `vaara trail verify` /
+   `scripts/verify_vaara_trail.py` invocation, mirrored in
+   `verify_instructions.txt` so a regulator with no Vaara install can act.
+
+The prose passes the strict anti-AI-tells pass before any of it is treated
+as outbound (it is regulator-facing).
+
+## Implementation sketch
+
+- New module `vaara/audit/article12_export.py`: `build_article12_report()`
+  (records + system_meta -> report dict) and `render_report()`
+  (dict -> md/html). Pure, testable without crypto.
+- New `export_article12()` in or beside `audit/export.py`: builds the
+  report, then calls the existing signed-zip writer with the two extra
+  files folded in before signing so they are covered.
+- New CLI `_cmd_trail_export_article12` wiring the above, mirroring
+  `_cmd_trail_export_incident`.
+
+## Threshold interaction
+
+If threshold signing (spec 1) is the active signer, the Article-12 package
+is threshold-signed transparently: the manifest carries the k-of-n fields,
+the report's integrity section states "signed by k of n named custodians."
+The two features compose; build threshold first.
+
+## Test plan
+
+- Round-trip: export a known trail, report record-count / event histogram /
+  chain status match the trail.
+- Tamper: mutate a record after export, `vaara trail verify` fails and the
+  report's stated `trail_sha256` no longer matches.
+- system-meta absent: renders "not provided", does not crash.
+- Period filter: only records in range are summarized; out-of-range
+  excluded from counts but the signed trail is still whole-trail (document
+  this clearly so the period is a report lens, not an evidence filter).
+- Article mapping: a trail with `regulatory_articles` tags produces the
+  obligation table; an untagged trail still renders with "no explicit tag".
+
+## Out of scope for v0.5
+
+- PDF rendering (md/html only; operators convert if a regulator needs PDF).
+- Auto-submission to any regulator intake portal.
+- Per-article legal interpretation beyond the static obligation checklist
+  (semantic-correctness layer; stays human-owned per the trust model).

--- a/docs/design/threshold-signing-spec.md
+++ b/docs/design/threshold-signing-spec.md
@@ -1,0 +1,194 @@
+# Design spec: k-of-n threshold signing for audit exports
+
+Status: draft for v0.5. Author target: Henri's signing-key sharding idea,
+scoped as k-of-n multisig (decided 2026-06-01). Companion to
+`docs/signing-keys.md`.
+
+## Goal
+
+Remove single-party control of audit-export issuance. Today one private key
+signs every export, so one key-holder (including the single maintainer) can
+issue or, if compromised, forge a trail. The fix recorded in the trust-model
+work is: **no single party holds a key that alone can issue evidence.**
+
+This closes the one attack `docs/signing-keys.md` says signing alone cannot
+stop ("The only attack that signing alone cannot stop is key compromise") by
+raising the bar from one key to k keys.
+
+## Why multisig, not Shamir or FROST
+
+Three models were on the table:
+
+- **k-of-n multisig (chosen).** n custodians, n independent Ed25519 keys.
+  Export carries each available signer's detached signature; verify requires
+  >= k valid signatures from the authorized set. No key is ever combined or
+  reconstructed. Builds on the existing `Signer` protocol, adds no crypto
+  dependency, and reads to a regulator as "5 of 7 named custodians signed
+  this export" - which is *more* legible than an opaque single signature.
+- **Shamir-shared single key.** Matches the literal "one key, n shards"
+  phrasing, but reconstructs the full key in memory at sign time - a
+  momentary single point of compromise the multisig model never has.
+  Rejected.
+- **FROST true threshold.** Cryptographically ideal (one group key, never
+  reconstructed, single output signature) but needs a round-based signing
+  protocol and a FROST library that is immature in pure Python. Against the
+  self-built ethos, heaviest, most fragile. Rejected for v0.5.
+
+Multisig also best satisfies the documented intent: there is never a single
+logical issuance key to hold or reconstruct at all.
+
+## Data model
+
+### Manifest additions (`manifest.json`)
+
+When threshold signing is used, the manifest carries:
+
+```json
+{
+  "signature_algorithm": "threshold-Ed25519",
+  "threshold_k": 5,
+  "signers_n": 7,
+  "member_algorithm": "Ed25519",
+  "signer_fingerprints": ["a1b2c3...", "c3d4e5...", "..."],
+  "...": "all existing fields unchanged"
+}
+```
+
+- `signature_algorithm` switches verify-side dispatch.
+- `threshold_k` / `signers_n` are the policy. Both are inside the signed
+  bytes (the digest is over `trail_bytes || manifest_bytes`), so an attacker
+  cannot downgrade k to 1 without invalidating every member signature.
+- `member_algorithm` lets members be Ed25519 today and ML-DSA-65 later
+  without a new top-level algorithm string.
+- `signer_fingerprints` is the **authorized set** (all n), in a fixed
+  order. Verify maps a present signature to an authorized fingerprint; an
+  unknown signer is ignored, not counted.
+
+### Zip layout
+
+```
+trail.jsonl
+manifest.json
+sigs/<fingerprint>.sig        # >= k present, one per signing custodian
+pubkeys/<fingerprint>.pem     # n present, the full authorized set
+```
+
+`trail.sig` and `signer_pubkey.pem` are **omitted** in threshold mode (a
+single-sig zip and a threshold zip are never ambiguous - dispatch is on
+`signature_algorithm`). Older single-sig exports are unchanged.
+
+## Signing flow (`export_signed_threshold`)
+
+A sibling to `export_signed`, sharing the manifest/zip plumbing:
+
+1. Build the manifest first, including `threshold_k`, `signers_n`,
+   `member_algorithm`, and the full ordered `signer_fingerprints` list.
+   The signing digest depends on the manifest, so k/n/the authorized set
+   are bound into what every custodian signs.
+2. Compute `digest = sha256(trail_bytes || manifest_bytes)` once.
+3. Each available custodian's `Signer` signs the *same* digest. Custodians
+   are passed in as a list of `Signer` instances (HSM/KMS-backed in
+   production - they need not be co-located; the coordinator collects
+   detached signatures).
+4. Require at least k signatures collected; else raise (the export is not
+   issuable under policy).
+5. Write `sigs/<fp>.sig` for each collected signature and
+   `pubkeys/<fp>.pem` for all n authorized public keys.
+
+The coordinator is untrusted: it cannot forge a signature it does not hold,
+and it cannot lower k (k is signed). The worst a malicious coordinator does
+is refuse to assemble an export - a liveness, not an integrity, failure.
+
+## Verify flow (`verify_signed`, threshold branch)
+
+Dispatch when `signature_algorithm == "threshold-Ed25519"`:
+
+1. Read `threshold_k`, `signers_n`, `signer_fingerprints` from the manifest.
+2. Load the n authorized public keys from `pubkeys/`. Check each loaded
+   key's fingerprint is in `signer_fingerprints` and that exactly n distinct
+   fingerprints are present (manifest and zip agree on the authorized set).
+3. Recompute `digest = sha256(trail_bytes || manifest_bytes)`.
+4. For each file in `sigs/`, verify it against the authorized key whose
+   fingerprint matches the filename. Count **distinct authorized signers**
+   with a valid signature over the digest.
+5. Pass iff `distinct_valid >= k`. An invalid or unauthorized signature is
+   ignored (does not subtract); a duplicate fingerprint counts once.
+6. All existing checks (trail sha256, hash-chain re-verify, record_count,
+   endpoints) run unchanged.
+
+The standalone verifier (`scripts/verify_vaara_trail.py`) gets the same
+branch - stdlib + `cryptography` only, no Vaara import.
+
+An out-of-band trusted authorized set may optionally be passed to verify; if
+given, the embedded `pubkeys/` set must be a subset (the same "don't trust
+the embedded key" discipline as the single-sig path).
+
+## Key lifecycle (the second half - not optional)
+
+The trust-model note frames threshold signing as a *governance* answer to
+key-person risk, so the lifecycle is part of the feature, not a follow-up.
+
+### Rotation
+
+- Each custodian rotates independently on the existing 12-month schedule
+  (`docs/signing-keys.md`). Rotating one of n does not invalidate prior
+  exports - each export names the authorized set that signed it.
+- Changing k or the membership set is a **policy event**, recorded (below)
+  so a verifier can see when and why the quorum changed.
+
+### Chain-anchored key-compromise markers
+
+This is what makes "issued before compromise" provable rather than asserted,
+and it reuses machinery already shipped:
+
+- A compromise/rotation event is written as an **audit record** in the trail
+  itself (`event_type: "key_lifecycle"`, data carries the affected
+  fingerprint, the action `rotated | revoked | added`, and the new k/n).
+  Because it is a record, it inherits the v0.47 hash chain and the v0.48
+  external time anchor.
+- The external anchor over chain heads is what defeats backdating: a
+  compromised key can re-sign, but it cannot re-anchor past chain heads to a
+  time source it does not control. So a `revoked` marker that was anchored
+  *before* the compromise window pins the revocation in time.
+- Verify surfaces any `key_lifecycle` records found in the trail so a
+  reviewer sees the custodian set's history inline with the evidence.
+
+This ties directly to the "If a Signing Key Is Compromised" section of the
+trust-model doc: with k-of-n plus chain-anchored markers, a single
+compromised custodian key is below quorum and is provably marked revoked at
+an externally-witnessed time.
+
+## Backward compatibility
+
+- Single-sig exports (`Ed25519`, `ML-DSA-65`) are untouched. No manifest
+  field changes for them; `trail.sig` / `signer_pubkey.pem` stay.
+- `verify_signed` dispatches on `signature_algorithm`; unknown stays an
+  error. Old verifiers reading a threshold zip get
+  `unknown signature_algorithm: 'threshold-Ed25519'` - a clean refusal, not
+  a false pass.
+- `member_algorithm` reserves the PQ upgrade path without a schema break.
+
+## Test plan
+
+- Round-trip: 3-of-5 export, all 5 sign, verify passes; verify still passes
+  with only 3 of 5 sigs present; fails with 2.
+- Downgrade attack: flip `threshold_k` 3->1 in the manifest, verify fails
+  (member signatures no longer match the mutated digest).
+- Unauthorized extra: drop a valid signature from a non-authorized key into
+  `sigs/`, verify ignores it and still requires k from the authorized set.
+- Tamper: mutate one trail record, verify fails on the chain check.
+- Standalone verifier parity: same zip through
+  `scripts/verify_vaara_trail.py` gives the same result.
+- Lifecycle: a `key_lifecycle` revoked record in the trail is surfaced by
+  verify and is covered by the hash chain.
+- PQ member: one 5-member set with `member_algorithm: ML-DSA-65` round-trips
+  (guarded by the `pq` extra).
+
+## Out of scope for v0.5
+
+- FROST / aggregate single-signature output.
+- Mixed-algorithm membership in one set (all members share
+  `member_algorithm`).
+- Automated cross-host signature collection transport (the coordinator
+  collecting detached sigs is the operator's integration, as with HSM
+  signing today).

--- a/docs/design/w3c-vc-receipt-spec.md
+++ b/docs/design/w3c-vc-receipt-spec.md
@@ -1,0 +1,125 @@
+# Design spec: W3C VC opt-in receipt serialization
+
+Status: draft for v0.5. Priority 3 of 3. Extends
+`vaara.attestation.receipt` / `_receipt_emit.py`.
+
+## Goal
+
+Emit execution receipts as W3C Verifiable Credentials **on request**, so a
+consumer who standardizes on VCs can ingest Vaara receipts without a custom
+parser. This neutralizes the one format edge a clone (Beacon emits receipts
+as VCs) has, while keeping JCS / SEP-2787 as Vaara's canonical core.
+
+Hard constraint: **the verification path is unchanged.** A VC is a
+presentation wrapper. The signed bytes stay the JCS-canonical receipt; the
+VC is recoverable back to that exact canonical form and verifies with the
+existing `verify_receipt_signature` stack. No new crypto, no second trust
+surface.
+
+## What already exists (reuse, do not rebuild)
+
+- `ExecutionReceipt` (`_receipt_types.py`) with `to_dict()` and
+  `receipt_from_dict()`.
+- `_signing_payload()` = JCS-canonical encoding of
+  `{version, alg, backLink, outcomeDerived, receiptAsserted}`; the
+  signature is over exactly these bytes and excludes itself.
+- `sign_es256` / `verify_es256` (and HS256 / RS256) in `_sep2787_signing`.
+
+The VC layer is pure serialization over these. It adds no signing.
+
+## Design: VC as a lossless wrapper
+
+The native receipt's signature already covers the canonical receipt blocks.
+So the VC must NOT re-sign or re-canonicalize the payload (that would create
+a second, divergent signature). Instead:
+
+- The VC `credentialSubject` carries the native receipt blocks verbatim
+  (the same dict `to_dict()` produces, minus the detached `signature`).
+- The VC `proof` carries the existing SEP-2787 signature, typed so a
+  verifier knows it is a detached JCS signature over the receipt blocks,
+  not a standard VC Data Integrity proof.
+- Verification recovers the native `ExecutionReceipt` from the VC and runs
+  `verify_receipt_signature` unchanged. Byte-for-byte the same payload that
+  was signed at emit time.
+
+This is the honest framing: the VC is a *view* of the receipt. We do not
+claim VC Data Integrity / JWT-VC conformance for the proof; we claim a VC
+envelope whose proof is the receipt's own detached signature. (A future
+true DataIntegrityProof variant is a separate, larger track; out of scope.)
+
+## Wire shape
+
+```json
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://vaara.io/credentials/execution-receipt/v1"
+  ],
+  "type": ["VerifiableCredential", "VaaraExecutionReceipt"],
+  "issuer": "<receiptAsserted.iss>",
+  "validFrom": "<receiptAsserted.iat>",
+  "credentialSubject": {
+    "version": 1,
+    "alg": "ES256",
+    "backLink": { "...": "verbatim receipt block" },
+    "outcomeDerived": { "...": "verbatim receipt block" },
+    "receiptAsserted": { "...": "verbatim receipt block" }
+  },
+  "proof": {
+    "type": "VaaraSep2787DetachedSignature2026",
+    "cryptosuite": "jcs-es256",
+    "verificationMethod": "<secretVersion or key id>",
+    "proofValue": "<the receipt.signature hex>"
+  }
+}
+```
+
+`@context` ships a Vaara term-definition document at the versioned URL; the
+context is static and vendored in-repo so verification needs no network.
+
+## API
+
+Opt-in, additive, default behavior unchanged:
+
+- `receipt_to_vc(receipt: ExecutionReceipt) -> dict` — wrap.
+- `receipt_from_vc(vc: dict) -> ExecutionReceipt` — unwrap, reconstructing
+  the exact `ExecutionReceipt` (inverse of `receipt_to_vc`).
+- Convenience on the public `receipt` surface, e.g. an emit helper or a
+  `serialization="vc"` flag, that emits the native receipt then wraps it.
+  The native path stays the default; VC is requested explicitly.
+
+`receipt_from_vc(receipt_to_vc(r)) == r` is the round-trip invariant the
+whole design hangs on.
+
+## Verification path (unchanged, restated)
+
+1. `receipt_from_vc(vc)` -> `ExecutionReceipt`.
+2. `verify_receipt_signature(receipt, verifying_material=...)` — the
+   existing call, same JCS payload, same ES256/RS256/HS256 check.
+3. Back-link and result-commitment checks compose as today.
+
+A consumer who only speaks VC can also read `credentialSubject` directly,
+but the *trust* decision always routes through step 2. There is no
+VC-native verification that bypasses the receipt signature.
+
+## Test plan
+
+- Round-trip identity: `receipt_from_vc(receipt_to_vc(r)) == r` for
+  ES256, RS256, HS256 receipts, with and without a result commitment.
+- Signature parity: a receipt verified natively and the same receipt
+  unwrapped from its VC verify identically; tampering with any
+  `credentialSubject` block fails verification after unwrap.
+- Proof tamper: mutating `proof.proofValue` fails; mutating a
+  `credentialSubject` field fails; both via the unchanged verifier.
+- Context offline: verification does not fetch `@context` (no network).
+- Schema presence: emitted VC has the required VCDM 2.0 fields
+  (`@context`, `type`, `issuer`, `validFrom`, `credentialSubject`,
+  `proof`).
+
+## Out of scope for v0.5
+
+- True VC Data Integrity proof / JWT-VC / SD-JWT conformance (separate
+  track; would add a second signing surface).
+- Verifiable Presentations, status lists, revocation registries.
+- DID-based `issuer` / `verificationMethod` (string identifiers for now;
+  DID resolution is a later option).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.49.0"
+version = "0.50.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/scripts/verify_vaara_trail.py
+++ b/scripts/verify_vaara_trail.py
@@ -42,6 +42,8 @@ except ImportError:
 
 
 REQUIRED_FILES = {"trail.jsonl", "manifest.json", "trail.sig"}
+CORE_FILES = {"trail.jsonl", "manifest.json"}
+THRESHOLD_PREFIX = "threshold-"
 
 
 def _load_pubkey(data: bytes) -> Ed25519PublicKey:
@@ -55,6 +57,74 @@ def _load_pubkey(data: bytes) -> Ed25519PublicKey:
     if not isinstance(loaded, Ed25519PublicKey):
         raise ValueError("public key is not Ed25519")
     return loaded
+
+
+def _raw_ed25519(loaded: Ed25519PublicKey) -> bytes:
+    if hasattr(loaded, "public_bytes_raw"):
+        return loaded.public_bytes_raw()
+    return loaded.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+
+def _verify_threshold(
+    manifest: dict, to_verify: bytes, sigs: dict, pubkeys: dict
+) -> list[str]:
+    """k-of-n threshold verification (Ed25519 members). Mirrors
+    vaara.audit.verify._verify_threshold so this standalone file gives the
+    same verdict with only the 'cryptography' package installed."""
+    errors: list[str] = []
+    member_algorithm = manifest.get("member_algorithm")
+    k = manifest.get("threshold_k")
+    fps = manifest.get("signer_fingerprints")
+    if not isinstance(k, int) or k < 1:
+        return [f"invalid threshold_k: {k!r}"]
+    if not isinstance(fps, list) or not fps or not all(isinstance(f, str) for f in fps):
+        return ["manifest signer_fingerprints missing or malformed"]
+    if manifest.get("signers_n") != len(fps):
+        errors.append("signers_n does not match signer_fingerprints length")
+    if k > len(fps):
+        return errors + [f"threshold_k ({k}) exceeds n ({len(fps)})"]
+    if member_algorithm != "Ed25519":
+        return errors + [
+            f"this standalone verifier supports Ed25519 members only, "
+            f"got {member_algorithm!r}"
+        ]
+
+    authorized: dict = {}
+    for fp in fps:
+        raw = pubkeys.get(fp)
+        if raw is None:
+            errors.append(f"missing pubkeys/ entry for authorized signer {fp}")
+            continue
+        try:
+            loaded = _load_pubkey(raw)
+        except ValueError as e:
+            errors.append(f"pubkey for {fp}: {e}")
+            continue
+        raw_norm = _raw_ed25519(loaded)
+        if hashlib.sha256(raw_norm).hexdigest()[:32] != fp:
+            errors.append(f"pubkey for {fp} does not match its fingerprint (substituted key)")
+            continue
+        authorized[fp] = raw_norm
+
+    valid = set()
+    for fp, sig in sigs.items():
+        raw_norm = authorized.get(fp)
+        if raw_norm is None:
+            continue
+        try:
+            Ed25519PublicKey.from_public_bytes(raw_norm).verify(sig, to_verify)
+            valid.add(fp)
+        except (InvalidSignature, ValueError):
+            pass
+    if len(valid) < k:
+        errors.append(
+            f"threshold not met: {len(valid)} valid signature(s) from the "
+            f"authorized set, need at least {k} of {len(fps)}"
+        )
+    return errors
 
 
 def _verify_chain(trail_bytes: bytes) -> str | None:
@@ -77,6 +147,13 @@ def _verify_chain(trail_bytes: bytes) -> str | None:
             "regulatory_articles": rec.get("regulatory_articles", []),
             "previous_hash": prev_hash,
         }
+        # Chain v2 (v0.47+) binds tenant_id and chain_version into the hash.
+        # Legacy v1 records omit both, so pre-v0.47 trails re-verify
+        # unchanged. Mirrors vaara.audit.verify._verify_chain_bytes.
+        chain_version = rec.get("chain_version", 1)
+        if isinstance(chain_version, int) and chain_version >= 2:
+            content["tenant_id"] = rec.get("tenant_id", "")
+            content["chain_version"] = chain_version
         canonical = json.dumps(
             content, sort_keys=True, separators=(",", ":"), allow_nan=False
         )
@@ -92,18 +169,26 @@ def verify(zip_path: Path, pubkey_path: Path | None) -> tuple[bool, list[str], d
     if not zip_path.exists():
         return False, [f"file not found: {zip_path}"], None
 
+    threshold_sigs: dict = {}
+    threshold_pubkeys: dict = {}
     try:
         with zipfile.ZipFile(zip_path, "r") as zf:
             names = set(zf.namelist())
-            missing = REQUIRED_FILES - names
+            missing = CORE_FILES - names
             if missing:
                 return False, [f"missing files in zip: {sorted(missing)}"], None
             trail_bytes = zf.read("trail.jsonl")
             manifest_bytes = zf.read("manifest.json")
-            signature = zf.read("trail.sig")
+            signature = zf.read("trail.sig") if "trail.sig" in names else None
             embedded_pubkey = (
                 zf.read("signer_pubkey.pem") if "signer_pubkey.pem" in names else None
             )
+            for name in names:
+                if name.startswith("sigs/") and name.endswith(".sig"):
+                    threshold_sigs[name[len("sigs/"):-len(".sig")]] = zf.read(name)
+                elif name.startswith("pubkeys/") and name != "pubkeys/":
+                    fp = name[len("pubkeys/"):].rsplit(".", 1)[0]
+                    threshold_pubkeys[fp] = zf.read(name)
     except zipfile.BadZipFile as e:
         return False, [f"corrupt zip: {e}"], None
 
@@ -119,19 +204,28 @@ def verify(zip_path: Path, pubkey_path: Path | None) -> tuple[bool, list[str], d
     if manifest.get("trail_sha256") != actual_sha:
         errors.append("trail.jsonl SHA-256 does not match manifest.trail_sha256 (tampered)")
 
-    if pubkey_path is not None:
-        pk_data = pubkey_path.read_bytes()
-    elif embedded_pubkey is not None:
-        pk_data = embedded_pubkey
-    else:
-        return False, errors + ["no --pubkey given and no signer_pubkey.pem in zip"], manifest
-
-    pk = _load_pubkey(pk_data)
+    algorithm = manifest.get("signature_algorithm", "Ed25519")
     to_verify = hashlib.sha256(trail_bytes + manifest_bytes).digest()
-    try:
-        pk.verify(signature, to_verify)
-    except InvalidSignature:
-        errors.append("Ed25519 signature did not verify")
+
+    if algorithm.startswith(THRESHOLD_PREFIX):
+        errors.extend(
+            _verify_threshold(manifest, to_verify, threshold_sigs, threshold_pubkeys)
+        )
+    else:
+        if pubkey_path is not None:
+            pk_data = pubkey_path.read_bytes()
+        elif embedded_pubkey is not None:
+            pk_data = embedded_pubkey
+        else:
+            return False, errors + ["no --pubkey given and no signer_pubkey.pem in zip"], manifest
+        pk = _load_pubkey(pk_data)
+        if signature is None:
+            errors.append("missing trail.sig in zip")
+        else:
+            try:
+                pk.verify(signature, to_verify)
+            except InvalidSignature:
+                errors.append("Ed25519 signature did not verify")
 
     chain_error = _verify_chain(trail_bytes)
     if chain_error is not None:

--- a/scripts/verify_vaara_trail.py
+++ b/scripts/verify_vaara_trail.py
@@ -164,6 +164,36 @@ def _verify_chain(trail_bytes: bytes) -> str | None:
     return None
 
 
+def _collect_key_lifecycle(zip_path: Path) -> list[dict]:
+    """Custodian key-lifecycle records in the trail, in chain order.
+
+    Informational only; the records are covered by the hash-chain check, so
+    a tampered lifecycle record fails on the chain, not here.
+    """
+    out: list[dict] = []
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            trail_bytes = zf.read("trail.jsonl")
+    except (zipfile.BadZipFile, KeyError, FileNotFoundError):
+        return out
+    for raw in (ln for ln in trail_bytes.splitlines() if ln.strip()):
+        try:
+            rec = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if rec.get("event_type") != "key_lifecycle":
+            continue
+        data = rec.get("data", {}) or {}
+        out.append({
+            "action": data.get("action"),
+            "fingerprint": data.get("fingerprint"),
+            "threshold_k": data.get("threshold_k"),
+            "signers_n": data.get("signers_n"),
+            "reason": data.get("reason", ""),
+        })
+    return out
+
+
 def verify(zip_path: Path, pubkey_path: Path | None) -> tuple[bool, list[str], dict | None]:
     errors: list[str] = []
     if not zip_path.exists():
@@ -277,6 +307,17 @@ def main(argv: list[str] | None = None) -> int:
             "agent_id",
         ):
             print(f"  {k:<30} {manifest.get(k)}")
+
+        events = _collect_key_lifecycle(Path(args.zip_path))
+        if events:
+            print(f"  {'key_lifecycle_events':<30} {len(events)}")
+            for ev in events:
+                line = f"    - {ev['action']} {ev['fingerprint']}"
+                if ev.get("threshold_k") is not None:
+                    line += f" (quorum now {ev['threshold_k']}-of-{ev['signers_n']})"
+                if ev.get("reason"):
+                    line += f": {ev['reason']}"
+                print(line)
 
     if ok:
         print("\nVerification: OK")

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.48.0",
+  "version": "0.50.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.48.0",
+      "version": "0.50.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.48.0",
+  "version": "0.50.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.48.0",
+      "version": "0.50.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.48.0"
+__version__ = "0.50.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_receipt_vc.py
+++ b/src/vaara/attestation/_receipt_vc.py
@@ -1,0 +1,130 @@
+"""W3C Verifiable Credential serialization for execution receipts (opt-in).
+
+Internal module. Public surface re-exports ``receipt_to_vc`` and
+``receipt_from_vc`` from ``vaara.attestation.receipt``.
+
+A consumer who standardizes on W3C VCs can ingest Vaara execution receipts
+without a custom parser. The VC is a lossless *view* of the native receipt,
+not a second trust surface:
+
+- ``credentialSubject`` carries the native receipt blocks verbatim (the same
+  dict ``ExecutionReceipt.to_dict()`` produces, minus the detached signature).
+- ``proof.proofValue`` carries the existing SEP-2787 detached signature, typed
+  so a verifier knows it is a detached JCS signature over the receipt blocks,
+  not a standard VC Data Integrity proof.
+- ``receipt_from_vc`` recovers the exact ``ExecutionReceipt`` and verification
+  routes through the unchanged ``verify_receipt_signature`` stack. The signed
+  bytes stay the JCS-canonical receipt; no new crypto, no re-canonicalization.
+
+The round-trip invariant the design hangs on::
+
+    receipt_from_vc(receipt_to_vc(r)) == r
+
+We do not claim VC Data Integrity / JWT-VC conformance for the proof; we claim
+a VCDM 2.0 envelope whose proof is the receipt's own detached signature. A true
+``DataIntegrityProof`` variant is a separate, larger track (out of scope).
+
+See ``docs/design/w3c-vc-receipt-spec.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vaara.attestation._receipt_types import ExecutionReceipt, receipt_from_dict
+from vaara.attestation._sep2787_types import AttestationError
+
+# VCDM 2.0 base context plus the Vaara term-definition document. Both are
+# declared in the credential; verification never fetches them (the trust
+# decision routes through the receipt signature), so this is offline-safe.
+VC_V2_CONTEXT = "https://www.w3.org/ns/credentials/v2"
+VAARA_RECEIPT_CONTEXT_URL = "https://vaara.io/credentials/execution-receipt/v1"
+
+PROOF_TYPE = "VaaraSep2787DetachedSignature2026"
+CREDENTIAL_TYPE = "VaaraExecutionReceipt"
+
+# Vendored term-definition document for VAARA_RECEIPT_CONTEXT_URL. Held as a
+# module constant rather than a fetched URL so that any verifier resolving the
+# context can do so entirely offline.
+VAARA_RECEIPT_CONTEXT_DOCUMENT: dict[str, Any] = {
+    "@context": {
+        "@protected": True,
+        "VaaraExecutionReceipt": VAARA_RECEIPT_CONTEXT_URL + "#VaaraExecutionReceipt",
+        "version": "https://schema.org/version",
+        "alg": VAARA_RECEIPT_CONTEXT_URL + "#alg",
+        "backLink": VAARA_RECEIPT_CONTEXT_URL + "#backLink",
+        "outcomeDerived": VAARA_RECEIPT_CONTEXT_URL + "#outcomeDerived",
+        "receiptAsserted": VAARA_RECEIPT_CONTEXT_URL + "#receiptAsserted",
+    }
+}
+
+
+def load_receipt_context() -> dict[str, Any]:
+    """Return the vendored Vaara receipt JSON-LD context document.
+
+    Offline only; no network resolution. Provided so a JSON-LD consumer can
+    resolve ``VAARA_RECEIPT_CONTEXT_URL`` from the package itself.
+    """
+    return VAARA_RECEIPT_CONTEXT_DOCUMENT
+
+
+def receipt_to_vc(receipt: ExecutionReceipt) -> dict[str, Any]:
+    """Wrap an ``ExecutionReceipt`` as a W3C Verifiable Credential.
+
+    The credential is a lossless view: ``credentialSubject`` holds the native
+    receipt blocks verbatim and ``proof.proofValue`` holds the receipt's
+    existing detached signature. No re-signing, no re-canonicalization.
+
+    Args:
+        receipt: The native execution receipt to present as a VC.
+
+    Returns:
+        A VCDM 2.0 credential dict.
+    """
+    blocks = receipt.to_dict()
+    signature = blocks.pop("signature")
+    return {
+        "@context": [VC_V2_CONTEXT, VAARA_RECEIPT_CONTEXT_URL],
+        "type": ["VerifiableCredential", CREDENTIAL_TYPE],
+        "issuer": receipt.receipt_asserted.iss,
+        "validFrom": receipt.receipt_asserted.iat,
+        # version, alg, backLink, outcomeDerived, receiptAsserted (verbatim)
+        "credentialSubject": blocks,
+        "proof": {
+            "type": PROOF_TYPE,
+            "cryptosuite": f"jcs-{receipt.alg.lower()}",
+            "verificationMethod": receipt.receipt_asserted.secret_version,
+            "proofValue": signature,
+        },
+    }
+
+
+def receipt_from_vc(vc: dict[str, Any]) -> ExecutionReceipt:
+    """Recover the exact ``ExecutionReceipt`` from its VC wrapper.
+
+    Inverse of :func:`receipt_to_vc`. The recovered receipt is byte-for-byte
+    the payload that was signed at emit time, so it verifies with the
+    unchanged ``verify_receipt_signature`` stack.
+
+    Args:
+        vc: A credential previously produced by :func:`receipt_to_vc`.
+
+    Returns:
+        The reconstructed execution receipt.
+
+    Raises:
+        AttestationError: If the VC is missing ``credentialSubject`` or a
+            ``proof`` with a ``proofValue``.
+    """
+    if not isinstance(vc, dict):
+        raise AttestationError("VC must be a JSON object")
+    subject = vc.get("credentialSubject")
+    proof = vc.get("proof")
+    if not isinstance(subject, dict):
+        raise AttestationError("VC missing credentialSubject object")
+    if not isinstance(proof, dict) or "proofValue" not in proof:
+        raise AttestationError("VC missing proof with proofValue")
+    # Rebuild the native to_dict() shape: receipt blocks + detached signature.
+    blocks = dict(subject)
+    blocks["signature"] = proof["proofValue"]
+    return receipt_from_dict(blocks)

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -54,6 +54,12 @@ from vaara.attestation._receipt_verifier import (
     make_back_link,
     verify_back_link,
 )
+from vaara.attestation._receipt_vc import (
+    VAARA_RECEIPT_CONTEXT_URL,
+    load_receipt_context,
+    receipt_from_vc,
+    receipt_to_vc,
+)
 
 # Result commitments reuse the SEP-2787 argument-commitment builders.
 # Re-export under result-oriented names so call sites read naturally.
@@ -63,6 +69,7 @@ from vaara.attestation._sep2787_canonical import (
 )
 
 __all__ = [
+    "VAARA_RECEIPT_CONTEXT_URL",
     "BackLink",
     "BackLinkResult",
     "ExecutionReceipt",
@@ -72,10 +79,13 @@ __all__ = [
     "ResultCommitment",
     "attestation_digest",
     "emit_receipt",
+    "load_receipt_context",
     "make_back_link",
     "make_result_digest",
     "make_result_projection",
     "parse_receipt",
+    "receipt_from_vc",
+    "receipt_to_vc",
     "verify_back_link",
     "verify_receipt_signature",
 ]

--- a/src/vaara/audit/article12_export.py
+++ b/src/vaara/audit/article12_export.py
@@ -1,0 +1,122 @@
+"""EU AI Act Article 12 one-command regulator export.
+
+Composes the existing signed-export path with a generated Article 12
+record-keeping report, packaged in one zip. See
+``docs/design/article12-export-spec.md`` and ``article12_report.py``.
+
+The signed core (trail.jsonl, manifest.json, signature, pubkey) is written
+first by ``export_signed`` / ``export_signed_threshold``. The report is then
+built from the *signed* trail bytes read back out of the zip, so it always
+describes exactly the trail that was signed, and folded into the zip:
+
+    article12_report.md      (or .html)
+    article12_summary.json
+    verify_instructions.txt
+
+The report is bound to the signed trail by the manifest ``trail_sha256`` it
+records. It is not itself signed; the verify instructions say so plainly.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Optional, Union
+
+from vaara.audit.article12_report import (
+    build_article12_report,
+    render_report_html,
+    render_report_md,
+    verify_instructions_text,
+)
+from vaara.audit.export import (
+    ExportResult,
+    export_signed,
+    export_signed_threshold,
+)
+from vaara.audit.trail import AuditRecord
+
+
+def _records_from_zip(zip_path: Path) -> tuple[list[AuditRecord], dict]:
+    """Read ``trail.jsonl`` + ``manifest.json`` back out of the signed zip.
+
+    Reading the trail from the just-written zip (rather than re-snapshotting
+    the live trail) guarantees the report describes exactly the bytes that
+    were signed: same records, same ``trail_sha256``.
+    """
+    records: list[AuditRecord] = []
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        trail_bytes = zf.read("trail.jsonl")
+        manifest = json.loads(zf.read("manifest.json"))
+    for raw in trail_bytes.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        records.append(AuditRecord.from_dict(json.loads(line)))
+    return records, manifest
+
+
+def export_article12(
+    trail,
+    out_path: Union[str, Path],
+    *,
+    signer_key=None,
+    signer=None,
+    signers: Optional[list] = None,
+    threshold_k: Optional[int] = None,
+    system_meta: Optional[dict] = None,
+    period: Optional[tuple] = None,
+    fmt: str = "md",
+    agent_id: str = "",
+) -> ExportResult:
+    """Write a signed Article 12 regulator package.
+
+    The signer arguments mirror the underlying export functions: pass
+    ``signer_key`` or ``signer`` for the single-signer path, or ``signers``
+    plus ``threshold_k`` for the k-of-n threshold path. ``system_meta`` and
+    ``period`` are passed through to the report builder; ``fmt`` selects
+    ``"md"`` or ``"html"`` for the human-readable report.
+
+    Returns the underlying :class:`ExportResult` (its ``manifest`` covers the
+    signed core; the Article 12 files are folded in afterwards).
+    """
+    if fmt not in ("md", "html"):
+        raise ValueError(f"fmt must be 'md' or 'html', got {fmt!r}")
+    out_path = Path(out_path)
+
+    threshold_mode = signers is not None or threshold_k is not None
+    if threshold_mode:
+        if not signers or threshold_k is None:
+            raise ValueError(
+                "threshold export needs both `signers` and `threshold_k`"
+            )
+        result = export_signed_threshold(
+            trail, out_path, signers=signers,
+            threshold_k=threshold_k, agent_id=agent_id,
+        )
+    else:
+        result = export_signed(
+            trail, out_path, signer_key=signer_key,
+            signer=signer, agent_id=agent_id,
+        )
+
+    # Build the report from the trail bytes that were actually signed.
+    records, manifest = _records_from_zip(out_path)
+    report = build_article12_report(
+        records, manifest, system_meta=system_meta, period=period,
+    )
+
+    report_name = f"article12_report.{fmt}"
+    report_body = (
+        render_report_html(report) if fmt == "html" else render_report_md(report)
+    )
+    summary_bytes = json.dumps(report, indent=2, sort_keys=False).encode("utf-8")
+    instructions = verify_instructions_text(report)
+
+    with zipfile.ZipFile(out_path, "a", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(report_name, report_body)
+        zf.writestr("article12_summary.json", summary_bytes)
+        zf.writestr("verify_instructions.txt", instructions + "\n")
+
+    return result

--- a/src/vaara/audit/article12_report.py
+++ b/src/vaara/audit/article12_report.py
@@ -1,0 +1,443 @@
+"""EU AI Act Article 12 record-keeping report — pure builders and renderers.
+
+Turns an audit trail into a regulator-facing mapping against the Article 12
+logging obligations. No crypto here: signing and zip assembly live in
+``vaara.audit.article12_export``. These functions are pure and testable on
+their own. Given the trail records and the signed-export manifest they
+produce a report dict, its Markdown/HTML rendering, and the verify
+instructions a regulator follows.
+
+The report is a derived, human-readable view of the signed trail. It is
+bound to that trail by the manifest ``trail_sha256`` it records, not by its
+own signature: a regulator verifies the signature over trail+manifest, then
+checks that the report names the same ``trail_sha256``. See
+``docs/design/article12-export-spec.md``.
+
+Schema version: ``vaara-article12/1.0``
+"""
+
+from __future__ import annotations
+
+import html as _html
+import time
+from typing import Optional, Sequence
+
+from vaara.audit.trail import AuditRecord, EventType
+
+SCHEMA_VERSION = "vaara-article12/1.0"
+
+# Static Article 12 / 26(5) obligation checklist. Each entry names a duty and
+# the event types whose presence in the trail evidences it. The mapping is a
+# structural aid, not a legal opinion: it shows which logs speak to which
+# obligation. The semantic-correctness judgement stays human-owned (see the
+# trust model). ``evidenced_by`` holds EventType values.
+ARTICLE12_OBLIGATIONS: tuple[dict, ...] = (
+    {
+        "id": "art12_1",
+        "article": "Article 12(1)",
+        "title": "Automatic recording of events over the system lifetime",
+        "evidenced_by": tuple(et.value for et in EventType),
+    },
+    {
+        "id": "art12_2_a",
+        "article": "Article 12(2)(a)",
+        "title": (
+            "Identifying situations that may present a risk (Article 79(1)) "
+            "or a substantial modification"
+        ),
+        "evidenced_by": (
+            EventType.ACTION_BLOCKED.value,
+            EventType.POLICY_OVERRIDE.value,
+            EventType.OUTCOME_RECORDED.value,
+        ),
+    },
+    {
+        "id": "art12_2_b",
+        "article": "Article 12(2)(b)",
+        "title": "Facilitating post-market monitoring (Article 72)",
+        "evidenced_by": (
+            EventType.OUTCOME_RECORDED.value,
+            EventType.ACTION_EXECUTED.value,
+        ),
+    },
+    {
+        "id": "art12_2_c",
+        "article": "Article 12(2)(c) / 26(5)",
+        "title": "Monitoring of operation by the deployer",
+        "evidenced_by": (
+            EventType.DECISION_MADE.value,
+            EventType.ACTION_EXECUTED.value,
+            EventType.ESCALATION_SENT.value,
+            EventType.ESCALATION_RESOLVED.value,
+        ),
+    },
+    {
+        "id": "art12_3_a",
+        "article": "Article 12(3)(a)",
+        "title": "Period of each use (start and end of operation)",
+        "evidenced_by": (
+            EventType.ACTION_REQUESTED.value,
+            EventType.ACTION_EXECUTED.value,
+        ),
+    },
+)
+
+
+def _iso(epoch: Optional[float]) -> str:
+    if epoch is None:
+        return ""
+    try:
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(float(epoch)))
+    except (ValueError, OverflowError, OSError):
+        return str(epoch)
+
+
+def _in_period(ts: float, period: Optional[tuple]) -> bool:
+    if period is None:
+        return True
+    start, end = period
+    if start is not None and ts < start:
+        return False
+    if end is not None and ts > end:
+        return False
+    return True
+
+
+def build_article12_report(
+    records: Sequence[AuditRecord],
+    manifest: dict,
+    *,
+    system_meta: Optional[dict] = None,
+    period: Optional[tuple] = None,
+) -> dict:
+    """Build the Article 12 report dict from a trail and its export manifest.
+
+    ``records`` is the full trail (whole-trail evidence). ``manifest`` is the
+    dict written by ``export_signed`` / ``export_signed_threshold``.
+    ``period`` is an optional ``(start_epoch, end_epoch)`` lens that narrows
+    which records the *summary* counts. It never narrows the signed trail,
+    which stays whole. ``system_meta`` carries operator-supplied identity the
+    trail does not hold; absent fields render as "not provided".
+    """
+    system_meta = dict(system_meta or {})
+    in_scope = [r for r in records if _in_period(r.timestamp, period)]
+
+    # Event histogram over the in-scope records, with per-type endpoints and
+    # a few example record ids.
+    histogram: dict[str, dict] = {}
+    for r in in_scope:
+        et = r.event_type.value
+        h = histogram.setdefault(
+            et, {"count": 0, "first": None, "last": None, "examples": []}
+        )
+        h["count"] += 1
+        if h["first"] is None or r.timestamp < h["first"]:
+            h["first"] = r.timestamp
+        if h["last"] is None or r.timestamp > h["last"]:
+            h["last"] = r.timestamp
+        if len(h["examples"]) < 3:
+            h["examples"].append(r.record_id)
+
+    # Obligation mapping: for each duty, which evidencing event types are
+    # present, the total count, and a few example record ids.
+    obligations = []
+    for ob in ARTICLE12_OBLIGATIONS:
+        present = [et for et in ob["evidenced_by"] if et in histogram]
+        count = sum(histogram[et]["count"] for et in present)
+        examples: list[str] = []
+        for et in present:
+            for rid in histogram[et]["examples"]:
+                if len(examples) < 3:
+                    examples.append(rid)
+        obligations.append({
+            "id": ob["id"],
+            "article": ob["article"],
+            "title": ob["title"],
+            "event_types_present": present,
+            "record_count": count,
+            "example_record_ids": examples,
+            "status": "evidenced" if present else "no_matching_events",
+        })
+
+    # Records carrying explicit regulatory tags written into the chain at
+    # record time, counted by referenced article.
+    tagged = 0
+    tagged_articles: dict[str, int] = {}
+    for r in in_scope:
+        if r.regulatory_articles:
+            tagged += 1
+            for a in r.regulatory_articles:
+                key = f"{a.get('domain', '')} {a.get('article', '')}".strip()
+                tagged_articles[key] = tagged_articles.get(key, 0) + 1
+
+    # Integrity-relevant markers surfaced inline (custodian key lifecycle and
+    # any fail-open anchor gaps).
+    key_lifecycle = [
+        {
+            "timestamp": _iso(r.timestamp),
+            "action": (r.data or {}).get("action"),
+            "fingerprint": (r.data or {}).get("fingerprint"),
+            "threshold_k": (r.data or {}).get("threshold_k"),
+            "signers_n": (r.data or {}).get("signers_n"),
+            "reason": (r.data or {}).get("reason", ""),
+        }
+        for r in in_scope if r.event_type == EventType.KEY_LIFECYCLE
+    ]
+    anchor_gaps = sum(1 for r in in_scope if r.event_type == EventType.ANCHOR_GAP)
+
+    timestamps = [r.timestamp for r in in_scope]
+    threshold = None
+    if "threshold_k" in manifest:
+        threshold = {
+            "threshold_k": manifest.get("threshold_k"),
+            "signers_n": manifest.get("signers_n"),
+            "signer_fingerprints": manifest.get("signer_fingerprints", []),
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "report_format": "article12",
+        "generated_utc": _iso(time.time()),
+        "regulation": {"framework": "EU AI Act", "articles": ["12", "26(5)"]},
+        "cover": {
+            "system_name": system_meta.get("system_name", "not provided"),
+            "provider": system_meta.get("provider", "not provided"),
+            "deployer": system_meta.get("deployer", "not provided"),
+            "intended_purpose": system_meta.get("intended_purpose", "not provided"),
+            "risk_classification": system_meta.get(
+                "risk_classification", "not provided"),
+            "export_created_utc": manifest.get("created_utc", ""),
+            "vaara_version": manifest.get("vaara_version", ""),
+            "signer_fingerprint": manifest.get("signer_pubkey_fingerprint", ""),
+            "signature_algorithm": manifest.get("signature_algorithm", ""),
+            "threshold": threshold,
+            "reporting_period": (
+                {"start": _iso(period[0]), "end": _iso(period[1])}
+                if period else None
+            ),
+        },
+        "record_keeping_summary": {
+            "records_in_trail": len(records),
+            "records_in_scope": len(in_scope),
+            "period_is_report_lens_only": period is not None,
+            "first_event_utc": _iso(min(timestamps)) if timestamps else "",
+            "last_event_utc": _iso(max(timestamps)) if timestamps else "",
+            "chain_intact_at_export": bool(
+                manifest.get("chain_intact_at_export", False)),
+            "trail_sha256": manifest.get("trail_sha256", ""),
+        },
+        "obligation_mapping": obligations,
+        "event_inventory": [
+            {
+                "event_type": et,
+                "count": h["count"],
+                "first_utc": _iso(h["first"]),
+                "last_utc": _iso(h["last"]),
+                "example_record_ids": h["examples"],
+            }
+            for et, h in sorted(histogram.items())
+        ],
+        "regulatory_tagging": {
+            "records_with_tags": tagged,
+            "articles_referenced": tagged_articles,
+        },
+        "integrity": {
+            "chain_intact_at_export": bool(
+                manifest.get("chain_intact_at_export", False)),
+            "trail_sha256": manifest.get("trail_sha256", ""),
+            "signature_algorithm": manifest.get("signature_algorithm", ""),
+            "key_lifecycle_events": key_lifecycle,
+            "anchor_gap_markers": anchor_gaps,
+            "trust_model": (
+                "A valid signature proves the integrity and provenance of "
+                "these logs. It does not prove the truth of every recorded "
+                "assertion."
+            ),
+        },
+    }
+
+
+def _md_cell(value) -> str:
+    """Render a table cell, neutralizing Markdown table breakers.
+
+    Cells can carry operator metadata or trail data (key-lifecycle reasons,
+    record ids). A raw ``|`` would split a column and a newline would inject a
+    row, so both are escaped/flattened before the value lands in the table.
+    """
+    return str(value).replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def _md_table(headers: Sequence[str], rows: Sequence[Sequence]) -> str:
+    out = ["| " + " | ".join(_md_cell(h) for h in headers) + " |",
+           "| " + " | ".join("---" for _ in headers) + " |"]
+    for row in rows:
+        out.append("| " + " | ".join(_md_cell(c) for c in row) + " |")
+    return "\n".join(out)
+
+
+def render_report_md(report: dict) -> str:
+    """Render the Article 12 report dict as Markdown."""
+    c = report["cover"]
+    s = report["record_keeping_summary"]
+    integ = report["integrity"]
+    out: list[str] = []
+    out.append("# EU AI Act Article 12 record-keeping report")
+    out.append("")
+    out.append(
+        f"Generated {report['generated_utc']} by Vaara {c['vaara_version']}."
+    )
+    out.append("")
+
+    out.append("## System")
+    out.append("")
+    out.append(_md_table(["Field", "Value"], [
+        ["System name", c["system_name"]],
+        ["Provider", c["provider"]],
+        ["Deployer", c["deployer"]],
+        ["Intended purpose", c["intended_purpose"]],
+        ["Risk classification", c["risk_classification"]],
+        ["Export created (UTC)", c["export_created_utc"]],
+        ["Signer fingerprint", c["signer_fingerprint"]],
+        ["Signature algorithm", c["signature_algorithm"]],
+    ]))
+    if c.get("threshold"):
+        t = c["threshold"]
+        out.append("")
+        out.append(
+            f"Signed by {t['threshold_k']} of {t['signers_n']} named custodians."
+        )
+    if c.get("reporting_period"):
+        p = c["reporting_period"]
+        out.append("")
+        out.append(
+            f"Reporting period: {p['start']} to {p['end']}. The period narrows "
+            "the counts below. The signed trail covers the whole record set, "
+            "not only the period."
+        )
+    out.append("")
+
+    out.append("## Record-keeping summary")
+    out.append("")
+    out.append(_md_table(["Field", "Value"], [
+        ["Records in signed trail", s["records_in_trail"]],
+        ["Records in reporting scope", s["records_in_scope"]],
+        ["First event (UTC)", s["first_event_utc"] or "none"],
+        ["Last event (UTC)", s["last_event_utc"] or "none"],
+        ["Hash chain intact at export", s["chain_intact_at_export"]],
+        ["Trail SHA-256", s["trail_sha256"]],
+    ]))
+    out.append("")
+
+    out.append("## Article 12 obligation mapping")
+    out.append("")
+    out.append(_md_table(
+        ["Obligation", "Title", "Status", "Records", "Event types present"],
+        [
+            [
+                ob["article"], ob["title"], ob["status"], ob["record_count"],
+                ", ".join(ob["event_types_present"]) or "none",
+            ]
+            for ob in report["obligation_mapping"]
+        ],
+    ))
+    out.append("")
+
+    out.append("## Event inventory")
+    out.append("")
+    out.append(_md_table(
+        ["Event type", "Count", "First (UTC)", "Last (UTC)"],
+        [
+            [e["event_type"], e["count"], e["first_utc"], e["last_utc"]]
+            for e in report["event_inventory"]
+        ] or [["none", 0, "", ""]],
+    ))
+    out.append("")
+
+    out.append("## Integrity")
+    out.append("")
+    out.append(f"Hash chain intact at export: {integ['chain_intact_at_export']}.")
+    out.append(f"Signature algorithm: {integ['signature_algorithm']}.")
+    out.append(f"Trail SHA-256: {integ['trail_sha256']}.")
+    if integ["key_lifecycle_events"]:
+        out.append("")
+        out.append("Custodian key-lifecycle events:")
+        out.append("")
+        out.append(_md_table(
+            ["When (UTC)", "Action", "Fingerprint", "k", "n", "Reason"],
+            [
+                [
+                    k["timestamp"], k["action"], k["fingerprint"],
+                    k["threshold_k"], k["signers_n"], k["reason"],
+                ]
+                for k in integ["key_lifecycle_events"]
+            ],
+        ))
+    if integ["anchor_gap_markers"]:
+        out.append("")
+        out.append(
+            f"Anchor-gap markers: {integ['anchor_gap_markers']} "
+            "(auto-anchor attempts that failed open and were recorded)."
+        )
+    out.append("")
+    out.append(integ["trust_model"])
+    out.append("See docs/signing-keys.md and the trust model for the boundary.")
+    out.append("")
+
+    out.append("## How to verify")
+    out.append("")
+    out.append(verify_instructions_text(report))
+    out.append("")
+    return "\n".join(out)
+
+
+def render_report_html(report: dict) -> str:
+    """Render the report as a minimal standalone HTML document.
+
+    Built from the Markdown body so the two views never drift. The Markdown
+    is escaped and wrapped in a ``<pre>`` block: regulators get a portable,
+    self-contained file without pulling in a Markdown renderer.
+    """
+    md = render_report_md(report)
+    title = "EU AI Act Article 12 record-keeping report"
+    return (
+        "<!doctype html>\n<html lang=\"en\">\n<head>\n"
+        "<meta charset=\"utf-8\">\n"
+        f"<title>{_html.escape(title)}</title>\n"
+        "<style>body{font-family:system-ui,sans-serif;margin:2rem;}"
+        "pre{white-space:pre-wrap;}</style>\n"
+        "</head>\n<body>\n<pre>\n"
+        f"{_html.escape(md)}\n"
+        "</pre>\n</body>\n</html>\n"
+    )
+
+
+def verify_instructions_text(report: dict) -> str:
+    """Plain-text steps a regulator follows to check the package."""
+    s = report["record_keeping_summary"]
+    threshold = report["cover"].get("threshold")
+    lines = [
+        "How to verify this Article 12 package",
+        "",
+        "1. Check the signature over the signed trail and manifest:",
+        "     python scripts/verify_vaara_trail.py <this_package>.zip",
+        "   or, with Vaara installed:",
+        "     vaara trail verify --zip <this_package>.zip",
+        "",
+        "2. Confirm this report describes the signed trail. The trail_sha256",
+        "   recorded in this report and in article12_summary.json must equal",
+        "   the trail_sha256 in manifest.json:",
+        f"     {s['trail_sha256']}",
+    ]
+    if threshold:
+        lines += [
+            "",
+            f"3. This package is threshold-signed: at least {threshold['threshold_k']}",
+            f"   of {threshold['signers_n']} named custodian signatures must verify.",
+        ]
+    lines += [
+        "",
+        "The signature covers trail.jsonl and manifest.json. This report and",
+        "article12_summary.json are a derived, human-readable view bound to the",
+        "signed trail by the trail_sha256 above. They are not themselves signed.",
+    ]
+    return "\n".join(lines)

--- a/src/vaara/audit/export.py
+++ b/src/vaara/audit/export.py
@@ -135,6 +135,47 @@ def _build_manifest(
     }
 
 
+def _snapshot_trail(
+    trail: "AuditTrail", out_path: Path
+) -> tuple[bytes, int, str, str, bool]:
+    """Snapshot a trail to bytes plus its endpoints and chain state.
+
+    Shared by the single-signer and threshold export paths. Returns
+    ``(trail_bytes, record_count, first_hash, last_hash, chain_intact)``.
+    """
+    from vaara.audit.trail import AuditTrail
+
+    if not isinstance(trail, AuditTrail):
+        raise TypeError(
+            f"trail must be an AuditTrail instance, got {type(trail).__name__}"
+        )
+    if not out_path.parent.exists():
+        raise FileNotFoundError(
+            f"Output directory does not exist: {out_path.parent}"
+        )
+
+    # Snapshot under the trail's own lock via its existing exporter. Use a
+    # temp path next to the final zip so large trails stream to disk.
+    tmp_jsonl = out_path.with_suffix(out_path.suffix + ".tmp.jsonl")
+    try:
+        record_count = trail.export_jsonl(tmp_jsonl)
+        trail_bytes = tmp_jsonl.read_bytes()
+    finally:
+        tmp_jsonl.unlink(missing_ok=True)
+
+    chain_error = trail.verify_chain()
+    chain_intact = chain_error is None
+    first_hash = ""
+    last_hash = ""
+    if record_count > 0:
+        lines = trail_bytes.splitlines()
+        if lines:
+            first_hash = json.loads(lines[0]).get("record_hash", "")
+            last_hash = json.loads(lines[-1]).get("record_hash", "")
+
+    return trail_bytes, record_count, first_hash, last_hash, chain_intact
+
+
 def export_signed(
     trail: "AuditTrail",
     out_path: Union[str, Path],
@@ -189,41 +230,11 @@ def export_signed(
     # Local import avoids a package-level dep on the trail module for tooling
     # that only imports the export helpers.
     from vaara import __version__ as vaara_version
-    from vaara.audit.trail import AuditTrail
-
-    if not isinstance(trail, AuditTrail):
-        raise TypeError(
-            f"trail must be an AuditTrail instance, got {type(trail).__name__}"
-        )
 
     out_path = Path(out_path)
-    if not out_path.parent.exists():
-        raise FileNotFoundError(
-            f"Output directory does not exist: {out_path.parent}"
-        )
-
-    # Snapshot under the trail's own lock by using its existing exporter.
-    # Use a temp path next to the final zip so we can stream large trails
-    # without holding everything in memory.
-    tmp_jsonl = out_path.with_suffix(out_path.suffix + ".tmp.jsonl")
-    try:
-        record_count = trail.export_jsonl(tmp_jsonl)
-        trail_bytes = tmp_jsonl.read_bytes()
-    finally:
-        tmp_jsonl.unlink(missing_ok=True)
-
-    # Snapshot chain state and endpoints.
-    chain_error = trail.verify_chain()
-    chain_intact = chain_error is None
-    first_hash = ""
-    last_hash = ""
-    if record_count > 0:
-        # Read the first and last lines from the bytes we just wrote so the
-        # manifest matches the exported file exactly, not a live re-read.
-        lines = trail_bytes.splitlines()
-        if lines:
-            first_hash = json.loads(lines[0]).get("record_hash", "")
-            last_hash = json.loads(lines[-1]).get("record_hash", "")
+    trail_bytes, record_count, first_hash, last_hash, chain_intact = (
+        _snapshot_trail(trail, out_path)
+    )
 
     manifest = _build_manifest(
         trail_jsonl_bytes=trail_bytes,
@@ -266,6 +277,210 @@ def export_signed(
         record_count,
         chain_intact,
         manifest["signer_pubkey_fingerprint"],
+    )
+
+    return ExportResult(path=out_path, manifest=manifest, chain_intact=chain_intact)
+
+
+_THRESHOLD_PREFIX = "threshold-"
+
+
+def _short_fp(raw_pubkey: bytes) -> str:
+    """32-hex-char (16-byte) fingerprint of a raw public key.
+
+    Matches the ``signer_pubkey_fingerprint`` convention used elsewhere in
+    the manifest (``public_key_fingerprint()[:32]``).
+    """
+    return hashlib.sha256(raw_pubkey).hexdigest()[:32]
+
+
+def _pubkey_member_bytes(raw_pubkey: bytes, member_algorithm: str) -> tuple[str, bytes]:
+    """Serialize an authorized member public key for the zip.
+
+    Returns ``(filename_ext, file_bytes)``: ``("pem", <PEM>)`` for Ed25519
+    so any cryptography client can load it, ``("bin", <raw>)`` otherwise.
+    """
+    if member_algorithm == "Ed25519":
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+        pub = Ed25519PublicKey.from_public_bytes(raw_pubkey)
+        return "pem", pub.public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    return "bin", raw_pubkey
+
+
+def export_signed_threshold(
+    trail: "AuditTrail",
+    out_path: Union[str, Path],
+    *,
+    signers: list["Signer"],
+    threshold_k: int,
+    authorized_pubkeys: Optional[list[bytes]] = None,
+    member_algorithm: str = "Ed25519",
+    agent_id: str = "",
+) -> ExportResult:
+    """Produce a k-of-n threshold-signed audit-trail export.
+
+    Unlike :func:`export_signed`, which carries one signature, this writes
+    one detached signature per available custodian. Verification requires
+    at least ``threshold_k`` valid signatures from the authorized set, so
+    no single key-holder can issue or forge a trail on their own.
+
+    See ``docs/design/threshold-signing-spec.md``.
+
+    Args:
+        trail: The :class:`AuditTrail` to export.
+        out_path: Where to write the zip. Parent directory must exist.
+        signers: The custodian ``Signer`` instances available to sign now.
+            Must number at least ``threshold_k`` and each must be a member
+            of the authorized set. All share ``member_algorithm``.
+        threshold_k: The quorum. ``1 <= threshold_k <= n``.
+        authorized_pubkeys: Raw public-key bytes of all ``n`` authorized
+            custodians. If omitted, the authorized set is exactly the
+            ``signers`` provided (the common "everyone signs" case) and
+            ``n == len(signers)``.
+        member_algorithm: Signature algorithm shared by every member
+            (``"Ed25519"`` by default; ``"ML-DSA-65"`` reserved for the PQ
+            extra). Mixed-algorithm sets are not supported.
+        agent_id: Optional scope hint written to the manifest. Does not
+            filter the exported records (export is whole-trail).
+
+    Returns:
+        ExportResult with the output path, manifest dict, and chain status.
+
+    Raises:
+        ValueError: If ``threshold_k`` is out of range, fewer than
+            ``threshold_k`` signers are supplied, a signer is not in the
+            authorized set, or any signer's algorithm differs from
+            ``member_algorithm``.
+        FileNotFoundError: If ``out_path`` parent directory does not exist.
+    """
+    if not signers:
+        raise ValueError("export_signed_threshold: `signers` must be non-empty")
+    for s in signers:
+        if s.algorithm != member_algorithm:
+            raise ValueError(
+                "export_signed_threshold: signer algorithm "
+                f"{s.algorithm!r} != member_algorithm {member_algorithm!r}"
+            )
+
+    # Resolve the authorized set (the n custodians). Default: everyone
+    # supplied is a member. De-duplicate by fingerprint, preserving order.
+    authorized_raw = (
+        [s.public_key_bytes() for s in signers]
+        if authorized_pubkeys is None
+        else list(authorized_pubkeys)
+    )
+    authorized_by_fp: dict[str, bytes] = {}
+    for raw in authorized_raw:
+        authorized_by_fp.setdefault(_short_fp(raw), raw)
+    n = len(authorized_by_fp)
+
+    if not isinstance(threshold_k, int) or threshold_k < 1:
+        raise ValueError("export_signed_threshold: threshold_k must be >= 1")
+    if threshold_k > n:
+        raise ValueError(
+            f"export_signed_threshold: threshold_k ({threshold_k}) exceeds n ({n})"
+        )
+
+    # Collect signing custodians, de-duplicated by fingerprint, each a
+    # member of the authorized set. A custodian counts once.
+    signing_by_fp: dict[str, "Signer"] = {}
+    for s in signers:
+        fp = s.public_key_fingerprint()[:32]
+        if fp not in authorized_by_fp:
+            raise ValueError(
+                f"export_signed_threshold: signer {fp} is not in the authorized set"
+            )
+        signing_by_fp.setdefault(fp, s)
+
+    if len(signing_by_fp) < threshold_k:
+        raise ValueError(
+            f"export_signed_threshold: have {len(signing_by_fp)} distinct "
+            f"signer(s), need at least threshold_k ({threshold_k})"
+        )
+
+    return _write_threshold_zip(
+        trail=trail,
+        out_path=Path(out_path),
+        signing_by_fp=signing_by_fp,
+        authorized_by_fp=authorized_by_fp,
+        threshold_k=threshold_k,
+        n=n,
+        member_algorithm=member_algorithm,
+        agent_id=agent_id,
+    )
+
+
+def _write_threshold_zip(
+    *,
+    trail: "AuditTrail",
+    out_path: Path,
+    signing_by_fp: dict,
+    authorized_by_fp: dict,
+    threshold_k: int,
+    n: int,
+    member_algorithm: str,
+    agent_id: str,
+) -> ExportResult:
+    """Build the manifest, collect member signatures, write the zip."""
+    from vaara import __version__ as vaara_version
+
+    trail_bytes, record_count, first_hash, last_hash, chain_intact = (
+        _snapshot_trail(trail, out_path)
+    )
+
+    # The authorized fingerprint list is part of the signed manifest, so k,
+    # n, and the membership set cannot be altered without invalidating every
+    # member signature. Sort for a stable, canonical set identity.
+    signer_fingerprints = sorted(authorized_by_fp)
+    set_fingerprint = hashlib.sha256(
+        "".join(signer_fingerprints).encode("ascii")
+    ).hexdigest()[:32]
+
+    manifest = _build_manifest(
+        trail_jsonl_bytes=trail_bytes,
+        record_count=record_count,
+        first_hash=first_hash,
+        last_hash=last_hash,
+        chain_intact=chain_intact,
+        signer_fingerprint=set_fingerprint,
+        signature_algorithm=f"{_THRESHOLD_PREFIX}{member_algorithm}",
+        vaara_version=vaara_version,
+        agent_id=agent_id,
+    )
+    manifest["threshold_k"] = threshold_k
+    manifest["signers_n"] = n
+    manifest["member_algorithm"] = member_algorithm
+    manifest["signer_fingerprints"] = signer_fingerprints
+    manifest_bytes = json.dumps(manifest, sort_keys=True, indent=2).encode("utf-8")
+
+    # Every custodian signs the identical digest over the trail and the
+    # manifest (which now pins k/n and the authorized set).
+    to_sign = hashlib.sha256(trail_bytes + manifest_bytes).digest()
+
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("trail.jsonl", trail_bytes)
+        zf.writestr("manifest.json", manifest_bytes)
+        for fp, s in signing_by_fp.items():
+            zf.writestr(f"sigs/{fp}.sig", s.sign(to_sign))
+        for fp, raw in authorized_by_fp.items():
+            ext, body = _pubkey_member_bytes(raw, member_algorithm)
+            zf.writestr(f"pubkeys/{fp}.{ext}", body)
+
+    logger.info(
+        "Exported threshold-signed trail: %s (%d records, chain_intact=%s, "
+        "%d-of-%d, set=%s)",
+        out_path,
+        record_count,
+        chain_intact,
+        threshold_k,
+        n,
+        set_fingerprint,
     )
 
     return ExportResult(path=out_path, manifest=manifest, chain_intact=chain_intact)

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -55,6 +55,7 @@ class EventType(str, Enum):
     OUTCOME_RECORDED = "outcome_recorded"   # Post-execution outcome observed
     POLICY_OVERRIDE = "policy_override"     # Manual override of policy decision
     ANCHOR_GAP = "anchor_gap"               # Auto-anchor attempt failed (fail-open marker)
+    KEY_LIFECYCLE = "key_lifecycle"         # Signing-key custodian rotated/revoked/added
 
 
 # ── Regulatory article mappings ───────────────────────────────────────────
@@ -146,6 +147,18 @@ EU_AI_ACT_MAPPINGS: dict[EventType, list[RegulatoryArticle]] = {
             "Every policy override is recorded as an immutable audit event with hash-chained integrity",
         ),
     ],
+    EventType.KEY_LIFECYCLE: [
+        RegulatoryArticle(
+            RegulatoryDomain.EU_AI_ACT, "Article 15(1)",
+            "High-risk AI systems shall achieve an appropriate level of accuracy, robustness and cybersecurity",
+            "Custodian key rotation/revocation/addition is recorded as a hash-chained, externally time-anchored audit event, so the signing-key control set is itself tamper-evident",
+        ),
+        RegulatoryArticle(
+            RegulatoryDomain.EU_AI_ACT, "Article 12(1)",
+            "Automatic recording of events (logging capabilities)",
+            "Every key-lifecycle change is captured as an immutable audit event pinned in the hash chain and the external time anchor",
+        ),
+    ],
 }
 
 DORA_MAPPINGS: dict[EventType, list[RegulatoryArticle]] = {
@@ -234,6 +247,11 @@ TRANSPARENCY_DEFAULTS: dict[EventType, dict[str, str]] = {
         "system_operation": "time_anchoring",
         "data_usage": "chain_head_digest",
         "decision_making": "n/a",
+    },
+    EventType.KEY_LIFECYCLE: {
+        "system_operation": "key_custodian_management",
+        "data_usage": "custodian_fingerprint+quorum",
+        "decision_making": "operator_action",
     },
 }
 
@@ -422,6 +440,11 @@ class AuditRecord:
             EventType.POLICY_OVERRIDE: (
                 f"{prefix} policy overridden: "
                 f"{_narrative_str(self.data.get('override_reason', 'no reason given'))}"
+            ),
+            EventType.KEY_LIFECYCLE: (
+                f"{prefix} signing-key custodian "
+                f"{_narrative_str(self.data.get('action', 'changed'), max_len=16)} "
+                f"({_narrative_str(self.data.get('fingerprint', 'unknown'), max_len=64)})"
             ),
         }
 
@@ -1037,6 +1060,91 @@ class AuditTrail:
             regulatory_articles=articles,
             tenant_id=self._tenant_for(action_id),
         ))
+
+    _KEY_LIFECYCLE_ACTIONS = ("rotated", "revoked", "added")
+
+    def record_key_lifecycle(
+        self,
+        action: str,
+        fingerprint: str,
+        *,
+        threshold_k: Optional[int] = None,
+        signers_n: Optional[int] = None,
+        reason: str = "",
+        actor: str = "",
+        agent_id: str = "system",
+        tenant_id: str = "",
+    ) -> str:
+        """Record a custodian key-lifecycle event (rotation, revocation, add).
+
+        Written as an ordinary audit record, so it inherits the v0.47 hash
+        chain and the v0.48 external time anchor. That is what makes
+        "revoked before compromise" provable rather than asserted: a
+        ``revoked`` marker anchored before a compromise window pins the
+        revocation in time, and a compromised key can re-sign but cannot
+        re-anchor past chain heads to a time source it does not control.
+        :func:`vaara.audit.verify.verify_signed` surfaces these records so a
+        reviewer sees the custodian set's history inline with the evidence.
+
+        See the "Key lifecycle" section of
+        ``docs/design/threshold-signing-spec.md``.
+
+        Args:
+            action: One of ``"rotated"``, ``"revoked"``, ``"added"``.
+            fingerprint: The affected custodian public-key fingerprint
+                (32-hex-char, as printed by ``vaara keygen`` and written to
+                threshold exports).
+            threshold_k: The quorum in force after this event, if it changed.
+            signers_n: The authorized-set size after this event, if changed.
+            reason: Free-text reason (e.g. ``"scheduled rotation"``,
+                ``"suspected compromise"``).
+            actor: Who performed the action (operator or custodian id).
+            agent_id: Defaults to ``"system"`` — lifecycle events are
+                operational, not agent-initiated.
+            tenant_id: Tenant scope bound into the hash chain.
+
+        Returns:
+            The new record's ``record_id``.
+
+        Raises:
+            ValueError: If ``action`` is not a recognized lifecycle action,
+                or ``fingerprint`` is empty.
+        """
+        if action not in self._KEY_LIFECYCLE_ACTIONS:
+            raise ValueError(
+                "record_key_lifecycle: action must be one of "
+                f"{list(self._KEY_LIFECYCLE_ACTIONS)}, got {action!r}"
+            )
+        if not fingerprint:
+            raise ValueError("record_key_lifecycle: fingerprint is required")
+
+        articles = self._get_regulatory_articles(
+            EventType.KEY_LIFECYCLE, frozenset({RegulatoryDomain.EU_AI_ACT}),
+        )
+        data: dict = {
+            "action": action,
+            "fingerprint": self._cap_record_str(fingerprint, 128),
+            "reason": self._cap_record_str(reason, self._MAX_OVERRIDE_REASON_LEN),
+            "actor": self._cap_record_str(actor, self._MAX_OVERRIDER_LEN),
+        }
+        if threshold_k is not None:
+            data["threshold_k"] = int(threshold_k)
+        if signers_n is not None:
+            data["signers_n"] = int(signers_n)
+
+        record_id = str(uuid.uuid4())
+        self._append(AuditRecord(
+            record_id=record_id,
+            action_id=str(uuid.uuid4()),
+            event_type=EventType.KEY_LIFECYCLE,
+            timestamp=time.time(),
+            agent_id=self._cap_record_str(agent_id, self._MAX_AGENT_ID_LEN),
+            tool_name="key_lifecycle",
+            data=data,
+            regulatory_articles=articles,
+            tenant_id=tenant_id,
+        ))
+        return record_id
 
     # ── Querying ──────────────────────────────────────────────────
 

--- a/src/vaara/audit/verify.py
+++ b/src/vaara/audit/verify.py
@@ -52,6 +52,11 @@ class VerifyResult:
     ok: bool
     errors: list[str] = field(default_factory=list)
     manifest: Optional[dict] = None
+    key_lifecycle: list[dict] = field(default_factory=list)
+    """Custodian key-lifecycle records found in the trail (rotations,
+    revocations, additions), in chain order. Informational: surfaced so a
+    reviewer sees the custodian set's history inline. Does not affect ``ok``.
+    """
 
 
 def _require_crypto() -> None:
@@ -432,4 +437,41 @@ def verify_signed(
         except json.JSONDecodeError:
             errors.append("could not parse first/last trail record")
 
-    return VerifyResult(ok=not errors, errors=errors, manifest=manifest)
+    lifecycle = _collect_key_lifecycle(lines)
+
+    return VerifyResult(
+        ok=not errors,
+        errors=errors,
+        manifest=manifest,
+        key_lifecycle=lifecycle,
+    )
+
+
+def _collect_key_lifecycle(lines: list[bytes]) -> list[dict]:
+    """Pull custodian key-lifecycle records out of the trail, in chain order.
+
+    Informational surfacing only (see :class:`VerifyResult.key_lifecycle`);
+    the records are already covered by the hash-chain check, so a tampered
+    lifecycle record fails verification on the chain, not here.
+    """
+    out: list[dict] = []
+    for ln in lines:
+        try:
+            rec = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        if rec.get("event_type") != "key_lifecycle":
+            continue
+        data = rec.get("data", {}) or {}
+        out.append(
+            {
+                "timestamp": rec.get("timestamp"),
+                "action": data.get("action"),
+                "fingerprint": data.get("fingerprint"),
+                "threshold_k": data.get("threshold_k"),
+                "signers_n": data.get("signers_n"),
+                "reason": data.get("reason", ""),
+                "actor": data.get("actor", ""),
+            }
+        )
+    return out

--- a/src/vaara/audit/verify.py
+++ b/src/vaara/audit/verify.py
@@ -30,6 +30,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _REQUIRED_FILES = {"trail.jsonl", "manifest.json", "trail.sig"}
+# Single-signer exports carry trail.sig; threshold exports carry sigs/ +
+# pubkeys/ instead. Both always carry these two.
+_CORE_FILES = {"trail.jsonl", "manifest.json"}
+_THRESHOLD_PREFIX = "threshold-"
 _INSTALL_HINT = (
     "Signed-trail verification requires the 'cryptography' package. "
     "Install with: pip install 'vaara[export]' (or 'pip install cryptography' "
@@ -129,6 +133,113 @@ def _verify_chain_bytes(trail_bytes: bytes) -> Optional[str]:
     return None
 
 
+def _raw_ed25519_bytes(loaded: "Ed25519PublicKey") -> bytes:
+    """Raw 32-byte encoding of an Ed25519 public key, version-tolerant."""
+    if hasattr(loaded, "public_bytes_raw"):
+        return loaded.public_bytes_raw()
+    return loaded.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+
+
+def _member_fingerprint(raw_pubkey: bytes) -> str:
+    """32-hex-char fingerprint of a raw public key (mirrors the signer)."""
+    return hashlib.sha256(raw_pubkey).hexdigest()[:32]
+
+
+def _verify_threshold(
+    *,
+    manifest: dict,
+    to_verify: bytes,
+    sigs: dict[str, bytes],
+    pubkeys: dict[str, bytes],
+) -> list[str]:
+    """Verify a k-of-n threshold export. Returns a list of error strings.
+
+    Requires at least ``threshold_k`` distinct authorized signers to carry
+    a valid signature over ``to_verify``. The authorized fingerprint list
+    lives in the signed manifest, and each stored public key is bound to
+    its manifest fingerprint, so a substituted pubkey is rejected and an
+    unauthorized extra signature is ignored rather than counted.
+    """
+    errors: list[str] = []
+    member_algorithm = manifest.get("member_algorithm")
+    k = manifest.get("threshold_k")
+    n = manifest.get("signers_n")
+    fps = manifest.get("signer_fingerprints")
+
+    if not isinstance(k, int) or k < 1:
+        return [f"invalid threshold_k: {k!r}"]
+    if not isinstance(fps, list) or not fps or not all(isinstance(f, str) for f in fps):
+        return ["manifest signer_fingerprints missing or malformed"]
+    if len(set(fps)) != len(fps):
+        errors.append("signer_fingerprints contains duplicates")
+    if n != len(fps):
+        errors.append(
+            f"signers_n ({n}) does not match signer_fingerprints length ({len(fps)})"
+        )
+    if k > len(fps):
+        return errors + [f"threshold_k ({k}) exceeds n ({len(fps)})"]
+    if member_algorithm not in ("Ed25519", "ML-DSA-65"):
+        return errors + [f"unsupported member_algorithm: {member_algorithm!r}"]
+
+    # Bind each authorized pubkey to its manifest fingerprint.
+    authorized: dict[str, bytes] = {}
+    for fp in fps:
+        raw = pubkeys.get(fp)
+        if raw is None:
+            errors.append(f"missing pubkeys/ entry for authorized signer {fp}")
+            continue
+        if member_algorithm == "Ed25519":
+            try:
+                loaded = serialization.load_pem_public_key(raw)
+            except (ValueError, UnsupportedAlgorithm) as e:
+                errors.append(f"pubkey for {fp} could not be parsed: {e}")
+                continue
+            if not isinstance(loaded, Ed25519PublicKey):
+                errors.append(f"pubkey for {fp} is not Ed25519")
+                continue
+            raw_norm = _raw_ed25519_bytes(loaded)
+        else:
+            raw_norm = raw
+        if _member_fingerprint(raw_norm) != fp:
+            errors.append(
+                f"pubkey for {fp} does not match its fingerprint (substituted key)"
+            )
+            continue
+        authorized[fp] = raw_norm
+
+    mldsa_cls = None
+    if member_algorithm == "ML-DSA-65":
+        try:
+            from vaara.audit.signer import MLDSA65Verifier as mldsa_cls  # type: ignore
+        except ImportError as exc:
+            return errors + [f"ML-DSA-65 verify requires the pq extra: {exc}"]
+
+    # Count distinct authorized signers with a valid signature.
+    valid: set[str] = set()
+    for fp, sig in sigs.items():
+        raw_norm = authorized.get(fp)
+        if raw_norm is None:
+            continue  # unknown or unauthorized signer; not counted
+        if member_algorithm == "Ed25519":
+            try:
+                Ed25519PublicKey.from_public_bytes(raw_norm).verify(sig, to_verify)
+                valid.add(fp)
+            except (InvalidSignature, ValueError):
+                pass
+        elif mldsa_cls(raw_norm).verify(to_verify, sig):
+            valid.add(fp)
+
+    if len(valid) < k:
+        errors.append(
+            f"threshold not met: {len(valid)} valid signature(s) from the "
+            f"authorized set, need at least {k} of {len(fps)}"
+        )
+    return errors
+
+
 def verify_signed(
     zip_path: Union[str, Path],
     public_key: Optional[Union[str, Path, bytes, "_PK"]] = None,
@@ -168,10 +279,15 @@ def verify_signed(
     if not zip_path.exists():
         return VerifyResult(ok=False, errors=[f"file not found: {zip_path}"])
 
+    threshold_sigs: dict[str, bytes] = {}
+    threshold_pubkeys: dict[str, bytes] = {}
     try:
         with zipfile.ZipFile(zip_path, "r") as zf:
             names = set(zf.namelist())
-            missing = _REQUIRED_FILES - names
+            # trail.jsonl + manifest.json are required for every export;
+            # the signature surface differs (single trail.sig vs threshold
+            # sigs/ + pubkeys/) and is resolved after the manifest is read.
+            missing = _CORE_FILES - names
             if missing:
                 return VerifyResult(
                     ok=False,
@@ -179,7 +295,7 @@ def verify_signed(
                 )
             trail_bytes = zf.read("trail.jsonl")
             manifest_bytes = zf.read("manifest.json")
-            signature = zf.read("trail.sig")
+            signature = zf.read("trail.sig") if "trail.sig" in names else None
             embedded_pubkey_pem = (
                 zf.read("signer_pubkey.pem")
                 if "signer_pubkey.pem" in names
@@ -190,6 +306,13 @@ def verify_signed(
                 if "signer_pubkey.bin" in names
                 else None
             )
+            for name in names:
+                if name.startswith("sigs/") and name.endswith(".sig"):
+                    threshold_sigs[name[len("sigs/"):-len(".sig")]] = zf.read(name)
+                elif name.startswith("pubkeys/") and name != "pubkeys/":
+                    stem = name[len("pubkeys/"):]
+                    fp = stem.rsplit(".", 1)[0]
+                    threshold_pubkeys[fp] = zf.read(name)
     except zipfile.BadZipFile as e:
         return VerifyResult(ok=False, errors=[f"corrupt zip: {e}"])
 
@@ -213,7 +336,16 @@ def verify_signed(
     algorithm = manifest.get("signature_algorithm", "Ed25519")
     to_verify = hashlib.sha256(trail_bytes + manifest_bytes).digest()
 
-    if algorithm == "Ed25519":
+    if algorithm.startswith(_THRESHOLD_PREFIX):
+        errors.extend(
+            _verify_threshold(
+                manifest=manifest,
+                to_verify=to_verify,
+                sigs=threshold_sigs,
+                pubkeys=threshold_pubkeys,
+            )
+        )
+    elif algorithm == "Ed25519":
         if public_key is None:
             if embedded_pubkey_pem is None:
                 return VerifyResult(
@@ -226,13 +358,16 @@ def verify_signed(
             pk = _load_public_key(embedded_pubkey_pem)
         else:
             pk = _load_public_key(public_key)
-        try:
-            pk.verify(signature, to_verify)
-        except InvalidSignature:
-            errors.append(
-                "Ed25519 signature did not verify "
-                "(wrong public key, tampered manifest, or tampered trail)"
-            )
+        if signature is None:
+            errors.append("missing trail.sig in zip")
+        else:
+            try:
+                pk.verify(signature, to_verify)
+            except InvalidSignature:
+                errors.append(
+                    "Ed25519 signature did not verify "
+                    "(wrong public key, tampered manifest, or tampered trail)"
+                )
     elif algorithm == "ML-DSA-65":
         try:
             from vaara.audit.signer import MLDSA65Verifier
@@ -264,12 +399,15 @@ def verify_signed(
                 ],
                 manifest=manifest,
             )
-        verifier = MLDSA65Verifier(pk_bytes)
-        if not verifier.verify(to_verify, signature):
-            errors.append(
-                "ML-DSA-65 signature did not verify "
-                "(wrong public key, tampered manifest, or tampered trail)"
-            )
+        if signature is None:
+            errors.append("missing trail.sig in zip")
+        else:
+            verifier = MLDSA65Verifier(pk_bytes)
+            if not verifier.verify(to_verify, signature):
+                errors.append(
+                    "ML-DSA-65 signature did not verify "
+                    "(wrong public key, tampered manifest, or tampered trail)"
+                )
     else:
         errors.append(f"unknown signature_algorithm: {algorithm!r}")
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -320,6 +320,66 @@ def _cmd_trail_export(args: argparse.Namespace) -> int:
     return 0 if result.chain_intact else 1
 
 
+def _cmd_trail_export_threshold(args: argparse.Namespace) -> int:
+    try:
+        from vaara.audit.export import (
+            _load_private_key,
+            export_signed_threshold,
+        )
+        from vaara.audit.signer import Ed25519Signer
+        from vaara.audit.trail import AuditRecord, AuditTrail
+    except ImportError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 2
+
+    trail_path = Path(args.trail).expanduser()
+    if not trail_path.exists():
+        print(f"trail JSONL not found: {trail_path}", file=sys.stderr)
+        return 2
+
+    trail = AuditTrail()
+    with open(trail_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = AuditRecord.from_dict(json.loads(line))
+            trail._records.append(rec)
+            trail._by_action[rec.action_id].append(rec)
+            if rec.record_hash:
+                trail._last_hash = rec.record_hash
+
+    signers = []
+    for key_path in args.key:
+        try:
+            signers.append(Ed25519Signer(_load_private_key(Path(key_path).expanduser())))
+        except (OSError, ValueError) as exc:
+            print(f"could not load signing key {key_path}: {exc}", file=sys.stderr)
+            return 2
+
+    out = Path(args.out).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        result = export_signed_threshold(
+            trail,
+            out_path=out,
+            signers=signers,
+            threshold_k=args.threshold_k,
+            agent_id=args.agent_id or "",
+        )
+    except ValueError as exc:
+        print(f"threshold export failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Exported {result.manifest['threshold_k']}-of-"
+          f"{result.manifest['signers_n']} threshold-signed trail to {result.path}")
+    print(f"  records:      {result.manifest['record_count']}")
+    print(f"  chain intact: {result.chain_intact}")
+    print(f"  signer set:   {result.manifest['signer_pubkey_fingerprint']}")
+    return 0 if result.chain_intact else 1
+
+
 def _cmd_trail_verify(args: argparse.Namespace) -> int:
     try:
         from vaara.audit.verify import verify_signed
@@ -334,7 +394,12 @@ def _cmd_trail_verify(args: argparse.Namespace) -> int:
         print("Manifest:")
         print(f"  schema:       {result.manifest.get('schema_version')}")
         print(f"  records:      {result.manifest.get('record_count')}")
+        print(f"  algorithm:    {result.manifest.get('signature_algorithm')}")
         print(f"  fingerprint:  {result.manifest.get('signer_pubkey_fingerprint')}")
+        if result.manifest.get("threshold_k") is not None:
+            print(f"  threshold:    {result.manifest.get('threshold_k')}-of-"
+                  f"{result.manifest.get('signers_n')} "
+                  f"({result.manifest.get('member_algorithm')})")
         print(f"  created:      {result.manifest.get('created_utc')}")
         print(f"  vaara:        {result.manifest.get('vaara_version')}")
     if result.ok:
@@ -1576,6 +1641,28 @@ def build_parser() -> argparse.ArgumentParser:
     pe.add_argument("--key", required=True, help="Path to Ed25519 signing private key (PEM)")
     pe.add_argument("--agent-id", default="", help="Optional agent_id tag for the manifest")
     pe.set_defaults(func=_cmd_trail_export)
+
+    pet = tsub.add_parser(
+        "export-threshold",
+        help="Export a k-of-n threshold-signed trail zip (no single-key issuance)",
+    )
+    pet.add_argument("--trail", required=True, help="Path to trail JSONL file")
+    pet.add_argument("--out", required=True, help="Path to write the signed zip")
+    pet.add_argument(
+        "--key",
+        required=True,
+        action="append",
+        help="Path to a custodian Ed25519 signing key (PEM). Repeat for each "
+             "of the n custodians.",
+    )
+    pet.add_argument(
+        "--threshold-k",
+        required=True,
+        type=int,
+        help="Quorum: minimum valid custodian signatures required to verify.",
+    )
+    pet.add_argument("--agent-id", default="", help="Optional agent_id tag for the manifest")
+    pet.set_defaults(func=_cmd_trail_export_threshold)
 
     pv = tsub.add_parser("verify", help="Verify a signed trail zip")
     pv.add_argument("--zip", required=True, help="Path to signed trail zip")

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -108,6 +108,7 @@ require ``pip install 'vaara[export]'`` (pulls cryptography). The
 from __future__ import annotations
 
 import argparse
+import calendar
 import hashlib
 import json
 import os
@@ -504,6 +505,101 @@ def _cmd_trail_export_incident(args: argparse.Namespace) -> int:
         f"to {out}"
     )
     return 0
+
+
+def _parse_period(spec: Optional[str]) -> Optional[tuple]:
+    """Parse a ``YYYY-MM-DD:YYYY-MM-DD`` period into a (start, end) epoch pair.
+
+    Either side may be empty for an open bound (``:2026-06-30`` or
+    ``2026-01-01:``). The end date is inclusive of its whole day. Returns
+    ``None`` when ``spec`` is falsy.
+    """
+    if not spec:
+        return None
+    if ":" not in spec:
+        raise ValueError(
+            "period must be START:END (YYYY-MM-DD:YYYY-MM-DD); either side may be empty"
+        )
+    start_s, end_s = spec.split(":", 1)
+
+    def _epoch(day: str, *, end_of_day: bool) -> Optional[float]:
+        day = day.strip()
+        if not day:
+            return None
+        t = time.strptime(day, "%Y-%m-%d")
+        epoch = calendar.timegm(t)
+        return epoch + 86399 if end_of_day else float(epoch)
+
+    return (_epoch(start_s, end_of_day=False), _epoch(end_s, end_of_day=True))
+
+
+def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
+    """Export a signed EU AI Act Article 12 regulator package from a trail."""
+    try:
+        from vaara.audit.article12_export import export_article12
+        from vaara.audit.trail import AuditRecord, AuditTrail
+    except ImportError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 2
+
+    trail_path = Path(args.trail).expanduser()
+    if not trail_path.exists():
+        print(f"trail JSONL not found: {trail_path}", file=sys.stderr)
+        return 2
+
+    system_meta = None
+    if args.system_meta:
+        meta_path = Path(args.system_meta).expanduser()
+        if not meta_path.exists():
+            print(f"system-meta JSON not found: {meta_path}", file=sys.stderr)
+            return 2
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                system_meta = json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"failed to read system-meta: {exc}", file=sys.stderr)
+            return 2
+
+    try:
+        period = _parse_period(args.period)
+    except ValueError as exc:
+        print(f"invalid --period: {exc}", file=sys.stderr)
+        return 2
+
+    trail = AuditTrail()
+    with open(trail_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = AuditRecord.from_dict(json.loads(line))
+            trail._records.append(rec)
+            trail._by_action[rec.action_id].append(rec)
+            if rec.record_hash:
+                trail._last_hash = rec.record_hash
+
+    out = Path(args.out).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        result = export_article12(
+            trail,
+            out_path=out,
+            signer_key=Path(args.key).expanduser(),
+            system_meta=system_meta,
+            period=period,
+            fmt=args.format,
+            agent_id=args.agent_id or "",
+        )
+    except (ValueError, ImportError) as exc:
+        print(f"Article 12 export failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Exported Article 12 regulator package to {result.path}")
+    print(f"  records:      {result.manifest['record_count']}")
+    print(f"  chain intact: {result.chain_intact}")
+    print(f"  report:       article12_report.{args.format}")
+    return 0 if result.chain_intact else 1
 
 
 def _cmd_trail_purge(args: argparse.Namespace) -> int:
@@ -1709,6 +1805,38 @@ def build_parser() -> argparse.ArgumentParser:
              "policy_override event in the trail is used.",
     )
     pei.set_defaults(func=_cmd_trail_export_incident)
+
+    pa12 = tsub.add_parser(
+        "export-article12",
+        help="Export a signed EU AI Act Article 12 regulator package",
+    )
+    pa12.add_argument("--trail", required=True, help="Path to trail JSONL file")
+    pa12.add_argument(
+        "--key", required=True,
+        help="Ed25519 private key (PEM) to sign the package",
+    )
+    pa12.add_argument("--out", required=True, help="Path to write the package zip")
+    pa12.add_argument(
+        "--system-meta", default=None,
+        help="Optional JSON with system identity (system_name, provider, "
+             "deployer, intended_purpose, risk_classification). Absent fields "
+             "render as 'not provided'.",
+    )
+    pa12.add_argument(
+        "--period", default=None,
+        help="Optional report lens START:END (YYYY-MM-DD:YYYY-MM-DD); either "
+             "side may be empty. Narrows the summary counts only; the signed "
+             "trail stays whole.",
+    )
+    pa12.add_argument(
+        "--format", choices=("md", "html"), default="md",
+        help="Human-readable report format (default: md)",
+    )
+    pa12.add_argument(
+        "--agent-id", default="",
+        help="Optional scope hint written to the manifest (does not filter records)",
+    )
+    pa12.set_defaults(func=_cmd_trail_export_article12)
 
     prec = tsub.add_parser(
         "receipt",

--- a/tests/test_article12_export.py
+++ b/tests/test_article12_export.py
@@ -1,0 +1,178 @@
+"""Tests for the EU AI Act Article 12 one-command regulator export.
+
+See ``docs/design/article12-export-spec.md``.
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cryptography")  # skip module when the export extra is absent
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vaara.audit.article12_export import export_article12
+from vaara.audit.trail import AuditTrail
+from vaara.audit.verify import verify_signed
+from vaara.taxonomy.actions import ActionRequest, create_default_registry
+
+_REGISTRY = create_default_registry()
+_TX_TRANSFER = _REGISTRY.get("tx.transfer")
+
+
+def _make_trail(n: int = 3) -> AuditTrail:
+    """A trail with a spread of event types so obligations are evidenced."""
+    trail = AuditTrail()
+    for i in range(n):
+        req = ActionRequest(
+            agent_id=f"agent-{i}",
+            tool_name="send_funds",
+            action_type=_TX_TRANSFER,
+            parameters={"to": f"0xabc{i}", "amount": 10 * i},
+        )
+        action_id = trail.record_action_requested(req)
+        decision = "deny" if i % 2 else "allow"
+        trail.record_decision(
+            action_id, f"agent-{i}", "send_funds", decision, "test", 0.5,
+        )
+        if decision == "allow":
+            trail.record_execution(action_id, f"agent-{i}", "send_funds", {"ok": True})
+            trail.record_outcome(action_id, f"agent-{i}", "send_funds", "success")
+    return trail
+
+
+def _key_pem(tmp_path: Path) -> Path:
+    key = Ed25519PrivateKey.generate()
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    p = tmp_path / "signer.pem"
+    p.write_bytes(pem)
+    return p
+
+
+def _read_summary(zip_path: Path) -> dict:
+    with zipfile.ZipFile(zip_path) as zf:
+        return json.loads(zf.read("article12_summary.json"))
+
+
+def test_package_contains_signed_core_and_article12_files(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path))
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+    assert {"trail.jsonl", "manifest.json", "trail.sig", "signer_pubkey.pem"} <= names
+    assert "article12_report.md" in names
+    assert "article12_summary.json" in names
+    assert "verify_instructions.txt" in names
+
+
+def test_signed_core_still_verifies(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path))
+    # Folding the report in via append mode must not disturb the signed core.
+    assert verify_signed(out).ok
+
+
+def test_summary_binds_the_signed_trail_sha256(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path))
+    summary = _read_summary(out)
+    with zipfile.ZipFile(out) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+    assert summary["record_keeping_summary"]["trail_sha256"] == manifest["trail_sha256"]
+    assert summary["integrity"]["trail_sha256"] == manifest["trail_sha256"]
+
+
+def test_report_counts_match_the_trail(tmp_path):
+    trail = _make_trail(4)
+    out = tmp_path / "art12.zip"
+    export_article12(trail, out, signer_key=_key_pem(tmp_path))
+    summary = _read_summary(out)
+    with zipfile.ZipFile(out) as zf:
+        lines = [ln for ln in zf.read("trail.jsonl").splitlines() if ln.strip()]
+    assert summary["record_keeping_summary"]["records_in_trail"] == len(lines)
+    assert sum(e["count"] for e in summary["event_inventory"]) == len(lines)
+
+
+def test_obligation_mapping_is_evidenced(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(4), out, signer_key=_key_pem(tmp_path))
+    by_id = {o["id"]: o for o in _read_summary(out)["obligation_mapping"]}
+    assert by_id["art12_1"]["status"] == "evidenced"
+    assert by_id["art12_2_c"]["status"] == "evidenced"
+    assert by_id["art12_2_a"]["status"] == "evidenced"
+
+
+def test_regulatory_tags_are_summarised(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(4), out, signer_key=_key_pem(tmp_path))
+    assert _read_summary(out)["regulatory_tagging"]["records_with_tags"] > 0
+
+
+def test_system_meta_absent_renders_not_provided(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path))
+    assert _read_summary(out)["cover"]["system_name"] == "not provided"
+    with zipfile.ZipFile(out) as zf:
+        assert "not provided" in zf.read("article12_report.md").decode("utf-8")
+
+
+def test_system_meta_present_renders(tmp_path):
+    out = tmp_path / "art12.zip"
+    meta = {"system_name": "Loan Triage", "provider": "Acme", "risk_classification": "high"}
+    export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path), system_meta=meta)
+    summary = _read_summary(out)
+    assert summary["cover"]["system_name"] == "Loan Triage"
+    assert summary["cover"]["risk_classification"] == "high"
+
+
+def test_period_narrows_scope_not_the_signed_trail(tmp_path):
+    out = tmp_path / "art12.zip"
+    # A period entirely in the past excludes every (just-now) record.
+    export_article12(
+        _make_trail(4), out, signer_key=_key_pem(tmp_path), period=(0.0, 1.0),
+    )
+    summary = _read_summary(out)
+    with zipfile.ZipFile(out) as zf:
+        lines = [ln for ln in zf.read("trail.jsonl").splitlines() if ln.strip()]
+    assert summary["record_keeping_summary"]["records_in_trail"] == len(lines)
+    assert summary["record_keeping_summary"]["records_in_scope"] == 0
+    assert summary["record_keeping_summary"]["period_is_report_lens_only"] is True
+    assert verify_signed(out).ok
+
+
+def test_tampering_the_trail_breaks_verification(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path))
+    tampered = tmp_path / "bad.zip"
+    with zipfile.ZipFile(out) as zin, zipfile.ZipFile(tampered, "w") as zout:
+        for name in zin.namelist():
+            data = zin.read(name)
+            if name == "trail.jsonl":
+                data = data + b'{"injected":true}\n'
+            zout.writestr(name, data)
+    assert not verify_signed(tampered).ok
+
+
+def test_html_format(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path), fmt="html")
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+        html = zf.read("article12_report.html").decode("utf-8")
+    assert "article12_report.html" in names
+    assert "article12_report.md" not in names
+    assert html.startswith("<!doctype html>")
+
+
+def test_bad_format_rejected(tmp_path):
+    out = tmp_path / "art12.zip"
+    with pytest.raises(ValueError):
+        export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path), fmt="pdf")

--- a/tests/test_receipt_vc.py
+++ b/tests/test_receipt_vc.py
@@ -1,0 +1,160 @@
+"""W3C VC opt-in serialization for execution receipts.
+
+The VC is a lossless view of the native receipt: round-trip identity holds,
+and trust always routes through the unchanged receipt-signature verifier.
+See ``docs/design/w3c-vc-receipt-spec.md``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+for _mod in ("rfc8785", "cryptography"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            "attestation extra not installed (pip install 'vaara[attestation]')",
+            allow_module_level=True,
+        )
+
+from cryptography.hazmat.primitives.asymmetric import ec, rsa  # noqa: E402
+
+from vaara.attestation.receipt import (  # noqa: E402
+    VAARA_RECEIPT_CONTEXT_URL,
+    OutcomeDerived,
+    emit_receipt,
+    load_receipt_context,
+    make_back_link,
+    make_result_digest,
+    receipt_from_vc,
+    receipt_to_vc,
+    verify_receipt_signature,
+)
+from vaara.attestation.sep2787 import (  # noqa: E402
+    PayloadDerived,
+    PlannerDeclared,
+    ToolCallBinding,
+    emit_attestation,
+    make_args_digest,
+)
+
+HS_SECRET = b"\x42" * 32
+RESULT = {"deleted": True, "path": "/archive/2024-Q3.md"}
+
+
+def _attestation():
+    payload = PayloadDerived(tool_calls=(ToolCallBinding(
+        name="delete_file",
+        server_fingerprint="sha256:" + "1" * 64,
+        args=make_args_digest({"path": "/archive/2024-Q3.md"}),
+    ),))
+    return emit_attestation(
+        planner_declared=PlannerDeclared(intent="archive obsolete report"),
+        payload_derived=payload,
+        iss="issuer://test",
+        sub="agent:archiver",
+        secret_version="v1",
+        alg="HS256",
+        signing_material=HS_SECRET,
+    )
+
+
+def _emit(commit_result=True, **overrides):
+    commitment = make_result_digest(RESULT) if commit_result else None
+    kwargs = dict(
+        back_link=make_back_link(_attestation()),
+        outcome_derived=OutcomeDerived(
+            status="executed",
+            completed_at="2026-05-29T10:00:00Z",
+            result_commitment=commitment,
+        ),
+        iss="issuer://test",
+        sub="agent:archiver",
+        secret_version="v1",
+        alg="HS256",
+        signing_material=HS_SECRET,
+    )
+    kwargs.update(overrides)
+    return emit_receipt(**kwargs)
+
+
+# ── Round-trip identity ─────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("commit_result", [True, False])
+def test_hs256_round_trip_identity(commit_result):
+    r = _emit(commit_result=commit_result)
+    assert receipt_from_vc(receipt_to_vc(r)) == r
+
+
+def test_es256_round_trip_identity():
+    priv = ec.generate_private_key(ec.SECP256R1())
+    r = _emit(alg="ES256", signing_material=priv)
+    assert receipt_from_vc(receipt_to_vc(r)) == r
+
+
+def test_rs256_round_trip_identity():
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    r = _emit(alg="RS256", signing_material=priv)
+    assert receipt_from_vc(receipt_to_vc(r)) == r
+
+
+# ── Signature parity: trust routes through the unchanged verifier ───────────
+
+def test_unwrapped_vc_verifies_like_native():
+    r = _emit()
+    assert verify_receipt_signature(r, verifying_material=HS_SECRET) is True
+    recovered = receipt_from_vc(receipt_to_vc(r))
+    assert verify_receipt_signature(recovered, verifying_material=HS_SECRET) is True
+
+
+def test_tampered_credential_subject_fails_after_unwrap():
+    r = _emit()
+    vc = receipt_to_vc(r)
+    vc["credentialSubject"]["outcomeDerived"]["status"] = "refused"
+    recovered = receipt_from_vc(vc)
+    assert verify_receipt_signature(recovered, verifying_material=HS_SECRET) is False
+
+
+def test_tampered_proof_value_fails_after_unwrap():
+    r = _emit()
+    vc = receipt_to_vc(r)
+    pv = vc["proof"]["proofValue"]
+    vc["proof"]["proofValue"] = ("0" if pv[0] != "0" else "1") + pv[1:]
+    recovered = receipt_from_vc(vc)
+    assert verify_receipt_signature(recovered, verifying_material=HS_SECRET) is False
+
+
+# ── Wire shape + offline ────────────────────────────────────────────────────
+
+def test_vcdm_required_fields_present():
+    vc = receipt_to_vc(_emit())
+    for field in ("@context", "type", "issuer", "validFrom", "credentialSubject", "proof"):
+        assert field in vc, field
+    assert vc["@context"][0] == "https://www.w3.org/ns/credentials/v2"
+    assert vc["@context"][1] == VAARA_RECEIPT_CONTEXT_URL
+    assert vc["type"] == ["VerifiableCredential", "VaaraExecutionReceipt"]
+    assert vc["proof"]["type"] == "VaaraSep2787DetachedSignature2026"
+    assert vc["proof"]["cryptosuite"] == "jcs-hs256"
+    assert "signature" not in vc["credentialSubject"]
+
+
+def test_issuer_and_validfrom_from_receipt():
+    r = _emit()
+    vc = receipt_to_vc(r)
+    assert vc["issuer"] == r.receipt_asserted.iss
+    assert vc["validFrom"] == r.receipt_asserted.iat
+
+
+def test_context_resolves_offline():
+    ctx = load_receipt_context()
+    assert "@context" in ctx
+    assert ctx["@context"]["VaaraExecutionReceipt"].startswith(VAARA_RECEIPT_CONTEXT_URL)
+
+
+def test_from_vc_rejects_malformed():
+    from vaara.attestation._sep2787_types import AttestationError
+    with pytest.raises(AttestationError):
+        receipt_from_vc({"credentialSubject": {}})  # no proof
+    with pytest.raises(AttestationError):
+        receipt_from_vc({"proof": {"proofValue": "x"}})  # no subject

--- a/tests/test_threshold_export.py
+++ b/tests/test_threshold_export.py
@@ -247,3 +247,58 @@ def test_standalone_verifier_parity(tmp_path):
     below = tmp_path / "b.zip"
     _drop_sigs(out, below, keep=2)
     assert _standalone(below) == 1
+
+
+# ── Key lifecycle markers (rotation / revocation / addition) ────────────────
+
+def test_key_lifecycle_record_validation():
+    trail = _make_trail()
+    with pytest.raises(ValueError):
+        trail.record_key_lifecycle("nonsense", "ab12")
+    with pytest.raises(ValueError):
+        trail.record_key_lifecycle("revoked", "")
+
+
+def test_key_lifecycle_surfaced_by_verify(tmp_path):
+    out = tmp_path / "t.zip"
+    trail = _make_trail()
+    trail.record_key_lifecycle(
+        "revoked", "deadbeef" * 4, reason="suspected compromise",
+        threshold_k=3, signers_n=5, actor="ops",
+    )
+    trail.record_key_lifecycle("added", "feedface" * 4, threshold_k=3, signers_n=6)
+    export_signed_threshold(trail, out, signers=_signers(5), threshold_k=3)
+
+    result = verify_signed(out)
+    assert result.ok, result.errors
+    assert len(result.key_lifecycle) == 2
+    revoked, added = result.key_lifecycle  # surfaced in chain order
+    assert revoked["action"] == "revoked"
+    assert revoked["fingerprint"] == "deadbeef" * 4
+    assert revoked["reason"] == "suspected compromise"
+    assert revoked["threshold_k"] == 3 and revoked["signers_n"] == 5
+    assert added["action"] == "added"
+    assert added["signers_n"] == 6
+
+
+def test_key_lifecycle_covered_by_hash_chain(tmp_path):
+    """A tampered lifecycle record fails the chain check, not silently passes."""
+    out = tmp_path / "t.zip"
+    trail = _make_trail()
+    trail.record_key_lifecycle("revoked", "cafe" * 8, reason="x")
+    export_signed_threshold(trail, out, signers=_signers(3), threshold_k=2)
+
+    with zipfile.ZipFile(out, "r") as zf:
+        trail_bytes = zf.read("trail.jsonl")
+        others = {n: zf.read(n) for n in zf.namelist() if n != "trail.jsonl"}
+    tampered = trail_bytes.replace(b"cafe" * 8, b"beef" * 8)
+    assert tampered != trail_bytes
+    rebuilt = tmp_path / "tampered.zip"
+    with zipfile.ZipFile(rebuilt, "w") as zf:
+        zf.writestr("trail.jsonl", tampered)
+        for name, body in others.items():
+            zf.writestr(name, body)
+
+    result = verify_signed(rebuilt)
+    assert not result.ok
+    assert any("hash chain" in e or "tamper" in e.lower() for e in result.errors)

--- a/tests/test_threshold_export.py
+++ b/tests/test_threshold_export.py
@@ -1,0 +1,249 @@
+"""Tests for k-of-n threshold-signed trail export / verify.
+
+See ``docs/design/threshold-signing-spec.md``.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cryptography")  # skip entire module when extra missing
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vaara.audit.export import _pubkey_member_bytes, export_signed_threshold
+from vaara.audit.signer import Ed25519Signer
+from vaara.audit.trail import AuditTrail
+from vaara.audit.verify import verify_signed
+from vaara.taxonomy.actions import ActionRequest, create_default_registry
+
+_REGISTRY = create_default_registry()
+_TX_TRANSFER = _REGISTRY.get("tx.transfer")
+
+
+def _make_trail(n: int = 3) -> AuditTrail:
+    trail = AuditTrail()
+    for i in range(n):
+        req = ActionRequest(
+            agent_id=f"agent-{i}",
+            tool_name="send_funds",
+            action_type=_TX_TRANSFER,
+            parameters={"to": f"0xabc{i}", "amount": 10 * i},
+        )
+        trail.record_action_requested(req)
+    return trail
+
+
+def _signers(n: int) -> list[Ed25519Signer]:
+    return [Ed25519Signer(Ed25519PrivateKey.generate()) for _ in range(n)]
+
+
+def _drop_sigs(src: Path, dst: Path, keep: int) -> None:
+    """Copy the zip keeping only the first ``keep`` sigs/ entries."""
+    with zipfile.ZipFile(src) as zin:
+        sigs = sorted(n for n in zin.namelist() if n.startswith("sigs/"))
+        keepset = set(sigs[:keep])
+        with zipfile.ZipFile(dst, "w") as zout:
+            for name in zin.namelist():
+                if name.startswith("sigs/") and name not in keepset:
+                    continue
+                zout.writestr(name, zin.read(name))
+
+
+# ── Happy path ─────────────────────────────────────────────────────────────
+
+def test_3_of_5_all_sign_verifies(tmp_path):
+    out = tmp_path / "t.zip"
+    res = export_signed_threshold(
+        _make_trail(), out, signers=_signers(5), threshold_k=3
+    )
+    assert res.manifest["signature_algorithm"] == "threshold-Ed25519"
+    assert res.manifest["threshold_k"] == 3
+    assert res.manifest["signers_n"] == 5
+    assert res.manifest["member_algorithm"] == "Ed25519"
+    assert len(res.manifest["signer_fingerprints"]) == 5
+    with zipfile.ZipFile(out) as zf:
+        assert sum(n.startswith("sigs/") for n in zf.namelist()) == 5
+        assert sum(n.startswith("pubkeys/") for n in zf.namelist()) == 5
+    assert verify_signed(out).ok
+
+
+def test_exactly_k_sigs_present_verifies(tmp_path):
+    out = tmp_path / "t.zip"
+    export_signed_threshold(_make_trail(), out, signers=_signers(5), threshold_k=3)
+    trimmed = tmp_path / "k.zip"
+    _drop_sigs(out, trimmed, keep=3)
+    assert verify_signed(trimmed).ok
+
+
+def test_below_k_sigs_fails(tmp_path):
+    out = tmp_path / "t.zip"
+    export_signed_threshold(_make_trail(), out, signers=_signers(5), threshold_k=3)
+    trimmed = tmp_path / "k.zip"
+    _drop_sigs(out, trimmed, keep=2)
+    res = verify_signed(trimmed)
+    assert not res.ok
+    assert any("threshold not met" in e for e in res.errors)
+
+
+# ── Attacks ────────────────────────────────────────────────────────────────
+
+def test_downgrade_k_to_1_fails(tmp_path):
+    """Lowering threshold_k in the manifest breaks every member signature."""
+    out = tmp_path / "t.zip"
+    export_signed_threshold(_make_trail(), out, signers=_signers(5), threshold_k=3)
+    tampered = tmp_path / "d.zip"
+    with zipfile.ZipFile(out) as zin:
+        man = json.loads(zin.read("manifest.json"))
+        man["threshold_k"] = 1
+        with zipfile.ZipFile(tampered, "w") as zout:
+            for name in zin.namelist():
+                if name == "manifest.json":
+                    zout.writestr(
+                        name, json.dumps(man, sort_keys=True, indent=2).encode()
+                    )
+                else:
+                    zout.writestr(name, zin.read(name))
+    assert not verify_signed(tampered).ok
+
+
+def test_unauthorized_extra_signature_ignored(tmp_path):
+    """An extra valid sig from a non-member key does not count toward k."""
+    out = tmp_path / "t.zip"
+    export_signed_threshold(_make_trail(), out, signers=_signers(5), threshold_k=3)
+    trimmed = tmp_path / "k.zip"
+    _drop_sigs(out, trimmed, keep=2)  # below quorum
+
+    with zipfile.ZipFile(trimmed) as zf:
+        digest = hashlib.sha256(
+            zf.read("trail.jsonl") + zf.read("manifest.json")
+        ).digest()
+    rogue = Ed25519Signer(Ed25519PrivateKey.generate())
+    rogue_fp = rogue.public_key_fingerprint()[:32]
+    injected = tmp_path / "inj.zip"
+    with zipfile.ZipFile(trimmed) as zin, zipfile.ZipFile(injected, "w") as zout:
+        for name in zin.namelist():
+            zout.writestr(name, zin.read(name))
+        zout.writestr(f"sigs/{rogue_fp}.sig", rogue.sign(digest))
+    res = verify_signed(injected)
+    assert not res.ok  # 2 authorized + 1 rogue = still below k=3
+    assert any("threshold not met" in e for e in res.errors)
+
+
+def test_substituted_pubkey_fails(tmp_path):
+    """Swapping a member pubkey file (different fingerprint) is rejected."""
+    out = tmp_path / "t.zip"
+    export_signed_threshold(_make_trail(), out, signers=_signers(5), threshold_k=3)
+    swapped = tmp_path / "s.zip"
+    rogue_raw = Ed25519PrivateKey.generate().public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    _, rogue_pem = _pubkey_member_bytes(rogue_raw, "Ed25519")
+    with zipfile.ZipFile(out) as zin:
+        target = next(n for n in zin.namelist() if n.startswith("pubkeys/"))
+        with zipfile.ZipFile(swapped, "w") as zout:
+            for name in zin.namelist():
+                body = rogue_pem if name == target else zin.read(name)
+                zout.writestr(name, body)
+    res = verify_signed(swapped)
+    assert not res.ok
+    assert any("fingerprint" in e or "threshold not met" in e for e in res.errors)
+
+
+def test_tampered_record_fails_chain(tmp_path):
+    out = tmp_path / "t.zip"
+    export_signed_threshold(_make_trail(), out, signers=_signers(5), threshold_k=3)
+    tampered = tmp_path / "c.zip"
+    with zipfile.ZipFile(out) as zin:
+        lines = zin.read("trail.jsonl").splitlines()
+        rec = json.loads(lines[0])
+        rec["data"] = {"tampered": True}
+        lines[0] = json.dumps(rec).encode()
+        with zipfile.ZipFile(tampered, "w") as zout:
+            for name in zin.namelist():
+                body = b"\n".join(lines) if name == "trail.jsonl" else zin.read(name)
+                zout.writestr(name, body)
+    assert not verify_signed(tampered).ok
+
+
+# ── Authorized-set semantics ────────────────────────────────────────────────
+
+def test_k_of_n_with_subset_present(tmp_path):
+    """Pass the full authorized set but only k signers available now."""
+    all_signers = _signers(5)
+    authorized = [s.public_key_bytes() for s in all_signers]
+    out = tmp_path / "t.zip"
+    res = export_signed_threshold(
+        _make_trail(),
+        out,
+        signers=all_signers[:3],
+        threshold_k=3,
+        authorized_pubkeys=authorized,
+    )
+    assert res.manifest["signers_n"] == 5
+    with zipfile.ZipFile(out) as zf:
+        assert sum(n.startswith("sigs/") for n in zf.namelist()) == 3
+        assert sum(n.startswith("pubkeys/") for n in zf.namelist()) == 5
+    assert verify_signed(out).ok
+
+
+# ── Validation ──────────────────────────────────────────────────────────────
+
+def test_k_exceeds_n_raises(tmp_path):
+    with pytest.raises(ValueError, match="exceeds n"):
+        export_signed_threshold(
+            _make_trail(), tmp_path / "t.zip", signers=_signers(3), threshold_k=5
+        )
+
+
+def test_too_few_signers_for_k_raises(tmp_path):
+    all_signers = _signers(5)
+    authorized = [s.public_key_bytes() for s in all_signers]
+    with pytest.raises(ValueError, match="need at least"):
+        export_signed_threshold(
+            _make_trail(),
+            tmp_path / "t.zip",
+            signers=all_signers[:2],
+            threshold_k=3,
+            authorized_pubkeys=authorized,
+        )
+
+
+def test_signer_not_in_authorized_set_raises(tmp_path):
+    authorized = [s.public_key_bytes() for s in _signers(3)]  # unrelated set
+    with pytest.raises(ValueError, match="not in the authorized set"):
+        export_signed_threshold(
+            _make_trail(),
+            tmp_path / "t.zip",
+            signers=_signers(3),
+            threshold_k=2,
+            authorized_pubkeys=authorized,
+        )
+
+
+# ── Standalone verifier parity ──────────────────────────────────────────────
+
+def _standalone(zip_path: Path) -> int:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "verify_vaara_trail.py"
+    return subprocess.run(
+        [sys.executable, str(script), str(zip_path)],
+        capture_output=True,
+    ).returncode
+
+
+def test_standalone_verifier_parity(tmp_path):
+    out = tmp_path / "t.zip"
+    export_signed_threshold(_make_trail(), out, signers=_signers(5), threshold_k=3)
+    assert _standalone(out) == 0
+
+    below = tmp_path / "b.zip"
+    _drop_sigs(out, below, keep=2)
+    assert _standalone(below) == 1


### PR DESCRIPTION
## v0.50.0: verifiable evidence plane

Bundles the three v0.5 evidence items plus the release bump. Full suite 1156 passed, 13 skipped, ruff clean.

### Threshold signing (k-of-n)
`export_signed_threshold` and `vaara trail export-threshold`. n custodians hold independent Ed25519 keys; an export carries one detached signature per available custodian and verification needs at least `threshold_k` of them. No single key-holder can issue or forge a trail. k, n, and the authorized fingerprint set live inside the signed manifest, so the quorum cannot be downgraded without breaking every member signature. The standalone verifier handles threshold exports with only the `cryptography` package.

### Chain-anchored key-lifecycle markers
`AuditTrail.record_key_lifecycle` records custodian rotation, revocation, and addition as ordinary audit records, so they inherit the v0.47 hash chain and the v0.48 external time anchor. A `revoked` marker anchored before a compromise window pins the revocation in time: a compromised key can re-sign but cannot re-anchor past chain heads. `verify_signed` surfaces any lifecycle records inline.

### W3C Verifiable Credential receipts (opt-in)
`receipt_to_vc` / `receipt_from_vc` present an `ExecutionReceipt` as a VCDM 2.0 credential and recover it losslessly. The VC is a view, not a second trust surface: `proof.proofValue` carries the existing SEP-2787 signature and verification routes through the unchanged stack. The `@context` is vendored, so verification needs no network.

### Article 12 one-command regulator export
`vaara trail export-article12` writes the signed evidence plus a generated report mapping the trail to the EU AI Act Article 12 / 26(5) record-keeping obligations, with verify instructions a regulator runs without a Vaara install. It composes the existing single-signer and threshold export paths rather than duplicating them. The report is built from the signed trail bytes and bound to them by the manifest `trail_sha256`; it is a derived view, not a second signed surface, and the package says so. `--period` is a report lens over the summary counts only; the signed trail stays whole.

### Release
All version surfaces bumped to 0.50.0 (`__init__.py`, pyproject, TS client, both MCP manifests). Corrects `__init__.py`, which lagged at 0.48.0 and made 0.49 exports misstamp `vaara_version`. Supersedes the standalone `fix/init-version-0490` branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * K-of-n threshold signing for audit trail exports with CLI and standalone verifier support
  * Custodian key-lifecycle tracking (rotation, revocation, additions) with chain-anchored audit records
  * Optional W3C Verifiable Credential serialization for execution receipts
  * One-command Article 12 regulator export producing signed evidence package and compliance report

* **Bug Fixes**
  * Fixed hash-chain verification for Chain v2 trails to correctly bind tenant ID and chain version parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->