### PR TITLE
test(sep2828): decision/outcome pairing conformance vectors

### DIFF
--- a/scripts/generate_decision_pairing_vectors.py
+++ b/scripts/generate_decision_pairing_vectors.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Generate the SEP-2828 decision/outcome pairing conformance vectors.
+
+Writes signed fixtures under ``tests/vectors/decision_pairing_v0/``. Each
+case holds the attestation, decision record, optional execution receipt,
+and an ``expected.json`` of verdicts an independent verifier MUST
+reproduce from the committed wire bytes alone. These are the SEP-owned
+fixtures requested on modelcontextprotocol/modelcontextprotocol#2828.
+
+Pairing model is the one the reference impl ships: a decision and a
+receipt pair when both carry the same attestation back-link
+(``records_paired``: attestationDigest constant-time equal AND
+attestationNonce equal). The "outcome resolves to the decision content
+digest" join discussed in #2828 is a distinct contract and is NOT
+exercised here; adopting it normatively adds a field and a case.
+
+Usage: python scripts/generate_decision_pairing_vectors.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from vaara.attestation._sep2787_canonical import canonical_json
+from vaara.attestation.decision import (
+    DecisionDerived, emit_decision_record, make_back_link,
+)
+from vaara.attestation.receipt import (
+    BackLink, OutcomeDerived, emit_receipt, make_result_digest,
+)
+from vaara.attestation.sep2787 import (
+    PayloadDerived, PlannerDeclared, ToolCallBinding,
+    emit_attestation, make_args_digest,
+)
+
+ROOT = Path(__file__).resolve().parent.parent
+OUT = ROOT / "tests" / "vectors" / "decision_pairing_v0"
+HS = bytes.fromhex("42" * 32)
+IAT = "2026-06-01T10:00:00Z"
+RESULT = {"rows": 10, "table": "employees"}
+ARGS = {"table": "employees", "limit": 10}
+COMMON = dict(iss="issuer://test", sub="agent:reader",
+              secret_version="v1", iat=IAT)
+
+
+def _write(path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n")
+
+
+def _attestation(nonce="fixed-attestation-nonce-000"):
+    payload = PayloadDerived(tool_calls=(ToolCallBinding(
+        name="query_table", server_fingerprint="sha256:" + "1" * 64,
+        args=make_args_digest(ARGS)),))
+    return emit_attestation(
+        planner_declared=PlannerDeclared(intent="show 10 employees"),
+        payload_derived=payload, iss="issuer://test", sub="agent:reader",
+        secret_version="v1", alg="HS256", signing_material=HS,
+        nonce=nonce, iat=IAT)
+
+
+def _decision(bl, verdict, *, key, alg, nonce):
+    return emit_decision_record(
+        back_link=bl, decision_derived=DecisionDerived(
+            decision=verdict, decided_at=IAT, risk_score="0.21",
+            threshold_allow="0.30", threshold_block="0.80",
+            policy_id="policy:read-only/3"),
+        alg=alg, signing_material=key, nonce=nonce, **COMMON)
+
+
+def _receipt(bl, status, *, key, alg, nonce, commit=True):
+    return emit_receipt(
+        back_link=bl, outcome_derived=OutcomeDerived(
+            status=status, completed_at=IAT,
+            result_commitment=make_result_digest(RESULT) if commit else None),
+        alg=alg, signing_material=key, nonce=nonce, **COMMON)
+
+
+def _fallback_backlink() -> BackLink:
+    # No SEP-2787 attestation: bind to SHA-256 over the JCS-canonical
+    # observed request envelope plus a server nonce. The BackLink is an
+    # opaque sha256: digest + nonce, so the fallback is what the
+    # enforcement point commits to as the digest.
+    envelope = {"method": "tools/call", "params": {
+        "name": "query_table", "arguments": ARGS,
+        "_meta": {"io.modelcontextprotocol/aiInvocation": {"turnId": "turn-7"}}}}
+    digest = hashlib.sha256(canonical_json(envelope)).hexdigest()
+    return BackLink(attestation_digest="sha256:" + digest,
+                    attestation_nonce="server-chosen-nonce-001")
+
+
+def main() -> None:
+    es = ec.generate_private_key(ec.SECP256R1())
+    keys = OUT / "keys"
+    keys.mkdir(parents=True, exist_ok=True)
+    (keys / "hs256_secret.bin").write_bytes(HS)
+    (keys / "es256_private.pem").write_bytes(es.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption()))
+    (keys / "es256_public.pem").write_bytes(es.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo))
+
+    att = _attestation()
+    bl = make_back_link(att)
+
+    def case(name, *, decision, receipt=None, expected):
+        d = OUT / "normative" / name
+        _write(d / "attestation.json", att.to_dict())
+        _write(d / "decision.json", decision.to_dict())
+        if receipt is not None:
+            _write(d / "receipt.json", receipt.to_dict())
+        _write(d / "expected.json", expected)
+
+    # 1. Valid allow + executed, paired on the same attestation back-link.
+    case("valid_pair_allow_executed",
+         decision=_decision(bl, "allow", key=HS, alg="HS256", nonce="d1"),
+         receipt=_receipt(bl, "executed", key=HS, alg="HS256", nonce="r1"),
+         expected={"decision_signature_ok": True, "decision_back_link_ok": True,
+                   "receipt_signature_ok": True, "receipt_back_link_ok": True,
+                   "records_paired": True})
+
+    # 2. Decision-only escalate: valid, no sibling outcome, not an error.
+    case("decision_only_escalate",
+         decision=_decision(bl, "escalate", key=es, alg="ES256", nonce="d2"),
+         expected={"decision_signature_ok": True, "decision_back_link_ok": True,
+                   "receipt_present": False, "outcome_required": False})
+
+    # 3. Substituted attestation back-link: receipt binds a different
+    #    attestation. Both verify alone; they do not pair.
+    other = _attestation(nonce="other-attestation-nonce-999")
+    case("substituted_attestation_backlink",
+         decision=_decision(bl, "allow", key=HS, alg="HS256", nonce="d3"),
+         receipt=_receipt(make_back_link(other), "executed", key=HS,
+                          alg="HS256", nonce="r3"),
+         expected={"decision_signature_ok": True, "decision_back_link_ok": True,
+                   "receipt_signature_ok": True,
+                   "receipt_back_link_ok_against_stored_attestation": False,
+                   "records_paired": False})
+
+    # 4. Substituted pairing nonce: same digest, mismatched nonce. The
+    #    nonce is the pairing link, so the pair is rejected.
+    tampered = BackLink(attestation_digest=bl.attestation_digest,
+                        attestation_nonce="substituted-nonce")
+    case("substituted_pairing_nonce",
+         decision=_decision(bl, "allow", key=HS, alg="HS256", nonce="d4"),
+         receipt=_receipt(tampered, "executed", key=HS, alg="HS256", nonce="r4"),
+         expected={"records_paired": False,
+                   "note": "same attestationDigest, mismatched attestationNonce"})
+
+    # 5. Equal-decidedAt supersession tie. The reference impl has NO
+    #    supersession ordering today; this pins the OPEN contract question.
+    d5 = OUT / "normative" / "supersession_equal_decidedat_tie"
+    _write(d5 / "attestation.json", att.to_dict())
+    _write(d5 / "decision_a.json",
+           _decision(bl, "block", key=HS, alg="HS256", nonce="d5a").to_dict())
+    _write(d5 / "decision_b.json",
+           _decision(bl, "allow", key=HS, alg="HS256", nonce="d5b").to_dict())
+    _write(d5 / "expected.json", {
+        "both_signatures_ok": True, "both_back_links_ok": True, "winner": None,
+        "open_contract": "equal decidedAt needs a deterministic tie-break "
+                         "(e.g. lexicographic on record nonce); unspecified "
+                         "in the reference impl as of v0.50.0"})
+
+    # 6. Fallback request-envelope binding, replay/substitution.
+    fb = _fallback_backlink()
+    d6 = OUT / "normative" / "fallback_envelope_binding"
+    _write(d6 / "decision.json",
+           _decision(fb, "allow", key=HS, alg="HS256", nonce="d6").to_dict())
+    rec = _receipt(fb, "executed", key=HS, alg="HS256", nonce="r6")
+    _write(d6 / "receipt.json", rec.to_dict())
+    replayed = rec.to_dict()
+    replayed["backLink"]["attestationDigest"] = "sha256:" + "0" * 64
+    _write(d6 / "receipt_replayed.json", replayed)
+    _write(d6 / "expected.json", {
+        "decision_signature_ok": True, "receipt_signature_ok": True,
+        "records_paired": True, "replayed_receipt_signature_ok": False,
+        "note": "fallback binding when no SEP-2787 attestation exists; the "
+                "BackLink digest is over the JCS-canonical request envelope"})
+
+    print(f"wrote vectors under {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_decision_pairing_vectors.py
+++ b/tests/test_decision_pairing_vectors.py
@@ -1,0 +1,41 @@
+"""Guard: the committed SEP-2828 decision/outcome vectors verify independently.
+
+Runs ``_check_independent.py`` (stdlib + cryptography + rfc8785, no Vaara
+imports) over the committed fixtures. If the format or a fixture drifts,
+the second-implementation checker fails here in CI rather than silently
+shipping broken vectors.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+for _mod in ("rfc8785", "cryptography"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            "attestation extra not installed (pip install 'vaara[attestation]')",
+            allow_module_level=True,
+        )
+
+VECTORS = Path(__file__).parent / "vectors" / "decision_pairing_v0"
+CHECKER = VECTORS / "_check_independent.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "_decision_pairing_vector_checker", CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_independent_walker_passes_all_cases():
+    assert _load_checker().main() == 0
+
+
+def test_at_least_six_cases_present():
+    cases = [p for p in (VECTORS / "normative").iterdir() if p.is_dir()]
+    assert len(cases) >= 6

--- a/tests/vectors/decision_pairing_v0/_check_independent.py
+++ b/tests/vectors/decision_pairing_v0/_check_independent.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Independent conformance checker for the SEP-2828 decision/outcome vectors.
+
+Imports only the standard library plus ``cryptography`` and ``rfc8785``.
+It does not import Vaara. It reads the committed fixtures from disk and
+reproduces signature verification, attestation back-link verification,
+and decision/outcome pairing for each case, then compares against
+``expected.json``.
+
+A second implementation that can run this file (or reproduce its logic)
+demonstrates the decision/outcome record format is consumable without
+depending on Vaara. Run:
+``python tests/vectors/decision_pairing_v0/_check_independent.py``.
+Exit code 0 means every case matched its expected verdict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+from pathlib import Path
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+HERE = Path(__file__).resolve().parent
+KEYS = HERE / "keys"
+
+_DECISION_BLOCKS = ("version", "alg", "backLink", "decisionDerived",
+                    "issuerAsserted")
+_RECEIPT_BLOCKS = ("version", "alg", "backLink", "outcomeDerived",
+                   "receiptAsserted")
+
+
+def _jcs(obj) -> bytes:
+    return rfc8785.dumps(obj)
+
+
+def _sha256_hex(content: bytes) -> str:
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+def _payload(record: dict, blocks) -> bytes:
+    return _jcs({k: record[k] for k in blocks})
+
+
+def verify_signature(record: dict, blocks) -> bool:
+    payload = _payload(record, blocks)
+    alg, sig = record["alg"], record["signature"]
+    if alg == "HS256":
+        secret = (KEYS / "hs256_secret.bin").read_bytes()
+        expected = hmac.new(secret, payload, hashlib.sha256).hexdigest()
+        return hmac.compare_digest(expected, sig)
+    if alg == "ES256":
+        pub = serialization.load_pem_public_key(
+            (KEYS / "es256_public.pem").read_bytes())
+        if len(sig) != 128:
+            return False
+        raw = bytes.fromhex(sig)
+        der = encode_dss_signature(
+            int.from_bytes(raw[:32], "big"), int.from_bytes(raw[32:], "big"))
+        try:
+            pub.verify(der, payload, ec.ECDSA(hashes.SHA256()))
+            return True
+        except InvalidSignature:
+            return False
+    return False
+
+
+def verify_back_link(record: dict, attestation: dict) -> bool:
+    expected = _sha256_hex(_jcs(attestation))
+    bl = record["backLink"]
+    if not hmac.compare_digest(bl["attestationDigest"], expected):
+        return False
+    return bl["attestationNonce"] == attestation["issuerAsserted"]["nonce"]
+
+
+def records_paired(decision: dict, receipt: dict) -> bool:
+    db, rb = decision["backLink"], receipt["backLink"]
+    if not hmac.compare_digest(db["attestationDigest"], rb["attestationDigest"]):
+        return False
+    return db["attestationNonce"] == rb["attestationNonce"]
+
+
+def _load(case: Path, name: str):
+    p = case / name
+    return json.loads(p.read_text()) if p.exists() else None
+
+
+# Declarative keys carried in expected.json that are documentation, not
+# crypto verdicts; the checker passes them through verbatim.
+_DOC_KEYS = {"outcome_required", "winner", "open_contract", "note"}
+
+
+def _verdicts(case: Path, expected: dict) -> dict:
+    att = _load(case, "attestation.json")
+    dec = _load(case, "decision.json")
+    rec = _load(case, "receipt.json")
+    got: dict = {}
+    for key in expected:
+        if key in _DOC_KEYS:
+            got[key] = expected[key]
+        elif key == "decision_signature_ok":
+            got[key] = verify_signature(dec, _DECISION_BLOCKS)
+        elif key == "decision_back_link_ok":
+            got[key] = verify_back_link(dec, att)
+        elif key == "receipt_signature_ok":
+            got[key] = verify_signature(rec, _RECEIPT_BLOCKS)
+        elif key in ("receipt_back_link_ok",
+                     "receipt_back_link_ok_against_stored_attestation"):
+            got[key] = verify_back_link(rec, att)
+        elif key == "records_paired":
+            got[key] = records_paired(dec, rec)
+        elif key == "receipt_present":
+            got[key] = rec is not None
+        elif key == "both_signatures_ok":
+            got[key] = (verify_signature(_load(case, "decision_a.json"),
+                                         _DECISION_BLOCKS)
+                        and verify_signature(_load(case, "decision_b.json"),
+                                             _DECISION_BLOCKS))
+        elif key == "both_back_links_ok":
+            got[key] = (verify_back_link(_load(case, "decision_a.json"), att)
+                        and verify_back_link(_load(case, "decision_b.json"), att))
+        elif key == "replayed_receipt_signature_ok":
+            got[key] = verify_signature(_load(case, "receipt_replayed.json"),
+                                        _RECEIPT_BLOCKS)
+        else:
+            raise ValueError(f"unknown expected key: {key!r}")
+    return got
+
+
+def main() -> int:
+    failures = 0
+    cases = sorted((HERE / "normative").iterdir())
+    for case in cases:
+        if not case.is_dir():
+            continue
+        expected = json.loads((case / "expected.json").read_text())
+        got = _verdicts(case, expected)
+        ok = got == expected
+        failures += 0 if ok else 1
+        print(f"[{'OK' if ok else 'FAIL'}] {case.name}: {got}")
+    print(f"\n{len(cases) - failures}/{len(cases)} cases matched expected.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/decision_pairing_v0/normative/decision_only_escalate/attestation.json
+++ b/tests/vectors/decision_pairing_v0/normative/decision_only_escalate/attestation.json
@@ -1,0 +1,29 @@
+{
+  "alg": "HS256",
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "fixed-attestation-nonce-000",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "args": {
+          "projection": "{\"digest\":\"sha256:f735ff54b51fbc531287ba646ac3f66218ed91b783947e3e45d5e9ee3771b673\"}",
+          "projectionDigest": "sha256:5e97a35c5ee74c9e30fceea86cb31d5f3829f09022b37a728f243bd3f7b3ca1a"
+        },
+        "name": "query_table",
+        "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ]
+  },
+  "plannerDeclared": {
+    "intent": "show 10 employees"
+  },
+  "signature": "7f7a6ae787bc5164de7e76185ecd81ee189d1f43fe383400c2bb92b12589f69b",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/decision_only_escalate/decision.json
+++ b/tests/vectors/decision_pairing_v0/normative/decision_only_escalate/decision.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "fixed-attestation-nonce-000"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "escalate",
+    "policyId": "policy:read-only/3",
+    "riskScore": "0.21",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "ES256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d2",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "017040a40f64f8ac718090ef545bb8edee738a110f18c9edbc71d345ed9fd08c0a538fde3dde59c9780bc1f4ef5ffc6e8b5ff79c5f56b1366b94f1f0cd353c7b",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/decision_only_escalate/expected.json
+++ b/tests/vectors/decision_pairing_v0/normative/decision_only_escalate/expected.json
@@ -1,0 +1,6 @@
+{
+  "decision_back_link_ok": true,
+  "decision_signature_ok": true,
+  "outcome_required": false,
+  "receipt_present": false
+}

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/decision.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/decision.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:1a6582cad584f2eb28ae65120ff1a54981d897b2c252c17771910a313bee66b2",
+    "attestationNonce": "server-chosen-nonce-001"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow",
+    "policyId": "policy:read-only/3",
+    "riskScore": "0.21",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d6",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "f469190fdd20ac6fc49090c0c8965c74c69ee298904d619ea7a785e517034adb",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/expected.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/expected.json
@@ -1,0 +1,7 @@
+{
+  "decision_signature_ok": true,
+  "note": "fallback binding when no SEP-2787 attestation exists; the BackLink digest is over the JCS-canonical request envelope",
+  "receipt_signature_ok": true,
+  "records_paired": true,
+  "replayed_receipt_signature_ok": false
+}

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:1a6582cad584f2eb28ae65120ff1a54981d897b2c252c17771910a313bee66b2",
+    "attestationNonce": "server-chosen-nonce-001"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r6",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "2ac6272a6c9e58fb9de42239c90e9700bd9252812aa29af989ce312535a6f34c",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt_replayed.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt_replayed.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "attestationNonce": "server-chosen-nonce-001"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r6",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "2ac6272a6c9e58fb9de42239c90e9700bd9252812aa29af989ce312535a6f34c",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/substituted_attestation_backlink/attestation.json
+++ b/tests/vectors/decision_pairing_v0/normative/substituted_attestation_backlink/attestation.json
@@ -1,0 +1,29 @@
+{
+  "alg": "HS256",
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "fixed-attestation-nonce-000",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "args": {
+          "projection": "{\"digest\":\"sha256:f735ff54b51fbc531287ba646ac3f66218ed91b783947e3e45d5e9ee3771b673\"}",
+          "projectionDigest": "sha256:5e97a35c5ee74c9e30fceea86cb31d5f3829f09022b37a728f243bd3f7b3ca1a"
+        },
+        "name": "query_table",
+        "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ]
+  },
+  "plannerDeclared": {
+    "intent": "show 10 employees"
+  },
+  "signature": "7f7a6ae787bc5164de7e76185ecd81ee189d1f43fe383400c2bb92b12589f69b",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/substituted_attestation_backlink/decision.json
+++ b/tests/vectors/decision_pairing_v0/normative/substituted_attestation_backlink/decision.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "fixed-attestation-nonce-000"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow",
+    "policyId": "policy:read-only/3",
+    "riskScore": "0.21",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d3",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "5e60186c4c47fd6b14d328028559783c13907b982eb6376863789e3559731dc9",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/substituted_attestation_backlink/expected.json
+++ b/tests/vectors/decision_pairing_v0/normative/substituted_attestation_backlink/expected.json
@@ -1,0 +1,7 @@
+{
+  "decision_back_link_ok": true,
+  "decision_signature_ok": true,
+  "receipt_back_link_ok_against_stored_attestation": false,
+  "receipt_signature_ok": true,
+  "records_paired": false
+}

--- a/tests/vectors/decision_pairing_v0/normative/substituted_attestation_backlink/receipt.json
+++ b/tests/vectors/decision_pairing_v0/normative/substituted_attestation_backlink/receipt.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:a67b27de2cc21ee1ed67a9cc3d72ee27ca3a5450844f5f6b2296552cedc6fe3d",
+    "attestationNonce": "other-attestation-nonce-999"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r3",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "3d96ecdfac6c05ab91efb766fda66e1c515153621b1d880db1047744de24de96",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/substituted_pairing_nonce/attestation.json
+++ b/tests/vectors/decision_pairing_v0/normative/substituted_pairing_nonce/attestation.json
@@ -1,0 +1,29 @@
+{
+  "alg": "HS256",
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "fixed-attestation-nonce-000",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "args": {
+          "projection": "{\"digest\":\"sha256:f735ff54b51fbc531287ba646ac3f66218ed91b783947e3e45d5e9ee3771b673\"}",
+          "projectionDigest": "sha256:5e97a35c5ee74c9e30fceea86cb31d5f3829f09022b37a728f243bd3f7b3ca1a"
+        },
+        "name": "query_table",
+        "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ]
+  },
+  "plannerDeclared": {
+    "intent": "show 10 employees"
+  },
+  "signature": "7f7a6ae787bc5164de7e76185ecd81ee189d1f43fe383400c2bb92b12589f69b",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/substituted_pairing_nonce/decision.json
+++ b/tests/vectors/decision_pairing_v0/normative/substituted_pairing_nonce/decision.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "fixed-attestation-nonce-000"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow",
+    "policyId": "policy:read-only/3",
+    "riskScore": "0.21",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d4",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "d485105f629b587a169b4b5a4e218a321aa5f806fd984038412ae2189aae6353",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/substituted_pairing_nonce/expected.json
+++ b/tests/vectors/decision_pairing_v0/normative/substituted_pairing_nonce/expected.json
@@ -1,0 +1,4 @@
+{
+  "note": "same attestationDigest, mismatched attestationNonce",
+  "records_paired": false
+}

--- a/tests/vectors/decision_pairing_v0/normative/substituted_pairing_nonce/receipt.json
+++ b/tests/vectors/decision_pairing_v0/normative/substituted_pairing_nonce/receipt.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "substituted-nonce"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r4",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "e4705c4982b71f3040fc9ae43f8e74d4b0ede45876340ebe1e9c5603248ac646",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/supersession_equal_decidedat_tie/attestation.json
+++ b/tests/vectors/decision_pairing_v0/normative/supersession_equal_decidedat_tie/attestation.json
@@ -1,0 +1,29 @@
+{
+  "alg": "HS256",
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "fixed-attestation-nonce-000",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "args": {
+          "projection": "{\"digest\":\"sha256:f735ff54b51fbc531287ba646ac3f66218ed91b783947e3e45d5e9ee3771b673\"}",
+          "projectionDigest": "sha256:5e97a35c5ee74c9e30fceea86cb31d5f3829f09022b37a728f243bd3f7b3ca1a"
+        },
+        "name": "query_table",
+        "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ]
+  },
+  "plannerDeclared": {
+    "intent": "show 10 employees"
+  },
+  "signature": "7f7a6ae787bc5164de7e76185ecd81ee189d1f43fe383400c2bb92b12589f69b",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/supersession_equal_decidedat_tie/decision_a.json
+++ b/tests/vectors/decision_pairing_v0/normative/supersession_equal_decidedat_tie/decision_a.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "fixed-attestation-nonce-000"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "block",
+    "policyId": "policy:read-only/3",
+    "riskScore": "0.21",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d5a",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "65b33bb7f667fc8d7465e0d15d4e9127c5890b3ac3e261ef5c54604cba4d18ed",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/supersession_equal_decidedat_tie/decision_b.json
+++ b/tests/vectors/decision_pairing_v0/normative/supersession_equal_decidedat_tie/decision_b.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "fixed-attestation-nonce-000"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow",
+    "policyId": "policy:read-only/3",
+    "riskScore": "0.21",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d5b",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "312205fc2d5f4b60ebb504b2a25f760bb846b5f3ad89a0715160da2897d876db",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/supersession_equal_decidedat_tie/expected.json
+++ b/tests/vectors/decision_pairing_v0/normative/supersession_equal_decidedat_tie/expected.json
@@ -1,0 +1,6 @@
+{
+  "both_back_links_ok": true,
+  "both_signatures_ok": true,
+  "open_contract": "equal decidedAt needs a deterministic tie-break (e.g. lexicographic on record nonce); unspecified in the reference impl as of v0.50.0",
+  "winner": null
+}

--- a/tests/vectors/decision_pairing_v0/normative/valid_pair_allow_executed/attestation.json
+++ b/tests/vectors/decision_pairing_v0/normative/valid_pair_allow_executed/attestation.json
@@ -1,0 +1,29 @@
+{
+  "alg": "HS256",
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "fixed-attestation-nonce-000",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "args": {
+          "projection": "{\"digest\":\"sha256:f735ff54b51fbc531287ba646ac3f66218ed91b783947e3e45d5e9ee3771b673\"}",
+          "projectionDigest": "sha256:5e97a35c5ee74c9e30fceea86cb31d5f3829f09022b37a728f243bd3f7b3ca1a"
+        },
+        "name": "query_table",
+        "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ]
+  },
+  "plannerDeclared": {
+    "intent": "show 10 employees"
+  },
+  "signature": "7f7a6ae787bc5164de7e76185ecd81ee189d1f43fe383400c2bb92b12589f69b",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/valid_pair_allow_executed/decision.json
+++ b/tests/vectors/decision_pairing_v0/normative/valid_pair_allow_executed/decision.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "fixed-attestation-nonce-000"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow",
+    "policyId": "policy:read-only/3",
+    "riskScore": "0.21",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "226d2a3c2998ecbd0366ac8080e27b5ce255e2680c8178fa478f69dceac571fb",
+  "version": 1
+}

--- a/tests/vectors/decision_pairing_v0/normative/valid_pair_allow_executed/expected.json
+++ b/tests/vectors/decision_pairing_v0/normative/valid_pair_allow_executed/expected.json
@@ -1,0 +1,7 @@
+{
+  "decision_back_link_ok": true,
+  "decision_signature_ok": true,
+  "receipt_back_link_ok": true,
+  "receipt_signature_ok": true,
+  "records_paired": true
+}

--- a/tests/vectors/decision_pairing_v0/normative/valid_pair_allow_executed/receipt.json
+++ b/tests/vectors/decision_pairing_v0/normative/valid_pair_allow_executed/receipt.json
@@ -1,0 +1,25 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "fixed-attestation-nonce-000"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "03731115968380aa9fbf41dc24d89676ab19ca806ce914fbb95447ff2eb58760",
+  "version": 1
+}


### PR DESCRIPTION
SEP-owned decision/outcome pairing conformance vectors, requested on modelcontextprotocol/modelcontextprotocol#2828 so independent verifiers can check the record shapes without sharing Vaara's emitter code.

Six committed cases under `tests/vectors/decision_pairing_v0/normative/`, each with `expected.json`:

- `valid_pair_allow_executed` — allow decision + executed outcome, paired
- `decision_only_escalate` — valid terminal/pending state, no sibling outcome
- `substituted_attestation_backlink` — receipt binds a different attestation, does not pair
- `substituted_pairing_nonce` — same attestationDigest, mismatched nonce, does not pair
- `supersession_equal_decidedat_tie` — two conflicting decisions at equal `decidedAt`; flags the open tie-break contract (no deterministic ordering in the impl as of v0.50.0)
- `fallback_envelope_binding` — no SEP-2787 attestation: bind to a SHA-256 over the JCS-canonical request envelope, plus a replay negative

A stdlib-only walker (`_check_independent.py`, no Vaara imports) reproduces the verdicts, guarded in CI by `tests/test_decision_pairing_vectors.py`. Pairing follows the shipped shared-attestation model (`records_paired`); the "outcome resolves to decision content digest" join under discussion in #2828 is noted as out of scope and would add a field and a case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test vectors for decision/outcome pairing validation across multiple scenarios
  * Added independent conformance checker to validate test case expectations
  * Includes test cases covering valid pairings, signature validation, back-link verification, and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->