### PR TITLE
chore: bump MCP registry manifests to 0.51.0

### DIFF
--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.50.0",
+  "version": "0.51.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.50.0",
+  "version": "0.51.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Follow-up to #186 (v0.51.0). The v0.51.0 commit bumped pyproject, `__init__`, CHANGELOG and the TS client but missed both MCP manifests (`server.json`, `server-vaara-server.json`), which still read 0.50.0.

The Release workflow publishes both manifests to the MCP Registry and then asserts the registry's latest active version equals the tag. With manifests at 0.50.0 a v0.51.0 tag fails that gate, exactly as the v0.49.0 release did. This bumps the listing version and the pypi package version in both manifests so the v0.51.0 tag publishes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)