### PR TITLE
v0.52.0: resolvable agent identity (did:web)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-06-02
+
+**Theme: resolvable agent identity (level 2). A receipt no longer just proves it
+was signed by some key; when its `receiptAsserted.iss` is a `did:web` identity it
+can prove the signing key is one the named agent actually publishes. The check is
+pinned-resolvable: the verifier supplies the DID document, so the property holds
+offline with no network fetch. It composes over the unchanged signature verifier,
+so every existing receipt and vector verifies byte for byte.**
+
+### Added
+- `vaara.attestation.verify_receipt_identity`: confirms a receipt whose
+  `receiptAsserted.iss` is a `did:web` identity was signed by a key listed in the
+  supplied DID document. Runs after, and on top of, ordinary signature
+  verification. `ES256`/`RS256` resolve against the document; `HS256` (symmetric)
+  never does, since a shared secret cannot bind a public identity.
+- `agent_identity_v0` conformance vector family (`bound.json`, `unbound.json`,
+  `expected.json`) plus a Vaara-free independent checker
+  (`_check_independent.py`), so an external party reproduces the bound/unbound
+  verdicts from the committed wire bytes with no Vaara import.
+- Design spec: `docs/design/resolvable-agent-identity-spec.md`.
+
+### Changed
+- Purely additive over 0.51. The wire `version` is unchanged; receipts without a
+  `did:web` issuer verify exactly as before. Level 3 (live HTTPS DID resolution
+  with caching and revocation) is the planned follow-up.
+
 ## [0.51.0] - 2026-06-02
 
 **Theme: SEP-2828 Check B. A decision and an outcome now pair on two checks, not

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.51.0"
+version = "0.52.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.51.0",
+  "version": "0.52.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.51.0",
+  "version": "0.52.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.51.0"
+__version__ = "0.52.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Releases the resolvable agent identity (did:web, level 2) work merged in #189 as v0.52.0.

## What ships
- `vaara.attestation.verify_receipt_identity`: confirms a receipt whose `receiptAsserted.iss` is a `did:web` identity was signed by a key listed in the supplied DID document. Pinned-resolvable (offline), composed over the unchanged signature verifier. `ES256`/`RS256` resolve; `HS256` never.
- `agent_identity_v0` conformance vector family plus a Vaara-free independent checker, so an external party reproduces the bound/unbound verdicts from committed wire bytes with no Vaara import.
- Design spec `docs/design/resolvable-agent-identity-spec.md`.

## Release mechanics
- Version bumped on all six surfaces: `pyproject.toml`, `src/vaara/__init__.py`, `clients/ts/package.json`, both MCP manifests (`server.json`, `server-vaara-server.json`).
- CHANGELOG `[Unreleased]` promoted to `[0.52.0]`.
- Purely additive over 0.51; envelope wire `version` stays 1. Existing receipts and vectors verify byte for byte.
- Full suite 1175 passed, 13 skipped; ruff clean.

Level 3 (live HTTPS DID resolution with caching and revocation) is the planned follow-up.
