### PR TITLE
v0.53.0: resolvable agent identity level 3 (live did:web + revocation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-06-03
+
+**Theme: resolvable agent identity, level 3. Level 2 confirmed a receipt was
+signed by a key a DID document lists, given the document. Level 3 fetches that
+document over HTTPS at audit time, records the resolution so it is
+reproducible, and adds revocation in time: a signing key revoked at or before
+the receipt was issued no longer yields a trusted verdict, even when the
+signature still verifies. A key revoked afterwards still binds, because
+revocation is not retroactive.**
+
+### Added
+- `vaara.attestation.verify_receipt_identity_live`: level-3 check that
+  resolves a `did:web` issuer over HTTPS (or from cache), runs the level-2
+  binding, then applies deactivation and revocation-in-time. Returns
+  `LiveIdentityResult` with a single `trusted` verdict plus `issued_at` and
+  `revoked_at`, so a verifier holding a stronger time anchor than the
+  self-asserted `iat` (the audit-trail hash chain) can re-decide.
+- `ResolutionMeta`: an auditable record of each resolve (`did`, `url`,
+  `fetched_at`, `document_digest` over the exact bytes, `from_cache`).
+- `DidDocumentCache`: in-memory TTL cache keyed by DID, caller-supplied clock
+  so it is deterministic under test.
+- `https_fetch`: the default size-capped, HTTPS-only DID-document fetcher.
+  Redirects are refused (an SSRF vector); deployers inject their own fetcher
+  for allowlisting, pinning, or proxy egress, or to verify offline against a
+  captured document.
+- A third `agent_identity_v0` conformance vector, `revoked.json` (bound but
+  not trusted, key revoked before issuance), with the Vaara-free independent
+  checker extended to reproduce the revocation verdict offline. `expected.json`
+  now carries `revoked` and `trusted` per case.
+
+### Changed
+- Purely additive over 0.52. The receipt envelope, canonicalization, and the
+  level-2 verifier are unchanged; existing receipts and the `bound`/`unbound`
+  vectors verify exactly as before.
+
 ## [0.52.0] - 2026-06-02
 
 **Theme: resolvable agent identity (level 2). A receipt no longer just proves it

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/design/resolvable-agent-identity-spec.md
+++ b/docs/design/resolvable-agent-identity-spec.md
@@ -98,16 +98,54 @@ ships as a *new* vector family (`agent_identity_v0`) carrying:
 This keeps the property the #2402 thread cares about: the record verifies
 against the spec and captured inputs, not against a live service or our code.
 
+The vector family also covers level-3 revocation offline: `revoked.json`
+carries a document that lists the signing key but marks it `revoked` before
+the receipt's `iat`, with the expected verdict `bound` but not `trusted`.
+That comparison needs no network, so it ships as a vector even though the
+fetch itself does not.
+
+## Implementation
+
+Level 2 (`verify_receipt_identity`) takes a DID document the caller already
+holds and returns `IdentityResult(resolved, bound, keyid, reason)`. It is
+pure and offline.
+
+Level 3 (`verify_receipt_identity_live`) wraps level 2 with resolution,
+caching, deactivation, and revocation, and returns `LiveIdentityResult`:
+
+- **Resolution record.** Each resolve produces `ResolutionMeta(did, url,
+  fetched_at, document_digest, from_cache)`. `document_digest` is
+  `sha256:<hex>` over the exact bytes fetched, so the resolution is
+  reproducible: hand a second auditor the same document and they recompute
+  the digest and the verdict. The default fetcher is a size-capped,
+  HTTPS-only stdlib GET; a deployer injects their own for allowlisting,
+  pinning, or proxy egress, or to verify offline against a captured document.
+- **Caching.** `DidDocumentCache` is an in-memory TTL cache keyed by DID, so
+  a verifier checking many receipts from one issuer resolves once per window.
+  The clock is caller-supplied, so it is deterministic under test.
+- **Revocation in time.** A verification method may carry a `revoked` ISO
+  8601 instant; a document may carry `deactivated: true`. A key revoked at or
+  before the receipt's `iat` yields `trusted=false` even when the signature
+  matches; a key revoked afterwards still binds, because revocation is not
+  retroactive. The result surfaces both `issued_at` and `revoked_at` so a
+  verifier with a stronger time anchor than the self-asserted `iat` (the
+  audit-trail hash chain) can re-decide.
+
+`trusted` is the single overall verdict: resolved, bound, not deactivated,
+and not revoked at or before issuance.
+
 ## Open questions
 
 - Whether `sub` (the acting subject, distinct from the issuer) should resolve
   by the same mechanism, or stay opaque when the subject is an end user rather
   than an agent.
-- DID-document key rotation: a receipt pins `iss_keyid`, but a document
-  fetched years later may have rotated that key out. The hash-chain timestamp
-  plus the recorded fetch metadata give the external time anchor needed to
-  reason about which key was valid when, the same anchor the trust-model work
-  relies on for key-compromise reasoning.
+- Key rotation across long spans is partly addressed: the level-3 result
+  records the fetch (URL, time, document digest) and surfaces the revocation
+  instant against issuance, and the audit-trail hash chain supplies the
+  external time anchor for which key was valid when. What remains is a
+  convention for pinning the resolved document digest into the trail at
+  verification time, so a re-verify years later can detect a since-rotated
+  document rather than silently resolving the current one.
 - Whether to register the receipt envelope's resolvable-identity convention
   as a follow-up to SEP-2828, so the MCP audit-context line and Vaara's
   envelope name identity the same way.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.52.0"
+version = "0.53.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.52.0",
+  "version": "0.53.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.52.0",
+  "version": "0.53.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.52.0"
+__version__ = "0.53.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_receipt_identity_live.py
+++ b/src/vaara/attestation/_receipt_identity_live.py
@@ -1,0 +1,360 @@
+"""Live-resolvable agent identity (did:web) for execution receipts.
+
+Internal module. Public surface is re-exported from
+``vaara.attestation.receipt``.
+
+Level-3 verification, per ``docs/design/resolvable-agent-identity-spec.md``:
+given a receipt whose ``receiptAsserted.iss`` is a ``did:web`` identifier,
+fetch the DID document over HTTPS at audit time, then run the level-2
+pinned-resolvable check against the freshly fetched document. Two properties
+distinguish level 3 from level 2:
+
+1. **Auditable resolution.** The fetch is recorded (URL, fetch time, and a
+   digest over the exact document bytes) so the resolution itself is
+   reproducible: a second auditor handed the same recorded document
+   reproduces the level-2 verdict offline, and the digest pins which document
+   was seen.
+2. **Revocation in time.** A DID document may mark a verification method
+   ``revoked`` (an ISO 8601 instant) or mark the whole identity
+   ``deactivated``. A key revoked at or before the receipt was issued does
+   not bind the receipt, even when the signature math still checks out. A key
+   revoked *after* issuance still binds: revocation is not retroactive, the
+   same "revoked before compromise" reasoning the threshold-signing
+   key-lifecycle markers use.
+
+The revocation comparison uses ``receiptAsserted.iat``, which is
+self-asserted. The verdict exposes both instants (``issued_at`` and
+``revoked_at``) so a verifier holding a stronger time anchor (the audit-trail
+hash chain) can re-decide rather than trust the receipt's own clock.
+
+This is purely additive. It composes ``verify_receipt_identity`` (level 2)
+and ``did_web_to_url`` unchanged, touches neither the receipt envelope nor
+the canonicalization, and pulls in no dependency beyond the standard library
+for the default fetch. The fetcher is injectable, so the unit tests and
+conformance vectors run with no network.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+from vaara.attestation._receipt_identity import (
+    IdentityResult,
+    did_web_to_url,
+    verify_receipt_identity,
+)
+from vaara.attestation._receipt_types import ExecutionReceipt
+from vaara.attestation._sep2787_types import AttestationError
+
+# A DID document is a small JSON file. Cap the read so a misbehaving or
+# hostile host cannot stream an unbounded body into the verifier.
+_DEFAULT_MAX_BYTES = 1 << 20  # 1 MiB
+_DEFAULT_TIMEOUT_S = 10.0
+_DEFAULT_CACHE_TTL_S = 3600.0
+
+# Fetcher signature: takes the resolved HTTPS URL, returns the raw document
+# bytes. Injectable so tests and conformance vectors run offline.
+Fetcher = Callable[[str], bytes]
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    """Parse an ISO 8601 instant to an aware UTC datetime, or None.
+
+    Accepts a trailing ``Z``. A naive timestamp is read as UTC so two
+    receipts are comparable regardless of which form an emitter used.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    text = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _parse_epoch(iso: str) -> float:
+    dt = _parse_iso(iso)
+    return 0.0 if dt is None else dt.timestamp()
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Refuse HTTP redirects: a did:web document resolves at a fixed URL.
+
+    Following redirects from a hostile host is an SSRF vector (a 3xx to an
+    internal address or to ``http://``). Returning None makes urllib raise
+    on the 3xx, which the caller treats as a resolution failure: fail closed
+    rather than chase the redirect.
+    """
+
+    def redirect_request(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+_NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
+def https_fetch(
+    url: str,
+    *,
+    timeout: float = _DEFAULT_TIMEOUT_S,
+    max_bytes: int = _DEFAULT_MAX_BYTES,
+) -> bytes:
+    """Default DID-document fetcher: a size-capped HTTPS GET, stdlib only.
+
+    HTTPS only, since ``did:web`` documents resolve over the web PKI, and
+    redirects are refused (an SSRF vector). The body is read up to
+    ``max_bytes`` and rejected if it exceeds the cap. Deployers needing host
+    allowlisting, pinning, or proxy egress inject their own fetcher instead.
+    """
+    if not url.startswith("https://"):
+        raise AttestationError(f"DID document URL is not HTTPS: {url!r}")
+    request = urllib.request.Request(
+        url, headers={"Accept": "application/did+json, application/json"}
+    )
+    with _NO_REDIRECT_OPENER.open(request, timeout=timeout) as response:  # noqa: S310
+        body = response.read(max_bytes + 1)
+    if len(body) > max_bytes:
+        raise AttestationError(f"DID document exceeds {max_bytes} bytes: {url!r}")
+    return body
+
+
+@dataclass(frozen=True)
+class ResolutionMeta:
+    """Auditable record of a DID-document resolution.
+
+    ``document_digest`` is ``sha256:<hex>`` over the exact bytes fetched, so
+    an auditor handed the same document reproduces the verdict and can
+    confirm it is the document that was seen. ``from_cache`` is True when the
+    document was served from a prior fetch within its TTL.
+    """
+
+    did: str
+    url: str
+    fetched_at: str
+    document_digest: str
+    from_cache: bool
+
+
+@dataclass(frozen=True)
+class LiveIdentityResult:
+    """Verdict of a level-3 live-resolvable identity check.
+
+    Extends the level-2 verdict with revocation, deactivation, and the
+    resolution record. ``trusted`` is the single overall verdict: the
+    issuer resolved, the signature bound to a key the document lists, the
+    identity is not deactivated, and the bound key was not revoked at or
+    before issuance.
+
+    ``revoked_at`` and ``issued_at`` are surfaced even on a pass so a
+    verifier with a stronger time anchor than the receipt's self-asserted
+    ``iat`` can re-decide.
+    """
+
+    resolved: bool
+    bound: bool
+    keyid: Optional[str]
+    revoked: bool
+    deactivated: bool
+    trusted: bool
+    reason: str
+    resolution: Optional[ResolutionMeta]
+    issued_at: Optional[str] = None
+    revoked_at: Optional[str] = None
+
+    @property
+    def identity(self) -> IdentityResult:
+        """The level-2 verdict embedded in this level-3 result."""
+        return IdentityResult(self.resolved, self.bound, self.keyid, self.reason)
+
+
+class DidDocumentCache:
+    """In-memory TTL cache of resolved DID documents, keyed by DID.
+
+    A verifier checking many receipts from the same issuer resolves the
+    document once per TTL window. The cache stores the parsed document and
+    the resolution metadata of the fetch that filled it; a cache hit reuses
+    that metadata with ``from_cache=True``. Time is supplied by the caller
+    (``now`` epoch seconds) so the cache is deterministic under test.
+    """
+
+    def __init__(self, ttl_seconds: float = _DEFAULT_CACHE_TTL_S) -> None:
+        self._ttl = ttl_seconds
+        self._entries: dict[str, tuple[float, dict[str, Any], ResolutionMeta]] = {}
+
+    def get(
+        self, did: str, *, now: float
+    ) -> Optional[tuple[dict[str, Any], ResolutionMeta]]:
+        entry = self._entries.get(did)
+        if entry is None:
+            return None
+        stored_at, document, meta = entry
+        if now - stored_at > self._ttl:
+            del self._entries[did]
+            return None
+        cached_meta = ResolutionMeta(
+            did=meta.did, url=meta.url, fetched_at=meta.fetched_at,
+            document_digest=meta.document_digest, from_cache=True,
+        )
+        return document, cached_meta
+
+    def put(
+        self, did: str, document: dict[str, Any], meta: ResolutionMeta, *, now: float
+    ) -> None:
+        self._entries[did] = (now, document, meta)
+
+
+def _revocation_instant(
+    did_document: dict[str, Any], keyid: Optional[str]
+) -> Optional[str]:
+    """Return the ``revoked`` instant of the named verification method, if any."""
+    if keyid is None:
+        return None
+    methods = did_document.get("verificationMethod")
+    if not isinstance(methods, list):
+        return None
+    for method in methods:
+        if isinstance(method, dict) and method.get("id") == keyid:
+            revoked = method.get("revoked")
+            return revoked if isinstance(revoked, str) else None
+    return None
+
+
+def _live_reason(
+    identity: IdentityResult,
+    deactivated: bool,
+    revoked: bool,
+    revoked_at: Optional[str],
+) -> str:
+    if deactivated:
+        return "DID document is deactivated"
+    if revoked:
+        return f"signing key was revoked at or before issuance ({revoked_at})"
+    return identity.reason
+
+
+def _fail(reason: str) -> "LiveIdentityResult":
+    return LiveIdentityResult(
+        False, False, None, False, False, False, reason, None
+    )
+
+
+def _resolve(
+    iss: str,
+    fetcher: Optional[Fetcher],
+    cache: Optional[DidDocumentCache],
+    fetched_at: str,
+    cache_now: float,
+) -> "tuple[dict[str, Any], ResolutionMeta] | LiveIdentityResult":
+    """Return ``(document, meta)`` or a failed ``LiveIdentityResult``."""
+    if cache is not None:
+        hit = cache.get(iss, now=cache_now)
+        if hit is not None:
+            return hit
+    try:
+        url = did_web_to_url(iss)
+    except AttestationError as exc:
+        return _fail(f"cannot map did:web to URL: {exc}")
+    fetch = fetcher if fetcher is not None else https_fetch
+    try:
+        raw = fetch(url)
+    except Exception as exc:  # noqa: BLE001 - any fetch failure is a resolution failure
+        return _fail(f"DID document fetch failed: {exc}")
+    raw_bytes = raw if isinstance(raw, bytes) else str(raw).encode("utf-8")
+    try:
+        parsed = json.loads(raw_bytes)
+    except (ValueError, TypeError) as exc:
+        return _fail(f"DID document is not valid JSON: {exc}")
+    if not isinstance(parsed, dict):
+        return _fail("DID document is not a JSON object")
+    meta = ResolutionMeta(
+        did=iss, url=url, fetched_at=fetched_at,
+        document_digest="sha256:" + hashlib.sha256(raw_bytes).hexdigest(),
+        from_cache=False,
+    )
+    if cache is not None:
+        cache.put(iss, parsed, meta, now=cache_now)
+    return parsed, meta
+
+
+def verify_receipt_identity_live(
+    receipt: ExecutionReceipt,
+    *,
+    fetcher: Optional[Fetcher] = None,
+    cache: Optional[DidDocumentCache] = None,
+    now: Optional[str] = None,
+    now_epoch: Optional[float] = None,
+    expected_keyid: Optional[str] = None,
+) -> LiveIdentityResult:
+    """Level-3 live-resolvable identity check.
+
+    Resolves the receipt's ``did:web`` ``iss`` to a DID document over HTTPS
+    (or from ``cache``), records the resolution, runs the level-2 check, and
+    then applies deactivation and revocation-in-time. ``fetcher`` defaults to
+    a size-capped stdlib HTTPS GET; pass your own for allowlisting, pinning,
+    or proxy egress, or to verify offline against a captured document.
+
+    ``now`` (ISO 8601) stamps the resolution record and is the default clock
+    for revocation; ``now_epoch`` drives the cache TTL. Both default to the
+    current UTC time. A plain-string ``iss`` is never failed for lack of a
+    DID: it returns ``resolved=False`` with no fetch attempted.
+    """
+    iss = receipt.receipt_asserted.iss
+    if not iss.startswith("did:web:"):
+        return _fail("iss is not a did:web identifier")
+
+    fetched_at = now if now is not None else _utc_now_iso()
+    cache_now = now_epoch if now_epoch is not None else _parse_epoch(fetched_at)
+
+    resolved = _resolve(iss, fetcher, cache, fetched_at, cache_now)
+    if isinstance(resolved, LiveIdentityResult):
+        return resolved
+    document, meta = resolved
+
+    identity = verify_receipt_identity(
+        receipt, document, expected_keyid=expected_keyid
+    )
+
+    deactivated = document.get("deactivated") is True
+    issued_at = receipt.receipt_asserted.iat
+
+    revoked = False
+    revoked_at: Optional[str] = None
+    if identity.bound:
+        revoked_at = _revocation_instant(document, identity.keyid)
+        if revoked_at is not None:
+            revoked_dt = _parse_iso(revoked_at)
+            issued_dt = _parse_iso(issued_at)
+            # Revoked binds only when revocation is at or before issuance.
+            # An unparseable revocation or issuance instant fails closed.
+            if revoked_dt is None or issued_dt is None or revoked_dt <= issued_dt:
+                revoked = True
+
+    trusted = (
+        identity.resolved and identity.bound and not deactivated and not revoked
+    )
+    reason = _live_reason(identity, deactivated, revoked, revoked_at)
+
+    return LiveIdentityResult(
+        resolved=identity.resolved,
+        bound=identity.bound,
+        keyid=identity.keyid,
+        revoked=revoked,
+        deactivated=deactivated,
+        trusted=trusted,
+        reason=reason,
+        resolution=meta,
+        issued_at=issued_at,
+        revoked_at=revoked_at,
+    )

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -44,6 +44,13 @@ from vaara.attestation._receipt_identity import (
     did_web_to_url,
     verify_receipt_identity,
 )
+from vaara.attestation._receipt_identity_live import (
+    DidDocumentCache,
+    LiveIdentityResult,
+    ResolutionMeta,
+    https_fetch,
+    verify_receipt_identity_live,
+)
 from vaara.attestation._receipt_types import (
     BackLink,
     ExecutionReceipt,
@@ -77,15 +84,19 @@ __all__ = [
     "VAARA_RECEIPT_CONTEXT_URL",
     "BackLink",
     "BackLinkResult",
+    "DidDocumentCache",
     "ExecutionReceipt",
     "IdentityResult",
+    "LiveIdentityResult",
     "OutcomeDerived",
     "ReceiptAsserted",
     "ReceiptStatus",
+    "ResolutionMeta",
     "ResultCommitment",
     "attestation_digest",
     "did_web_to_url",
     "emit_receipt",
+    "https_fetch",
     "load_receipt_context",
     "make_back_link",
     "make_result_digest",
@@ -95,5 +106,6 @@ __all__ = [
     "receipt_to_vc",
     "verify_back_link",
     "verify_receipt_identity",
+    "verify_receipt_identity_live",
     "verify_receipt_signature",
 ]

--- a/tests/test_agent_identity_vectors.py
+++ b/tests/test_agent_identity_vectors.py
@@ -24,7 +24,11 @@ for _mod in ("rfc8785", "cryptography"):
             allow_module_level=True,
         )
 
-from vaara.attestation.receipt import parse_receipt, verify_receipt_identity  # noqa: E402
+from vaara.attestation.receipt import (  # noqa: E402
+    parse_receipt,
+    verify_receipt_identity,
+    verify_receipt_identity_live,
+)
 
 VECTORS = Path(__file__).resolve().parent / "vectors" / "agent_identity_v0"
 
@@ -33,7 +37,7 @@ def _expected():
     return json.loads((VECTORS / "expected.json").read_text())
 
 
-@pytest.mark.parametrize("name", ["bound", "unbound"])
+@pytest.mark.parametrize("name", ["bound", "unbound", "revoked"])
 def test_vaara_reproduces_vector_verdict(name):
     case = json.loads((VECTORS / f"{name}.json").read_text())
     receipt = parse_receipt(case["receipt"])
@@ -42,6 +46,22 @@ def test_vaara_reproduces_vector_verdict(name):
     assert result.resolved is want["resolved"]
     assert result.bound is want["bound"]
     assert result.keyid == want["keyid"]
+
+
+@pytest.mark.parametrize("name", ["bound", "unbound", "revoked"])
+def test_vaara_live_reproduces_vector_verdict(name):
+    # Level 3 against the captured document via an offline fetcher: the
+    # full verdict, including revoked/trusted, reproduces with no network.
+    case = json.loads((VECTORS / f"{name}.json").read_text())
+    receipt = parse_receipt(case["receipt"])
+    raw = json.dumps(case["didDocument"]).encode("utf-8")
+    result = verify_receipt_identity_live(receipt, fetcher=lambda url: raw)
+    want = _expected()[name]
+    assert result.resolved is want["resolved"]
+    assert result.bound is want["bound"]
+    assert result.keyid == want["keyid"]
+    assert result.revoked is want["revoked"]
+    assert result.trusted is want["trusted"]
 
 
 def test_independent_checker_passes():

--- a/tests/test_receipt_identity_live.py
+++ b/tests/test_receipt_identity_live.py
@@ -1,0 +1,212 @@
+"""Tests for level-3 live-resolvable agent identity (did:web).
+
+The fetcher is injected throughout, so no test makes a network call. These
+cover resolution, the auditable resolution record, the cache (hit, TTL
+expiry), deactivation, and revocation-in-time (revoked before vs after
+issuance), all composed over the unchanged level-2 check.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from vaara.attestation._sep2787_types import AttestationError
+from vaara.attestation.receipt import (
+    DidDocumentCache,
+    OutcomeDerived,
+    emit_receipt,
+    https_fetch,
+    make_back_link,
+    verify_receipt_identity_live,
+)
+from vaara.attestation.sep2787 import (
+    PayloadDerived,
+    PlannerDeclared,
+    ToolCallBinding,
+    emit_attestation,
+    make_args_digest,
+)
+
+DID = "did:web:agents.example.com:billing"
+KEYID = DID + "#key-2026"
+ISSUED = "2026-05-29T10:00:00Z"
+SCALAR_A = 0x1F2E3D4C5B6A79887766554433221100FFEEDDCCBBAA99887766554433221101
+SCALAR_B = 0x0A1B2C3D4E5F60718293A4B5C6D7E8F9001122334455667788990AABBCCDDEEFF
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _ec_jwk(public_key: ec.EllipticCurvePublicKey) -> dict:
+    nums = public_key.public_numbers()
+    return {
+        "kty": "EC", "crv": "P-256",
+        "x": _b64u(nums.x.to_bytes(32, "big")),
+        "y": _b64u(nums.y.to_bytes(32, "big")),
+    }
+
+
+def _did_document(public_key, *, revoked=None, deactivated=False) -> dict:
+    method = {
+        "id": KEYID, "type": "JsonWebKey2020", "controller": DID,
+        "publicKeyJwk": _ec_jwk(public_key),
+    }
+    if revoked is not None:
+        method["revoked"] = revoked
+    doc = {"id": DID, "verificationMethod": [method]}
+    if deactivated:
+        doc["deactivated"] = True
+    return doc
+
+
+def _receipt(key):
+    attestation = emit_attestation(
+        planner_declared=PlannerDeclared(intent="settle invoice"),
+        payload_derived=PayloadDerived(tool_calls=(ToolCallBinding(
+            name="charge_card", server_fingerprint="sha256:" + "1" * 64,
+            args=make_args_digest({"amount": 4200}),
+        ),)),
+        iss="issuer://test", sub="agent:billing", secret_version="v1",
+        alg="HS256", signing_material=b"\x42" * 32,
+        nonce="att-nonce-0001", iat="2026-05-29T09:59:59Z",
+    )
+    return emit_receipt(
+        back_link=make_back_link(attestation),
+        outcome_derived=OutcomeDerived(status="executed", completed_at=ISSUED),
+        iss=DID, sub=DID, secret_version="v1", alg="ES256",
+        signing_material=key, nonce="rcpt-nonce-0001", iat=ISSUED,
+    )
+
+
+def _fetcher_for(document: dict):
+    raw = json.dumps(document).encode("utf-8")
+    calls = {"n": 0}
+
+    def fetch(url: str) -> bytes:
+        calls["n"] += 1
+        return raw
+
+    fetch.calls = calls  # type: ignore[attr-defined]
+    return fetch
+
+
+@pytest.fixture
+def key_a():
+    return ec.derive_private_key(SCALAR_A, ec.SECP256R1())
+
+
+@pytest.fixture
+def key_b():
+    return ec.derive_private_key(SCALAR_B, ec.SECP256R1())
+
+
+def test_bound_and_trusted(key_a):
+    receipt = _receipt(key_a)
+    fetch = _fetcher_for(_did_document(key_a.public_key()))
+    result = verify_receipt_identity_live(receipt, fetcher=fetch, now="2026-06-03T00:00:00Z")
+    assert result.resolved and result.bound and result.trusted
+    assert result.keyid == KEYID
+    assert not result.revoked and not result.deactivated
+    assert result.resolution is not None
+    assert result.resolution.url == "https://agents.example.com/billing/did.json"
+    assert result.resolution.document_digest.startswith("sha256:")
+    assert result.resolution.fetched_at == "2026-06-03T00:00:00Z"
+    assert result.resolution.from_cache is False
+
+
+def test_unbound_when_document_lists_a_different_key(key_a, key_b):
+    receipt = _receipt(key_a)
+    fetch = _fetcher_for(_did_document(key_b.public_key()))
+    result = verify_receipt_identity_live(receipt, fetcher=fetch)
+    assert result.resolved and not result.bound and not result.trusted
+
+
+def test_revoked_before_issuance_is_not_trusted(key_a):
+    receipt = _receipt(key_a)
+    doc = _did_document(key_a.public_key(), revoked="2026-05-29T09:00:00Z")
+    result = verify_receipt_identity_live(receipt, fetcher=_fetcher_for(doc))
+    assert result.bound is True  # signature still matches the key
+    assert result.revoked is True and result.trusted is False
+    assert result.revoked_at == "2026-05-29T09:00:00Z"
+    assert "revoked" in result.reason
+
+
+def test_revoked_after_issuance_still_trusted(key_a):
+    receipt = _receipt(key_a)
+    doc = _did_document(key_a.public_key(), revoked="2026-06-01T00:00:00Z")
+    result = verify_receipt_identity_live(receipt, fetcher=_fetcher_for(doc))
+    assert result.bound and result.trusted
+    assert result.revoked is False
+    assert result.revoked_at == "2026-06-01T00:00:00Z"  # surfaced even on a pass
+
+
+def test_revoked_exactly_at_issuance_is_not_trusted(key_a):
+    receipt = _receipt(key_a)
+    doc = _did_document(key_a.public_key(), revoked=ISSUED)
+    result = verify_receipt_identity_live(receipt, fetcher=_fetcher_for(doc))
+    assert result.revoked is True and result.trusted is False
+
+
+def test_deactivated_document_is_not_trusted(key_a):
+    receipt = _receipt(key_a)
+    doc = _did_document(key_a.public_key(), deactivated=True)
+    result = verify_receipt_identity_live(receipt, fetcher=_fetcher_for(doc))
+    assert result.deactivated is True and result.trusted is False
+    assert "deactivated" in result.reason
+
+
+def test_plain_string_iss_is_not_resolved(key_a):
+    receipt = _receipt(key_a)
+    object.__setattr__(receipt.receipt_asserted, "iss", "billing-agent")
+    fetch = _fetcher_for(_did_document(key_a.public_key()))
+    result = verify_receipt_identity_live(receipt, fetcher=fetch)
+    assert result.resolved is False and result.resolution is None
+    assert fetch.calls["n"] == 0  # no fetch attempted
+
+
+def test_fetch_failure_is_a_resolution_failure(key_a):
+    receipt = _receipt(key_a)
+
+    def boom(url: str) -> bytes:
+        raise OSError("connection refused")
+
+    result = verify_receipt_identity_live(receipt, fetcher=boom)
+    assert result.resolved is False and not result.trusted
+    assert "fetch failed" in result.reason
+
+
+def test_cache_hit_avoids_second_fetch(key_a):
+    receipt = _receipt(key_a)
+    fetch = _fetcher_for(_did_document(key_a.public_key()))
+    cache = DidDocumentCache(ttl_seconds=3600)
+    first = verify_receipt_identity_live(receipt, fetcher=fetch, cache=cache, now_epoch=1000.0)
+    second = verify_receipt_identity_live(receipt, fetcher=fetch, cache=cache, now_epoch=1500.0)
+    assert fetch.calls["n"] == 1
+    assert first.resolution.from_cache is False
+    assert second.resolution.from_cache is True
+    assert second.trusted
+
+
+def test_cache_ttl_expiry_refetches(key_a):
+    receipt = _receipt(key_a)
+    fetch = _fetcher_for(_did_document(key_a.public_key()))
+    cache = DidDocumentCache(ttl_seconds=100)
+    verify_receipt_identity_live(receipt, fetcher=fetch, cache=cache, now_epoch=1000.0)
+    verify_receipt_identity_live(receipt, fetcher=fetch, cache=cache, now_epoch=1201.0)
+    assert fetch.calls["n"] == 2
+
+
+def test_malformed_document_fails_closed(key_a):
+    receipt = _receipt(key_a)
+    result = verify_receipt_identity_live(receipt, fetcher=lambda url: b"not json")
+    assert result.resolved is False and "JSON" in result.reason
+
+
+def test_https_fetch_rejects_non_https():
+    with pytest.raises(AttestationError, match="not HTTPS"):
+        https_fetch("http://agents.example.com/.well-known/did.json")

--- a/tests/test_receipt_identity_live.py
+++ b/tests/test_receipt_identity_live.py
@@ -9,13 +9,22 @@ issuance), all composed over the unchanged level-2 check.
 from __future__ import annotations
 
 import base64
+import importlib.util
 import json
 
 import pytest
-from cryptography.hazmat.primitives.asymmetric import ec
 
-from vaara.attestation._sep2787_types import AttestationError
-from vaara.attestation.receipt import (
+for _mod in ("rfc8785", "cryptography"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            "attestation extra not installed (pip install 'vaara[attestation]')",
+            allow_module_level=True,
+        )
+
+from cryptography.hazmat.primitives.asymmetric import ec  # noqa: E402
+
+from vaara.attestation._sep2787_types import AttestationError  # noqa: E402
+from vaara.attestation.receipt import (  # noqa: E402
     DidDocumentCache,
     OutcomeDerived,
     emit_receipt,
@@ -23,7 +32,7 @@ from vaara.attestation.receipt import (
     make_back_link,
     verify_receipt_identity_live,
 )
-from vaara.attestation.sep2787 import (
+from vaara.attestation.sep2787 import (  # noqa: E402
     PayloadDerived,
     PlannerDeclared,
     ToolCallBinding,

--- a/tests/vectors/agent_identity_v0/README.md
+++ b/tests/vectors/agent_identity_v0/README.md
@@ -1,7 +1,7 @@
 # agent_identity_v0 conformance vectors
 
-Resolvable agent identity (did:web) for execution receipts, level-2
-pinned-resolvable verification. See
+Resolvable agent identity (did:web) for execution receipts: level-2
+pinned-resolvable verification plus the level-3 revocation-in-time rule. See
 `docs/design/resolvable-agent-identity-spec.md`.
 
 A receipt names its issuer in `receiptAsserted.iss`. When that value is a
@@ -14,12 +14,21 @@ call.
 ## Cases
 
 - `bound.json`: an ES256 receipt whose `iss` is `did:web:agents.example.com:billing`,
-  plus a DID document that lists the signing key. Expected: `resolved` and `bound`.
+  plus a DID document that lists the signing key. Expected: `resolved`,
+  `bound`, `trusted`.
 - `unbound.json`: the same receipt against a DID document that lists a
-  different key. Expected: `resolved`, not `bound` (the signature matches no
-  key the document publishes).
+  different key. Expected: `resolved`, not `bound`, not `trusted` (the
+  signature matches no key the document publishes).
+- `revoked.json`: the same receipt against a document that lists the signing
+  key but marks it `revoked` before the receipt's `iat`. Expected:
+  `resolved` and `bound` (the signature still matches the key) but `revoked`
+  and not `trusted`. A key revoked at or before issuance does not yield a
+  trusted verdict; one revoked afterwards still would, because revocation is
+  not retroactive. The comparison is purely the receipt `iat` against the
+  method `revoked` instant, so it reproduces offline from the captured
+  document.
 - `expected.json`: the verdict each case must produce
-  (`resolved`, `bound`, `keyid`).
+  (`resolved`, `bound`, `keyid`, `revoked`, `trusted`).
 
 The existing `decision_pairing_v0` vectors are unaffected: this family is
 additive, the receipt envelope is unchanged, and an opaque-string `iss` is

--- a/tests/vectors/agent_identity_v0/_check_independent.py
+++ b/tests/vectors/agent_identity_v0/_check_independent.py
@@ -2,10 +2,12 @@
 """Independent conformance checker for the agent_identity_v0 vectors.
 
 Imports only the standard library plus ``cryptography`` and ``rfc8785``.
-It does not import Vaara. For each committed case it reproduces level-2
-pinned-resolvable identity verification: confirm the receipt's did:web
-``iss`` matches the DID document id, then verify the ES256 receipt
-signature against a verification key the document lists. Verdicts are
+It does not import Vaara. For each committed case it reproduces resolvable
+identity verification: confirm the receipt's did:web ``iss`` matches the DID
+document id, verify the ES256 receipt signature against a verification key
+the document lists (level 2), then apply the level-3 revocation-in-time
+rule: a key marked ``revoked`` at or before the receipt's ``iat`` does not
+yield a trusted verdict even when the signature matches. Verdicts are
 compared against ``expected.json``.
 
 A second implementation that can run this file (or reproduce its logic)
@@ -19,6 +21,7 @@ from __future__ import annotations
 import base64
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import rfc8785
@@ -62,14 +65,30 @@ def _es256_verifies(payload: bytes, signature_hex: str, public_key) -> bool:
         return False
 
 
+def _parse_iso(value):
+    if not isinstance(value, str) or not value:
+        return None
+    text = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed
+
+
+def _miss(resolved: bool) -> dict:
+    return {"resolved": resolved, "bound": False, "keyid": None,
+            "revoked": False, "trusted": False}
+
+
 def _evaluate(case: dict) -> dict:
     receipt = case["receipt"]
     doc = case["didDocument"]
     iss = receipt["receiptAsserted"]["iss"]
     if not iss.startswith("did:web:") or doc.get("id") != iss:
-        return {"resolved": False, "bound": False, "keyid": None}
+        return _miss(False)
     if receipt["alg"] != "ES256":
-        return {"resolved": False, "bound": False, "keyid": None}
+        return _miss(False)
 
     payload = rfc8785.dumps({k: receipt[k] for k in _RECEIPT_BLOCKS})
     for method in doc.get("verificationMethod", []):
@@ -77,14 +96,25 @@ def _evaluate(case: dict) -> dict:
         if key is None:
             continue
         if _es256_verifies(payload, receipt["signature"], key):
-            return {"resolved": True, "bound": True, "keyid": method.get("id")}
-    return {"resolved": True, "bound": False, "keyid": None}
+            # Bound. Now apply revocation-in-time and deactivation.
+            revoked = False
+            revoked_at = _parse_iso(method.get("revoked"))
+            issued_at = _parse_iso(receipt["receiptAsserted"]["iat"])
+            if method.get("revoked") is not None:
+                revoked = (
+                    revoked_at is None or issued_at is None or revoked_at <= issued_at
+                )
+            deactivated = doc.get("deactivated") is True
+            trusted = not revoked and not deactivated
+            return {"resolved": True, "bound": True, "keyid": method.get("id"),
+                    "revoked": revoked, "trusted": trusted}
+    return _miss(True)
 
 
 def main() -> int:
     expected = json.loads((HERE / "expected.json").read_text())
     failures = []
-    for name in ("bound", "unbound"):
+    for name in ("bound", "unbound", "revoked"):
         case = json.loads((HERE / f"{name}.json").read_text())
         got = _evaluate(case)
         want = expected[name]

--- a/tests/vectors/agent_identity_v0/_generate.py
+++ b/tests/vectors/agent_identity_v0/_generate.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python3
 """Generate the agent_identity_v0 conformance vectors.
 
-Emits two cases with Vaara, using did:web resolvable agent identity:
+Emits three cases with Vaara, using did:web resolvable agent identity:
 
 - ``bound.json``: an ES256 receipt whose ``iss`` is a did:web identity,
-  plus a DID document that lists the signing key. Expected: resolved and
-  bound.
+  plus a DID document that lists the signing key. Expected: resolved,
+  bound, trusted.
 - ``unbound.json``: the same receipt against a DID document that lists a
-  different key. Expected: resolved, not bound.
+  different key. Expected: resolved, not bound, not trusted.
+- ``revoked.json``: the receipt against a document that lists the signing
+  key but marks it ``revoked`` before the receipt's ``iat``. Expected:
+  resolved and bound (the signature matches the key) but revoked and not
+  trusted (the key was revoked at or before issuance). This is the level-3
+  revocation-in-time property, reproducible offline from the captured
+  document because the comparison is purely the receipt ``iat`` against the
+  method ``revoked`` instant.
 
 ECDSA signatures are randomized, so re-running this overwrites the cases
 with fresh but equivalent vectors. The committed JSON is the vector;
@@ -61,18 +68,20 @@ def _ec_jwk(public_key: ec.EllipticCurvePublicKey) -> dict:
     }
 
 
-def _did_document(jwk: dict) -> dict:
-    return {
-        "id": DID,
-        "verificationMethod": [
-            {
-                "id": KEYID,
-                "type": "JsonWebKey2020",
-                "controller": DID,
-                "publicKeyJwk": jwk,
-            }
-        ],
+RECEIPT_IAT = "2026-05-29T10:00:00Z"
+REVOKED_BEFORE_IAT = "2026-05-29T09:30:00Z"
+
+
+def _did_document(jwk: dict, *, revoked: str | None = None) -> dict:
+    method = {
+        "id": KEYID,
+        "type": "JsonWebKey2020",
+        "controller": DID,
+        "publicKeyJwk": jwk,
     }
+    if revoked is not None:
+        method["revoked"] = revoked
+    return {"id": DID, "verificationMethod": [method]}
 
 
 def _attestation():
@@ -111,9 +120,11 @@ def main() -> None:
     )
     receipt_dict = receipt.to_dict()
 
+    jwk_a = _ec_jwk(key_a.public_key())
+
     (HERE / "bound.json").write_text(json.dumps({
         "receipt": receipt_dict,
-        "didDocument": _did_document(_ec_jwk(key_a.public_key())),
+        "didDocument": _did_document(jwk_a),
     }, indent=2, sort_keys=True) + "\n")
 
     (HERE / "unbound.json").write_text(json.dumps({
@@ -121,12 +132,27 @@ def main() -> None:
         "didDocument": _did_document(_ec_jwk(key_b.public_key())),
     }, indent=2, sort_keys=True) + "\n")
 
-    (HERE / "expected.json").write_text(json.dumps({
-        "bound": {"resolved": True, "bound": True, "keyid": KEYID},
-        "unbound": {"resolved": True, "bound": False, "keyid": None},
+    (HERE / "revoked.json").write_text(json.dumps({
+        "receipt": receipt_dict,
+        "didDocument": _did_document(jwk_a, revoked=REVOKED_BEFORE_IAT),
     }, indent=2, sort_keys=True) + "\n")
 
-    print("wrote bound.json, unbound.json, expected.json")
+    (HERE / "expected.json").write_text(json.dumps({
+        "bound": {
+            "resolved": True, "bound": True, "keyid": KEYID,
+            "revoked": False, "trusted": True,
+        },
+        "unbound": {
+            "resolved": True, "bound": False, "keyid": None,
+            "revoked": False, "trusted": False,
+        },
+        "revoked": {
+            "resolved": True, "bound": True, "keyid": KEYID,
+            "revoked": True, "trusted": False,
+        },
+    }, indent=2, sort_keys=True) + "\n")
+
+    print("wrote bound.json, unbound.json, revoked.json, expected.json")
 
 
 if __name__ == "__main__":

--- a/tests/vectors/agent_identity_v0/bound.json
+++ b/tests/vectors/agent_identity_v0/bound.json
@@ -33,7 +33,7 @@
       "secretVersion": "v1",
       "sub": "did:web:agents.example.com:billing"
     },
-    "signature": "4a0368fea2011a7a163b0f88a6e6edce9eeadcb0bfa037b350317ca3794044a0b1f3213aaa4a07b2e0ead23d337c762512b53a6cf6737bcce2d1fbdd8dc9201c",
+    "signature": "05326442cbe46fc7762d3ed2e0df4b7a32ff179fcf63144a0fc48d645254f0867309859a834b111f715159357889d1558f6034bcb12e5ad34f50b0cc4803f73d",
     "version": 1
   }
 }

--- a/tests/vectors/agent_identity_v0/expected.json
+++ b/tests/vectors/agent_identity_v0/expected.json
@@ -2,11 +2,22 @@
   "bound": {
     "bound": true,
     "keyid": "did:web:agents.example.com:billing#key-2026",
-    "resolved": true
+    "resolved": true,
+    "revoked": false,
+    "trusted": true
+  },
+  "revoked": {
+    "bound": true,
+    "keyid": "did:web:agents.example.com:billing#key-2026",
+    "resolved": true,
+    "revoked": true,
+    "trusted": false
   },
   "unbound": {
     "bound": false,
     "keyid": null,
-    "resolved": true
+    "resolved": true,
+    "revoked": false,
+    "trusted": false
   }
 }

--- a/tests/vectors/agent_identity_v0/revoked.json
+++ b/tests/vectors/agent_identity_v0/revoked.json
@@ -8,9 +8,10 @@
         "publicKeyJwk": {
           "crv": "P-256",
           "kty": "EC",
-          "x": "AcuJDg5_TIBVj2pPoQS8aRNAZ97wcgHTf1chwfrHA8Q",
-          "y": "4tuSsTfTGUw8fYFageZoFNfqP2zp8dZNzKR22OTG0Us"
+          "x": "B2Bb3IA08MGNseH1UseCTbv_Q-J10isZuVS7galZBEU",
+          "y": "pF0OwY17c4EPwvJJYAjp6z9tVfFo37FGfhFrwVZS_iM"
         },
+        "revoked": "2026-05-29T09:30:00Z",
         "type": "JsonWebKey2020"
       }
     ]


### PR DESCRIPTION
Level 3 of resolvable agent identity, the planned follow-up to the level-2 work released in v0.52.0 (#190).

## What ships
- `vaara.attestation.verify_receipt_identity_live`: resolves a `did:web` issuer over HTTPS (or from a TTL cache), records the resolution, runs the unchanged level-2 binding, then applies deactivation and revocation-in-time. Returns `LiveIdentityResult` with one `trusted` verdict plus `issued_at` and `revoked_at`.
- **Revocation in time:** a signing key revoked at or before the receipt's `iat` is not trusted even when the signature still verifies; a key revoked afterwards still binds, because revocation is not retroactive. Both instants are surfaced so a verifier with a stronger time anchor (the audit-trail hash chain) can re-decide.
- `ResolutionMeta` (auditable resolve record: did, url, fetched_at, document digest, from_cache), `DidDocumentCache` (TTL cache, caller-supplied clock), and `https_fetch` (default HTTPS-only, size-capped fetcher that refuses redirects as an SSRF guard).
- New `agent_identity_v0` vector `revoked.json` (bound but not trusted), with the Vaara-free independent checker extended to reproduce the revocation verdict offline. `expected.json` now carries `revoked` and `trusted` per case.

## Release mechanics
- Version bumped on all six surfaces; CHANGELOG `[Unreleased]` promoted to `[0.53.0]`.
- Purely additive over 0.52: the receipt envelope, canonicalization, and the level-2 verifier are unchanged; existing receipts and the `bound`/`unbound` vectors verify byte for byte.
- 1191 passed, 13 skipped; ruff clean; mypy clean. Independent checker reproduces all three cases with no Vaara import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added level-3 live-resolvable identity verification for `did:web` issuers with HTTPS document fetching and auditable resolution metadata.
  * Introduced in-memory TTL caching for resolved DID documents.
  * Added revocation-in-time evaluation to detect keys revoked before receipt issuance.

* **Tests**
  * Added comprehensive conformance test vectors for the new revocation scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->