### PR TITLE
v0.54.0: append-only consistency proofs for the transparency log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-06-05
+
+**Theme: append-only consistency proofs for the transparency log. The log
+already issued inclusion proofs: evidence that a given receipt is in the log.
+An inclusion proof says nothing about whether earlier history was rewritten.
+A consistency proof does: it shows the log at an earlier size is a verifiable
+prefix of the log at a later size, so a fork or a quiet rewrite of past
+entries is detectable even when every individual inclusion proof still
+verifies. A monitor that pins the log's root over time and checks a
+consistency proof between successive roots gets the append-only guarantee a
+transparency log exists to provide. RFC 9162 (RFC 6962-bis) section 2.1.4.**
+
+### Added
+- `vaara.attestation.verify_consistency`: verifies an RFC 9162 consistency
+  proof between two tree sizes and their roots, returning whether the smaller
+  tree is a verifiable prefix of the larger one. Recomputes both roots from
+  the proof; a single returned `bool`.
+- `ConsistencyProof`: the proof object (`first_size`, `second_size`, and the
+  ordered sibling `hashes`), shaped to match what a sigstore Rekor-backed
+  adapter would expose at the same call site.
+- `InProcessTransparencyLog.consistency_proof(first_size, second_size)`:
+  produces a proof between any two sizes the log has reached, empty for the
+  trivial cases (an empty prefix, or identical sizes).
+- `InProcessTransparencyLog.root_at(tree_size)`: the Merkle root over the
+  first `tree_size` leaves, for pinning a historical signed tree head before
+  requesting a consistency proof against a later one.
+- A `transparency_consistency_v0` conformance vector set (nine cases over a
+  twelve-leaf log, covering power-of-two and non-power-of-two prefixes plus a
+  tampered-proof and a forked-history negative) with a Vaara-free,
+  standard-library-only independent checker that reproduces every verdict.
+
+### Changed
+- Purely additive over 0.53. No change to the receipt envelope,
+  canonicalization, inclusion-proof format, or signature verification; the
+  envelope version stays 1.
+
 ## [0.53.0] - 2026-06-03
 
 **Theme: resolvable agent identity, level 3. Level 2 confirmed a receipt was

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.53.0",
+  "version": "0.54.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/design/transparency-log-consistency-spec.md
+++ b/docs/design/transparency-log-consistency-spec.md
@@ -1,0 +1,81 @@
+# Design spec: append-only consistency proofs for the transparency log
+
+Status: draft for v0.54. Companion to the Merkle transparency log in
+`src/vaara/attestation/transparency_log.py` (inclusion proofs, since v0.13)
+and the OVERT Phase 3 IAP in `src/vaara/attestation/iap.py`.
+
+## Goal
+
+The transparency log already issues inclusion proofs: given a receipt and a
+published root, a verifier confirms the receipt is in the log. An inclusion
+proof says nothing about whether the log operator rewrote earlier history.
+A log operator could serve one tree to one auditor and a forked tree, with
+some past entry quietly altered or dropped, to another. Every inclusion proof
+against the matching root still verifies, so inclusion alone does not detect
+the fork.
+
+A consistency proof closes that gap. It shows the log at an earlier size is a
+verifiable prefix of the log at a later size: every leaf in the smaller tree
+is present, in the same position, in the larger one, and nothing earlier
+changed. That is the append-only property a transparency log exists to
+provide.
+
+## Mechanism
+
+The log is an RFC 6962 binary Merkle tree (leaf hash `SHA-256(0x00 || leaf)`,
+node hash `SHA-256(0x01 || left || right)`). Consistency proofs follow
+RFC 9162 (RFC 6962-bis) section 2.1.4: a prover emits the minimal set of
+subtree hashes that lets a verifier recompute both the old root (at
+`first_size`) and the new root (at `second_size`) and confirm the old tree is
+a prefix of the new one.
+
+New surface, all additive:
+
+- `consistency_proof(first_size, second_size)` on the log returns a
+  `ConsistencyProof` (`first_size`, `second_size`, ordered sibling `hashes`).
+  The proof is empty for the trivial cases: an empty prefix (`first_size` is
+  0) or identical sizes.
+- `root_at(tree_size)` returns the Merkle root over the first `tree_size`
+  leaves, so a monitor can pin a historical signed tree head before asking for
+  a proof against a later one.
+- `verify_consistency(first_size, first_root, second_size, second_root, proof)`
+  recomputes both roots from the proof and returns a single `bool`. The two
+  roots are supplied by the verifier (the signed tree heads it holds at two
+  points in time); the proof hashes alone do not bind to a specific pair of
+  roots, exactly as with inclusion proofs.
+
+The receipt envelope, canonicalization, inclusion-proof format, and signature
+verification are unchanged. The envelope version stays 1.
+
+## Trust model
+
+A consistency proof is a statement about the log's structure, not about who
+signs the tree heads. It detects a rewrite *if* the verifier holds an
+authentic earlier root to check against. The earlier root has to come from a
+trustworthy channel: a signed tree head from the log operator that the
+verifier recorded earlier, an independent monitor's witness cosignature, or
+Vaara's own audit-trail hash chain, which already anchors roots over time. The
+proof turns "trust the operator not to rewrite history" into "check that the
+operator did not rewrite history," conditional on a pinned reference root.
+
+This is the same separation the rest of the evidence plane keeps: durability
+from the hash chain and the transparency log, issuance-correctness from
+conformance vectors and independent implementations, and semantic-correctness
+left to governance and review.
+
+## Production logs
+
+The in-process log is the reference operator for demonstrations. The public
+surface (`append`, `inclusion_proof`, `consistency_proof`, `root_at`,
+`root_hash`) is shaped to match what a sigstore Rekor-backed adapter would
+expose, so a future `RekorTransparencyLog` drops into the same call sites
+without changing verifier code.
+
+## Conformance
+
+`tests/vectors/transparency_consistency_v0/` carries nine cases over a
+twelve-leaf log: power-of-two and non-power-of-two prefixes, an empty prefix,
+identical trees, and two negatives (a flipped proof hash, and a proof checked
+against a forked second root). `_check_independent.py` reproduces every
+verdict using only the Python standard library and without importing Vaara,
+so the append-only guarantee is consumable by a second implementation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.53.0"
+version = "0.54.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.53.0",
+  "version": "0.54.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.53.0",
+  "version": "0.54.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.53.0",
+      "version": "0.54.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.53.0"
+__version__ = "0.54.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/__init__.py
+++ b/src/vaara/attestation/__init__.py
@@ -62,10 +62,12 @@ from vaara.attestation.iap import (
     verify_phase3_attestation,
 )
 from vaara.attestation.transparency_log import (
+    ConsistencyProof,
     InProcessTransparencyLog,
     InclusionProof,
     LogEntry,
     TransparencyLogError,
+    verify_consistency,
     verify_inclusion,
 )
 from vaara.attestation.tee import (
@@ -120,6 +122,7 @@ __all__ = [
     "BackLinkResult",
     "BaseEnvelope",
     "ConformalExtension",
+    "ConsistencyProof",
     "EnvelopeError",
     "ExecutionReceipt",
     "IAPError",
@@ -169,6 +172,7 @@ __all__ = [
     "sep2787_verify_attestation",
     "verify_back_link",
     "verify_base_envelope",
+    "verify_consistency",
     "verify_envelope_binding",
     "verify_inclusion",
     "verify_phase3_attestation",

--- a/src/vaara/attestation/transparency_log.py
+++ b/src/vaara/attestation/transparency_log.py
@@ -46,6 +46,28 @@ class LogEntry:
 
 
 @dataclass(frozen=True)
+class ConsistencyProof:
+    """RFC 9162 (RFC 6962-bis) consistency proof between two tree sizes.
+
+    Proves that the log of ``first_size`` leaves whose root was
+    ``first_root`` is a prefix of the log of ``second_size`` leaves whose
+    root is ``second_root``: every leaf in the smaller tree is present, in
+    the same position, in the larger one, and nothing earlier was rewritten.
+    This is the append-only guarantee. An inclusion proof shows an entry is
+    *in* the log; a consistency proof shows the log only ever *grew*.
+
+    ``first_size <= second_size``. The proof verifies against two roots the
+    verifier obtained independently (e.g. signed tree heads published by the
+    log operator at two points in time); the hashes alone do not bind to a
+    specific pair of roots.
+    """
+
+    first_size: int
+    second_size: int
+    hashes: tuple[bytes, ...]
+
+
+@dataclass(frozen=True)
 class InclusionProof:
     """RFC 6962-style inclusion proof.
 
@@ -112,6 +134,94 @@ def _proof_for(leaves: list[bytes], index: int) -> tuple[bytes, ...]:
         nodes = next_level
         idx //= 2
     return tuple(proof)
+
+
+def _largest_power_of_two_lt(n: int) -> int:
+    """Largest power of two strictly less than ``n`` (requires ``n >= 2``)."""
+    k = 1
+    while k * 2 < n:
+        k *= 2
+    return k
+
+
+def _subproof(m: int, leaves: list[bytes], on_path: bool) -> list[bytes]:
+    """RFC 9162 SUBPROOF over ``leaves`` for prefix size ``m``.
+
+    ``on_path`` is the spec's ``b`` flag: when the recursion has narrowed to
+    the subtree that exactly equals the ``m``-leaf prefix and that subtree is
+    still on the path from the root, its hash is implied (the verifier
+    recomputes it) and omitted; otherwise the subtree hash is included.
+    """
+    n = len(leaves)
+    if m == n:
+        return [] if on_path else [_root_from_leaves(leaves)]
+    k = _largest_power_of_two_lt(n)
+    if m <= k:
+        return _subproof(m, leaves[:k], on_path) + [_root_from_leaves(leaves[k:])]
+    return _subproof(m - k, leaves[k:], False) + [_root_from_leaves(leaves[:k])]
+
+
+def verify_consistency(
+    *,
+    first_size: int,
+    first_root: bytes,
+    second_size: int,
+    second_root: bytes,
+    proof: ConsistencyProof,
+) -> bool:
+    """Verify an RFC 9162 consistency proof between two tree heads.
+
+    Recomputes both ``first_root`` and ``second_root`` from the proof and
+    returns whether both match. A ``True`` result means the ``first_size``
+    tree is a verifiable prefix of the ``second_size`` tree: the log is
+    append-only across the two snapshots. Implements RFC 9162 section 2.1.4.2.
+    """
+    if proof.first_size != first_size or proof.second_size != second_size:
+        return False
+    if first_size > second_size:
+        return False
+    if first_size == second_size:
+        # Same tree: nothing to prove beyond identical roots.
+        return not proof.hashes and first_root == second_root
+    if first_size == 0:
+        # The empty tree is a prefix of every tree; no path hashes needed.
+        return not proof.hashes
+
+    # 0 < first_size < second_size. For a power-of-two first tree the spec
+    # omits first_root from the path because the verifier already holds it;
+    # prepend it so the seed logic below is uniform.
+    path = list(proof.hashes)
+    if first_size & (first_size - 1) == 0:
+        path = [first_root, *path]
+    if not path:
+        return False
+
+    fn = first_size - 1
+    sn = second_size - 1
+    # Strip the shared low run: these bits are interior to the first subtree
+    # and contribute no path node.
+    while fn & 1:
+        fn >>= 1
+        sn >>= 1
+
+    nodes = iter(path)
+    fr = sr = next(nodes)
+    for sibling in nodes:
+        if sn == 0:
+            # More path nodes than the second tree can account for.
+            return False
+        if fn & 1 or fn == sn:
+            fr = _hash_node(sibling, fr)
+            sr = _hash_node(sibling, sr)
+            while fn != 0 and not (fn & 1):
+                fn >>= 1
+                sn >>= 1
+        else:
+            sr = _hash_node(sr, sibling)
+        fn >>= 1
+        sn >>= 1
+
+    return sn == 0 and fr == first_root and sr == second_root
 
 
 def verify_inclusion(
@@ -183,6 +293,53 @@ class InProcessTransparencyLog:
             siblings = _proof_for(list(self._leaves), log_index)
             return InclusionProof(
                 log_index=log_index, tree_size=size, siblings=siblings,
+            )
+
+    def root_at(self, tree_size: int) -> bytes:
+        """Merkle root over the first ``tree_size`` leaves.
+
+        ``root_at(0)`` is the empty-tree hash; ``root_at(tree_size)`` equals
+        the ``root_hash`` the log had after its first ``tree_size`` appends.
+        Useful for pinning a historical signed tree head before requesting a
+        consistency proof against a later one.
+        """
+        with self._lock:
+            if not (0 <= tree_size <= len(self._leaves)):
+                raise TransparencyLogError(
+                    f"tree_size {tree_size} out of range for log of "
+                    f"{len(self._leaves)} leaves"
+                )
+            return _root_from_leaves(self._leaves[:tree_size])
+
+    def consistency_proof(
+        self, first_size: int, second_size: int
+    ) -> ConsistencyProof:
+        """Prove the ``first_size`` tree is a prefix of the ``second_size`` one.
+
+        ``0 <= first_size <= second_size <= tree_size``. The proof is empty
+        for the trivial cases (``first_size`` is 0 or equals ``second_size``).
+        Pair the result with ``root_at(first_size)`` and ``root_at(second_size)``,
+        or with two independently published roots, and check it via
+        ``verify_consistency``.
+        """
+        with self._lock:
+            size = len(self._leaves)
+            if not (0 <= first_size <= second_size <= size):
+                raise TransparencyLogError(
+                    f"consistency proof requires 0 <= first_size "
+                    f"({first_size}) <= second_size ({second_size}) <= "
+                    f"tree_size ({size})"
+                )
+            if first_size == 0 or first_size == second_size:
+                hashes: tuple[bytes, ...] = ()
+            else:
+                hashes = tuple(
+                    _subproof(first_size, self._leaves[:second_size], True)
+                )
+            return ConsistencyProof(
+                first_size=first_size,
+                second_size=second_size,
+                hashes=hashes,
             )
 
     @property

--- a/tests/test_transparency_consistency.py
+++ b/tests/test_transparency_consistency.py
@@ -1,0 +1,221 @@
+"""Tests for RFC 9162 transparency-log consistency proofs (v0.54).
+
+Consistency proofs are the append-only guarantee: they show the log at an
+earlier size is a verifiable prefix of the log at a later size, so a fork or
+a rewrite of earlier history is detectable even when every inclusion proof
+still verifies.
+
+Coverage:
+1. Genuine prover/verifier agreement across every (first, second) size pair
+   in a range, including the non-power-of-two cases.
+2. Rejection of a tampered proof, a wrong root, and a forked second tree.
+3. Edge cases (empty prefix, identical trees) and input-range guards.
+4. The committed transparency_consistency_v0 vectors verify two ways: via
+   Vaara, and via the standalone stdlib-only checker.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vaara.attestation.transparency_log import (
+    ConsistencyProof,
+    InProcessTransparencyLog,
+    TransparencyLogError,
+    verify_consistency,
+)
+
+VECTORS = Path(__file__).resolve().parent / "vectors" / "transparency_consistency_v0"
+
+
+def _log(n: int) -> InProcessTransparencyLog:
+    log = InProcessTransparencyLog()
+    for i in range(n):
+        log.append(f"leaf-{i}".encode())
+    return log
+
+
+# ── Genuine prover/verifier agreement ───────────────────────────────────────
+
+@pytest.mark.parametrize("second", range(0, 18))
+def test_genuine_proof_verifies_for_every_prefix(second: int) -> None:
+    log = _log(second)
+    for first in range(0, second + 1):
+        proof = log.consistency_proof(first, second)
+        assert verify_consistency(
+            first_size=first,
+            first_root=log.root_at(first),
+            second_size=second,
+            second_root=log.root_at(second),
+            proof=proof,
+        ), f"genuine proof {first} to {second} failed"
+
+
+def test_root_at_matches_root_hash_at_full_size() -> None:
+    log = _log(11)
+    assert log.root_at(11) == log.root_hash
+    assert log.tree_size == 11
+
+
+def test_root_at_matches_append_time_root() -> None:
+    log = InProcessTransparencyLog()
+    roots = [log.root_at(0)]
+    for i in range(9):
+        entry = log.append(f"x{i}".encode())
+        assert entry.root_hash_at_append == log.root_at(i + 1)
+        roots.append(entry.root_hash_at_append)
+    # Each historical root is reproducible after later appends.
+    for size, root in enumerate(roots):
+        assert log.root_at(size) == root
+
+
+# ── Negative: tamper, wrong root, forked history ────────────────────────────
+
+def test_tampered_proof_hash_is_rejected() -> None:
+    log = _log(12)
+    proof = log.consistency_proof(3, 12)
+    flipped = list(proof.hashes)
+    flipped[0] = bytes([flipped[0][0] ^ 0x01, *flipped[0][1:]])
+    bad = dataclasses.replace(proof, hashes=tuple(flipped))
+    assert not verify_consistency(
+        first_size=3, first_root=log.root_at(3),
+        second_size=12, second_root=log.root_at(12), proof=bad,
+    )
+
+
+def test_wrong_second_root_is_rejected() -> None:
+    log = _log(12)
+    proof = log.consistency_proof(5, 12)
+    assert not verify_consistency(
+        first_size=5, first_root=log.root_at(5),
+        second_size=12, second_root=b"\x00" * 32, proof=proof,
+    )
+
+
+def test_forked_history_is_rejected() -> None:
+    """A second tree that rewrote earlier leaves has no valid proof."""
+    honest = _log(12)
+    forked = InProcessTransparencyLog()
+    for i in range(12):
+        forked.append(f"FORKED-{i}".encode())
+    # Honest 4-leaf prefix root against the forked tree's later root: no proof
+    # from either tree should reconcile them.
+    for proof in (honest.consistency_proof(4, 12), forked.consistency_proof(4, 12)):
+        assert not verify_consistency(
+            first_size=4, first_root=honest.root_at(4),
+            second_size=12, second_root=forked.root_at(12), proof=proof,
+        )
+
+
+def test_proof_size_mismatch_is_rejected() -> None:
+    log = _log(10)
+    proof = log.consistency_proof(3, 10)
+    mismatched = dataclasses.replace(proof, second_size=9)
+    assert not verify_consistency(
+        first_size=3, first_root=log.root_at(3),
+        second_size=10, second_root=log.root_at(10), proof=mismatched,
+    )
+
+
+def test_extra_proof_hash_is_rejected() -> None:
+    log = _log(12)
+    proof = log.consistency_proof(3, 12)
+    padded = dataclasses.replace(proof, hashes=(*proof.hashes, b"\x11" * 32))
+    assert not verify_consistency(
+        first_size=3, first_root=log.root_at(3),
+        second_size=12, second_root=log.root_at(12), proof=padded,
+    )
+
+
+# ── Edge cases and input guards ─────────────────────────────────────────────
+
+def test_empty_prefix_is_trivially_consistent() -> None:
+    log = _log(7)
+    proof = log.consistency_proof(0, 7)
+    assert proof.hashes == ()
+    assert verify_consistency(
+        first_size=0, first_root=log.root_at(0),
+        second_size=7, second_root=log.root_at(7), proof=proof,
+    )
+
+
+def test_identical_trees_need_empty_proof_and_equal_roots() -> None:
+    log = _log(6)
+    proof = log.consistency_proof(6, 6)
+    assert proof.hashes == ()
+    root = log.root_at(6)
+    assert verify_consistency(
+        first_size=6, first_root=root,
+        second_size=6, second_root=root, proof=proof,
+    )
+    assert not verify_consistency(
+        first_size=6, first_root=root,
+        second_size=6, second_root=b"\x00" * 32, proof=proof,
+    )
+    assert not verify_consistency(
+        first_size=6, first_root=root, second_size=6, second_root=root,
+        proof=ConsistencyProof(6, 6, (b"\x22" * 32,)),
+    )
+
+
+def test_first_larger_than_second_is_rejected() -> None:
+    log = _log(8)
+    assert not verify_consistency(
+        first_size=8, first_root=log.root_at(8),
+        second_size=4, second_root=log.root_at(4),
+        proof=ConsistencyProof(8, 4, ()),
+    )
+
+
+def test_consistency_proof_out_of_range_raises() -> None:
+    log = _log(5)
+    with pytest.raises(TransparencyLogError):
+        log.consistency_proof(3, 9)  # second_size > tree_size
+    with pytest.raises(TransparencyLogError):
+        log.consistency_proof(4, 2)  # first_size > second_size
+    with pytest.raises(TransparencyLogError):
+        log.consistency_proof(-1, 5)  # negative first_size
+
+
+def test_root_at_out_of_range_raises() -> None:
+    log = _log(5)
+    with pytest.raises(TransparencyLogError):
+        log.root_at(6)
+    with pytest.raises(TransparencyLogError):
+        log.root_at(-1)
+
+
+# ── Committed conformance vectors ───────────────────────────────────────────
+
+def test_vaara_reproduces_committed_vectors() -> None:
+    cases = json.loads((VECTORS / "cases.json").read_text())
+    expected = json.loads((VECTORS / "expected.json").read_text())
+    for case in cases:
+        proof = ConsistencyProof(
+            first_size=case["first_size"],
+            second_size=case["second_size"],
+            hashes=tuple(bytes.fromhex(h) for h in case["proof"]),
+        )
+        got = verify_consistency(
+            first_size=case["first_size"],
+            first_root=bytes.fromhex(case["first_root"]),
+            second_size=case["second_size"],
+            second_root=bytes.fromhex(case["second_root"]),
+            proof=proof,
+        )
+        assert got is expected[case["name"]]["consistent"], case["name"]
+
+
+def test_independent_checker_passes() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr

--- a/tests/vectors/transparency_consistency_v0/README.md
+++ b/tests/vectors/transparency_consistency_v0/README.md
@@ -1,0 +1,58 @@
+# transparency_consistency_v0 conformance vectors
+
+Append-only consistency proofs for Vaara's Merkle transparency log, following
+RFC 9162 (RFC 6962-bis) section 2.1.4. See
+`docs/design/transparency-log-consistency-spec.md`.
+
+A transparency log exists to be append-only: once an entry is logged, the
+operator cannot quietly rewrite or drop earlier history. An *inclusion* proof
+shows an entry is in the log; a *consistency* proof shows that the log at an
+earlier size is a verifiable prefix of the log at a later size. A monitor that
+pins the log's signed tree head over time, then checks a consistency proof
+between consecutive heads, detects any fork or rewrite even if every
+individual inclusion proof still verifies.
+
+These vectors are pure SHA-256 Merkle hashing, no signatures, so they verify
+with only the standard library:
+
+- leaf hash: `SHA-256(0x00 || leaf)`
+- internal node hash: `SHA-256(0x01 || left || right)`
+
+## Files
+
+- `log.json`: the committed log content (the ordered leaves) plus the hashing
+  rule, so a verifier can recompute every root itself.
+- `cases.json`: each case carries `first_size`, `second_size`, the two roots a
+  verifier would hold at those sizes (`first_root`, `second_root`), and the
+  `proof` hashes (hex).
+- `expected.json`: the expected `consistent` verdict per case.
+
+## Cases
+
+Positive cases (`consistent: true`) cover the sizes the algorithm most often
+gets wrong: an empty prefix (`0 to 12`, empty proof), a power-of-two prefix
+(`1 to 12`, `8 to 12`), non-power-of-two prefixes (`3 to 12`, `7 to 12`,
+`5 to 9`), and identical trees (`12 to 12`, empty proof).
+
+Negative cases (`consistent: false`) keep a genuine proof but corrupt one
+input, so a checker that always returned `true` is caught:
+
+- `tampered_proof_hash_3_to_12`: one sibling hash in the proof is flipped.
+- `forked_second_root_3_to_12`: the proof is checked against a `second_root`
+  taken from an unrelated (forked) log, the rewrite a consistency proof exists
+  to detect.
+
+## Reproducing
+
+Verify the committed vectors with no Vaara dependency:
+
+```
+python tests/vectors/transparency_consistency_v0/_check_independent.py
+```
+
+Regenerate them with Vaara (the committed JSON is the vector; the checker
+verifies whatever is committed):
+
+```
+python tests/vectors/transparency_consistency_v0/_generate.py
+```

--- a/tests/vectors/transparency_consistency_v0/_check_independent.py
+++ b/tests/vectors/transparency_consistency_v0/_check_independent.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Independent conformance checker for the transparency_consistency_v0 vectors.
+
+Imports only the Python standard library. It does not import Vaara. For each
+committed case it reproduces RFC 9162 (RFC 6962-bis) consistency verification:
+given two tree sizes, the two roots a verifier holds, and the proof hashes,
+recompute both roots and confirm the smaller tree is a verifiable prefix of
+the larger one. Verdicts are compared against ``expected.json``.
+
+As a second, stronger check it recomputes ``first_root`` and ``second_root``
+directly from the committed log leaves and confirms each positive case's roots
+are the genuine Merkle roots over those leaves, so the vectors cannot pass by
+asserting roots that no honest log would produce.
+
+A second implementation that can run this file (or reproduce its logic) shows
+the append-only guarantee is consumable without depending on Vaara. Run:
+``python tests/vectors/transparency_consistency_v0/_check_independent.py``.
+Exit code 0 means every case matched its expected verdict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def _hash_leaf(data: bytes) -> bytes:
+    return hashlib.sha256(b"\x00" + data).digest()
+
+
+def _hash_node(left: bytes, right: bytes) -> bytes:
+    return hashlib.sha256(b"\x01" + left + right).digest()
+
+
+def _root_from_leaves(leaf_hashes: list[bytes]) -> bytes:
+    if not leaf_hashes:
+        return hashlib.sha256(b"").digest()
+    nodes = list(leaf_hashes)
+    while len(nodes) > 1:
+        nxt: list[bytes] = []
+        for i in range(0, len(nodes), 2):
+            if i + 1 < len(nodes):
+                nxt.append(_hash_node(nodes[i], nodes[i + 1]))
+            else:
+                nxt.append(nodes[i])
+        nodes = nxt
+    return nodes[0]
+
+
+def verify_consistency(
+    first_size: int,
+    first_root: bytes,
+    second_size: int,
+    second_root: bytes,
+    proof: list[bytes],
+) -> bool:
+    """RFC 9162 section 2.1.4.2 consistency-proof verification."""
+    if first_size > second_size:
+        return False
+    if first_size == second_size:
+        return not proof and first_root == second_root
+    if first_size == 0:
+        return not proof
+
+    path = list(proof)
+    if first_size & (first_size - 1) == 0:
+        path = [first_root, *path]
+    if not path:
+        return False
+
+    fn = first_size - 1
+    sn = second_size - 1
+    while fn & 1:
+        fn >>= 1
+        sn >>= 1
+
+    nodes = iter(path)
+    fr = sr = next(nodes)
+    for sibling in nodes:
+        if sn == 0:
+            return False
+        if fn & 1 or fn == sn:
+            fr = _hash_node(sibling, fr)
+            sr = _hash_node(sibling, sr)
+            while fn != 0 and not (fn & 1):
+                fn >>= 1
+                sn >>= 1
+        else:
+            sr = _hash_node(sr, sibling)
+        fn >>= 1
+        sn >>= 1
+
+    return sn == 0 and fr == first_root and sr == second_root
+
+
+def main() -> int:
+    log_doc = json.loads((HERE / "log.json").read_text())
+    cases = json.loads((HERE / "cases.json").read_text())
+    expected = json.loads((HERE / "expected.json").read_text())
+
+    leaf_hashes = [_hash_leaf(s.encode("utf-8")) for s in log_doc["leaves"]]
+
+    failures = 0
+    for case in cases:
+        name = case["name"]
+        first_root = bytes.fromhex(case["first_root"])
+        second_root = bytes.fromhex(case["second_root"])
+        proof = [bytes.fromhex(h) for h in case["proof"]]
+
+        got = verify_consistency(
+            case["first_size"], first_root,
+            case["second_size"], second_root, proof,
+        )
+        want = expected[name]["consistent"]
+        if got != want:
+            print(f"FAIL {name}: consistency={got}, expected {want}")
+            failures += 1
+            continue
+
+        # For positive cases, the committed roots must be the genuine Merkle
+        # roots over the log prefixes. (Negative cases intentionally carry a
+        # corrupted root, so this stronger check applies only when consistent.)
+        if want:
+            real_first = _root_from_leaves(leaf_hashes[: case["first_size"]])
+            real_second = _root_from_leaves(leaf_hashes[: case["second_size"]])
+            if real_first != first_root or real_second != second_root:
+                print(f"FAIL {name}: committed roots are not the genuine log roots")
+                failures += 1
+                continue
+
+        print(f"ok   {name}: consistent={got}")
+
+    if failures:
+        print(f"\n{failures} case(s) failed")
+        return 1
+    print(f"\nall {len(cases)} cases matched expected verdicts")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/transparency_consistency_v0/_generate.py
+++ b/tests/vectors/transparency_consistency_v0/_generate.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Generate the transparency_consistency_v0 conformance vectors.
+
+These vectors capture RFC 9162 (RFC 6962-bis) consistency proofs over an
+append-only Merkle transparency log. A consistency proof shows that the log
+at one size is a verifiable prefix of the log at a later size: nothing
+earlier was rewritten, the log only ever grew. That is the append-only
+guarantee a transparency log exists to provide.
+
+The committed log is a fixed sequence of leaves. Each case names a
+``first_size`` and ``second_size`` and carries the proof hashes plus the two
+roots an independent verifier would hold (the signed tree heads at those two
+points). Positive cases expect ``consistent: true``. Negative cases keep a
+genuine proof but corrupt an input (a flipped proof hash, a root from an
+unrelated tree); they expect ``consistent: false``, so a checker that always
+returned true would be caught.
+
+Hashing is RFC 6962: ``SHA-256(0x00 || leaf)`` for leaves,
+``SHA-256(0x01 || left || right)`` for internal nodes. No signatures, so the
+vectors need only the standard library to verify. The committed JSON is the
+vector; ``_check_independent.py`` verifies whatever is committed. Run from
+the repo root: ``python tests/vectors/transparency_consistency_v0/_generate.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaara.attestation.transparency_log import InProcessTransparencyLog
+
+HERE = Path(__file__).resolve().parent
+
+# A fixed, deterministic log. Twelve leaves exercise non-power-of-two tree
+# sizes, the case the consistency algorithm is most likely to get wrong.
+LEAVES = [f"entry-{i:02d}".encode() for i in range(12)]
+
+
+def _hex(b: bytes) -> str:
+    return b.hex()
+
+
+def main() -> None:
+    log = InProcessTransparencyLog()
+    for leaf in LEAVES:
+        log.append(leaf)
+
+    # A second, unrelated log: same length, different leaves. Its root stands
+    # in for a forked history in the negative case.
+    forked = InProcessTransparencyLog()
+    for i in range(12):
+        forked.append(f"forked-{i:02d}".encode())
+
+    positive_pairs = [
+        (0, 12),   # empty prefix: trivially consistent, empty proof
+        (1, 12),   # single-leaf (power-of-two) prefix
+        (3, 12),   # non-power-of-two first size
+        (7, 12),   # odd, deep first size
+        (8, 12),   # power-of-two first size, partial second
+        (12, 12),  # identical trees: empty proof
+        (5, 9),    # both non-power-of-two
+    ]
+
+    cases = []
+    for first_size, second_size in positive_pairs:
+        proof = log.consistency_proof(first_size, second_size)
+        cases.append({
+            "name": f"consistent_{first_size}_to_{second_size}",
+            "first_size": first_size,
+            "second_size": second_size,
+            "first_root": _hex(log.root_at(first_size)),
+            "second_root": _hex(log.root_at(second_size)),
+            "proof": [_hex(h) for h in proof.hashes],
+        })
+
+    # Negative 1: a genuine 3->12 proof with one sibling hash flipped.
+    p = log.consistency_proof(3, 12)
+    tampered = [_hex(h) for h in p.hashes]
+    first = bytes.fromhex(tampered[0])
+    tampered[0] = bytes([first[0] ^ 0x01, *first[1:]]).hex()
+    cases.append({
+        "name": "tampered_proof_hash_3_to_12",
+        "first_size": 3,
+        "second_size": 12,
+        "first_root": _hex(log.root_at(3)),
+        "second_root": _hex(log.root_at(12)),
+        "proof": tampered,
+    })
+
+    # Negative 2: a genuine 3->12 proof checked against a second root taken
+    # from a forked log. The first three leaves never produced that root.
+    p = log.consistency_proof(3, 12)
+    cases.append({
+        "name": "forked_second_root_3_to_12",
+        "first_size": 3,
+        "second_size": 12,
+        "first_root": _hex(log.root_at(3)),
+        "second_root": _hex(forked.root_at(12)),
+        "proof": [_hex(h) for h in p.hashes],
+    })
+
+    expected = {
+        "consistent_0_to_12": {"consistent": True},
+        "consistent_1_to_12": {"consistent": True},
+        "consistent_3_to_12": {"consistent": True},
+        "consistent_7_to_12": {"consistent": True},
+        "consistent_8_to_12": {"consistent": True},
+        "consistent_12_to_12": {"consistent": True},
+        "consistent_5_to_9": {"consistent": True},
+        "tampered_proof_hash_3_to_12": {"consistent": False},
+        "forked_second_root_3_to_12": {"consistent": False},
+    }
+
+    log_doc = {
+        "leaf_hashing": "SHA-256(0x00 || leaf)",
+        "node_hashing": "SHA-256(0x01 || left || right)",
+        "leaves": [leaf.decode() for leaf in LEAVES],
+    }
+
+    (HERE / "log.json").write_text(json.dumps(log_doc, indent=2) + "\n")
+    (HERE / "cases.json").write_text(json.dumps(cases, indent=2) + "\n")
+    (HERE / "expected.json").write_text(json.dumps(expected, indent=2) + "\n")
+    print(f"wrote {len(cases)} cases over a {len(LEAVES)}-leaf log")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/vectors/transparency_consistency_v0/cases.json
+++ b/tests/vectors/transparency_consistency_v0/cases.json
@@ -1,0 +1,111 @@
+[
+  {
+    "name": "consistent_0_to_12",
+    "first_size": 0,
+    "second_size": 12,
+    "first_root": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "proof": []
+  },
+  {
+    "name": "consistent_1_to_12",
+    "first_size": 1,
+    "second_size": 12,
+    "first_root": "22cbdb5d0ce627110e22c430ac505c6851c6fcd2ccb368453effb11cce8f9b7b",
+    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "proof": [
+      "5bc0582d78fe58e0b498dd7f39a86b652ce8827e67ad85ad9ea255ec848c2177",
+      "567bf67fddbf02217c5675e6416421a887fadf2f7044ebee35d523b529155314",
+      "4cad0fdb69d80c4668b49335603a9a1ce781af4d71d5388135eca696fc4d6b05",
+      "d9891e6ddaaf11f458297eebeaf87e2ccb596786c929974b3abdf4a956be3b9d"
+    ]
+  },
+  {
+    "name": "consistent_3_to_12",
+    "first_size": 3,
+    "second_size": 12,
+    "first_root": "de311156c685eb3ffac89639c3c5cbea9f624deba44d735657c72c769fd869e2",
+    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "proof": [
+      "07e406c42e27bd86c15eca79a9d6ccbc1774e3a9cadf9d5c4f76bf0081baaa11",
+      "3b1b1db30d87a51b6573b287df6b29be1a1dfe06ec4d6d1125604792fe3e9c9c",
+      "0e5d77c98b1f366752ce0ada3a187af7642d864d7e2ab3416eb236c83dd1bff8",
+      "4cad0fdb69d80c4668b49335603a9a1ce781af4d71d5388135eca696fc4d6b05",
+      "d9891e6ddaaf11f458297eebeaf87e2ccb596786c929974b3abdf4a956be3b9d"
+    ]
+  },
+  {
+    "name": "consistent_7_to_12",
+    "first_size": 7,
+    "second_size": 12,
+    "first_root": "767baabad6fa9b70b543341d78794196dab7205da44fd159869da3eee02de1ce",
+    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "proof": [
+      "6243fb18bafa2d8bd377119c4f0fb3f27069efa2389d1f2114064d87ffd16b86",
+      "d5a92ef8b1e994acd78e8e8753161e68872a64b5a22f7c06628b8ef34bd9f8a8",
+      "9604db3dcd2557d2dc883668a18d4d298be252d26e88b90b3804fc2e7305d603",
+      "8070185a3e93a45a1e2d4c4149ef795d8543249c0295dc95245d2a2a513a0ba8",
+      "d9891e6ddaaf11f458297eebeaf87e2ccb596786c929974b3abdf4a956be3b9d"
+    ]
+  },
+  {
+    "name": "consistent_8_to_12",
+    "first_size": 8,
+    "second_size": 12,
+    "first_root": "cf13081aab6a87268ae7ed59230cad72abce4d476ce0ffe98ac68ff5b5aaab6b",
+    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "proof": [
+      "d9891e6ddaaf11f458297eebeaf87e2ccb596786c929974b3abdf4a956be3b9d"
+    ]
+  },
+  {
+    "name": "consistent_12_to_12",
+    "first_size": 12,
+    "second_size": 12,
+    "first_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "proof": []
+  },
+  {
+    "name": "consistent_5_to_9",
+    "first_size": 5,
+    "second_size": 9,
+    "first_root": "27460c9ac9d56a303abd9900a86bdd270d3f3da8ba4ad90ef6b703cfafa95115",
+    "second_root": "e578bb063ec525f923f8b77b8f57bbf805739b4513701d67fb9aaed93860e5d0",
+    "proof": [
+      "36ec2b842ce19ff8e2a7f484eec3ccf44e71cf59d458581ab9098e3e36ed8189",
+      "f7e7bd4e314e13708b39187ce4b169492ae29ab78c4fa5b3835dd3986e62a526",
+      "77f68d5dd98b38d65e09aa66250705321302dded9938c821a4232bb91e0415b6",
+      "8070185a3e93a45a1e2d4c4149ef795d8543249c0295dc95245d2a2a513a0ba8",
+      "d3be918716c264b58cb219f5fc900dc6909ca4c86eb7292e0427decdc915d33f"
+    ]
+  },
+  {
+    "name": "tampered_proof_hash_3_to_12",
+    "first_size": 3,
+    "second_size": 12,
+    "first_root": "de311156c685eb3ffac89639c3c5cbea9f624deba44d735657c72c769fd869e2",
+    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "proof": [
+      "06e406c42e27bd86c15eca79a9d6ccbc1774e3a9cadf9d5c4f76bf0081baaa11",
+      "3b1b1db30d87a51b6573b287df6b29be1a1dfe06ec4d6d1125604792fe3e9c9c",
+      "0e5d77c98b1f366752ce0ada3a187af7642d864d7e2ab3416eb236c83dd1bff8",
+      "4cad0fdb69d80c4668b49335603a9a1ce781af4d71d5388135eca696fc4d6b05",
+      "d9891e6ddaaf11f458297eebeaf87e2ccb596786c929974b3abdf4a956be3b9d"
+    ]
+  },
+  {
+    "name": "forked_second_root_3_to_12",
+    "first_size": 3,
+    "second_size": 12,
+    "first_root": "de311156c685eb3ffac89639c3c5cbea9f624deba44d735657c72c769fd869e2",
+    "second_root": "e9aa0edeb661e07075dfdaea256359b0b29359746cf67bdd2682adafaa20b4e7",
+    "proof": [
+      "07e406c42e27bd86c15eca79a9d6ccbc1774e3a9cadf9d5c4f76bf0081baaa11",
+      "3b1b1db30d87a51b6573b287df6b29be1a1dfe06ec4d6d1125604792fe3e9c9c",
+      "0e5d77c98b1f366752ce0ada3a187af7642d864d7e2ab3416eb236c83dd1bff8",
+      "4cad0fdb69d80c4668b49335603a9a1ce781af4d71d5388135eca696fc4d6b05",
+      "d9891e6ddaaf11f458297eebeaf87e2ccb596786c929974b3abdf4a956be3b9d"
+    ]
+  }
+]

--- a/tests/vectors/transparency_consistency_v0/expected.json
+++ b/tests/vectors/transparency_consistency_v0/expected.json
@@ -1,0 +1,29 @@
+{
+  "consistent_0_to_12": {
+    "consistent": true
+  },
+  "consistent_1_to_12": {
+    "consistent": true
+  },
+  "consistent_3_to_12": {
+    "consistent": true
+  },
+  "consistent_7_to_12": {
+    "consistent": true
+  },
+  "consistent_8_to_12": {
+    "consistent": true
+  },
+  "consistent_12_to_12": {
+    "consistent": true
+  },
+  "consistent_5_to_9": {
+    "consistent": true
+  },
+  "tampered_proof_hash_3_to_12": {
+    "consistent": false
+  },
+  "forked_second_root_3_to_12": {
+    "consistent": false
+  }
+}

--- a/tests/vectors/transparency_consistency_v0/log.json
+++ b/tests/vectors/transparency_consistency_v0/log.json
@@ -1,0 +1,18 @@
+{
+  "leaf_hashing": "SHA-256(0x00 || leaf)",
+  "node_hashing": "SHA-256(0x01 || left || right)",
+  "leaves": [
+    "entry-00",
+    "entry-01",
+    "entry-02",
+    "entry-03",
+    "entry-04",
+    "entry-05",
+    "entry-06",
+    "entry-07",
+    "entry-08",
+    "entry-09",
+    "entry-10",
+    "entry-11"
+  ]
+}


### PR DESCRIPTION
The transparency log already issued inclusion proofs: evidence that a given receipt is in the log. An inclusion proof says nothing about whether the operator rewrote earlier history. A consistency proof does. It shows the log at an earlier size is a verifiable prefix of the log at a later size, so a fork or a quiet rewrite of past entries is detectable even when every inclusion proof still verifies. A monitor that pins the log's root over time and checks a consistency proof between successive roots gets the append-only guarantee a transparency log exists to provide. RFC 9162 (RFC 6962-bis) section 2.1.4.

## What's new (all additive over 0.53)
- `verify_consistency(...)`: verify a consistency proof between two tree sizes and their roots; returns a single bool.
- `ConsistencyProof`: the proof object (first_size, second_size, ordered sibling hashes).
- `InProcessTransparencyLog.consistency_proof(first, second)` and `root_at(tree_size)`.
- `transparency_consistency_v0` conformance vectors (nine cases over a twelve-leaf log) with a standard-library-only, Vaara-free independent checker.

No change to the receipt envelope, canonicalization, inclusion-proof format, or signature verification. Envelope version stays 1.

## Verification
- 1223 passed, 13 skipped.
- ruff clean; mypy clean on the gated set (src/vaara/policy/).
- The independent checker reproduces all nine verdicts with no Vaara import.

Design: docs/design/transparency-log-consistency-spec.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transparency-log consistency proof support enabling verification of append-only behavior between tree snapshots.
  * New APIs for computing and verifying Merkle tree consistency proofs.

* **Documentation**
  * Added design specification for transparency-log consistency proofs.
  * Added conformance test vectors and documentation.

* **Tests**
  * Added comprehensive test suite for consistency proof validation including edge cases and negative scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->