### PR TITLE
fix(build-bundle): exit cleanly on a wrong-shape receipt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- `vaara build-bundle`: a receipt that is valid JSON but the wrong shape (for
+  example missing a required field) now exits 1 with `cannot assemble bundle:
+  ...` instead of letting an `AttestationError` traceback escape. The handler
+  around `build_bundle_document` caught only `ValueError`; the validation path
+  can also raise `AttestationError`, `KeyError`, or `TypeError`, so it now
+  catches all four, matching the other attestation CLI commands.
+
 ## [0.58.0] - 2026-06-05
 
 **Theme: one command for the party producing evidence, the mirror of

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -1624,6 +1624,7 @@ def _cmd_build_bundle(args: argparse.Namespace) -> int:
             load_bundle_pieces_from_dir,
             verify_evidence_bundle,
         )
+        from vaara.attestation.sep2787 import AttestationError
     except ImportError:
         print(_ATTESTATION_HINT, file=sys.stderr)
         return 2
@@ -1679,7 +1680,7 @@ def _cmd_build_bundle(args: argparse.Namespace) -> int:
 
     try:
         doc = build_bundle_document(**pieces)
-    except ValueError as exc:
+    except (AttestationError, KeyError, TypeError, ValueError) as exc:
         print(f"vaara build-bundle: cannot assemble bundle: {exc}", file=sys.stderr)
         return 1
 

--- a/tests/test_build_bundle_cli.py
+++ b/tests/test_build_bundle_cli.py
@@ -195,3 +195,16 @@ def test_cli_malformed_piece(tmp_path, capsys):
     ])
     assert rc == 1
     assert "cannot assemble bundle" in capsys.readouterr().err
+
+
+def test_cli_wrong_shape_receipt_reports_cleanly(tmp_path, capsys):
+    # A receipt that is valid JSON but the wrong shape fails validation with an
+    # AttestationError, not a ValueError. The handler must catch it and exit 1
+    # with a clean message rather than letting a traceback escape.
+    bad = tmp_path / "receipt.json"
+    bad.write_text(json.dumps({"not": "a receipt"}))
+    rc = main(["build-bundle", "--receipt", str(bad)])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "cannot assemble bundle" in err
+    assert "Traceback" not in err


### PR DESCRIPTION
## What
A receipt that is valid JSON but the wrong shape (missing a required field, say) made `vaara build-bundle` print a Python traceback and exit 1, instead of a clean error.

## Why
The handler around `build_bundle_document` caught only `ValueError`. The validation path (`build_bundle_document` to `evidence_bundle_from_json` to `receipt_from_dict`) raises `AttestationError`, which subclasses `RuntimeError`, not `ValueError`, so it escaped. It can also raise `KeyError` or `TypeError` on odd shapes.

## Fix
Catch `(AttestationError, KeyError, TypeError, ValueError)`, the same set the other attestation CLI commands already catch (`attest verify`, `verify-bundle`). A bad piece now reports `cannot assemble bundle: ...` and exits 1 without a traceback. Regression test asserts the clean message and that no traceback reaches stderr.

Found during a bughunt pass feeding malformed pieces to `build-bundle`. The bad-hex path was already clean (it raises `ValueError`); only the wrong-shape path leaked. 1309 passed, ruff clean, mypy strict clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `vaara build-bundle` command to gracefully handle invalid receipt JSON files (valid JSON but missing required fields) by exiting with status code 1 and a user-friendly error message, instead of displaying an uncaught traceback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->