### PR TITLE
v0.59.0: time-anchored Article 12 regulator pack (Article 19 existence-in-time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.59.0] - 2026-06-07
+
+**Theme: the regulator package now proves when, not just what. The Article 12
+export already produced a signed, self-describing record-keeping package. This
+release folds an external RFC 3161 time anchor over the signed trail head into
+that package, so a regulator can confirm the logs existed at a point in time
+independently of the operator's signing key. Pinned to an eIDAS-qualified
+Time-Stamp Authority, that timestamp is the form an EU regulator already
+recognises, which is the Article 19 existence-in-time property.**
+
+### Added
+- `vaara trail export-article12 --anchor-tsa URL` (or `--anchor-file PATH`):
+  fold an external RFC 3161 time anchor over the signed trail head into the
+  Article 12 package as `time_anchor.json`. The anchor binds to the trail it
+  ships with; the export verifies the chain-head position and the RFC 3161
+  token over that exact `record_hash` before writing it, so a package never
+  claims an anchor it cannot back. The report gains an "External time anchor
+  (Article 19)" section and an `art19_logs` obligation row, and
+  `article12_summary.json` carries a `time_anchor` block.
+- `vaara trail verify-anchor --zip PACKAGE`: verify that anchor offline. It
+  checks the anchored `chain_head_hash` equals the last `record_hash` in
+  `trail.jsonl` and that the RFC 3161 token verifies. Pin the TSA certificate
+  to enforce an eIDAS-qualified authority.
+
 ### Changed
 - Dropped the superseded classifier bundles `adversarial_classifier_v1`,
   `v2`, `v3`, `v5`, `v6`, `v7` from the repository (about 5.5 MB). The

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/design/article12-export-spec.md
+++ b/docs/design/article12-export-spec.md
@@ -45,13 +45,18 @@ vaara trail export-article12 \
   --out art12_package.zip \
   [--system-meta system.json] \
   [--period 2026-01-01:2026-06-30] \
-  [--format md|html]
+  [--format md|html] \
+  [--anchor-tsa https://tsa.example/tsr | --anchor-file anchor.json]
 ```
 
 `--system-meta` is a small operator-supplied JSON (system name, provider,
 intended purpose, deployer, AI Act risk classification) that the report's
 cover section needs and the trail does not carry. Optional; absent fields
 render as "not provided" rather than failing.
+
+`--anchor-tsa` / `--anchor-file` (added v0.59.0, mutually exclusive) fold an
+external RFC 3161 time anchor over the signed trail head into the package as
+Article 19 existence-in-time evidence. See "External time anchor" below.
 
 ## Package contents (zip)
 
@@ -65,6 +70,8 @@ signer_pubkey.pem        # unchanged
 article12_report.md      # NEW: the human-readable mapping (or .html)
 article12_summary.json   # NEW: machine-readable version of the report
 verify_instructions.txt  # NEW: how the regulator checks the package
+time_anchor.json         # NEW (v0.59.0): RFC 3161 anchor over the trail head,
+                         #   present only when --anchor-tsa/--anchor-file is used
 ```
 
 The report and summary are inside the signed set: the manifest's
@@ -97,6 +104,34 @@ Generated, deterministic, from the trail + system-meta:
 
 The prose passes the strict anti-AI-tells pass before any of it is treated
 as outbound (it is regulator-facing).
+
+## External time anchor (Article 19), v0.59.0
+
+The signature proves the logs are intact and who signed them. It does not,
+on its own, prove *when* they existed: the timestamps and the signature both
+come from the operator's own key, so a later key compromise could backdate an
+alternate trail. Article 19 requires the automatically generated logs to be
+kept for the appropriate period; "kept since when" needs an anchor outside
+the operator's trust boundary.
+
+`--anchor-tsa URL` takes the signed trail head (the last record's
+`record_hash`) to an RFC 3161 Time-Stamp Authority and folds the returned
+token in as `time_anchor.json`. Pinned to an eIDAS-qualified TSA the timestamp
+is recognised EU-wide, so existence-in-time holds independently of the signing
+key. `--anchor-file` folds a pre-fetched anchor instead (for air-gapped
+issuance). The anchor binds to *this* trail: `export_article12` re-checks that
+the anchor's `chain_position` is the head and that the token verifies over that
+exact `record_hash` before writing it, so a package never claims an anchor it
+cannot back.
+
+The regulator verifies it offline with `vaara trail verify-anchor --zip
+<package>.zip`: the anchored `chain_head_hash` must equal the last
+`record_hash` in `trail.jsonl`, and the RFC 3161 token must verify under a TSA
+the regulator trusts. This reuses `vaara/audit/timeanchor.py`
+(`verify_anchor_over_records`); the report's "External time anchor (Article
+19)" section and `article12_summary.json["time_anchor"]` surface the attested
+time. Versus a blockchain-anchored digest, an eIDAS-qualified RFC 3161
+timestamp is the form an EU regulator already recognises.
 
 ## Implementation sketch
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.58.0"
+version = "0.59.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.58.0",
+  "version": "0.59.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.58.0",
+      "version": "0.59.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.58.0",
+  "version": "0.59.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.58.0",
+      "version": "0.59.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.58.0"
+__version__ = "0.59.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/audit/article12_export.py
+++ b/src/vaara/audit/article12_export.py
@@ -12,9 +12,12 @@ describes exactly the trail that was signed, and folded into the zip:
     article12_report.md      (or .html)
     article12_summary.json
     verify_instructions.txt
+    time_anchor.json         (when an external time anchor is supplied)
 
 The report is bound to the signed trail by the manifest ``trail_sha256`` it
-records. It is not itself signed; the verify instructions say so plainly.
+records. It is not itself signed; the verify instructions say so plainly. An
+optional RFC 3161 time anchor over the signed trail head adds Article 19
+existence-in-time evidence that holds independently of the signing key.
 """
 
 from __future__ import annotations
@@ -22,7 +25,10 @@ from __future__ import annotations
 import json
 import zipfile
 from pathlib import Path
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    from vaara.audit.timeanchor import TimeAnchor
 
 from vaara.audit.article12_report import (
     build_article12_report,
@@ -67,6 +73,7 @@ def export_article12(
     threshold_k: Optional[int] = None,
     system_meta: Optional[dict] = None,
     period: Optional[tuple] = None,
+    time_anchor: "Optional[TimeAnchor]" = None,
     fmt: str = "md",
     agent_id: str = "",
 ) -> ExportResult:
@@ -77,6 +84,13 @@ def export_article12(
     plus ``threshold_k`` for the k-of-n threshold path. ``system_meta`` and
     ``period`` are passed through to the report builder; ``fmt`` selects
     ``"md"`` or ``"html"`` for the human-readable report.
+
+    ``time_anchor`` is an optional
+    :class:`~vaara.audit.timeanchor.TimeAnchor` over the signed trail head. It
+    must anchor the final record (the chain head); the binding and the RFC 3161
+    token are verified here, and a mismatch raises. When present it is folded
+    in as ``time_anchor.json`` and surfaced in the report as Article 19
+    existence-in-time evidence, independent of the signing key.
 
     Returns the underlying :class:`ExportResult` (its ``manifest`` covers the
     signed core; the Article 12 files are folded in afterwards).
@@ -103,8 +117,28 @@ def export_article12(
 
     # Build the report from the trail bytes that were actually signed.
     records, manifest = _records_from_zip(out_path)
+
+    # An optional external time anchor must bind to the head of the trail we
+    # just signed. Verify both the chain-head binding and the RFC 3161 token
+    # before folding it in, so a package never claims an anchor it cannot back.
+    anchor_dict: Optional[dict] = None
+    if time_anchor is not None:
+        from vaara.audit.timeanchor import verify_anchor_over_records
+
+        head_position = len(records) - 1
+        if time_anchor.chain_position != head_position:
+            raise ValueError(
+                "time_anchor must anchor the trail head (position "
+                f"{head_position}), got {time_anchor.chain_position}"
+            )
+        # Raises TimeAnchorError if the anchor refers to a different chain or
+        # the token does not verify over its attested digest.
+        verify_anchor_over_records(time_anchor, [r.record_hash for r in records])
+        anchor_dict = time_anchor.to_dict()
+
     report = build_article12_report(
         records, manifest, system_meta=system_meta, period=period,
+        time_anchor=anchor_dict,
     )
 
     report_name = f"article12_report.{fmt}"
@@ -118,5 +152,10 @@ def export_article12(
         zf.writestr(report_name, report_body)
         zf.writestr("article12_summary.json", summary_bytes)
         zf.writestr("verify_instructions.txt", instructions + "\n")
+        if anchor_dict is not None:
+            zf.writestr(
+                "time_anchor.json",
+                json.dumps(anchor_dict, indent=2, sort_keys=True).encode("utf-8"),
+            )
 
     return result

--- a/src/vaara/audit/article12_report.py
+++ b/src/vaara/audit/article12_report.py
@@ -80,6 +80,15 @@ ARTICLE12_OBLIGATIONS: tuple[dict, ...] = (
             EventType.ACTION_EXECUTED.value,
         ),
     },
+    {
+        "id": "art19_logs",
+        "article": "Article 19(1)",
+        "title": (
+            "Keeping the automatically generated logs under the deployer's "
+            "control for the appropriate retention period"
+        ),
+        "evidenced_by": tuple(et.value for et in EventType),
+    },
 )
 
 
@@ -109,6 +118,7 @@ def build_article12_report(
     *,
     system_meta: Optional[dict] = None,
     period: Optional[tuple] = None,
+    time_anchor: Optional[dict] = None,
 ) -> dict:
     """Build the Article 12 report dict from a trail and its export manifest.
 
@@ -118,6 +128,10 @@ def build_article12_report(
     which records the *summary* counts. It never narrows the signed trail,
     which stays whole. ``system_meta`` carries operator-supplied identity the
     trail does not hold; absent fields render as "not provided".
+    ``time_anchor`` is an optional :class:`~vaara.audit.timeanchor.TimeAnchor`
+    serialised with ``to_dict()``: an external trusted timestamp over the
+    signed trail head, evidencing Article 19 existence-in-time independently of
+    the signing key. Its chain-head binding is checked by the caller.
     """
     system_meta = dict(system_meta or {})
     in_scope = [r for r in records if _in_period(r.timestamp, period)]
@@ -198,7 +212,7 @@ def build_article12_report(
         "schema_version": SCHEMA_VERSION,
         "report_format": "article12",
         "generated_utc": _iso(time.time()),
-        "regulation": {"framework": "EU AI Act", "articles": ["12", "26(5)"]},
+        "regulation": {"framework": "EU AI Act", "articles": ["12", "19", "26(5)"]},
         "cover": {
             "system_name": system_meta.get("system_name", "not provided"),
             "provider": system_meta.get("provider", "not provided"),
@@ -254,6 +268,27 @@ def build_article12_report(
                 "assertion."
             ),
         },
+        "time_anchor": (
+            {
+                "anchored": True,
+                "backend": time_anchor.get("backend", ""),
+                "tsa_url": time_anchor.get("tsa_url", ""),
+                "hash_algorithm": time_anchor.get("hash_algorithm", ""),
+                "chain_position": time_anchor.get("chain_position"),
+                "chain_head_hash": time_anchor.get("chain_head_hash", ""),
+                "anchored_time": time_anchor.get("anchored_time", ""),
+                "attests": (
+                    "An authority outside Vaara's control timestamped the "
+                    "signed trail head, proving these logs existed no later "
+                    "than the attested time independently of the signing key. "
+                    "Pinned to an eIDAS-qualified Time-Stamp Authority this is "
+                    "EU-recognised evidence of existence-in-time over the "
+                    "Article 19 retention window."
+                ),
+            }
+            if time_anchor
+            else {"anchored": False}
+        ),
     }
 
 
@@ -383,6 +418,30 @@ def render_report_md(report: dict) -> str:
     out.append("See docs/signing-keys.md and the trust model for the boundary.")
     out.append("")
 
+    anchor = report.get("time_anchor") or {"anchored": False}
+    out.append("## External time anchor (Article 19)")
+    out.append("")
+    if anchor.get("anchored"):
+        out.append(_md_table(["Field", "Value"], [
+            ["Anchored", "yes"],
+            ["Backend", anchor.get("backend", "")],
+            ["Time-Stamp Authority", anchor.get("tsa_url", "")],
+            ["Hash algorithm", anchor.get("hash_algorithm", "")],
+            ["Anchored chain position", anchor.get("chain_position", "")],
+            ["Anchored chain head", anchor.get("chain_head_hash", "")],
+            ["Attested time (UTC)", anchor.get("anchored_time", "")],
+        ]))
+        out.append("")
+        out.append(anchor.get("attests", ""))
+    else:
+        out.append(
+            "No external time anchor is included in this package. The signature "
+            "proves integrity and provenance; on its own it does not prove when "
+            "the logs existed. Add an RFC 3161 (eIDAS-qualified) time anchor "
+            "with: vaara trail export-article12 --anchor-tsa <url>."
+        )
+    out.append("")
+
     out.append("## How to verify")
     out.append("")
     out.append(verify_instructions_text(report))
@@ -415,6 +474,7 @@ def verify_instructions_text(report: dict) -> str:
     """Plain-text steps a regulator follows to check the package."""
     s = report["record_keeping_summary"]
     threshold = report["cover"].get("threshold")
+    anchor = report.get("time_anchor") or {"anchored": False}
     lines = [
         "How to verify this Article 12 package",
         "",
@@ -428,12 +488,34 @@ def verify_instructions_text(report: dict) -> str:
         "   the trail_sha256 in manifest.json:",
         f"     {s['trail_sha256']}",
     ]
+    step = 3
     if threshold:
         lines += [
             "",
-            f"3. This package is threshold-signed: at least {threshold['threshold_k']}",
-            f"   of {threshold['signers_n']} named custodian signatures must verify.",
+            f"{step}. This package is threshold-signed: at least "
+            f"{threshold['threshold_k']}",
+            f"   of {threshold['signers_n']} named custodian signatures must "
+            "verify.",
         ]
+        step += 1
+    if anchor.get("anchored"):
+        lines += [
+            "",
+            f"{step}. Verify the external time anchor in time_anchor.json. It "
+            "proves the signed",
+            "   trail head existed no later than the attested time, "
+            "independently of the",
+            "   signing key. With Vaara installed:",
+            "     vaara trail verify-anchor --zip <this_package>.zip",
+            "   The anchor's chain_head_hash must equal the last record_hash "
+            "in trail.jsonl,",
+            "   and the RFC 3161 token must verify under a Time-Stamp Authority "
+            "you trust",
+            "   (pin an eIDAS-qualified TSA certificate to enforce that). "
+            "Anchored head:",
+            f"     {anchor.get('chain_head_hash', '')}",
+        ]
+        step += 1
     lines += [
         "",
         "The signature covers trail.jsonl and manifest.json. This report and",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -550,10 +550,111 @@ def _parse_period(spec: Optional[str]) -> Optional[tuple]:
     return (_epoch(start_s, end_of_day=False), _epoch(end_s, end_of_day=True))
 
 
+def _cmd_trail_verify_anchor(args: argparse.Namespace) -> int:
+    """Verify the external time anchor folded into an Article 12 package."""
+    import zipfile
+
+    try:
+        from vaara.audit.timeanchor import (
+            TimeAnchor,
+            TimeAnchorError,
+            verify_anchor_over_records,
+        )
+        from vaara.audit.trail import AuditRecord
+    except ImportError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 2
+
+    zip_path = Path(args.zip).expanduser()
+    if not zip_path.exists():
+        print(f"package zip not found: {zip_path}", file=sys.stderr)
+        return 2
+
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            if "time_anchor.json" not in set(zf.namelist()):
+                print(
+                    "no time_anchor.json in package (it is not time-anchored)",
+                    file=sys.stderr,
+                )
+                return 2
+            anchor = TimeAnchor.from_dict(json.loads(zf.read("time_anchor.json")))
+            trail_bytes = zf.read("trail.jsonl")
+    except (zipfile.BadZipFile, KeyError, json.JSONDecodeError, OSError,
+            TypeError) as exc:
+        print(f"could not read package: {exc}", file=sys.stderr)
+        return 2
+
+    record_hashes = [
+        AuditRecord.from_dict(json.loads(line)).record_hash
+        for line in (ln.strip() for ln in trail_bytes.splitlines())
+        if line
+    ]
+
+    try:
+        attested = verify_anchor_over_records(anchor, record_hashes)
+    except TimeAnchorError as exc:
+        print(f"time anchor INVALID: {exc}", file=sys.stderr)
+        return 1
+
+    print("time anchor OK")
+    print(f"  backend:        {anchor.backend}")
+    print(f"  TSA:            {anchor.tsa_url}")
+    print(f"  anchored head:  {anchor.chain_head_hash}")
+    print(f"  attested (UTC): {attested.isoformat()}")
+    print("  note: pin the TSA certificate to enforce an eIDAS-qualified authority.")
+    return 0
+
+
+def _obtain_time_anchor(args: argparse.Namespace, trail):
+    """Build or load the optional Article 19 time anchor over the trail head.
+
+    Returns ``None`` when neither ``--anchor-tsa`` nor ``--anchor-file`` is
+    given. Raises ``ValueError`` on any anchor failure so the CLI reports it
+    cleanly. The anchor is taken over the trail's final record (its head); the
+    export then re-verifies the binding before folding it in.
+    """
+    anchor_tsa = getattr(args, "anchor_tsa", None)
+    anchor_file = getattr(args, "anchor_file", None)
+    if not anchor_tsa and not anchor_file:
+        return None
+
+    from vaara.audit.timeanchor import (
+        RFC3161TimeAnchorClient,
+        TimeAnchor,
+        TimeAnchorError,
+    )
+
+    records = trail._records
+    if not records:
+        raise ValueError("cannot time-anchor an empty trail")
+    head_position = len(records) - 1
+    head_hash = records[-1].record_hash
+    if not head_hash:
+        raise ValueError("trail head has no record_hash to anchor")
+
+    if anchor_file:
+        path = Path(anchor_file).expanduser()
+        if not path.exists():
+            raise ValueError(f"anchor file not found: {path}")
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return TimeAnchor.from_dict(json.load(f))
+        except (json.JSONDecodeError, OSError, KeyError, TypeError) as exc:
+            raise ValueError(f"failed to read anchor file: {exc}") from exc
+
+    try:
+        client = RFC3161TimeAnchorClient(anchor_tsa)
+        return client.anchor(head_position, head_hash)
+    except TimeAnchorError as exc:
+        raise ValueError(f"time anchoring failed: {exc}") from exc
+
+
 def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
     """Export a signed EU AI Act Article 12 regulator package from a trail."""
     try:
         from vaara.audit.article12_export import export_article12
+        from vaara.audit.timeanchor import TimeAnchorError
         from vaara.audit.trail import AuditRecord, AuditTrail
     except ImportError:
         print(_INSTALL_HINT, file=sys.stderr)
@@ -599,16 +700,18 @@ def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
     out.parent.mkdir(parents=True, exist_ok=True)
 
     try:
+        time_anchor = _obtain_time_anchor(args, trail)
         result = export_article12(
             trail,
             out_path=out,
             signer_key=Path(args.key).expanduser(),
             system_meta=system_meta,
             period=period,
+            time_anchor=time_anchor,
             fmt=args.format,
             agent_id=args.agent_id or "",
         )
-    except (ValueError, ImportError) as exc:
+    except (ValueError, ImportError, TimeAnchorError) as exc:
         print(f"Article 12 export failed: {exc}", file=sys.stderr)
         return 2
 
@@ -616,6 +719,8 @@ def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
     print(f"  records:      {result.manifest['record_count']}")
     print(f"  chain intact: {result.chain_intact}")
     print(f"  report:       article12_report.{args.format}")
+    if time_anchor is not None:
+        print(f"  time anchor:  {time_anchor.anchored_time} ({time_anchor.backend})")
     return 0 if result.chain_intact else 1
 
 
@@ -1962,6 +2067,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     pv.set_defaults(func=_cmd_trail_verify)
 
+    pva = tsub.add_parser(
+        "verify-anchor",
+        help="Verify the external time anchor in an Article 12 package",
+    )
+    pva.add_argument("--zip", required=True, help="Path to the package zip")
+    pva.set_defaults(func=_cmd_trail_verify_anchor)
+
     pep = tsub.add_parser(
         "export-prov",
         help="Export the trail as W3C PROV-JSON (no signing, zero extra deps)",
@@ -2028,6 +2140,19 @@ def build_parser() -> argparse.ArgumentParser:
     pa12.add_argument(
         "--agent-id", default="",
         help="Optional scope hint written to the manifest (does not filter records)",
+    )
+    pa12_anchor = pa12.add_mutually_exclusive_group()
+    pa12_anchor.add_argument(
+        "--anchor-tsa", default=None, metavar="URL",
+        help="Fetch an RFC 3161 time anchor over the trail head from this "
+             "Time-Stamp Authority and fold it in as Article 19 "
+             "existence-in-time evidence. Needs the 'timeanchor' extra and "
+             "network access.",
+    )
+    pa12_anchor.add_argument(
+        "--anchor-file", default=None, metavar="PATH",
+        help="Fold in a pre-fetched time anchor (TimeAnchor JSON over the "
+             "trail head) instead of fetching one.",
     )
     pa12.set_defaults(func=_cmd_trail_export_article12)
 

--- a/tests/test_article12_export.py
+++ b/tests/test_article12_export.py
@@ -176,3 +176,153 @@ def test_bad_format_rejected(tmp_path):
     out = tmp_path / "art12.zip"
     with pytest.raises(ValueError):
         export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path), fmt="pdf")
+
+
+# --- Article 19 external time anchor -------------------------------------
+
+
+def _anchor_over_trail(trail):
+    """Build a real RFC 3161 anchor over the trail head via an in-process TSA.
+
+    Mirrors tests/test_timeanchor.py: a self-signed EC TSA issues a genuine
+    TimeStampToken over the chain head, so the full anchor path is exercised
+    with no network. Skips when the 'timeanchor' extra is absent.
+    """
+    pytest.importorskip("asn1crypto")
+    import datetime
+    import hashlib
+
+    from asn1crypto import algos, cms, tsp
+    from asn1crypto import x509 as asn1_x509
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    from vaara.audit.timeanchor import RFC3161TimeAnchorClient
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Vaara Test TSA")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2020, 1, 1))
+        .not_valid_after(datetime.datetime(2035, 1, 1))
+        .sign(key, hashes.SHA256())
+    )
+    cert_asn1 = asn1_x509.Certificate.load(
+        cert.public_bytes(serialization.Encoding.DER)
+    )
+
+    def _issue(digest):
+        tst = tsp.TSTInfo({
+            "version": 1, "policy": "1.3.6.1.4.1.99999.1",
+            "message_imprint": tsp.MessageImprint({
+                "hash_algorithm": algos.DigestAlgorithm({"algorithm": "sha256"}),
+                "hashed_message": digest,
+            }),
+            "serial_number": 1,
+            "gen_time": datetime.datetime(
+                2026, 6, 7, 12, 0, 0, tzinfo=datetime.timezone.utc),
+        })
+        attrs = cms.CMSAttributes([
+            cms.CMSAttribute({"type": "content_type", "values": ["tst_info"]}),
+            cms.CMSAttribute({
+                "type": "message_digest",
+                "values": [hashlib.sha256(tst.dump()).digest()],
+            }),
+        ])
+        signer_info = cms.SignerInfo({
+            "version": "v1",
+            "sid": cms.SignerIdentifier({
+                "issuer_and_serial_number": cms.IssuerAndSerialNumber({
+                    "issuer": cert_asn1.issuer,
+                    "serial_number": cert_asn1.serial_number,
+                }),
+            }),
+            "digest_algorithm": algos.DigestAlgorithm({"algorithm": "sha256"}),
+            "signed_attrs": attrs,
+            "signature_algorithm": algos.SignedDigestAlgorithm(
+                {"algorithm": "sha256_ecdsa"}),
+            "signature": key.sign(attrs.dump(), ec.ECDSA(hashes.SHA256())),
+        })
+        signed = cms.SignedData({
+            "version": "v3",
+            "digest_algorithms": [algos.DigestAlgorithm({"algorithm": "sha256"})],
+            "encap_content_info": cms.EncapsulatedContentInfo({
+                "content_type": "tst_info", "content": tst,
+            }),
+            "certificates": [cms.CertificateChoices({"certificate": cert_asn1})],
+            "signer_infos": [signer_info],
+        })
+        return cms.ContentInfo(
+            {"content_type": "signed_data", "content": signed}).dump()
+
+    def transport(url, der_request, timeout):
+        req = tsp.TimeStampReq.load(der_request)
+        digest = req["message_imprint"]["hashed_message"].native
+        return tsp.TimeStampResp({
+            "status": tsp.PKIStatusInfo({"status": "granted"}),
+            "time_stamp_token": cms.ContentInfo.load(_issue(digest)),
+        }).dump()
+
+    client = RFC3161TimeAnchorClient("https://tsa.test/tsr", transport=transport)
+    records = trail._records
+    return client.anchor(len(records) - 1, records[-1].record_hash)
+
+
+def test_anchor_folded_into_package(tmp_path):
+    trail = _make_trail()
+    anchor = _anchor_over_trail(trail)
+    out = tmp_path / "art12.zip"
+    export_article12(trail, out, signer_key=_key_pem(tmp_path), time_anchor=anchor)
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+    assert "time_anchor.json" in names
+    ta = _read_summary(out)["time_anchor"]
+    assert ta["anchored"] is True
+    assert ta["chain_head_hash"] == anchor.chain_head_hash
+    # Folding the anchor in via append mode must not disturb the signed core.
+    assert verify_signed(out).ok
+
+
+def test_anchor_absent_marks_not_anchored(tmp_path):
+    out = tmp_path / "art12.zip"
+    export_article12(_make_trail(), out, signer_key=_key_pem(tmp_path))
+    assert _read_summary(out)["time_anchor"]["anchored"] is False
+    with zipfile.ZipFile(out) as zf:
+        assert "time_anchor.json" not in set(zf.namelist())
+
+
+def test_anchor_must_bind_the_trail_head(tmp_path):
+    from vaara.audit.timeanchor import TimeAnchorError
+
+    # An anchor over a different trail must not be accepted for this one.
+    foreign = _anchor_over_trail(_make_trail(2))
+    out = tmp_path / "art12.zip"
+    with pytest.raises((ValueError, TimeAnchorError)):
+        export_article12(
+            _make_trail(4), out,
+            signer_key=_key_pem(tmp_path), time_anchor=foreign,
+        )
+
+
+def test_packaged_anchor_verifies_offline(tmp_path):
+    from vaara.audit.timeanchor import TimeAnchor, verify_anchor_over_records
+    from vaara.audit.trail import AuditRecord
+
+    trail = _make_trail()
+    anchor = _anchor_over_trail(trail)
+    out = tmp_path / "art12.zip"
+    export_article12(trail, out, signer_key=_key_pem(tmp_path), time_anchor=anchor)
+    # Re-verify from the packaged bytes alone, the way a regulator would.
+    with zipfile.ZipFile(out) as zf:
+        loaded = TimeAnchor.from_dict(json.loads(zf.read("time_anchor.json")))
+        record_hashes = [
+            AuditRecord.from_dict(json.loads(ln)).record_hash
+            for ln in zf.read("trail.jsonl").splitlines() if ln.strip()
+        ]
+    attested = verify_anchor_over_records(loaded, record_hashes)
+    assert attested.year == 2026


### PR DESCRIPTION
## What

`vaara trail export-article12` can now fold an external RFC 3161 time anchor over the signed trail head into the regulator package, and a new `vaara trail verify-anchor` checks it offline.

The Article 12 export already produced a signed, self-describing record-keeping package. The signature proves the logs are intact and who signed them; it does not prove when they existed, since the timestamps and the signature both come from the operator's own key. An external trusted timestamp closes that gap. Pinned to an eIDAS-qualified Time-Stamp Authority, it is the existence-in-time evidence Article 19 calls for, in the form an EU regulator already recognises.

## Changes

- `export_article12(time_anchor=...)` plus `--anchor-tsa URL` / `--anchor-file PATH` (mutually exclusive). The anchor binds to the trail it ships with: the export verifies the head position and the RFC 3161 token over that exact `record_hash` before writing `time_anchor.json`.
- Report: new "External time anchor (Article 19)" section, an `art19_logs` obligation row, and a `time_anchor` block in `article12_summary.json`.
- New `vaara trail verify-anchor --zip PACKAGE` for offline verification.
- Reuses the existing `vaara/audit/timeanchor.py` (RFC 3161 / eIDAS); no new crypto.

## Tests

- 4 new tests (in-process TSA, no network): anchor folded and binds the head, absent marks not-anchored, foreign anchor rejected, packaged anchor re-verifies from the zip alone.
- Full suite: 1313 passed, 13 skipped. ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.59.0

* **New Features**
  * Added external RFC 3161 time anchor support for Article 12 exports with new `--anchor-tsa` and `--anchor-file` CLI options.
  * Introduced `vaara trail verify-anchor` command to verify embedded time anchors offline.
  * Time anchor evidence now included in exported packages as Article 19 existence-in-time proof.

* **Documentation**
  * Updated design specifications for Article 12 export with time anchor integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->