### PR TITLE
chore(security): bump gradio in the HF Space example to clear 10 OSV advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Security
+- Bumped `gradio` in the Hugging Face Space example
+  (`examples/huggingface-space/requirements.txt`) from `>=5.0` to `>=6.16.0`,
+  clearing 10 OSV advisories (path traversal, SSRF, CORS bypass, open redirect)
+  that OpenSSF Scorecard flagged. Example-only: `gradio` is not a dependency of
+  the Vaara package or the published wheel, so package users were never exposed.
+
 ## [0.59.0] - 2026-06-07
 
 **Theme: the regulator package now proves when, not just what. The Article 12

--- a/examples/huggingface-space/requirements.txt
+++ b/examples/huggingface-space/requirements.txt
@@ -1,2 +1,2 @@
 vaara>=0.19.1
-gradio>=5.0
+gradio>=6.16.0


### PR DESCRIPTION
## What

OpenSSF Scorecard's Vulnerabilities check flagged 10 OSV advisories, all in `gradio` (path traversal, SSRF, CORS bypass, open redirect). `gradio` is not a dependency of the Vaara package or the published wheel. It appears only in `examples/huggingface-space/requirements.txt`, which pinned `gradio>=5.0`.

The recent advisories are fixed in gradio 6.6.0 and 6.7.0, so the floor moves to `>=6.16.0` (current latest). The demo uses only stable Blocks APIs (`Blocks`/`Row`/`Column`/`Textbox`/`Dropdown`/`Code`/`Button`/`themes`), which are unchanged across the 5 to 6 major.

Example-only hygiene: no package change, no version bump. Clears the Scorecard Vulnerabilities check (was 0/10).

## Note

The other Scorecard movers are structural, not code-fixable here: Code-Review (0/26 approved, a solo-maintainer self-merge artifact) and Maintained=0 (repo is under 90 days old, self-heals).
