### PR TITLE
docs(readme): note the time anchor folds into the Article 12 regulator pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ from vaara.audit.timeanchor import RFC3161TimeAnchorClient
 trail.anchor_head(RFC3161TimeAnchorClient("https://freetsa.org/tsr"))
 ```
 
+The anchor also folds into the one-command regulator package: `vaara trail export-article12 --anchor-tsa https://freetsa.org/tsr` writes the timestamp beside the signed trail as Article 19 existence-in-time evidence, and `vaara trail verify-anchor --zip <package>.zip` checks it offline.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## What

The README's "External time anchor" section described the anchor as a Python-API feature only. v0.59.0 (#206) made it reachable from the one-command regulator export (`vaara trail export-article12 --anchor-tsa`) and verifiable offline (`vaara trail verify-anchor`). This adds one line so the section reflects that.

Docs only; no package or version change.
