### PR TITLE
chore: add Sponsor button to the repo (FUNDING.yml)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [vaaraio]


### PR DESCRIPTION
Points the repo Sponsor button at the approved github.com/sponsors/vaaraio listing, so it shows on the vaaraio/vaara header, not only on the profile. One line: `github: [vaaraio]`. No code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated funding configuration to include GitHub sponsorship information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->