### PR TITLE
feat: verify-records, set-level conformance over a directory of SEP-2828 records

### DIFF
--- a/src/vaara/attestation/_record_set_conformance.py
+++ b/src/vaara/attestation/_record_set_conformance.py
@@ -1,0 +1,215 @@
+"""Set-level conformance for a pile of SEP-2828 execution records.
+
+``check_record_conformance`` answers a question about one record. An
+auditor who receives a directory of records, possibly from more than one
+emitter, asks a different question: over the whole set, how many conform,
+and where are the gaps in the chain? This is the receiving side of the
+evidence, and it needs no signing key either.
+
+Two things stack here. First, every record is conformance-checked on its
+own. Second, the set is checked for properties that only show up across
+records:
+
+* **Unique calls.** Each record pins the attestation it answers through
+  ``backLink``. Two records pinning the same ``(attestationDigest,
+  attestationNonce)`` mean the same call was recorded twice, a replay or
+  a double-write. Required: a set that double-counts a call is not a
+  faithful record of what happened.
+* **Outcome coverage.** A record whose status is ``executed`` but that
+  carries no ``resultCommitment`` is a gap: the action ran and left no
+  committed evidence of its result. Advisory, not malformed, but exactly
+  the hole a regulator looks for under EU AI Act Article 12.
+
+Set-level checks run only over records that individually conform, since
+the linkage fields of a malformed record cannot be trusted. The set
+conforms iff every record conforms and no required finding fired.
+
+Pure standard library; importable without the ``attestation`` extra.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from vaara.attestation._receipt_conformance import (
+    ADVISORY,
+    REQUIRED,
+    check_record_conformance,
+)
+
+SET_SCHEMA_NAME = "sep2828-execution-record-set"
+SET_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class RecordSetEntry:
+    """Per-record verdict inside a set."""
+
+    name: str
+    conforms: bool
+    required_failed: tuple[str, ...]
+    advisories: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "conforms": self.conforms,
+            "requiredFailed": list(self.required_failed),
+            "advisories": list(self.advisories),
+        }
+
+
+@dataclass(frozen=True)
+class SetFinding:
+    """A property that holds (or fails) across more than one record.
+
+    ``required`` findings gate set conformance; ``advisory`` findings are
+    reported as gaps but do not. ``records`` is sorted for a stable report.
+    """
+
+    id: str
+    severity: str
+    detail: str
+    records: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "severity": self.severity,
+            "detail": self.detail,
+            "records": list(self.records),
+        }
+
+
+@dataclass(frozen=True)
+class RecordSetReport:
+    """Outcome of checking a set of candidate records together."""
+
+    conforms: bool
+    total: int
+    conforming: int
+    entries: tuple[RecordSetEntry, ...]
+    findings: tuple[SetFinding, ...]
+    status_counts: dict[str, int]
+
+    @property
+    def required_findings(self) -> tuple[SetFinding, ...]:
+        return tuple(f for f in self.findings if f.severity == REQUIRED)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": SET_SCHEMA_NAME,
+            "schemaVersion": SET_SCHEMA_VERSION,
+            "conforms": self.conforms,
+            "total": self.total,
+            "conforming": self.conforming,
+            "statusCounts": dict(self.status_counts),
+            "findings": [f.to_dict() for f in self.findings],
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+
+def check_record_set(records: Sequence[tuple[str, Any]]) -> RecordSetReport:
+    """Check a set of ``(name, parsed_json)`` candidates together.
+
+    Each record is conformance-checked on its own; the set is then checked
+    for cross-record properties over the records that conform. Never raises
+    on a malformed record. The set conforms iff every record conforms and
+    no required-severity finding fired.
+    """
+    entries: list[RecordSetEntry] = []
+    conforming: list[tuple[str, Any]] = []
+
+    for name, doc in records:
+        report = check_record_conformance(doc)
+        entries.append(
+            RecordSetEntry(
+                name=name,
+                conforms=report.conforms,
+                required_failed=report.required_failed,
+                advisories=report.advisories,
+            )
+        )
+        if report.conforms:
+            conforming.append((name, doc))
+
+    findings = list(_unique_call_findings(conforming))
+    findings.extend(_outcome_coverage_findings(conforming))
+    findings.sort(key=lambda f: (f.id, f.records))
+
+    all_conform = all(e.conforms for e in entries)
+    no_required = not any(f.severity == REQUIRED for f in findings)
+
+    return RecordSetReport(
+        conforms=all_conform and no_required,
+        total=len(entries),
+        conforming=len(conforming),
+        entries=tuple(entries),
+        findings=tuple(findings),
+        status_counts=_status_counts(conforming),
+    )
+
+
+def _call_key(doc: Any) -> tuple[str, str]:
+    """The ``(attestationDigest, attestationNonce)`` a conforming record pins.
+
+    Safe to read only for records that already passed conformance, where
+    ``backLink`` is guaranteed to be an object with both string fields.
+    """
+    bl = doc["backLink"]
+    return bl["attestationDigest"], bl["attestationNonce"]
+
+
+def _unique_call_findings(conforming: Sequence[tuple[str, Any]]) -> list[SetFinding]:
+    by_call: dict[tuple[str, str], list[str]] = {}
+    for name, doc in conforming:
+        by_call.setdefault(_call_key(doc), []).append(name)
+    findings: list[SetFinding] = []
+    for (digest, nonce), names in by_call.items():
+        if len(names) > 1:
+            findings.append(
+                SetFinding(
+                    id="duplicate_call",
+                    severity=REQUIRED,
+                    detail=(
+                        f"{len(names)} records pin the same call "
+                        f"(attestationDigest {digest}, nonce {nonce}); "
+                        "a call MUST be recorded once"
+                    ),
+                    records=tuple(sorted(names)),
+                )
+            )
+    return findings
+
+
+def _outcome_coverage_findings(
+    conforming: Sequence[tuple[str, Any]],
+) -> list[SetFinding]:
+    uncovered = sorted(
+        name
+        for name, doc in conforming
+        if doc["outcomeDerived"].get("status") == "executed"
+        and doc["outcomeDerived"].get("resultCommitment") is None
+    )
+    if not uncovered:
+        return []
+    return [
+        SetFinding(
+            id="executed_without_result_commitment",
+            severity=ADVISORY,
+            detail=(
+                f"{len(uncovered)} executed records carry no resultCommitment; "
+                "an executed action SHOULD commit to its result"
+            ),
+            records=tuple(uncovered),
+        )
+    ]
+
+
+def _status_counts(conforming: Sequence[tuple[str, Any]]) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for _name, doc in conforming:
+        counter[doc["outcomeDerived"]["status"]] += 1
+    return dict(sorted(counter.items()))

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -51,6 +51,12 @@ from vaara.attestation._receipt_conformance import (
     ConformanceReport,
     check_record_conformance,
 )
+from vaara.attestation._record_set_conformance import (
+    RecordSetEntry,
+    RecordSetReport,
+    SetFinding,
+    check_record_set,
+)
 from vaara.attestation._receipt_emit import (
     emit_receipt,
     verify_receipt_signature,
@@ -114,6 +120,10 @@ __all__ = [
     "ConformanceCheck",
     "ConformanceReport",
     "check_record_conformance",
+    "RecordSetEntry",
+    "RecordSetReport",
+    "SetFinding",
+    "check_record_set",
     "DidDocumentCache",
     "EvidenceBundle",
     "ExecutionReceipt",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -112,6 +112,13 @@ Subcommands:
         checked too, still keyless. The neutral check a party runs on a
         record someone else produced. Exit 0 iff the record conforms.
 
+    vaara verify-records DIR [--glob '*.json'] [--json]
+        Conformance-check a whole directory of SEP-2828 records at once: the
+        receiving side an auditor works from. Reports how many conform, which
+        fail and why, and the cross-record gaps verify-record cannot see (a
+        call recorded twice, an executed action that committed no result).
+        Keyless. Exit 0 iff every record conforms and no required gap fired.
+
     vaara build-bundle (--receipt RECEIPT.json | --from-dir DIR) [piece flags]
             [--out BUNDLE.json]
         Assemble a complete evidence bundle on disk from the issuer's
@@ -1808,6 +1815,63 @@ def _record_back_link(attestation_path: str, doc: Any) -> dict[str, Any]:
                        else "record does not pin this attestation")}
 
 
+def _cmd_verify_records(args: argparse.Namespace) -> int:
+    """Conformance-check a whole directory of SEP-2828 records at once.
+
+    The receiving side of the evidence: an auditor points this at a pile of
+    records, possibly from more than one emitter, and gets the roll-up that
+    ``verify-record`` cannot give on its own. How many conform, which fail
+    and why, and the cross-record gaps: a call recorded twice, an executed
+    action that committed no result. Keyless, like ``verify-record``.
+    """
+    from vaara.attestation.receipt import check_record_set
+
+    directory = Path(args.directory).expanduser()
+    if not directory.is_dir():
+        print(f"vaara verify-records: not a directory: {directory}", file=sys.stderr)
+        return 2
+
+    paths = sorted(p for p in directory.glob(args.glob) if p.is_file())
+    if not paths:
+        print(f"vaara verify-records: no files matched {args.glob!r} in {directory}",
+              file=sys.stderr)
+        return 2
+
+    parsed: list[tuple[str, Any]] = []
+    unreadable: list[tuple[str, str]] = []
+    for path in paths:
+        try:
+            parsed.append((path.name, json.loads(path.read_text(encoding="utf-8"))))
+        except (json.JSONDecodeError, OSError) as exc:
+            unreadable.append((path.name, str(exc)))
+
+    report = check_record_set(parsed)
+    ok = report.conforms and not unreadable
+
+    if args.json:
+        out: dict[str, Any] = report.to_dict()
+        out["ok"] = ok
+        out["unreadable"] = [{"name": n, "error": e} for n, e in unreadable]
+        print(json.dumps(out, indent=2))
+    else:
+        verdict = "CONFORMS" if ok else "NON-CONFORMING"
+        print(f"record set: {verdict}  ({report.conforming}/{report.total} records conform)")
+        if report.status_counts:
+            tally = ", ".join(f"{s}: {n}" for s, n in report.status_counts.items())
+            print(f"  outcomes: {tally}")
+        for entry in report.entries:
+            if not entry.conforms:
+                print(f"  [FAIL] {entry.name}: {', '.join(entry.required_failed)}")
+        for finding in report.findings:
+            mark = "FAIL" if finding.severity == "required" else "warn"
+            print(f"  [{mark}] {finding.id}: {finding.detail}")
+            print(f"         {', '.join(finding.records)}")
+        for name, exc in unreadable:
+            print(f"  [FAIL] {name}: unreadable ({exc})")
+
+    return 0 if ok else 1
+
+
 def _cmd_build_bundle(args: argparse.Namespace) -> int:
     """Assemble an evidence bundle on disk from the issuer's pieces.
 
@@ -2668,6 +2732,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the full conformance report as JSON",
     )
     pvr.set_defaults(func=_cmd_verify_record)
+
+    pvrs = sub.add_parser(
+        "verify-records",
+        help="Conformance-check a whole directory of SEP-2828 records at once. "
+             "The receiving side of the evidence: how many conform, which fail, "
+             "and the cross-record gaps (a call recorded twice, an executed "
+             "action that committed no result). Keyless, like verify-record.",
+    )
+    pvrs.add_argument(
+        "directory",
+        help="Directory of JSON files, each claiming to be a SEP-2828 record",
+    )
+    pvrs.add_argument(
+        "--glob", default="*.json",
+        help="Glob for record files within the directory (default: *.json)",
+    )
+    pvrs.add_argument(
+        "--json", action="store_true",
+        help="Emit the full set conformance report as JSON",
+    )
+    pvrs.set_defaults(func=_cmd_verify_records)
 
     pbb = sub.add_parser(
         "build-bundle",

--- a/tests/test_record_set_conformance.py
+++ b/tests/test_record_set_conformance.py
@@ -1,0 +1,183 @@
+"""SEP-2828 set-level conformance and the `vaara verify-records` command.
+
+The receiving side of the evidence: an auditor points the tool at a
+directory of records, possibly from more than one emitter, and gets the
+roll-up that `verify-record` cannot give on its own. Like the per-record
+check, this is keyless, so the suite does NOT skip when the attestation
+extra is absent: the workbench runs in the base install.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vaara.attestation._record_set_conformance import (
+    SET_SCHEMA_NAME,
+    check_record_set,
+)
+from vaara.cli import main
+
+VECTORS = Path(__file__).resolve().parent / "vectors" / "record_set_v0"
+SETS = VECTORS / "sets"
+
+
+def _expected() -> dict:
+    return json.loads((VECTORS / "expected.json").read_text())
+
+
+def _cases():
+    return sorted(_expected().keys())
+
+
+def _load_set(name: str):
+    files = sorted((SETS / name).glob("*.json"))
+    return [(p.name, json.loads(p.read_text())) for p in files]
+
+
+# ── Vectors ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", _cases())
+def test_module_reproduces_vector_verdict(name):
+    want = _expected()[name]
+    report = check_record_set(_load_set(name))
+    got = {
+        "conforms": report.conforms,
+        "total": report.total,
+        "conforming": report.conforming,
+        "statusCounts": report.status_counts,
+        "findings": [
+            {"id": f.id, "severity": f.severity, "records": list(f.records)}
+            for f in report.findings
+        ],
+    }
+    assert got == want
+
+
+def test_independent_checker_passes():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_at_least_four_cases_present():
+    assert len(_cases()) >= 4
+
+
+def test_public_reexport_is_wired():
+    from vaara.attestation.receipt import check_record_set as public
+    assert public is check_record_set
+
+
+# ── Unit behaviour ────────────────────────────────────────────────────────────
+
+
+def test_duplicate_call_is_required_and_gates():
+    report = check_record_set(_load_set("duplicate_call"))
+    assert not report.conforms
+    ids = [f.id for f in report.required_findings]
+    assert "duplicate_call" in ids
+
+
+def test_executed_gap_is_advisory_and_does_not_gate():
+    report = check_record_set(_load_set("executed_gap"))
+    assert report.conforms
+    advisory = [f for f in report.findings if f.severity == "advisory"]
+    assert [f.id for f in advisory] == ["executed_without_result_commitment"]
+    assert report.required_findings == ()
+
+
+def test_malformed_record_gates_but_does_not_raise():
+    report = check_record_set(_load_set("mixed_nonconforming"))
+    assert not report.conforms
+    assert report.conforming == 1
+    # Cross-record reasoning ran only over the one conforming record, so no
+    # set-level finding fired off the malformed one.
+    assert report.findings == ()
+
+
+def test_set_findings_run_only_over_conforming_records():
+    # A malformed duplicate of a conforming record must NOT raise a
+    # duplicate_call finding: the malformed one is excluded from linkage.
+    doc = _load_set("clean")[0][1]
+    broken = dict(doc)
+    broken["version"] = 99  # malformed: fails per-record conformance
+    report = check_record_set([("good.json", doc), ("broken.json", broken)])
+    assert not report.conforms  # broken record gates
+    assert report.findings == ()  # but no spurious duplicate_call
+
+
+def test_empty_set_conforms_vacuously():
+    report = check_record_set([])
+    assert report.conforms
+    assert report.total == 0
+    assert report.findings == ()
+
+
+def test_report_to_dict_shape():
+    d = check_record_set(_load_set("clean")).to_dict()
+    assert d["schema"] == SET_SCHEMA_NAME
+    assert d["conforms"] is True
+    assert d["total"] == 2
+    assert d["statusCounts"] == {"executed": 1, "refused": 1}
+    assert d["findings"] == []
+    assert all({"name", "conforms"} <= set(e) for e in d["entries"])
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def test_cli_clean_set_exit_0(capsys):
+    rc = main(["verify-records", str(SETS / "clean")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "CONFORMS" in out
+    assert "executed: 1" in out
+
+
+def test_cli_duplicate_set_exit_1(capsys):
+    rc = main(["verify-records", str(SETS / "duplicate_call")])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "NON-CONFORMING" in out
+    assert "duplicate_call" in out
+
+
+def test_cli_json_output(capsys):
+    rc = main(["verify-records", str(SETS / "executed_gap"), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["schema"] == SET_SCHEMA_NAME
+    assert payload["unreadable"] == []
+    assert payload["findings"][0]["id"] == "executed_without_result_commitment"
+
+
+def test_cli_unreadable_file_gates(tmp_path, capsys):
+    (tmp_path / "good.json").write_text(
+        (SETS / "clean" / "r1.json").read_text()
+    )
+    (tmp_path / "bad.json").write_text("{ not json")
+    rc = main(["verify-records", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "unreadable" in out
+
+
+def test_cli_not_a_directory(tmp_path, capsys):
+    rc = main(["verify-records", str(tmp_path / "nope")])
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_cli_empty_directory(tmp_path, capsys):
+    rc = main(["verify-records", str(tmp_path)])
+    assert rc == 2
+    assert "no files matched" in capsys.readouterr().err

--- a/tests/vectors/record_set_v0/README.md
+++ b/tests/vectors/record_set_v0/README.md
@@ -1,0 +1,48 @@
+# Record-set conformance vectors, v0
+
+Fixtures for the set-level conformance check on a directory of SEP-2828
+execution records: the receiving side an auditor works from. Where
+`record_conformance_v0` asks "is this one record well-formed", these
+vectors ask the question that only shows up across a pile of records,
+possibly from more than one emitter: how many conform, and where are the
+gaps in the chain? Like the per-record check, this needs no signing key.
+
+Two properties stack on top of per-record conformance:
+
+- **Unique calls** (required). Each record pins the attestation it
+  answers through `backLink`. Two records pinning the same
+  `(attestationDigest, attestationNonce)` recorded the same call twice, a
+  replay or a double-write. A set that double-counts a call is not a
+  faithful record, so this gates set conformance.
+- **Outcome coverage** (advisory). An `executed` record carrying no
+  `resultCommitment` is a gap: the action ran and left no committed
+  evidence of its result. Reported, not gating, but exactly the hole a
+  regulator looks for under EU AI Act Article 12.
+
+Set-level checks run only over records that individually conform, since
+the linkage fields of a malformed record cannot be trusted. A set
+conforms iff every record conforms and no required finding fired.
+
+## Layout
+
+```
+sets/<case>/*.json     a directory of candidate records (one set)
+expected.json          {case: {conforms, total, conforming,
+                                statusCounts, findings[]}}
+_check_independent.py   stdlib only (hashlib + re + json), no Vaara import
+```
+
+Each `findings` entry is `{id, severity, records}` with `records` sorted,
+so a case is order-independent.
+
+## Cases
+
+- `clean` — two conforming records, distinct calls, no findings.
+- `duplicate_call` — two conforming records pinning the same call; one
+  required `duplicate_call` finding, set does not conform.
+- `executed_gap` — two executed records, one without a result commitment;
+  one advisory `executed_without_result_commitment` finding, set still
+  conforms (advisory does not gate).
+- `mixed_nonconforming` — one conforming record and one malformed; set
+  does not conform because a record does not, and cross-record reasoning
+  runs only over the conforming one.

--- a/tests/vectors/record_set_v0/_check_independent.py
+++ b/tests/vectors/record_set_v0/_check_independent.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Independent set-conformance checker for the v0 record-set vectors.
+
+A second implementation of the SEP-2828 set-level rules, written from the
+schema alone with only the standard library. It does not import Vaara. For
+each committed set it reproduces the aggregate verdict, the conform count,
+the status tally, and the cross-record findings, then compares against
+``expected.json``.
+
+The receiving side of the evidence has to be checkable by a neutral party
+with no shared code: not just "is each record well-formed" but "is the set
+faithful" (no call recorded twice) and "is it complete" (no executed action
+left without a committed result). This file demonstrates that both fall out
+of the records alone, with nothing but a hash function and the schema.
+
+Run: ``python tests/vectors/record_set_v0/_check_independent.py``.
+Exit 0 means every set matched its expected verdict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+VALID_ALGS = {"HS256", "ES256", "RS256"}
+VALID_STATUSES = {"executed", "refused", "errored"}
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+HEX_RE = re.compile(r"^[0-9a-f]+$")
+
+
+def conforms(doc) -> bool:
+    """Minimal per-record conformance: enough to gate set-level reasoning."""
+    if not isinstance(doc, dict):
+        return False
+    if doc.get("version") != 1:
+        return False
+    alg = doc.get("alg")
+    if alg not in VALID_ALGS:
+        return False
+    sig = doc.get("signature")
+    if not (isinstance(sig, str) and HEX_RE.match(sig) and len(sig) % 2 == 0):
+        return False
+    bl = doc.get("backLink")
+    if not isinstance(bl, dict):
+        return False
+    if not (isinstance(bl.get("attestationDigest"), str)
+            and DIGEST_RE.match(bl["attestationDigest"])):
+        return False
+    if not isinstance(bl.get("attestationNonce"), str):
+        return False
+    ra = doc.get("receiptAsserted")
+    if not isinstance(ra, dict):
+        return False
+    if any(f not in ra for f in ("alg", "iat", "iss", "nonce", "secretVersion", "sub")):
+        return False
+    if ra.get("alg") != alg:
+        return False
+    od = doc.get("outcomeDerived")
+    if not isinstance(od, dict):
+        return False
+    if od.get("status") not in VALID_STATUSES:
+        return False
+    if not isinstance(od.get("completedAt"), str):
+        return False
+    rc = od.get("resultCommitment")
+    if isinstance(rc, dict) and "projection" in rc:
+        proj, pdg = rc.get("projection"), rc.get("projectionDigest")
+        if not (isinstance(proj, str) and isinstance(pdg, str)):
+            return False
+        if "sha256:" + hashlib.sha256(proj.encode("utf-8")).hexdigest() != pdg:
+            return False
+    return True
+
+
+def check_set(records):
+    """Reproduce the set verdict from (name, doc) pairs."""
+    conforming = [(n, d) for n, d in records if conforms(d)]
+    findings = []
+
+    by_call = {}
+    for name, doc in conforming:
+        bl = doc["backLink"]
+        by_call.setdefault((bl["attestationDigest"], bl["attestationNonce"]), []).append(name)
+    for names in by_call.values():
+        if len(names) > 1:
+            findings.append({"id": "duplicate_call", "severity": "required",
+                             "records": sorted(names)})
+
+    gap = sorted(n for n, d in conforming
+                 if d["outcomeDerived"].get("status") == "executed"
+                 and d["outcomeDerived"].get("resultCommitment") is None)
+    if gap:
+        findings.append({"id": "executed_without_result_commitment",
+                         "severity": "advisory", "records": gap})
+
+    findings.sort(key=lambda f: (f["id"], f["records"]))
+
+    counts = {}
+    for _n, d in conforming:
+        counts[d["outcomeDerived"]["status"]] = counts.get(d["outcomeDerived"]["status"], 0) + 1
+
+    all_conform = len(conforming) == len(records)
+    no_required = not any(f["severity"] == "required" for f in findings)
+    return {
+        "conforms": all_conform and no_required,
+        "total": len(records),
+        "conforming": len(conforming),
+        "statusCounts": dict(sorted(counts.items())),
+        "findings": findings,
+    }
+
+
+def main() -> int:
+    expected = json.loads((HERE / "expected.json").read_text())
+    failures = 0
+    for name in sorted(expected):
+        files = sorted((HERE / "sets" / name).glob("*.json"))
+        records = [(p.name, json.loads(p.read_text())) for p in files]
+        got = check_set(records)
+        ok = got == expected[name]
+        failures += 0 if ok else 1
+        print(f"[{'OK' if ok else 'FAIL'}] {name}: {got['conforming']}/{got['total']} conform")
+        if not ok:
+            print("  want:", expected[name])
+            print("  got :", got)
+    print(f"\n{len(expected) - failures}/{len(expected)} sets matched expected.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/record_set_v0/expected.json
+++ b/tests/vectors/record_set_v0/expected.json
@@ -1,0 +1,34 @@
+{
+  "clean": {
+    "conforms": true,
+    "total": 2,
+    "conforming": 2,
+    "statusCounts": {"executed": 1, "refused": 1},
+    "findings": []
+  },
+  "duplicate_call": {
+    "conforms": false,
+    "total": 2,
+    "conforming": 2,
+    "statusCounts": {"executed": 1, "refused": 1},
+    "findings": [
+      {"id": "duplicate_call", "severity": "required", "records": ["r1.json", "r2.json"]}
+    ]
+  },
+  "executed_gap": {
+    "conforms": true,
+    "total": 2,
+    "conforming": 2,
+    "statusCounts": {"executed": 2},
+    "findings": [
+      {"id": "executed_without_result_commitment", "severity": "advisory", "records": ["r1.json"]}
+    ]
+  },
+  "mixed_nonconforming": {
+    "conforms": false,
+    "total": 2,
+    "conforming": 1,
+    "statusCounts": {"executed": 1},
+    "findings": []
+  }
+}

--- a/tests/vectors/record_set_v0/sets/clean/r1.json
+++ b/tests/vectors/record_set_v0/sets/clean/r1.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd",
+    "attestationNonce": "nonce-A"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"ok\":true}",
+      "projectionDigest": "sha256:4062edaf750fb8074e7e83e0c9028c94e32468a8b6f1614774328ef045150f93"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-A",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/clean/r2.json
+++ b/tests/vectors/record_set_v0/sets/clean/r2.json
@@ -1,0 +1,21 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c",
+    "attestationNonce": "nonce-B"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "status": "refused"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-B",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/duplicate_call/r1.json
+++ b/tests/vectors/record_set_v0/sets/duplicate_call/r1.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:6b23c0d5f35d1b11f9b683f0b0a617355deb11277d91ae091d399c655b87940d",
+    "attestationNonce": "nonce-C"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"ok\":true}",
+      "projectionDigest": "sha256:4062edaf750fb8074e7e83e0c9028c94e32468a8b6f1614774328ef045150f93"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-C",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/duplicate_call/r2.json
+++ b/tests/vectors/record_set_v0/sets/duplicate_call/r2.json
@@ -1,0 +1,21 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:6b23c0d5f35d1b11f9b683f0b0a617355deb11277d91ae091d399c655b87940d",
+    "attestationNonce": "nonce-C"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "status": "refused"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-C",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/executed_gap/r1.json
+++ b/tests/vectors/record_set_v0/sets/executed_gap/r1.json
@@ -1,0 +1,21 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:3f39d5c348e5b79d06e842c114e6cc571583bbf44e4b0ebfda1a01ec05745d43",
+    "attestationNonce": "nonce-D"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-D",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/executed_gap/r2.json
+++ b/tests/vectors/record_set_v0/sets/executed_gap/r2.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:a9f51566bd6705f7ea6ad54bb9deb449f795582d6529a0e22207b8981233ec58",
+    "attestationNonce": "nonce-E"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"done\":1}",
+      "projectionDigest": "sha256:365f5f94b674aa7451be3cf564e930141fc2156f97a6a2ec4364b63ccf8c32d8"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-E",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/mixed_nonconforming/bad.json
+++ b/tests/vectors/record_set_v0/sets/mixed_nonconforming/bad.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:f67ab10ad4e4c53121b6a5fe4da9c10ddee905b978d3788d2723d7bfacbe28a9",
+    "attestationNonce": "nonce-F"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"x\":1}",
+      "projectionDigest": "sha256:5041bf1f713df204784353e82f6a4a535931cb64f1f4b4a5aeaffcb720918b22"
+    },
+    "status": "frobnicated"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-F",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/mixed_nonconforming/good.json
+++ b/tests/vectors/record_set_v0/sets/mixed_nonconforming/good.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:f67ab10ad4e4c53121b6a5fe4da9c10ddee905b978d3788d2723d7bfacbe28a9",
+    "attestationNonce": "nonce-F"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"ok\":true}",
+      "projectionDigest": "sha256:4062edaf750fb8074e7e83e0c9028c94e32468a8b6f1614774328ef045150f93"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-F",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}


### PR DESCRIPTION
The receiving side of the evidence: the auditor's workbench. `verify-record` checks one record; `vaara verify-records DIR` checks a whole pile, possibly from more than one emitter, and reports how many conform plus the cross-record gaps a single-record check cannot see.

- **duplicate_call** (required): two records pinning the same call (attestationDigest + nonce) recorded it twice; gates set conformance.
- **executed_without_result_commitment** (advisory): an executed action that committed no result, the Article 12 hole.

Keyless, base install (no attestation extra). New pure-stdlib `_record_set_conformance.py`, the `verify-records` command, and `record_set_v0` vectors with a Vaara-free second implementation that reproduces every verdict from the schema alone. 19 tests, full suite 1356 passing, ruff + mypy --strict clean.

Purely additive. No version bump or tag (release stays a separate call). Multi-emitter input works today: the checker never imports a producer.