### PR TITLE
feat: verify-records coverage critic (decision/outcome pairing), A2

### DIFF
--- a/src/vaara/attestation/_decision_conformance.py
+++ b/src/vaara/attestation/_decision_conformance.py
@@ -1,0 +1,136 @@
+"""Producer-agnostic conformance check for SEP-2828 decision records.
+
+The sibling of ``_receipt_conformance``. A decision record is the
+*before* half of an execution record: the governing server's verdict
+(``allow`` / ``block`` / ``escalate``) and the basis for it, pinned to the
+same SEP-2787 attestation the outcome record answers. This checks that a
+candidate is a well-formed decision record, with no signing key and no
+matching attestation, so a neutral party can judge a record someone else
+produced.
+
+Like the receipt check it covers the wire schema only: required fields,
+types, supported ``alg``, valid verdict, ``sha256:<hex>`` digest format,
+and that ``issuerAsserted.alg`` matches the envelope ``alg``. The
+signature and the back-link to a held attestation are out of scope here;
+they need external material and live in the decision verifier.
+
+Pure standard library; importable without the ``attestation`` extra, so
+it runs in the base install beside ``verify-records``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from vaara.attestation._receipt_conformance import (
+    ADVISORY,
+    REQUIRED,
+    _DIGEST_RE,
+    _HEX_RE,
+    _SIG_HEX_LEN,
+    VALID_ALGS,
+    ConformanceCheck,
+    ConformanceReport,
+)
+
+VALID_VERDICTS: frozenset[str] = frozenset({"allow", "block", "escalate"})
+
+DECISION_SCHEMA_NAME = "sep2828-decision-record"
+
+# Risk-basis fields are decimal strings on the wire (floats are banned at
+# the JCS boundary). When present they SHOULD be strings.
+_RISK_FIELDS = ("riskScore", "thresholdAllow", "thresholdBlock")
+
+
+def check_decision_conformance(doc: Any) -> ConformanceReport:
+    """Check a parsed JSON value against the SEP-2828 decision-record schema.
+
+    Returns a report listing every applicable check; never raises on a
+    malformed record. ``conforms`` is true iff every applicable
+    ``required`` check passed. The report's ``status`` slot carries the
+    decision verdict (the salient enum), mirroring the receipt report.
+    """
+    checks: list[ConformanceCheck] = []
+
+    def add(check_id: str, ok: bool, severity: str, detail: str) -> None:
+        checks.append(ConformanceCheck(check_id, ok, severity, detail))
+
+    def finish(alg: Any, verdict: Any) -> ConformanceReport:
+        conforms = all(c.ok for c in checks if c.severity == REQUIRED)
+        return ConformanceReport(
+            conforms=conforms,
+            checks=tuple(checks),
+            alg=alg if isinstance(alg, str) else None,
+            status=verdict if isinstance(verdict, str) else None,
+        )
+
+    if not isinstance(doc, dict):
+        add("top_level_object", False, REQUIRED, "record MUST be a JSON object")
+        return finish(None, None)
+    add("top_level_object", True, REQUIRED, "record is a JSON object")
+
+    version = doc.get("version")
+    add("version", version == 1, REQUIRED, f"version MUST be 1; got {version!r}")
+
+    alg = doc.get("alg")
+    add("alg_supported", alg in VALID_ALGS, REQUIRED,
+        f"alg MUST be one of {sorted(VALID_ALGS)}; got {alg!r}")
+
+    sig = doc.get("signature")
+    sig_hex = isinstance(sig, str) and bool(_HEX_RE.match(sig)) and len(sig) % 2 == 0
+    add("signature_hex", sig_hex, REQUIRED,
+        "signature MUST be an even-length lowercase hex string")
+    if sig_hex and isinstance(sig, str) and isinstance(alg, str) and alg in _SIG_HEX_LEN:
+        want = _SIG_HEX_LEN[alg]
+        add("signature_length", len(sig) == want, ADVISORY,
+            f"{alg} signature SHOULD be {want} hex chars; got {len(sig)}")
+
+    _check_back_link(doc.get("backLink"), add)
+
+    ia = doc.get("issuerAsserted")
+    if not isinstance(ia, dict):
+        add("issuer_asserted_present", False, REQUIRED,
+            "issuerAsserted MUST be an object")
+    else:
+        ia_fields = ("alg", "iat", "iss", "nonce", "secretVersion", "sub")
+        missing = [f for f in ia_fields if f not in ia]
+        add("issuer_asserted_present", not missing, REQUIRED,
+            f"issuerAsserted MUST carry {list(ia_fields)}; missing {missing}")
+        add("issuer_asserted_alg_matches", ia.get("alg") == alg, REQUIRED,
+            "issuerAsserted.alg MUST equal the top-level alg")
+
+    verdict = _check_decision_derived(doc.get("decisionDerived"), add)
+    return finish(alg, verdict)
+
+
+def _check_back_link(bl: Any, add: Any) -> None:
+    if not isinstance(bl, dict):
+        add("back_link_present", False, REQUIRED, "backLink MUST be an object")
+        return
+    add("back_link_present",
+        "attestationDigest" in bl and "attestationNonce" in bl, REQUIRED,
+        "backLink MUST carry attestationDigest and attestationNonce")
+    ad = bl.get("attestationDigest")
+    add("back_link_digest_format",
+        isinstance(ad, str) and bool(_DIGEST_RE.match(ad)), REQUIRED,
+        "backLink.attestationDigest MUST be 'sha256:<64 lowercase hex>'")
+    add("back_link_nonce_type", isinstance(bl.get("attestationNonce"), str),
+        REQUIRED, "backLink.attestationNonce MUST be a string")
+
+
+def _check_decision_derived(dd: Any, add: Any) -> Optional[str]:
+    if not isinstance(dd, dict):
+        add("decision_present", False, REQUIRED, "decisionDerived MUST be an object")
+        return None
+    verdict = dd.get("decision")
+    add("decision_present", "decision" in dd and "decidedAt" in dd, REQUIRED,
+        "decisionDerived MUST carry decision and decidedAt")
+    add("decision_valid", verdict in VALID_VERDICTS, REQUIRED,
+        f"decision MUST be one of {sorted(VALID_VERDICTS)}; got {verdict!r}")
+    add("decided_at_type", isinstance(dd.get("decidedAt"), str), REQUIRED,
+        "decisionDerived.decidedAt MUST be a string")
+    for field in _RISK_FIELDS:
+        if field in dd:
+            add(f"{field}_is_string", isinstance(dd[field], str), ADVISORY,
+                f"decisionDerived.{field} SHOULD be a decimal string, not a number")
+    return verdict if isinstance(verdict, str) else None

--- a/src/vaara/attestation/_record_set_conformance.py
+++ b/src/vaara/attestation/_record_set_conformance.py
@@ -1,4 +1,4 @@
-"""Set-level conformance for a pile of SEP-2828 execution records.
+"""Set-level conformance for a pile of SEP-2828 records.
 
 ``check_record_conformance`` answers a question about one record. An
 auditor who receives a directory of records, possibly from more than one
@@ -6,23 +6,29 @@ emitter, asks a different question: over the whole set, how many conform,
 and where are the gaps in the chain? This is the receiving side of the
 evidence, and it needs no signing key either.
 
-Two things stack here. First, every record is conformance-checked on its
-own. Second, the set is checked for properties that only show up across
-records:
+A set is not all one shape. SEP-2828 carries two record types that pair:
+a **decision** record (``decisionDerived``: allow / block / escalate,
+before the act) and an **outcome** record (``outcomeDerived``: executed /
+refused / errored, after). Each is classified by which derived block it
+carries and checked against its own schema; a record carrying neither (or
+both) is an unknown shape and fails. The shared ``backLink`` pairs the two
+with no signing key.
 
-* **Unique calls.** Each record pins the attestation it answers through
-  ``backLink``. Two records pinning the same ``(attestationDigest,
-  attestationNonce)`` mean the same call was recorded twice, a replay or
-  a double-write. Required: a set that double-counts a call is not a
-  faithful record of what happened.
-* **Outcome coverage.** A record whose status is ``executed`` but that
-  carries no ``resultCommitment`` is a gap: the action ran and left no
-  committed evidence of its result. Advisory, not malformed, but exactly
-  the hole a regulator looks for under EU AI Act Article 12.
+Cross-record properties stack on top of the per-record checks:
 
-Set-level checks run only over records that individually conform, since
-the linkage fields of a malformed record cannot be trusted. The set
-conforms iff every record conforms and no required finding fired.
+* **Unique calls** (required). Two *outcome* records pinning the same
+  call recorded it twice, a replay or double-write. A decision and an
+  outcome on one call are the expected *pair*, so this looks at outcomes.
+* **Pairing coverage** (advisory). In a set holding both kinds, an
+  allow/escalate decision with no matching outcome, or an outcome with no
+  matching decision: was every authorised action recorded, and was every
+  recorded action authorised?
+* **Outcome coverage** (advisory). An ``executed`` outcome with no
+  ``resultCommitment``: the Article 12 hole.
+
+Cross-record checks run only over records that individually conform. The
+set conforms iff every record conforms and no required finding fired; the
+advisory gaps are reported but do not gate.
 
 Pure standard library; importable without the ``attestation`` extra.
 """
@@ -31,16 +37,24 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Literal, Sequence
 
+from vaara.attestation._decision_conformance import check_decision_conformance
 from vaara.attestation._receipt_conformance import (
-    ADVISORY,
     REQUIRED,
     check_record_conformance,
+)
+from vaara.attestation._record_set_findings import (
+    SetFinding,
+    duplicate_outcome_findings,
+    outcome_coverage_findings,
+    pairing_findings,
 )
 
 SET_SCHEMA_NAME = "sep2828-execution-record-set"
 SET_SCHEMA_VERSION = 1
+
+RecordKind = Literal["decision", "outcome", "unknown"]
 
 
 @dataclass(frozen=True)
@@ -48,6 +62,7 @@ class RecordSetEntry:
     """Per-record verdict inside a set."""
 
     name: str
+    kind: RecordKind
     conforms: bool
     required_failed: tuple[str, ...]
     advisories: tuple[str, ...]
@@ -55,31 +70,10 @@ class RecordSetEntry:
     def to_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,
+            "kind": self.kind,
             "conforms": self.conforms,
             "requiredFailed": list(self.required_failed),
             "advisories": list(self.advisories),
-        }
-
-
-@dataclass(frozen=True)
-class SetFinding:
-    """A property that holds (or fails) across more than one record.
-
-    ``required`` findings gate set conformance; ``advisory`` findings are
-    reported as gaps but do not. ``records`` is sorted for a stable report.
-    """
-
-    id: str
-    severity: str
-    detail: str
-    records: tuple[str, ...]
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "id": self.id,
-            "severity": self.severity,
-            "detail": self.detail,
-            "records": list(self.records),
         }
 
 
@@ -93,6 +87,7 @@ class RecordSetReport:
     entries: tuple[RecordSetEntry, ...]
     findings: tuple[SetFinding, ...]
     status_counts: dict[str, int]
+    verdict_counts: dict[str, int]
 
     @property
     def required_findings(self) -> tuple[SetFinding, ...]:
@@ -106,37 +101,74 @@ class RecordSetReport:
             "total": self.total,
             "conforming": self.conforming,
             "statusCounts": dict(self.status_counts),
+            "verdictCounts": dict(self.verdict_counts),
             "findings": [f.to_dict() for f in self.findings],
             "entries": [e.to_dict() for e in self.entries],
         }
 
 
+def classify_record(doc: Any) -> RecordKind:
+    """Sort a candidate into ``decision`` / ``outcome`` / ``unknown``.
+
+    A SEP-2828 record carries exactly one derived block: ``decisionDerived``
+    for the verdict before the act, ``outcomeDerived`` for what happened
+    after. A record carrying neither, or both, is an unknown shape that no
+    per-type schema can judge, so it cannot conform.
+    """
+    if not isinstance(doc, dict):
+        return "unknown"
+    has_decision = isinstance(doc.get("decisionDerived"), dict)
+    has_outcome = isinstance(doc.get("outcomeDerived"), dict)
+    if has_decision and not has_outcome:
+        return "decision"
+    if has_outcome and not has_decision:
+        return "outcome"
+    return "unknown"
+
+
 def check_record_set(records: Sequence[tuple[str, Any]]) -> RecordSetReport:
     """Check a set of ``(name, parsed_json)`` candidates together.
 
-    Each record is conformance-checked on its own; the set is then checked
-    for cross-record properties over the records that conform. Never raises
-    on a malformed record. The set conforms iff every record conforms and
-    no required-severity finding fired.
+    Each record is classified and conformance-checked against its own
+    type's schema; the set is then checked for cross-record properties over
+    the records that conform. Never raises on a malformed record. The set
+    conforms iff every record conforms and no required-severity finding
+    fired (the advisory pairing gaps are reported, not gating).
     """
     entries: list[RecordSetEntry] = []
-    conforming: list[tuple[str, Any]] = []
+    decisions: list[tuple[str, Any]] = []
+    outcomes: list[tuple[str, Any]] = []
 
     for name, doc in records:
-        report = check_record_conformance(doc)
+        kind = classify_record(doc)
+        if kind == "decision":
+            report = check_decision_conformance(doc)
+        elif kind == "outcome":
+            report = check_record_conformance(doc)
+        else:
+            entries.append(RecordSetEntry(name, "unknown", False, ("record_type",), ()))
+            continue
+
         entries.append(
             RecordSetEntry(
                 name=name,
+                kind=kind,
                 conforms=report.conforms,
                 required_failed=report.required_failed,
                 advisories=report.advisories,
             )
         )
         if report.conforms:
-            conforming.append((name, doc))
+            (decisions if kind == "decision" else outcomes).append((name, doc))
 
-    findings = list(_unique_call_findings(conforming))
-    findings.extend(_outcome_coverage_findings(conforming))
+    findings: list[SetFinding] = []
+    findings.extend(duplicate_outcome_findings(outcomes))
+    # Pairing is meaningful only when the set holds both kinds; a set of
+    # outcomes alone (or decisions alone) has nothing to pair against, and
+    # flagging every record as unpaired would be noise, not a gap.
+    if decisions and outcomes:
+        findings.extend(pairing_findings(decisions, outcomes))
+    findings.extend(outcome_coverage_findings(outcomes))
     findings.sort(key=lambda f: (f.id, f.records))
 
     all_conform = all(e.conforms for e in entries)
@@ -145,71 +177,23 @@ def check_record_set(records: Sequence[tuple[str, Any]]) -> RecordSetReport:
     return RecordSetReport(
         conforms=all_conform and no_required,
         total=len(entries),
-        conforming=len(conforming),
+        conforming=len(decisions) + len(outcomes),
         entries=tuple(entries),
         findings=tuple(findings),
-        status_counts=_status_counts(conforming),
+        status_counts=_status_counts(outcomes),
+        verdict_counts=_verdict_counts(decisions),
     )
 
 
-def _call_key(doc: Any) -> tuple[str, str]:
-    """The ``(attestationDigest, attestationNonce)`` a conforming record pins.
-
-    Safe to read only for records that already passed conformance, where
-    ``backLink`` is guaranteed to be an object with both string fields.
-    """
-    bl = doc["backLink"]
-    return bl["attestationDigest"], bl["attestationNonce"]
-
-
-def _unique_call_findings(conforming: Sequence[tuple[str, Any]]) -> list[SetFinding]:
-    by_call: dict[tuple[str, str], list[str]] = {}
-    for name, doc in conforming:
-        by_call.setdefault(_call_key(doc), []).append(name)
-    findings: list[SetFinding] = []
-    for (digest, nonce), names in by_call.items():
-        if len(names) > 1:
-            findings.append(
-                SetFinding(
-                    id="duplicate_call",
-                    severity=REQUIRED,
-                    detail=(
-                        f"{len(names)} records pin the same call "
-                        f"(attestationDigest {digest}, nonce {nonce}); "
-                        "a call MUST be recorded once"
-                    ),
-                    records=tuple(sorted(names)),
-                )
-            )
-    return findings
-
-
-def _outcome_coverage_findings(
-    conforming: Sequence[tuple[str, Any]],
-) -> list[SetFinding]:
-    uncovered = sorted(
-        name
-        for name, doc in conforming
-        if doc["outcomeDerived"].get("status") == "executed"
-        and doc["outcomeDerived"].get("resultCommitment") is None
-    )
-    if not uncovered:
-        return []
-    return [
-        SetFinding(
-            id="executed_without_result_commitment",
-            severity=ADVISORY,
-            detail=(
-                f"{len(uncovered)} executed records carry no resultCommitment; "
-                "an executed action SHOULD commit to its result"
-            ),
-            records=tuple(uncovered),
-        )
-    ]
-
-
-def _status_counts(conforming: Sequence[tuple[str, Any]]) -> dict[str, int]:
+def _status_counts(outcomes: Sequence[tuple[str, Any]]) -> dict[str, int]:
     counter: Counter[str] = Counter()
-    for _name, doc in conforming:
+    for _name, doc in outcomes:
         counter[doc["outcomeDerived"]["status"]] += 1
+    return dict(sorted(counter.items()))
+
+
+def _verdict_counts(decisions: Sequence[tuple[str, Any]]) -> dict[str, int]:
+    counter: Counter[str] = Counter()
+    for _name, doc in decisions:
+        counter[doc["decisionDerived"]["decision"]] += 1
     return dict(sorted(counter.items()))

--- a/src/vaara/attestation/_record_set_findings.py
+++ b/src/vaara/attestation/_record_set_findings.py
@@ -1,0 +1,140 @@
+"""Cross-record findings for a set of SEP-2828 records.
+
+The properties that only show up across records, factored out of
+``_record_set_conformance`` so each stays under one screen. Every
+function takes already-conforming records (the linkage fields of a
+malformed record cannot be trusted) and returns ``SetFinding`` rows.
+
+Two record types pair here. A decision record (``decisionDerived``:
+allow / block / escalate, before the act) and an outcome record
+(``outcomeDerived``: executed / refused / errored, after) for the same
+call share the same ``backLink``. That shared key is what lets an auditor
+ask the completeness question with no signing key: was every authorised
+action recorded, and was every recorded action authorised?
+
+Pure standard library.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+from vaara.attestation._receipt_conformance import ADVISORY, REQUIRED
+
+# Verdicts that authorise the call to proceed, so a missing outcome is a
+# real gap. A ``block`` decision legitimately has no outcome.
+_ACTING_VERDICTS = frozenset({"allow", "escalate"})
+
+
+@dataclass(frozen=True)
+class SetFinding:
+    """A property that holds (or fails) across more than one record.
+
+    ``required`` findings gate set conformance; ``advisory`` findings are
+    reported as gaps but do not. ``records`` is sorted for a stable report.
+    """
+
+    id: str
+    severity: str
+    detail: str
+    records: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "severity": self.severity,
+            "detail": self.detail,
+            "records": list(self.records),
+        }
+
+
+def call_key(doc: Any) -> tuple[str, str]:
+    """The ``(attestationDigest, attestationNonce)`` a conforming record pins.
+
+    Safe to read only for records that already passed conformance, where
+    ``backLink`` is an object with both string fields. Both decision and
+    outcome records carry it, which is what makes them pairable.
+    """
+    bl = doc["backLink"]
+    return bl["attestationDigest"], bl["attestationNonce"]
+
+
+def _by_call(records: Sequence[tuple[str, Any]]) -> dict[tuple[str, str], list[str]]:
+    out: dict[tuple[str, str], list[str]] = {}
+    for name, doc in records:
+        out.setdefault(call_key(doc), []).append(name)
+    return out
+
+
+def duplicate_outcome_findings(outcomes: Sequence[tuple[str, Any]]) -> list[SetFinding]:
+    """An executed/refused outcome recorded twice for one call: a replay or double-write."""
+    findings: list[SetFinding] = []
+    for (digest, nonce), names in _by_call(outcomes).items():
+        if len(names) > 1:
+            findings.append(SetFinding(
+                "duplicate_call", REQUIRED,
+                f"{len(names)} outcome records pin the same call "
+                f"(attestationDigest {digest}, nonce {nonce}); "
+                "a call MUST be recorded once",
+                tuple(sorted(names)),
+            ))
+    return findings
+
+
+def pairing_findings(
+    decisions: Sequence[tuple[str, Any]],
+    outcomes: Sequence[tuple[str, Any]],
+) -> list[SetFinding]:
+    """The completeness gaps: an authorised act with no outcome, an act with no decision."""
+    decision_calls = _by_call(decisions)
+    outcome_calls = _by_call(outcomes)
+
+    acting = {
+        key: names for key, names in decision_calls.items()
+        if any(_verdict(d) in _ACTING_VERDICTS for n, d in decisions if call_key(d) == key)
+    }
+    no_outcome = sorted(
+        n for key, names in acting.items() if key not in outcome_calls for n in names
+    )
+    no_decision = sorted(
+        n for key, names in outcome_calls.items() if key not in decision_calls for n in names
+    )
+
+    findings: list[SetFinding] = []
+    if no_outcome:
+        findings.append(SetFinding(
+            "decision_without_outcome", ADVISORY,
+            f"{len(no_outcome)} allow/escalate decisions have no matching outcome "
+            "record; an authorised action SHOULD leave a recorded outcome",
+            tuple(no_outcome),
+        ))
+    if no_decision:
+        findings.append(SetFinding(
+            "outcome_without_decision", ADVISORY,
+            f"{len(no_decision)} outcome records have no matching decision record; "
+            "a recorded action SHOULD trace to the decision that authorised it",
+            tuple(no_decision),
+        ))
+    return findings
+
+
+def outcome_coverage_findings(outcomes: Sequence[tuple[str, Any]]) -> list[SetFinding]:
+    """An executed action that committed no result: the Article 12 hole."""
+    uncovered = sorted(
+        name for name, doc in outcomes
+        if doc["outcomeDerived"].get("status") == "executed"
+        and doc["outcomeDerived"].get("resultCommitment") is None
+    )
+    if not uncovered:
+        return []
+    return [SetFinding(
+        "executed_without_result_commitment", ADVISORY,
+        f"{len(uncovered)} executed records carry no resultCommitment; "
+        "an executed action SHOULD commit to its result",
+        tuple(uncovered),
+    )]
+
+
+def _verdict(doc: Any) -> Any:
+    return doc["decisionDerived"].get("decision")

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -46,6 +46,9 @@ from vaara.attestation._bundle_io import (
     evidence_bundle_from_json,
     load_bundle_pieces_from_dir,
 )
+from vaara.attestation._decision_conformance import (
+    check_decision_conformance,
+)
 from vaara.attestation._receipt_conformance import (
     ConformanceCheck,
     ConformanceReport,
@@ -56,6 +59,7 @@ from vaara.attestation._record_set_conformance import (
     RecordSetReport,
     SetFinding,
     check_record_set,
+    classify_record,
 )
 from vaara.attestation._receipt_emit import (
     emit_receipt,
@@ -120,10 +124,12 @@ __all__ = [
     "ConformanceCheck",
     "ConformanceReport",
     "check_record_conformance",
+    "check_decision_conformance",
     "RecordSetEntry",
     "RecordSetReport",
     "SetFinding",
     "check_record_set",
+    "classify_record",
     "DidDocumentCache",
     "EvidenceBundle",
     "ExecutionReceipt",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -1856,6 +1856,9 @@ def _cmd_verify_records(args: argparse.Namespace) -> int:
     else:
         verdict = "CONFORMS" if ok else "NON-CONFORMING"
         print(f"record set: {verdict}  ({report.conforming}/{report.total} records conform)")
+        if report.verdict_counts:
+            tally = ", ".join(f"{v}: {n}" for v, n in report.verdict_counts.items())
+            print(f"  decisions: {tally}")
         if report.status_counts:
             tally = ", ".join(f"{s}: {n}" for s, n in report.status_counts.items())
             print(f"  outcomes: {tally}")

--- a/tests/test_record_set_conformance.py
+++ b/tests/test_record_set_conformance.py
@@ -19,6 +19,7 @@ import pytest
 from vaara.attestation._record_set_conformance import (
     SET_SCHEMA_NAME,
     check_record_set,
+    classify_record,
 )
 from vaara.cli import main
 
@@ -51,6 +52,7 @@ def test_module_reproduces_vector_verdict(name):
         "total": report.total,
         "conforming": report.conforming,
         "statusCounts": report.status_counts,
+        "verdictCounts": report.verdict_counts,
         "findings": [
             {"id": f.id, "severity": f.severity, "records": list(f.records)}
             for f in report.findings
@@ -127,8 +129,96 @@ def test_report_to_dict_shape():
     assert d["conforms"] is True
     assert d["total"] == 2
     assert d["statusCounts"] == {"executed": 1, "refused": 1}
+    assert d["verdictCounts"] == {}
     assert d["findings"] == []
-    assert all({"name", "conforms"} <= set(e) for e in d["entries"])
+    assert all({"name", "kind", "conforms"} <= set(e) for e in d["entries"])
+    assert {e["kind"] for e in d["entries"]} == {"outcome"}
+
+
+# ── Type-aware classification ───────────────────────────────────────────────────
+
+
+def test_classify_decision_outcome_and_unknown():
+    decision = _load_set("proper_pair")
+    kinds = {n: classify_record(doc) for n, doc in decision}
+    assert kinds == {"decision.json": "decision", "outcome.json": "outcome"}
+    assert classify_record({"version": 1}) == "unknown"  # neither block
+    assert classify_record({"decisionDerived": {}, "outcomeDerived": {}}) == "unknown"
+    assert classify_record("not an object") == "unknown"
+
+
+def test_unknown_shape_record_gates_without_raising():
+    good = _load_set("proper_pair")[0]  # a decision record
+    report = check_record_set([good, ("weird.json", {"version": 1})])
+    assert not report.conforms
+    entry = next(e for e in report.entries if e.name == "weird.json")
+    assert entry.kind == "unknown"
+    assert entry.conforms is False
+    assert entry.required_failed == ("record_type",)
+
+
+def test_decision_record_is_conformance_checked_as_a_decision():
+    # A decision with an invalid verdict fails the decision schema, not the
+    # outcome schema (which would reject it for a missing outcomeDerived).
+    name, doc = _load_set("proper_pair")[0]
+    broken = dict(doc)
+    broken["decisionDerived"] = {**doc["decisionDerived"], "decision": "maybe"}
+    report = check_record_set([(name, broken)])
+    assert not report.conforms
+    entry = report.entries[0]
+    assert entry.kind == "decision"
+    assert "decision_valid" in entry.required_failed
+
+
+# ── Pairing: the coverage critic ────────────────────────────────────────────────
+
+
+def test_proper_pair_is_not_a_duplicate():
+    report = check_record_set(_load_set("proper_pair"))
+    assert report.conforms
+    assert report.findings == ()  # a decision + its outcome is the pair
+    assert report.verdict_counts == {"allow": 1}
+    assert report.status_counts == {"executed": 1}
+
+
+def test_decision_without_outcome_is_advisory_and_does_not_gate():
+    report = check_record_set(_load_set("decision_without_outcome"))
+    assert report.conforms
+    assert report.required_findings == ()
+    advisory = [f for f in report.findings if f.severity == "advisory"]
+    assert [f.id for f in advisory] == ["decision_without_outcome"]
+    assert advisory[0].records == ("decision_b.json",)
+    assert report.verdict_counts == {"allow": 1, "escalate": 1}
+
+
+def test_outcome_without_decision_is_advisory_and_does_not_gate():
+    report = check_record_set(_load_set("outcome_without_decision"))
+    assert report.conforms
+    assert report.required_findings == ()
+    advisory = [f for f in report.findings if f.severity == "advisory"]
+    assert [f.id for f in advisory] == ["outcome_without_decision"]
+    assert advisory[0].records == ("outcome_b.json",)
+
+
+def test_block_decision_alone_is_not_a_coverage_gap():
+    # A blocked call legitimately has no outcome, so a block decision paired
+    # with an unrelated outcome raises no decision_without_outcome.
+    dname, ddoc = _load_set("proper_pair")[0]
+    blocked = dict(ddoc)
+    blocked["decisionDerived"] = {**ddoc["decisionDerived"], "decision": "block"}
+    oname, odoc = _load_set("clean")[1]  # a refused outcome on a different call
+    report = check_record_set([(dname, blocked), (oname, odoc)])
+    assert report.conforms
+    ids = [f.id for f in report.findings]
+    assert "decision_without_outcome" not in ids
+
+
+def test_homogeneous_outcome_set_raises_no_pairing_findings():
+    # clean is two outcomes, no decisions: nothing to pair, so no
+    # outcome_without_decision noise.
+    report = check_record_set(_load_set("clean"))
+    assert report.conforms
+    assert report.findings == ()
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
@@ -158,6 +248,23 @@ def test_cli_json_output(capsys):
     assert payload["schema"] == SET_SCHEMA_NAME
     assert payload["unreadable"] == []
     assert payload["findings"][0]["id"] == "executed_without_result_commitment"
+
+
+def test_cli_pairing_set_reports_decisions_and_gap(capsys):
+    rc = main(["verify-records", str(SETS / "decision_without_outcome")])
+    out = capsys.readouterr().out
+    assert rc == 0  # advisory pairing gap does not gate
+    assert "CONFORMS" in out
+    assert "decisions: allow: 1, escalate: 1" in out
+    assert "decision_without_outcome" in out
+
+
+def test_cli_json_includes_verdict_counts(capsys):
+    rc = main(["verify-records", str(SETS / "proper_pair"), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["verdictCounts"] == {"allow": 1}
+    assert {e["kind"] for e in payload["entries"]} == {"decision", "outcome"}
 
 
 def test_cli_unreadable_file_gates(tmp_path, capsys):

--- a/tests/vectors/record_set_v0/README.md
+++ b/tests/vectors/record_set_v0/README.md
@@ -7,42 +7,62 @@ vectors ask the question that only shows up across a pile of records,
 possibly from more than one emitter: how many conform, and where are the
 gaps in the chain? Like the per-record check, this needs no signing key.
 
-Two properties stack on top of per-record conformance:
+A set is not all one shape. Each record is classified as a **decision**
+(`decisionDerived`: allow / block / escalate) or an **outcome**
+(`outcomeDerived`: executed / refused / errored) by which derived block it
+carries, and checked against that type's schema; a record carrying neither
+(or both) is unknown and cannot conform. The shared `backLink` pairs a
+decision with its outcome.
 
-- **Unique calls** (required). Each record pins the attestation it
-  answers through `backLink`. Two records pinning the same
+Cross-record properties stack on top of per-record conformance:
+
+- **Unique calls** (required). Two *outcome* records pinning the same
   `(attestationDigest, attestationNonce)` recorded the same call twice, a
-  replay or a double-write. A set that double-counts a call is not a
-  faithful record, so this gates set conformance.
-- **Outcome coverage** (advisory). An `executed` record carrying no
+  replay or a double-write, and this gates conformance. A decision and an
+  outcome on one call are the expected *pair*, not a duplicate.
+- **Pairing coverage** (advisory). In a set holding both kinds, an
+  allow/escalate decision with no matching outcome
+  (`decision_without_outcome`), or an outcome with no matching decision
+  (`outcome_without_decision`): was every authorised action recorded, and
+  was every recorded action authorised?
+- **Outcome coverage** (advisory). An `executed` outcome carrying no
   `resultCommitment` is a gap: the action ran and left no committed
-  evidence of its result. Reported, not gating, but exactly the hole a
-  regulator looks for under EU AI Act Article 12.
+  evidence of its result, the EU AI Act Article 12 hole.
 
 Set-level checks run only over records that individually conform, since
 the linkage fields of a malformed record cannot be trusted. A set
-conforms iff every record conforms and no required finding fired.
+conforms iff every record conforms and no required finding fired; the
+advisory pairing gaps are reported but do not gate.
 
 ## Layout
 
 ```
 sets/<case>/*.json     a directory of candidate records (one set)
-expected.json          {case: {conforms, total, conforming,
-                                statusCounts, findings[]}}
+expected.json          {case: {conforms, total, conforming, statusCounts,
+                                verdictCounts, findings[]}}
 _check_independent.py   stdlib only (hashlib + re + json), no Vaara import
 ```
 
 Each `findings` entry is `{id, severity, records}` with `records` sorted,
-so a case is order-independent.
+so a case is order-independent. `statusCounts` tallies outcome statuses,
+`verdictCounts` tallies decision verdicts.
 
 ## Cases
 
-- `clean` — two conforming records, distinct calls, no findings.
-- `duplicate_call` — two conforming records pinning the same call; one
+- `clean` — two conforming outcome records, distinct calls, no findings.
+- `duplicate_call` — two conforming outcomes pinning the same call; one
   required `duplicate_call` finding, set does not conform.
-- `executed_gap` — two executed records, one without a result commitment;
+- `executed_gap` — two executed outcomes, one without a result commitment;
   one advisory `executed_without_result_commitment` finding, set still
   conforms (advisory does not gate).
 - `mixed_nonconforming` — one conforming record and one malformed; set
   does not conform because a record does not, and cross-record reasoning
   runs only over the conforming one.
+- `proper_pair` — a decision and its outcome on the same call; the
+  expected pair, so no `duplicate_call`, no pairing gap, set conforms.
+- `decision_without_outcome` — a paired decision+outcome plus a lone
+  `escalate` decision with no outcome; one advisory
+  `decision_without_outcome` finding, set still conforms.
+- `outcome_without_decision` — a paired decision+outcome plus a lone
+  outcome with no decision; one advisory `outcome_without_decision`
+  finding, set still conforms.

--- a/tests/vectors/record_set_v0/_check_independent.py
+++ b/tests/vectors/record_set_v0/_check_independent.py
@@ -3,15 +3,17 @@
 
 A second implementation of the SEP-2828 set-level rules, written from the
 schema alone with only the standard library. It does not import Vaara. For
-each committed set it reproduces the aggregate verdict, the conform count,
-the status tally, and the cross-record findings, then compares against
+each committed set it classifies every record (decision or outcome),
+reproduces the aggregate verdict, the conform count, the status and verdict
+tallies, and the cross-record findings, then compares against
 ``expected.json``.
 
 The receiving side of the evidence has to be checkable by a neutral party
 with no shared code: not just "is each record well-formed" but "is the set
-faithful" (no call recorded twice) and "is it complete" (no executed action
-left without a committed result). This file demonstrates that both fall out
-of the records alone, with nothing but a hash function and the schema.
+faithful" (no call recorded twice), "is it complete" (every authorised act
+left an outcome, every recorded act traces to a decision), and "is every
+executed action committed to its result". This file shows all of that falls
+out of the records alone, with nothing but a hash function and the schema.
 
 Run: ``python tests/vectors/record_set_v0/_check_independent.py``.
 Exit 0 means every set matched its expected verdict.
@@ -28,14 +30,27 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 VALID_ALGS = {"HS256", "ES256", "RS256"}
 VALID_STATUSES = {"executed", "refused", "errored"}
+VALID_VERDICTS = {"allow", "block", "escalate"}
+ACTING_VERDICTS = {"allow", "escalate"}
 DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 HEX_RE = re.compile(r"^[0-9a-f]+$")
 
 
-def conforms(doc) -> bool:
-    """Minimal per-record conformance: enough to gate set-level reasoning."""
+def classify(doc) -> str:
+    """decision / outcome / unknown, by which derived block the record carries."""
     if not isinstance(doc, dict):
-        return False
+        return "unknown"
+    has_d = isinstance(doc.get("decisionDerived"), dict)
+    has_o = isinstance(doc.get("outcomeDerived"), dict)
+    if has_d and not has_o:
+        return "decision"
+    if has_o and not has_d:
+        return "outcome"
+    return "unknown"
+
+
+def _envelope_ok(doc, asserted_key) -> bool:
+    """Shared wire-schema checks for both record types."""
     if doc.get("version") != 1:
         return False
     alg = doc.get("alg")
@@ -52,16 +67,18 @@ def conforms(doc) -> bool:
         return False
     if not isinstance(bl.get("attestationNonce"), str):
         return False
-    ra = doc.get("receiptAsserted")
-    if not isinstance(ra, dict):
+    a = doc.get(asserted_key)
+    if not isinstance(a, dict):
         return False
-    if any(f not in ra for f in ("alg", "iat", "iss", "nonce", "secretVersion", "sub")):
+    if any(f not in a for f in ("alg", "iat", "iss", "nonce", "secretVersion", "sub")):
         return False
-    if ra.get("alg") != alg:
+    return a.get("alg") == alg
+
+
+def conforms_outcome(doc) -> bool:
+    if not _envelope_ok(doc, "receiptAsserted"):
         return False
-    od = doc.get("outcomeDerived")
-    if not isinstance(od, dict):
-        return False
+    od = doc["outcomeDerived"]
     if od.get("status") not in VALID_STATUSES:
         return False
     if not isinstance(od.get("completedAt"), str):
@@ -76,21 +93,62 @@ def conforms(doc) -> bool:
     return True
 
 
+def conforms_decision(doc) -> bool:
+    if not _envelope_ok(doc, "issuerAsserted"):
+        return False
+    dd = doc["decisionDerived"]
+    if dd.get("decision") not in VALID_VERDICTS:
+        return False
+    return isinstance(dd.get("decidedAt"), str)
+
+
+def _call_key(doc):
+    bl = doc["backLink"]
+    return bl["attestationDigest"], bl["attestationNonce"]
+
+
+def _by_call(records):
+    out = {}
+    for name, doc in records:
+        out.setdefault(_call_key(doc), []).append(name)
+    return out
+
+
 def check_set(records):
     """Reproduce the set verdict from (name, doc) pairs."""
-    conforming = [(n, d) for n, d in records if conforms(d)]
+    decisions, outcomes = [], []
+    for name, doc in records:
+        kind = classify(doc)
+        if kind == "decision" and conforms_decision(doc):
+            decisions.append((name, doc))
+        elif kind == "outcome" and conforms_outcome(doc):
+            outcomes.append((name, doc))
+
     findings = []
 
-    by_call = {}
-    for name, doc in conforming:
-        bl = doc["backLink"]
-        by_call.setdefault((bl["attestationDigest"], bl["attestationNonce"]), []).append(name)
-    for names in by_call.values():
+    for names in _by_call(outcomes).values():
         if len(names) > 1:
             findings.append({"id": "duplicate_call", "severity": "required",
                              "records": sorted(names)})
 
-    gap = sorted(n for n, d in conforming
+    if decisions and outcomes:
+        decision_calls = _by_call(decisions)
+        outcome_calls = _by_call(outcomes)
+        acting = {k: v for k, v in decision_calls.items()
+                  if any(d["decisionDerived"].get("decision") in ACTING_VERDICTS
+                         for n, d in decisions if _call_key(d) == k)}
+        no_outcome = sorted(n for k, v in acting.items()
+                            if k not in outcome_calls for n in v)
+        no_decision = sorted(n for k, v in outcome_calls.items()
+                             if k not in decision_calls for n in v)
+        if no_outcome:
+            findings.append({"id": "decision_without_outcome", "severity": "advisory",
+                             "records": no_outcome})
+        if no_decision:
+            findings.append({"id": "outcome_without_decision", "severity": "advisory",
+                             "records": no_decision})
+
+    gap = sorted(n for n, d in outcomes
                  if d["outcomeDerived"].get("status") == "executed"
                  and d["outcomeDerived"].get("resultCommitment") is None)
     if gap:
@@ -99,17 +157,24 @@ def check_set(records):
 
     findings.sort(key=lambda f: (f["id"], f["records"]))
 
-    counts = {}
-    for _n, d in conforming:
-        counts[d["outcomeDerived"]["status"]] = counts.get(d["outcomeDerived"]["status"], 0) + 1
+    status_counts = {}
+    for _n, d in outcomes:
+        s = d["outcomeDerived"]["status"]
+        status_counts[s] = status_counts.get(s, 0) + 1
+    verdict_counts = {}
+    for _n, d in decisions:
+        v = d["decisionDerived"]["decision"]
+        verdict_counts[v] = verdict_counts.get(v, 0) + 1
 
-    all_conform = len(conforming) == len(records)
+    conforming = len(decisions) + len(outcomes)
+    all_conform = conforming == len(records)
     no_required = not any(f["severity"] == "required" for f in findings)
     return {
         "conforms": all_conform and no_required,
         "total": len(records),
-        "conforming": len(conforming),
-        "statusCounts": dict(sorted(counts.items())),
+        "conforming": conforming,
+        "statusCounts": dict(sorted(status_counts.items())),
+        "verdictCounts": dict(sorted(verdict_counts.items())),
         "findings": findings,
     }
 

--- a/tests/vectors/record_set_v0/expected.json
+++ b/tests/vectors/record_set_v0/expected.json
@@ -4,6 +4,7 @@
     "total": 2,
     "conforming": 2,
     "statusCounts": {"executed": 1, "refused": 1},
+    "verdictCounts": {},
     "findings": []
   },
   "duplicate_call": {
@@ -11,6 +12,7 @@
     "total": 2,
     "conforming": 2,
     "statusCounts": {"executed": 1, "refused": 1},
+    "verdictCounts": {},
     "findings": [
       {"id": "duplicate_call", "severity": "required", "records": ["r1.json", "r2.json"]}
     ]
@@ -20,6 +22,7 @@
     "total": 2,
     "conforming": 2,
     "statusCounts": {"executed": 2},
+    "verdictCounts": {},
     "findings": [
       {"id": "executed_without_result_commitment", "severity": "advisory", "records": ["r1.json"]}
     ]
@@ -29,6 +32,35 @@
     "total": 2,
     "conforming": 1,
     "statusCounts": {"executed": 1},
+    "verdictCounts": {},
     "findings": []
+  },
+  "proper_pair": {
+    "conforms": true,
+    "total": 2,
+    "conforming": 2,
+    "statusCounts": {"executed": 1},
+    "verdictCounts": {"allow": 1},
+    "findings": []
+  },
+  "decision_without_outcome": {
+    "conforms": true,
+    "total": 3,
+    "conforming": 3,
+    "statusCounts": {"executed": 1},
+    "verdictCounts": {"allow": 1, "escalate": 1},
+    "findings": [
+      {"id": "decision_without_outcome", "severity": "advisory", "records": ["decision_b.json"]}
+    ]
+  },
+  "outcome_without_decision": {
+    "conforms": true,
+    "total": 3,
+    "conforming": 3,
+    "statusCounts": {"executed": 1, "refused": 1},
+    "verdictCounts": {"allow": 1},
+    "findings": [
+      {"id": "outcome_without_decision", "severity": "advisory", "records": ["outcome_b.json"]}
+    ]
   }
 }

--- a/tests/vectors/record_set_v0/sets/decision_without_outcome/decision_a.json
+++ b/tests/vectors/record_set_v0/sets/decision_without_outcome/decision_a.json
@@ -1,0 +1,21 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "226d2a3c2998ecbd0366ac8080e27b5ce255e2680c8178fa478f69dceac571fb",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/decision_without_outcome/decision_b.json
+++ b/tests/vectors/record_set_v0/sets/decision_without_outcome/decision_b.json
@@ -1,0 +1,21 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd",
+    "attestationNonce": "call-B"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T11:00:00Z",
+    "decision": "escalate"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T11:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d2",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "226d2a3c2998ecbd0366ac8080e27b5ce255e2680c8178fa478f69dceac571fb",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/decision_without_outcome/outcome_a.json
+++ b/tests/vectors/record_set_v0/sets/decision_without_outcome/outcome_a.json
@@ -1,0 +1,26 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "decisionDigest": "sha256:bc1a28955291e73f991374b6ba5a72be528db6049ed2f53042d6d429fbe9ac9b",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "f4b87ef796407eef8d6644ca001a616deb09838b4d2584a809c4fbb4ee3c9db6",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/outcome_without_decision/decision_a.json
+++ b/tests/vectors/record_set_v0/sets/outcome_without_decision/decision_a.json
@@ -1,0 +1,21 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "226d2a3c2998ecbd0366ac8080e27b5ce255e2680c8178fa478f69dceac571fb",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/outcome_without_decision/outcome_a.json
+++ b/tests/vectors/record_set_v0/sets/outcome_without_decision/outcome_a.json
@@ -1,0 +1,26 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "decisionDigest": "sha256:bc1a28955291e73f991374b6ba5a72be528db6049ed2f53042d6d429fbe9ac9b",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "f4b87ef796407eef8d6644ca001a616deb09838b4d2584a809c4fbb4ee3c9db6",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/outcome_without_decision/outcome_b.json
+++ b/tests/vectors/record_set_v0/sets/outcome_without_decision/outcome_b.json
@@ -1,0 +1,21 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:559aead08264d5795d3909718cdd05abd49572e84fe55590eef31a88a08fdffd",
+    "attestationNonce": "call-B"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T11:00:00Z",
+    "status": "refused"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T11:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r2",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "f4b87ef796407eef8d6644ca001a616deb09838b4d2584a809c4fbb4ee3c9db6",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/proper_pair/decision.json
+++ b/tests/vectors/record_set_v0/sets/proper_pair/decision.json
@@ -1,0 +1,21 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "226d2a3c2998ecbd0366ac8080e27b5ce255e2680c8178fa478f69dceac571fb",
+  "version": 1
+}

--- a/tests/vectors/record_set_v0/sets/proper_pair/outcome.json
+++ b/tests/vectors/record_set_v0/sets/proper_pair/outcome.json
@@ -1,0 +1,26 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "decisionDigest": "sha256:bc1a28955291e73f991374b6ba5a72be528db6049ed2f53042d6d429fbe9ac9b",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "f4b87ef796407eef8d6644ca001a616deb09838b4d2584a809c4fbb4ee3c9db6",
+  "version": 1
+}


### PR DESCRIPTION
**A2 of the widening plan.** The set-level check now reads two SEP-2828 record types, not one, and answers the coverage question a regulator actually asks: was every authorised action recorded, and was every recorded action authorised? Keyless, by pairing on the shared `backLink`.

## What changed

- **Type-aware classification.** Each record is sorted into `decision` (`decisionDerived`: allow/block/escalate), `outcome` (`outcomeDerived`: executed/refused/errored), or `unknown` (neither, or both) by which derived block it carries, then checked against that type's schema. An unknown shape cannot conform.
- **`duplicate_call` is now outcome-only.** A decision plus an outcome on one call is the expected pair, not a duplicate. Only two outcomes pinning one call is the replay or double-write that gates.
- **Pairing coverage (advisory).** In a set holding both kinds: an allow/escalate decision with no matching outcome (`decision_without_outcome`), or an outcome with no matching decision (`outcome_without_decision`). These report gaps but do not gate set conformance. Pairing runs only on mixed sets, so a pile of outcomes alone raises no noise.
- **`verdict_counts`** (decision verdicts) joins `status_counts` (outcome statuses) in the report and the CLI.

## Shape

`SetFinding` and the finding functions live in the new `_record_set_findings`. `_record_set_conformance` keeps the orchestration. `check_decision_conformance` and `classify_record` are re-exported from `receipt.py`. Pure stdlib, base install, no attestation extra.

## Vectors and tests

`record_set_v0` grows `proper_pair`, `decision_without_outcome`, and `outcome_without_decision`. `expected.json` carries `verdictCounts`. The Vaara-free `_check_independent.py` is now type-aware and reproduces all 7 cases. 1369 passed, 13 skipped, ruff and `mypy --strict` clean.

No version bump. v0.60.0 stays current until release.
