### PR TITLE
feat: verify-bundles, batch full-lens over a directory of evidence bundles (A3)

### DIFF
--- a/src/vaara/attestation/_bundle_set.py
+++ b/src/vaara/attestation/_bundle_set.py
@@ -1,0 +1,169 @@
+"""Full-lens verification over a whole directory of evidence bundles.
+
+``verify_evidence_bundle`` runs every lens over one bundle. An auditor who
+receives a pile of bundles, possibly from more than one issuer, asks the
+batch question: over the whole set, how many verify, and what does the
+evidence cover? ``check_bundle_set`` is the receiving side of that, the
+full-lens twin of :func:`check_record_set` (which answers the keyless
+conformance question; this one runs the signed, crypto-backed lenses).
+
+Each bundle document is loaded with :func:`evidence_bundle_from_json` and
+run through :func:`verify_evidence_bundle`. The set then rolls up:
+
+* **Pass count.** How many bundles are ``ok``: signature established and
+  every applicable lens passed. A bundle that fails to load (a malformed
+  document) is a failing entry that gates the set, never a silent drop.
+* **Authentication count.** How many had their signature established at
+  all. A set whose bundles verify their logs but never their signatures is
+  a different posture than one that authenticates every issuer.
+* **Lens coverage.** For each lens, how many bundles carried the evidence
+  it needs and how many passed. The coverage gap (advisory) names the
+  lenses no bundle in the set exercised: evidence the whole set never
+  carried, the batch analogue of the executed-coverage hole.
+
+The set is ``ok`` iff every bundle loaded and every loaded bundle verified;
+the coverage gaps are reported but do not gate. Unlike ``check_record_set``,
+this needs the crypto the lenses use, so it runs only with the attestation
+extra installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+from vaara.attestation._bundle import LENS_NAMES, verify_evidence_bundle
+from vaara.attestation._bundle_io import evidence_bundle_from_json
+
+BUNDLE_SET_SCHEMA_NAME = "sep2828-evidence-bundle-set"
+BUNDLE_SET_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class BundleSetEntry:
+    """Per-bundle verdict inside a set.
+
+    ``loaded`` is False when the document did not parse into a bundle; then
+    ``error`` names why and ``lens_states`` is empty. Otherwise ``ok`` and
+    ``authenticity_established`` come from the bundle verdict and
+    ``lens_states`` maps each lens to ``pass`` / ``fail`` / ``n/a``.
+    """
+
+    name: str
+    loaded: bool
+    ok: bool
+    authenticity_established: bool
+    keyid: Optional[str]
+    lens_states: dict[str, str]
+    error: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "loaded": self.loaded,
+            "ok": self.ok,
+            "authenticityEstablished": self.authenticity_established,
+            "keyid": self.keyid,
+            "lensStates": dict(self.lens_states),
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class BundleSetReport:
+    """Outcome of running the full lens stack over a set of bundles."""
+
+    ok: bool
+    total: int
+    loaded: int
+    passed: int
+    authenticated: int
+    entries: tuple[BundleSetEntry, ...]
+    lens_applicable: dict[str, int]
+    lens_passed: dict[str, int]
+    lens_gaps: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": BUNDLE_SET_SCHEMA_NAME,
+            "schemaVersion": BUNDLE_SET_SCHEMA_VERSION,
+            "ok": self.ok,
+            "total": self.total,
+            "loaded": self.loaded,
+            "passed": self.passed,
+            "authenticated": self.authenticated,
+            "lensApplicable": dict(self.lens_applicable),
+            "lensPassed": dict(self.lens_passed),
+            "lensGaps": list(self.lens_gaps),
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+
+def check_bundle_set(bundles: Sequence[tuple[str, Any]]) -> BundleSetReport:
+    """Run the full lens stack over a set of ``(name, parsed_json)`` bundles.
+
+    Each document is loaded into an :class:`EvidenceBundle` and verified;
+    the set rolls up the pass and authentication counts and the per-lens
+    coverage. Never raises on a malformed document: it becomes a failing
+    entry that gates the set. The set is ``ok`` iff every document loaded
+    and every loaded bundle verified. The coverage gaps (lenses no bundle
+    exercised) are advisory and do not gate.
+    """
+    entries: list[BundleSetEntry] = []
+    lens_applicable: dict[str, int] = {name: 0 for name in LENS_NAMES}
+    lens_passed: dict[str, int] = {name: 0 for name in LENS_NAMES}
+    loaded = 0
+    passed = 0
+    authenticated = 0
+
+    for name, doc in bundles:
+        try:
+            bundle = evidence_bundle_from_json(doc)
+        except ValueError as exc:
+            entries.append(
+                BundleSetEntry(name, False, False, False, None, {}, str(exc))
+            )
+            continue
+
+        loaded += 1
+        verdict = verify_evidence_bundle(bundle)
+        states: dict[str, str] = {}
+        for result in verdict.lenses:
+            if result.applicable:
+                lens_applicable[result.lens] += 1
+                if result.ok:
+                    lens_passed[result.lens] += 1
+                states[result.lens] = "pass" if result.ok else "fail"
+            else:
+                states[result.lens] = "n/a"
+        if verdict.authenticity_established:
+            authenticated += 1
+        if verdict.ok:
+            passed += 1
+        entries.append(
+            BundleSetEntry(
+                name=name,
+                loaded=True,
+                ok=verdict.ok,
+                authenticity_established=verdict.authenticity_established,
+                keyid=verdict.keyid,
+                lens_states=states,
+                error=None,
+            )
+        )
+
+    lens_gaps = tuple(name for name in LENS_NAMES if lens_applicable[name] == 0)
+    all_loaded = all(e.loaded for e in entries)
+    all_ok = all(e.ok for e in entries if e.loaded)
+
+    return BundleSetReport(
+        ok=all_loaded and all_ok,
+        total=len(entries),
+        loaded=loaded,
+        passed=passed,
+        authenticated=authenticated,
+        entries=tuple(entries),
+        lens_applicable=lens_applicable,
+        lens_passed=lens_passed,
+        lens_gaps=lens_gaps,
+    )

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -46,6 +46,12 @@ from vaara.attestation._bundle_io import (
     evidence_bundle_from_json,
     load_bundle_pieces_from_dir,
 )
+from vaara.attestation._bundle_set import (
+    BUNDLE_SET_SCHEMA_NAME,
+    BundleSetEntry,
+    BundleSetReport,
+    check_bundle_set,
+)
 from vaara.attestation._decision_conformance import (
     check_decision_conformance,
 )
@@ -130,6 +136,10 @@ __all__ = [
     "SetFinding",
     "check_record_set",
     "classify_record",
+    "BUNDLE_SET_SCHEMA_NAME",
+    "BundleSetEntry",
+    "BundleSetReport",
+    "check_bundle_set",
     "DidDocumentCache",
     "EvidenceBundle",
     "ExecutionReceipt",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -1875,6 +1875,71 @@ def _cmd_verify_records(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def _cmd_verify_bundles(args: argparse.Namespace) -> int:
+    """Run the full lens stack over a whole directory of evidence bundles.
+
+    The batch twin of ``verify-bundle``: an auditor points this at a pile of
+    bundle documents, possibly from more than one issuer, and gets the
+    roll-up a single-file check cannot give. How many verify, how many had
+    their signature established, and what the evidence covers, with the
+    advisory gap naming the lenses no bundle in the set exercised. Requires
+    the attestation extra, like ``verify-bundle``.
+    """
+    try:
+        from vaara.attestation.receipt import check_bundle_set
+    except ImportError:
+        print(_ATTESTATION_HINT, file=sys.stderr)
+        return 2
+
+    directory = Path(args.directory).expanduser()
+    if not directory.is_dir():
+        print(f"vaara verify-bundles: not a directory: {directory}", file=sys.stderr)
+        return 2
+
+    paths = sorted(p for p in directory.glob(args.glob) if p.is_file())
+    if not paths:
+        print(f"vaara verify-bundles: no files matched {args.glob!r} in {directory}",
+              file=sys.stderr)
+        return 2
+
+    parsed: list[tuple[str, Any]] = []
+    unreadable: list[tuple[str, str]] = []
+    for path in paths:
+        try:
+            parsed.append((path.name, json.loads(path.read_text(encoding="utf-8"))))
+        except (json.JSONDecodeError, OSError) as exc:
+            unreadable.append((path.name, str(exc)))
+
+    report = check_bundle_set(parsed)
+    ok = report.ok and not unreadable
+
+    if args.json:
+        out: dict[str, Any] = report.to_dict()
+        out["ok"] = ok
+        out["unreadable"] = [{"name": n, "error": e} for n, e in unreadable]
+        print(json.dumps(out, indent=2))
+    else:
+        verdict = "OK" if ok else "FAILED"
+        print(f"bundle set: {verdict}  ({report.passed}/{report.total} bundles verify, "
+              f"{report.authenticated} authenticated)")
+        for name, count in report.lens_applicable.items():
+            tally = f"{report.lens_passed[name]}/{count} pass" if count else "not present"
+            print(f"  {name:12s} {tally}")
+        if report.lens_gaps:
+            print(f"  coverage gap: no bundle carried {', '.join(report.lens_gaps)}")
+        for entry in report.entries:
+            if not entry.loaded:
+                print(f"  [FAIL] {entry.name}: not a valid bundle ({entry.error})")
+            elif not entry.ok:
+                failed = [ln for ln, st in entry.lens_states.items() if st == "fail"]
+                reason = ", ".join(failed) if failed else "authenticity not established"
+                print(f"  [FAIL] {entry.name}: {reason}")
+        for name, exc in unreadable:
+            print(f"  [FAIL] {name}: unreadable ({exc})")
+
+    return 0 if ok else 1
+
+
 def _cmd_build_bundle(args: argparse.Namespace) -> int:
     """Assemble an evidence bundle on disk from the issuer's pieces.
 
@@ -2756,6 +2821,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the full set conformance report as JSON",
     )
     pvrs.set_defaults(func=_cmd_verify_records)
+
+    pvbs = sub.add_parser(
+        "verify-bundles",
+        help="Run the full lens stack over a whole directory of evidence "
+             "bundles at once. The batch twin of verify-bundle: how many "
+             "verify, how many authenticate, and what the evidence covers, "
+             "with the gap naming the lenses no bundle exercised. Requires the "
+             "attestation extra.",
+    )
+    pvbs.add_argument(
+        "directory",
+        help="Directory of evidence-bundle JSON documents (the shape "
+             "verify-bundle reads)",
+    )
+    pvbs.add_argument(
+        "--glob", default="*.json",
+        help="Glob for bundle files within the directory (default: *.json)",
+    )
+    pvbs.add_argument(
+        "--json", action="store_true",
+        help="Emit the full set verdict report as JSON",
+    )
+    pvbs.set_defaults(func=_cmd_verify_bundles)
 
     pbb = sub.add_parser(
         "build-bundle",

--- a/tests/test_bundle_set.py
+++ b/tests/test_bundle_set.py
@@ -1,0 +1,198 @@
+"""Batch full-lens verification and the `vaara verify-bundles` command.
+
+The batch twin of `verify-bundle`: an auditor points the tool at a directory
+of evidence bundles and gets the roll-up a single-file check cannot give.
+Covers the `bundle_set_v0` vectors through both Vaara and the standalone
+Vaara-free checker, the module behaviour (malformed documents, coverage gaps,
+gating), and the CLI end to end. Runs the lenses' crypto, so the suite skips
+when the attestation extra is absent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+for _mod in ("rfc8785", "cryptography"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            "attestation extra not installed (pip install 'vaara[attestation]')",
+            allow_module_level=True,
+        )
+
+from vaara.attestation.receipt import (  # noqa: E402
+    BUNDLE_SET_SCHEMA_NAME,
+    check_bundle_set,
+)
+from vaara.cli import main  # noqa: E402
+
+VECTORS = Path(__file__).resolve().parent / "vectors" / "bundle_set_v0"
+SETS = VECTORS / "sets"
+DOC_BUNDLES = Path(__file__).resolve().parent / "vectors" / "bundle_doc_v0" / "bundles"
+
+
+def _expected() -> dict:
+    return json.loads((VECTORS / "expected.json").read_text())
+
+
+def _cases():
+    return sorted(_expected().keys())
+
+
+def _load_set(name: str):
+    files = sorted((SETS / name).glob("*.json"))
+    return [(p.name, json.loads(p.read_text())) for p in files]
+
+
+# ── Vectors ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", _cases())
+def test_module_reproduces_vector_rollup(name):
+    want = _expected()[name]
+    report = check_bundle_set(_load_set(name))
+    got = {
+        "ok": report.ok,
+        "total": report.total,
+        "loaded": report.loaded,
+        "passed": report.passed,
+        "authenticated": report.authenticated,
+        "lensApplicable": report.lens_applicable,
+        "lensPassed": report.lens_passed,
+        "lensGaps": list(report.lens_gaps),
+    }
+    assert got == want
+
+
+def test_independent_checker_passes():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_public_reexport_is_wired():
+    from vaara.attestation.receipt import check_bundle_set as public
+    assert public is check_bundle_set
+
+
+# ── Unit behaviour ────────────────────────────────────────────────────────────
+
+
+def test_clean_set_is_ok_with_no_gap():
+    report = check_bundle_set(_load_set("clean"))
+    assert report.ok
+    assert report.passed == report.total == 2
+    assert report.authenticated == 2
+    assert report.lens_gaps == ()
+
+
+def test_mixed_set_gates_on_a_failing_bundle():
+    report = check_bundle_set(_load_set("mixed"))
+    assert not report.ok
+    assert report.passed == 1
+    failing = [e for e in report.entries if not e.ok]
+    assert len(failing) == 1
+    assert failing[0].lens_states["inclusion"] == "fail"
+    assert report.lens_gaps == ("signature",)  # no bundle carried signature material
+
+
+def test_thin_set_is_ok_but_reports_gaps_in_lens_order():
+    report = check_bundle_set(_load_set("thin"))
+    assert report.ok  # a thin but valid set still verifies
+    # Ordering follows the lens stack, not the alphabet.
+    assert report.lens_gaps == (
+        "identity", "back_link", "inclusion", "consistency", "revocation",
+    )
+
+
+def test_unauthenticated_bundle_gates_and_lowers_auth_count():
+    report = check_bundle_set(_load_set("unauthenticated"))
+    assert not report.ok
+    assert report.authenticated == 1  # one of two established its signature
+    unauth = next(e for e in report.entries if not e.authenticity_established)
+    assert not unauth.ok
+
+
+def test_malformed_document_is_a_failing_entry_not_a_raise():
+    good = _load_set("clean")[0]
+    report = check_bundle_set([good, ("broken.json", {"not": "a bundle"})])
+    assert not report.ok  # a non-loadable document gates the set
+    broken = next(e for e in report.entries if e.name == "broken.json")
+    assert broken.loaded is False
+    assert broken.ok is False
+    assert broken.error is not None
+    assert report.loaded == 1  # the good one still loaded
+
+
+def test_empty_set_is_ok_with_all_lenses_gapped():
+    report = check_bundle_set([])
+    assert report.ok and report.total == 0 and len(report.lens_gaps) == 6
+
+
+def test_report_to_dict_shape():
+    d = check_bundle_set(_load_set("clean")).to_dict()
+    assert d["schema"] == BUNDLE_SET_SCHEMA_NAME
+    assert d["ok"] is True
+    assert d["total"] == 2
+    assert d["lensGaps"] == []
+    assert all({"name", "loaded", "ok", "lensStates"} <= set(e) for e in d["entries"])
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def test_cli_clean_set_exit_0(capsys):
+    rc = main(["verify-bundles", str(SETS / "clean")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "OK" in out
+    assert "2/2 bundles verify" in out
+
+
+def test_cli_mixed_set_exit_1(capsys):
+    rc = main(["verify-bundles", str(SETS / "mixed")])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAILED" in out
+    assert "tampered_inclusion.json" in out
+    assert "coverage gap" in out
+
+
+def test_cli_json_output(capsys):
+    rc = main(["verify-bundles", str(SETS / "unauthenticated"), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["ok"] is False
+    assert payload["schema"] == BUNDLE_SET_SCHEMA_NAME
+    assert payload["authenticated"] == 1
+    assert payload["lensGaps"] == ["signature"]
+    assert payload["unreadable"] == []
+
+
+def test_cli_not_a_directory(tmp_path, capsys):
+    rc = main(["verify-bundles", str(tmp_path / "nope")])
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_cli_no_matching_files(tmp_path, capsys):
+    rc = main(["verify-bundles", str(tmp_path)])
+    assert rc == 2
+    assert "no files matched" in capsys.readouterr().err
+
+
+def test_cli_unreadable_file_gates(tmp_path, capsys):
+    (tmp_path / "good.json").write_text((DOC_BUNDLES / "all_lenses_pass.json").read_text())
+    (tmp_path / "bad.json").write_text("{ not json")
+    rc = main(["verify-bundles", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["ok"] is False
+    assert [u["name"] for u in payload["unreadable"]] == ["bad.json"]

--- a/tests/vectors/bundle_set_v0/README.md
+++ b/tests/vectors/bundle_set_v0/README.md
@@ -1,0 +1,52 @@
+# Evidence-bundle set vectors, v0
+
+Fixtures for the batch full-lens check on a directory of evidence bundles:
+what `vaara verify-bundles` produces. Where `bundle_doc_v0` asks "does this
+one bundle verify", these vectors ask the question that only shows up across
+a pile of bundles, possibly from more than one issuer: how many verify, how
+many authenticate, and what does the evidence cover?
+
+Each bundle document is the same on-disk shape `bundle_doc_v0` commits (one
+receipt plus whatever identity, signature, back-link, inclusion, consistency,
+and revocation evidence accompanies it). Each is loaded and run through the
+full lens stack, then the set rolls up:
+
+- **Pass count** — how many bundles are `ok`: signature established and every
+  applicable lens passed.
+- **Authentication count** — how many had their signature established at all,
+  by identity or by the signature lens.
+- **Lens coverage** — for each lens, how many bundles carried the evidence it
+  needs (`lensApplicable`) and how many passed (`lensPassed`).
+- **Coverage gap** (advisory) — `lensGaps` names the lenses no bundle in the
+  set exercised: evidence the whole set never carried. Advisory, does not
+  gate.
+
+The set is `ok` iff every bundle loaded and every loaded bundle verified.
+Unlike the keyless record-set check, this needs the crypto the lenses use, so
+the vectors run only with the attestation extra installed.
+
+## Layout
+
+```
+sets/<case>/*.json      a directory of evidence-bundle documents (one set)
+expected.json           {case: {ok, total, loaded, passed, authenticated,
+                                 lensApplicable, lensPassed, lensGaps}}
+_check_independent.py    reuses the Vaara-free evidence_bundle_v0 evaluator,
+                         no Vaara import
+```
+
+`lensGaps` is in lens order (identity, signature, back_link, inclusion,
+consistency, revocation), not alphabetical.
+
+## Cases
+
+- `clean` — `all_lenses_pass` + `signature_only`, both verify; every lens is
+  exercised somewhere in the set, so no coverage gap.
+- `mixed` — `all_lenses_pass` + `tampered_inclusion`; one bundle fails its
+  inclusion proof, so the set is not `ok`. No bundle carries signature-lens
+  material, so `signature` is a coverage gap.
+- `thin` — `signature_only` alone; it verifies, so the set is `ok`, but five
+  of the six lenses are never exercised: a thin but valid set.
+- `unauthenticated` — `all_lenses_pass` + `unauthenticated_in_log`; the second
+  bundle sits in the log but never establishes its signature, so it is not
+  `ok` and the set is not `ok`. Authenticated count is 1 of 2.

--- a/tests/vectors/bundle_set_v0/_check_independent.py
+++ b/tests/vectors/bundle_set_v0/_check_independent.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Independent batch full-lens checker for the bundle_set_v0 vectors.
+
+A second implementation of the set-level roll-up that ``vaara verify-bundles``
+produces: load each evidence-bundle document in a set, run the full lens stack,
+and aggregate. It does not import Vaara. The per-bundle verdict logic is the
+same one the ``bundle_doc_v0`` checker uses, so rather than copy it this file
+reuses ``_evaluate`` from the ``evidence_bundle_v0`` sibling checker by path.
+That module is itself Vaara-free (standard library plus ``rfc8785`` and
+``cryptography``), so the whole chain stays independent of Vaara.
+
+The batch question a single-file check cannot answer: over a pile of bundles,
+how many verify, how many had their signature established at all, and what does
+the evidence cover. The coverage gap names the lenses no bundle in the set
+exercised, the evidence the whole set never carried. This checker reproduces
+that roll-up from the bundles alone and compares it to ``expected.json``; exit
+0 means every set matched.
+
+Run: ``python tests/vectors/bundle_set_v0/_check_independent.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SETS = HERE / "sets"
+SIBLING = HERE.parent / "evidence_bundle_v0" / "_check_independent.py"
+
+# The six lenses, in the order the verdict reports them.
+LENS_NAMES = (
+    "identity",
+    "signature",
+    "back_link",
+    "inclusion",
+    "consistency",
+    "revocation",
+)
+
+
+def _load_evaluate():
+    spec = importlib.util.spec_from_file_location("evidence_bundle_v0_check", SIBLING)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load sibling checker at {SIBLING}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module._evaluate
+
+
+def check_set(evaluate, bundles):
+    """Reproduce the set roll-up from (name, doc) pairs.
+
+    Every vector document is a well-formed bundle, so no load-failure path is
+    needed here; ``loaded`` always equals the bundle count. The Vaara module
+    carries the malformed-document path, exercised by its unit tests.
+    """
+    lens_applicable = {name: 0 for name in LENS_NAMES}
+    lens_passed = {name: 0 for name in LENS_NAMES}
+    passed = 0
+    authenticated = 0
+
+    for _name, doc in bundles:
+        verdict = evaluate(doc)
+        for lens in LENS_NAMES:
+            res = verdict["lenses"][lens]
+            if res["applicable"]:
+                lens_applicable[lens] += 1
+                if res["ok"]:
+                    lens_passed[lens] += 1
+        if verdict["authenticity_established"]:
+            authenticated += 1
+        if verdict["ok"]:
+            passed += 1
+
+    total = len(bundles)
+    lens_gaps = [name for name in LENS_NAMES if lens_applicable[name] == 0]
+    return {
+        "ok": passed == total,
+        "total": total,
+        "loaded": total,
+        "passed": passed,
+        "authenticated": authenticated,
+        "lensApplicable": lens_applicable,
+        "lensPassed": lens_passed,
+        "lensGaps": lens_gaps,
+    }
+
+
+def main() -> int:
+    evaluate = _load_evaluate()
+    expected = json.loads((HERE / "expected.json").read_text())
+    failures = 0
+    for name in sorted(expected):
+        files = sorted((SETS / name).glob("*.json"))
+        bundles = [(p.name, json.loads(p.read_text())) for p in files]
+        got = check_set(evaluate, bundles)
+        ok = got == expected[name]
+        failures += 0 if ok else 1
+        print(f"[{'OK' if ok else 'FAIL'}] {name}: {got['passed']}/{got['total']} verify")
+        if not ok:
+            print("  want:", expected[name])
+            print("  got :", got)
+    print(f"\n{len(expected) - failures}/{len(expected)} sets matched expected.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/bundle_set_v0/expected.json
+++ b/tests/vectors/bundle_set_v0/expected.json
@@ -1,0 +1,108 @@
+{
+  "clean": {
+    "authenticated": 2,
+    "lensApplicable": {
+      "back_link": 1,
+      "consistency": 1,
+      "identity": 1,
+      "inclusion": 1,
+      "revocation": 1,
+      "signature": 1
+    },
+    "lensGaps": [],
+    "lensPassed": {
+      "back_link": 1,
+      "consistency": 1,
+      "identity": 1,
+      "inclusion": 1,
+      "revocation": 1,
+      "signature": 1
+    },
+    "loaded": 2,
+    "ok": true,
+    "passed": 2,
+    "total": 2
+  },
+  "mixed": {
+    "authenticated": 2,
+    "lensApplicable": {
+      "back_link": 2,
+      "consistency": 1,
+      "identity": 2,
+      "inclusion": 2,
+      "revocation": 2,
+      "signature": 0
+    },
+    "lensGaps": [
+      "signature"
+    ],
+    "lensPassed": {
+      "back_link": 2,
+      "consistency": 1,
+      "identity": 2,
+      "inclusion": 1,
+      "revocation": 2,
+      "signature": 0
+    },
+    "loaded": 2,
+    "ok": false,
+    "passed": 1,
+    "total": 2
+  },
+  "thin": {
+    "authenticated": 1,
+    "lensApplicable": {
+      "back_link": 0,
+      "consistency": 0,
+      "identity": 0,
+      "inclusion": 0,
+      "revocation": 0,
+      "signature": 1
+    },
+    "lensGaps": [
+      "identity",
+      "back_link",
+      "inclusion",
+      "consistency",
+      "revocation"
+    ],
+    "lensPassed": {
+      "back_link": 0,
+      "consistency": 0,
+      "identity": 0,
+      "inclusion": 0,
+      "revocation": 0,
+      "signature": 1
+    },
+    "loaded": 1,
+    "ok": true,
+    "passed": 1,
+    "total": 1
+  },
+  "unauthenticated": {
+    "authenticated": 1,
+    "lensApplicable": {
+      "back_link": 1,
+      "consistency": 1,
+      "identity": 1,
+      "inclusion": 2,
+      "revocation": 2,
+      "signature": 0
+    },
+    "lensGaps": [
+      "signature"
+    ],
+    "lensPassed": {
+      "back_link": 1,
+      "consistency": 1,
+      "identity": 1,
+      "inclusion": 2,
+      "revocation": 2,
+      "signature": 0
+    },
+    "loaded": 2,
+    "ok": false,
+    "passed": 1,
+    "total": 2
+  }
+}

--- a/tests/vectors/bundle_set_v0/sets/clean/all_lenses_pass.json
+++ b/tests/vectors/bundle_set_v0/sets/clean/all_lenses_pass.json
@@ -1,0 +1,91 @@
+{
+  "attestation": {
+    "alg": "HS256",
+    "issuerAsserted": {
+      "alg": "HS256",
+      "expSeconds": 300,
+      "iat": "2026-05-29T09:59:59Z",
+      "iss": "issuer://test",
+      "nonce": "att-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "agent:billing"
+    },
+    "payloadDerived": {
+      "toolCalls": [
+        {
+          "args": {
+            "projection": "{\"digest\":\"sha256:c6a6831ac1abd02d15c339d34514c7a2171bdf61f88762075e8af6ddb70764c8\"}",
+            "projectionDigest": "sha256:af9b301c121c56ef3b87557824487e0e525ab877300ee9297337fb3f5e2098c8"
+          },
+          "name": "charge_card",
+          "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    },
+    "plannerDeclared": {
+      "intent": "settle invoice"
+    },
+    "signature": "a56a65957ed4df74e3041255cfef3fe47c706274f99ec9e0f5c66c4f783a18bd",
+    "version": 1
+  },
+  "consistency": {
+    "first_root_hex": "498b70582ec73c6934935c91370c03b4cd9e2e75d9db002d6268c502139c20ac",
+    "first_size": 4,
+    "hashes_hex": [
+      "987403f55e274e1a4ba8c147684044d4bf300f240bcc2eede881f524a8060c97"
+    ],
+    "second_root_hex": "ac3012ef2f6230b062e1ea53918b5c35419cf5347a249a4788b259a2fa168cdb",
+    "second_size": 6
+  },
+  "did_document": {
+    "id": "did:web:agents.example.com:billing",
+    "verificationMethod": [
+      {
+        "controller": "did:web:agents.example.com:billing",
+        "id": "did:web:agents.example.com:billing#key-2026",
+        "publicKeyJwk": {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "B2Bb3IA08MGNseH1UseCTbv_Q-J10isZuVS7galZBEU",
+          "y": "pF0OwY17c4EPwvJJYAjp6z9tVfFo37FGfhFrwVZS_iM"
+        },
+        "type": "JsonWebKey2020"
+      }
+    ]
+  },
+  "expected_keyid": "did:web:agents.example.com:billing#key-2026",
+  "inclusion": {
+    "log_index": 2,
+    "root_hex": "498b70582ec73c6934935c91370c03b4cd9e2e75d9db002d6268c502139c20ac",
+    "siblings_hex": [
+      "851bfadbc6cacd2467c107c9f4c73dd930d7f0a59726b1cf869f89a342eae1ef",
+      "4b87bb07c29e106d681ab06ae97cf1b29e2ede0247b562f21a142813a3ae4c09"
+    ],
+    "tree_size": 4
+  },
+  "receipt": {
+    "alg": "ES256",
+    "backLink": {
+      "attestationDigest": "sha256:8f4ae37b34b9be4056ce0c243dabb819d225864b4aee04561ee9bdd67b9080dc",
+      "attestationNonce": "att-nonce-fixed-0001"
+    },
+    "outcomeDerived": {
+      "completedAt": "2026-05-29T10:00:00Z",
+      "status": "executed"
+    },
+    "receiptAsserted": {
+      "alg": "ES256",
+      "iat": "2026-05-29T10:00:00Z",
+      "iss": "did:web:agents.example.com:billing",
+      "nonce": "rcpt-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "did:web:agents.example.com:billing"
+    },
+    "signature": "862d6ebc949c323cdd695290ee88818390ee49880b37b012c923e3ea823fa164720f19683959c633d614d87b84d93e42bdf17c0d0ff2765f35570d93f813fadb",
+    "version": 1
+  },
+  "registry": {
+    "entries": [],
+    "version": 1
+  }
+}

--- a/tests/vectors/bundle_set_v0/sets/clean/signature_only.json
+++ b/tests/vectors/bundle_set_v0/sets/clean/signature_only.json
@@ -1,0 +1,29 @@
+{
+  "receipt": {
+    "alg": "ES256",
+    "backLink": {
+      "attestationDigest": "sha256:8f4ae37b34b9be4056ce0c243dabb819d225864b4aee04561ee9bdd67b9080dc",
+      "attestationNonce": "att-nonce-fixed-0001"
+    },
+    "outcomeDerived": {
+      "completedAt": "2026-05-29T10:00:00Z",
+      "status": "executed"
+    },
+    "receiptAsserted": {
+      "alg": "ES256",
+      "iat": "2026-05-29T10:00:00Z",
+      "iss": "did:web:agents.example.com:billing",
+      "nonce": "rcpt-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "did:web:agents.example.com:billing"
+    },
+    "signature": "862d6ebc949c323cdd695290ee88818390ee49880b37b012c923e3ea823fa164720f19683959c633d614d87b84d93e42bdf17c0d0ff2765f35570d93f813fadb",
+    "version": 1
+  },
+  "verifying_jwk": {
+    "crv": "P-256",
+    "kty": "EC",
+    "x": "B2Bb3IA08MGNseH1UseCTbv_Q-J10isZuVS7galZBEU",
+    "y": "pF0OwY17c4EPwvJJYAjp6z9tVfFo37FGfhFrwVZS_iM"
+  }
+}

--- a/tests/vectors/bundle_set_v0/sets/mixed/all_lenses_pass.json
+++ b/tests/vectors/bundle_set_v0/sets/mixed/all_lenses_pass.json
@@ -1,0 +1,91 @@
+{
+  "attestation": {
+    "alg": "HS256",
+    "issuerAsserted": {
+      "alg": "HS256",
+      "expSeconds": 300,
+      "iat": "2026-05-29T09:59:59Z",
+      "iss": "issuer://test",
+      "nonce": "att-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "agent:billing"
+    },
+    "payloadDerived": {
+      "toolCalls": [
+        {
+          "args": {
+            "projection": "{\"digest\":\"sha256:c6a6831ac1abd02d15c339d34514c7a2171bdf61f88762075e8af6ddb70764c8\"}",
+            "projectionDigest": "sha256:af9b301c121c56ef3b87557824487e0e525ab877300ee9297337fb3f5e2098c8"
+          },
+          "name": "charge_card",
+          "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    },
+    "plannerDeclared": {
+      "intent": "settle invoice"
+    },
+    "signature": "a56a65957ed4df74e3041255cfef3fe47c706274f99ec9e0f5c66c4f783a18bd",
+    "version": 1
+  },
+  "consistency": {
+    "first_root_hex": "498b70582ec73c6934935c91370c03b4cd9e2e75d9db002d6268c502139c20ac",
+    "first_size": 4,
+    "hashes_hex": [
+      "987403f55e274e1a4ba8c147684044d4bf300f240bcc2eede881f524a8060c97"
+    ],
+    "second_root_hex": "ac3012ef2f6230b062e1ea53918b5c35419cf5347a249a4788b259a2fa168cdb",
+    "second_size": 6
+  },
+  "did_document": {
+    "id": "did:web:agents.example.com:billing",
+    "verificationMethod": [
+      {
+        "controller": "did:web:agents.example.com:billing",
+        "id": "did:web:agents.example.com:billing#key-2026",
+        "publicKeyJwk": {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "B2Bb3IA08MGNseH1UseCTbv_Q-J10isZuVS7galZBEU",
+          "y": "pF0OwY17c4EPwvJJYAjp6z9tVfFo37FGfhFrwVZS_iM"
+        },
+        "type": "JsonWebKey2020"
+      }
+    ]
+  },
+  "expected_keyid": "did:web:agents.example.com:billing#key-2026",
+  "inclusion": {
+    "log_index": 2,
+    "root_hex": "498b70582ec73c6934935c91370c03b4cd9e2e75d9db002d6268c502139c20ac",
+    "siblings_hex": [
+      "851bfadbc6cacd2467c107c9f4c73dd930d7f0a59726b1cf869f89a342eae1ef",
+      "4b87bb07c29e106d681ab06ae97cf1b29e2ede0247b562f21a142813a3ae4c09"
+    ],
+    "tree_size": 4
+  },
+  "receipt": {
+    "alg": "ES256",
+    "backLink": {
+      "attestationDigest": "sha256:8f4ae37b34b9be4056ce0c243dabb819d225864b4aee04561ee9bdd67b9080dc",
+      "attestationNonce": "att-nonce-fixed-0001"
+    },
+    "outcomeDerived": {
+      "completedAt": "2026-05-29T10:00:00Z",
+      "status": "executed"
+    },
+    "receiptAsserted": {
+      "alg": "ES256",
+      "iat": "2026-05-29T10:00:00Z",
+      "iss": "did:web:agents.example.com:billing",
+      "nonce": "rcpt-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "did:web:agents.example.com:billing"
+    },
+    "signature": "862d6ebc949c323cdd695290ee88818390ee49880b37b012c923e3ea823fa164720f19683959c633d614d87b84d93e42bdf17c0d0ff2765f35570d93f813fadb",
+    "version": 1
+  },
+  "registry": {
+    "entries": [],
+    "version": 1
+  }
+}

--- a/tests/vectors/bundle_set_v0/sets/mixed/tampered_inclusion.json
+++ b/tests/vectors/bundle_set_v0/sets/mixed/tampered_inclusion.json
@@ -1,0 +1,81 @@
+{
+  "attestation": {
+    "alg": "HS256",
+    "issuerAsserted": {
+      "alg": "HS256",
+      "expSeconds": 300,
+      "iat": "2026-05-29T09:59:59Z",
+      "iss": "issuer://test",
+      "nonce": "att-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "agent:billing"
+    },
+    "payloadDerived": {
+      "toolCalls": [
+        {
+          "args": {
+            "projection": "{\"digest\":\"sha256:c6a6831ac1abd02d15c339d34514c7a2171bdf61f88762075e8af6ddb70764c8\"}",
+            "projectionDigest": "sha256:af9b301c121c56ef3b87557824487e0e525ab877300ee9297337fb3f5e2098c8"
+          },
+          "name": "charge_card",
+          "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    },
+    "plannerDeclared": {
+      "intent": "settle invoice"
+    },
+    "signature": "a56a65957ed4df74e3041255cfef3fe47c706274f99ec9e0f5c66c4f783a18bd",
+    "version": 1
+  },
+  "did_document": {
+    "id": "did:web:agents.example.com:billing",
+    "verificationMethod": [
+      {
+        "controller": "did:web:agents.example.com:billing",
+        "id": "did:web:agents.example.com:billing#key-2026",
+        "publicKeyJwk": {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "B2Bb3IA08MGNseH1UseCTbv_Q-J10isZuVS7galZBEU",
+          "y": "pF0OwY17c4EPwvJJYAjp6z9tVfFo37FGfhFrwVZS_iM"
+        },
+        "type": "JsonWebKey2020"
+      }
+    ]
+  },
+  "inclusion": {
+    "log_index": 2,
+    "root_hex": "b6748fa7d138c396cb6ca36ec8f3fc4b3261d18a2624ffd29d973afdec63df53",
+    "siblings_hex": [
+      "851bfadbc6cacd2467c107c9f4c73dd930d7f0a59726b1cf869f89a342eae1ef",
+      "4b87bb07c29e106d681ab06ae97cf1b29e2ede0247b562f21a142813a3ae4c09"
+    ],
+    "tree_size": 4
+  },
+  "receipt": {
+    "alg": "ES256",
+    "backLink": {
+      "attestationDigest": "sha256:8f4ae37b34b9be4056ce0c243dabb819d225864b4aee04561ee9bdd67b9080dc",
+      "attestationNonce": "att-nonce-fixed-0001"
+    },
+    "outcomeDerived": {
+      "completedAt": "2026-05-29T10:00:00Z",
+      "status": "executed"
+    },
+    "receiptAsserted": {
+      "alg": "ES256",
+      "iat": "2026-05-29T10:00:00Z",
+      "iss": "did:web:agents.example.com:billing",
+      "nonce": "rcpt-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "did:web:agents.example.com:billing"
+    },
+    "signature": "862d6ebc949c323cdd695290ee88818390ee49880b37b012c923e3ea823fa164720f19683959c633d614d87b84d93e42bdf17c0d0ff2765f35570d93f813fadb",
+    "version": 1
+  },
+  "registry": {
+    "entries": [],
+    "version": 1
+  }
+}

--- a/tests/vectors/bundle_set_v0/sets/thin/signature_only.json
+++ b/tests/vectors/bundle_set_v0/sets/thin/signature_only.json
@@ -1,0 +1,29 @@
+{
+  "receipt": {
+    "alg": "ES256",
+    "backLink": {
+      "attestationDigest": "sha256:8f4ae37b34b9be4056ce0c243dabb819d225864b4aee04561ee9bdd67b9080dc",
+      "attestationNonce": "att-nonce-fixed-0001"
+    },
+    "outcomeDerived": {
+      "completedAt": "2026-05-29T10:00:00Z",
+      "status": "executed"
+    },
+    "receiptAsserted": {
+      "alg": "ES256",
+      "iat": "2026-05-29T10:00:00Z",
+      "iss": "did:web:agents.example.com:billing",
+      "nonce": "rcpt-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "did:web:agents.example.com:billing"
+    },
+    "signature": "862d6ebc949c323cdd695290ee88818390ee49880b37b012c923e3ea823fa164720f19683959c633d614d87b84d93e42bdf17c0d0ff2765f35570d93f813fadb",
+    "version": 1
+  },
+  "verifying_jwk": {
+    "crv": "P-256",
+    "kty": "EC",
+    "x": "B2Bb3IA08MGNseH1UseCTbv_Q-J10isZuVS7galZBEU",
+    "y": "pF0OwY17c4EPwvJJYAjp6z9tVfFo37FGfhFrwVZS_iM"
+  }
+}

--- a/tests/vectors/bundle_set_v0/sets/unauthenticated/all_lenses_pass.json
+++ b/tests/vectors/bundle_set_v0/sets/unauthenticated/all_lenses_pass.json
@@ -1,0 +1,91 @@
+{
+  "attestation": {
+    "alg": "HS256",
+    "issuerAsserted": {
+      "alg": "HS256",
+      "expSeconds": 300,
+      "iat": "2026-05-29T09:59:59Z",
+      "iss": "issuer://test",
+      "nonce": "att-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "agent:billing"
+    },
+    "payloadDerived": {
+      "toolCalls": [
+        {
+          "args": {
+            "projection": "{\"digest\":\"sha256:c6a6831ac1abd02d15c339d34514c7a2171bdf61f88762075e8af6ddb70764c8\"}",
+            "projectionDigest": "sha256:af9b301c121c56ef3b87557824487e0e525ab877300ee9297337fb3f5e2098c8"
+          },
+          "name": "charge_card",
+          "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    },
+    "plannerDeclared": {
+      "intent": "settle invoice"
+    },
+    "signature": "a56a65957ed4df74e3041255cfef3fe47c706274f99ec9e0f5c66c4f783a18bd",
+    "version": 1
+  },
+  "consistency": {
+    "first_root_hex": "498b70582ec73c6934935c91370c03b4cd9e2e75d9db002d6268c502139c20ac",
+    "first_size": 4,
+    "hashes_hex": [
+      "987403f55e274e1a4ba8c147684044d4bf300f240bcc2eede881f524a8060c97"
+    ],
+    "second_root_hex": "ac3012ef2f6230b062e1ea53918b5c35419cf5347a249a4788b259a2fa168cdb",
+    "second_size": 6
+  },
+  "did_document": {
+    "id": "did:web:agents.example.com:billing",
+    "verificationMethod": [
+      {
+        "controller": "did:web:agents.example.com:billing",
+        "id": "did:web:agents.example.com:billing#key-2026",
+        "publicKeyJwk": {
+          "crv": "P-256",
+          "kty": "EC",
+          "x": "B2Bb3IA08MGNseH1UseCTbv_Q-J10isZuVS7galZBEU",
+          "y": "pF0OwY17c4EPwvJJYAjp6z9tVfFo37FGfhFrwVZS_iM"
+        },
+        "type": "JsonWebKey2020"
+      }
+    ]
+  },
+  "expected_keyid": "did:web:agents.example.com:billing#key-2026",
+  "inclusion": {
+    "log_index": 2,
+    "root_hex": "498b70582ec73c6934935c91370c03b4cd9e2e75d9db002d6268c502139c20ac",
+    "siblings_hex": [
+      "851bfadbc6cacd2467c107c9f4c73dd930d7f0a59726b1cf869f89a342eae1ef",
+      "4b87bb07c29e106d681ab06ae97cf1b29e2ede0247b562f21a142813a3ae4c09"
+    ],
+    "tree_size": 4
+  },
+  "receipt": {
+    "alg": "ES256",
+    "backLink": {
+      "attestationDigest": "sha256:8f4ae37b34b9be4056ce0c243dabb819d225864b4aee04561ee9bdd67b9080dc",
+      "attestationNonce": "att-nonce-fixed-0001"
+    },
+    "outcomeDerived": {
+      "completedAt": "2026-05-29T10:00:00Z",
+      "status": "executed"
+    },
+    "receiptAsserted": {
+      "alg": "ES256",
+      "iat": "2026-05-29T10:00:00Z",
+      "iss": "did:web:agents.example.com:billing",
+      "nonce": "rcpt-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "did:web:agents.example.com:billing"
+    },
+    "signature": "862d6ebc949c323cdd695290ee88818390ee49880b37b012c923e3ea823fa164720f19683959c633d614d87b84d93e42bdf17c0d0ff2765f35570d93f813fadb",
+    "version": 1
+  },
+  "registry": {
+    "entries": [],
+    "version": 1
+  }
+}

--- a/tests/vectors/bundle_set_v0/sets/unauthenticated/unauthenticated_in_log.json
+++ b/tests/vectors/bundle_set_v0/sets/unauthenticated/unauthenticated_in_log.json
@@ -1,0 +1,36 @@
+{
+  "inclusion": {
+    "log_index": 2,
+    "root_hex": "498b70582ec73c6934935c91370c03b4cd9e2e75d9db002d6268c502139c20ac",
+    "siblings_hex": [
+      "851bfadbc6cacd2467c107c9f4c73dd930d7f0a59726b1cf869f89a342eae1ef",
+      "4b87bb07c29e106d681ab06ae97cf1b29e2ede0247b562f21a142813a3ae4c09"
+    ],
+    "tree_size": 4
+  },
+  "receipt": {
+    "alg": "ES256",
+    "backLink": {
+      "attestationDigest": "sha256:8f4ae37b34b9be4056ce0c243dabb819d225864b4aee04561ee9bdd67b9080dc",
+      "attestationNonce": "att-nonce-fixed-0001"
+    },
+    "outcomeDerived": {
+      "completedAt": "2026-05-29T10:00:00Z",
+      "status": "executed"
+    },
+    "receiptAsserted": {
+      "alg": "ES256",
+      "iat": "2026-05-29T10:00:00Z",
+      "iss": "did:web:agents.example.com:billing",
+      "nonce": "rcpt-nonce-fixed-0001",
+      "secretVersion": "v1",
+      "sub": "did:web:agents.example.com:billing"
+    },
+    "signature": "862d6ebc949c323cdd695290ee88818390ee49880b37b012c923e3ea823fa164720f19683959c633d614d87b84d93e42bdf17c0d0ff2765f35570d93f813fadb",
+    "version": 1
+  },
+  "registry": {
+    "entries": [],
+    "version": 1
+  }
+}


### PR DESCRIPTION
verify-bundle runs every lens over one bundle. verify-records runs set conformance over a directory of records. This fills the missing corner: verify-bundles runs the full lens stack over a whole directory of bundles, the receiving side an auditor works from when the evidence arrives as a pile.

What it rolls up across the set:
- pass count: how many bundles verify, meaning the signature was established and every applicable lens passed
- authentication count: how many established their signature at all, by identity or by the signature lens
- per-lens coverage: for each lens, how many bundles carried the evidence it needs and how many passed
- coverage gap (advisory): the lenses no bundle in the set exercised, the batch analogue of the executed-coverage hole the record checks report

The set is ok iff every bundle loaded and every loaded bundle verified. A malformed document becomes a failing entry that gates the set, never a silent drop. The coverage gaps are reported but do not gate.

Same discipline as A1 and A2: additive (it composes the existing lenses unchanged), vectors plus a Vaara-free checker, tests, gate green.

- new `_bundle_set.py`: `check_bundle_set` returning a `BundleSetReport`, re-exported from `attestation.receipt`
- `vaara verify-bundles DIR [--glob] [--json]`
- `bundle_set_v0` vectors (4 sets built from the `bundle_doc_v0` documents) plus a checker that reuses the Vaara-free `evidence_bundle_v0` evaluator, so the whole chain stays independent of Vaara
- 19 tests; 1388 passed, 13 skipped, ruff clean, the new module mypy --strict clean

Requires the attestation extra, like verify-bundle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch verification for evidence bundles with per-bundle reporting of authentication status and lens coverage metrics.
  * New `verify-bundles` CLI command to verify multiple bundles from a directory, with support for both human-readable and JSON output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->