### PR TITLE
v0.61.0: the auditor's workbench (verify-records, verify-bundles, audit-summary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.61.0] - 2026-06-08
+
+**Theme: the auditor's workbench. 0.60 made Vaara the neutral checker of one
+record. This release adds the receiving side an auditor works from: point it at
+a whole directory of records or bundles and get the set-level answer, then read
+it as a page a regulator can follow.**
+
+### Added
+- `vaara verify-records DIR [--glob] [--json]`: set-level conformance over a
+  directory of SEP-2828 records, possibly from more than one emitter. Each
+  record is classified (decision or outcome) and checked against its type's
+  schema, then the set is checked for cross-record properties: a call recorded
+  twice (required), an allow or escalate decision with no matching outcome or an
+  outcome with no matching decision (advisory pairing gaps), and an executed
+  action that committed no result (the Article 12 hole, advisory). Keyless. New
+  `check_record_set` on the public `vaara.attestation.receipt` surface;
+  `record_set_v0` vectors with a Vaara-free checker.
+- `vaara verify-bundles DIR [--glob] [--json]`: the full lens stack over a
+  directory of evidence bundles. Rolls up how many bundles verify, how many
+  establish their signature, and per-lens coverage, with an advisory gap naming
+  the lenses no bundle in the set exercised. New `check_bundle_set`;
+  `bundle_set_v0` vectors reusing the `bundle_doc_v0` documents with a Vaara-free
+  checker. Requires the attestation extra.
+- `vaara audit-summary DIR [--glob] [--out FILE]`: the human-readable face of
+  `verify-records`. Renders the verdict, the record counts, and the findings as
+  a one-page Markdown report a regulator reads, deterministic and keyless (no
+  timestamp, no signing key). New `render_record_set_summary`;
+  `audit_summary_v0` golden pages.
+
 ## [0.60.0] - 2026-06-07
 
 **Theme: verify anyone's record, not just your own. The trust plane could

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.60.0"
+version = "0.61.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.60.0",
+  "version": "0.61.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.60.0",
+      "version": "0.61.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.60.0",
+  "version": "0.61.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.60.0",
+      "version": "0.61.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.60.0"
+__version__ = "0.61.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_audit_summary.py
+++ b/src/vaara/attestation/_audit_summary.py
@@ -1,0 +1,123 @@
+"""The one-page audit summary: the record-set verdict a regulator reads.
+
+``check_record_set`` answers the machine question and ``verify-records`` prints
+a terse roll-up. A regulator wants the same facts as a page of plain prose:
+what was checked, how many records conform, where the gaps are, and why the
+answer can be trusted without a key. ``render_record_set_summary`` turns the
+report into that page.
+
+The page is a derived view of the set check, not new evidence. It states only
+what the report already found and adds no judgement of its own. Every count and
+finding traces back to a record any party can re-run with ``verify-records``,
+so the summary is reproducible from the records alone. It carries no timestamp
+and no key: the same set always renders the same page.
+
+Markdown, pure standard library, importable without the attestation extra.
+"""
+
+from __future__ import annotations
+
+from vaara.attestation._record_set_conformance import RecordSetReport
+
+SUMMARY_SCHEMA = "vaara-record-set-summary/1"
+
+_DEFAULT_TITLE = "Execution-record conformance summary"
+
+_WHAT = (
+    "Each record was checked against the SEP-2828 execution-record schema for "
+    "its type, decision or outcome, with no signing key: the wire shape and the "
+    "record's own self-proving digest. Across the set, calls were checked for "
+    "duplicates and decisions were paired with their outcomes."
+)
+
+_KEYLESS = (
+    "No signing key was used to produce this summary. Any party can reproduce "
+    "every count and finding above from the records alone with "
+    "`vaara verify-records`."
+)
+
+
+def render_record_set_summary(
+    report: RecordSetReport, *, title: str = _DEFAULT_TITLE
+) -> str:
+    """Render a record-set report as a one-page Markdown audit summary.
+
+    Deterministic: the page depends only on ``report`` (no clock, no version),
+    so the same set renders byte-identical every time. The verdict line, the
+    counts, and the findings restate the report; nothing is inferred beyond it.
+    """
+    lines: list[str] = [f"# {title}", ""]
+
+    verdict = "CONFORMS" if report.conforms else "NON-CONFORMING"
+    lines.append(f"**Verdict: {verdict}**")
+    lines.append("")
+    if report.total == 0:
+        lines.append("No records were supplied.")
+    else:
+        lines.append(
+            f"{report.total} record{_s(report.total)} checked, "
+            f"{report.conforming} conform{'s' if report.conforming == 1 else ''}."
+        )
+    lines.append("")
+
+    lines.append("## What was checked")
+    lines.append("")
+    lines.append(_WHAT)
+    lines.append("")
+
+    if report.verdict_counts or report.status_counts:
+        lines.append("## Records")
+        lines.append("")
+        if report.verdict_counts:
+            lines.append(f"- Decisions: {_tally(report.verdict_counts)}")
+        if report.status_counts:
+            lines.append(f"- Outcomes: {_tally(report.status_counts)}")
+        lines.append("")
+
+    required = [f for f in report.findings if f.severity == "required"]
+    advisory = [f for f in report.findings if f.severity == "advisory"]
+    lines.append("## Findings")
+    lines.append("")
+    if not report.findings:
+        lines.append("No cross-record findings.")
+        lines.append("")
+    else:
+        if required:
+            lines.append("Required (these gate conformance):")
+            lines.append("")
+            for f in required:
+                lines.append(f"- **{f.id}** — {f.detail} ({_names(f.records)})")
+            lines.append("")
+        if advisory:
+            lines.append("Advisory (gaps that do not gate conformance):")
+            lines.append("")
+            for f in advisory:
+                lines.append(f"- **{f.id}** — {f.detail} ({_names(f.records)})")
+            lines.append("")
+
+    nonconforming = [e for e in report.entries if not e.conforms]
+    if nonconforming:
+        lines.append("## Non-conforming records")
+        lines.append("")
+        for e in nonconforming:
+            why = ", ".join(e.required_failed) if e.required_failed else "did not conform"
+            lines.append(f"- `{e.name}` ({e.kind}): {why}")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append(_KEYLESS)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _s(n: int) -> str:
+    return "" if n == 1 else "s"
+
+
+def _tally(counts: dict[str, int]) -> str:
+    return ", ".join(f"{k} {v}" for k, v in counts.items())
+
+
+def _names(records: tuple[str, ...]) -> str:
+    return ", ".join(records)

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -52,6 +52,10 @@ from vaara.attestation._bundle_set import (
     BundleSetReport,
     check_bundle_set,
 )
+from vaara.attestation._audit_summary import (
+    SUMMARY_SCHEMA,
+    render_record_set_summary,
+)
 from vaara.attestation._decision_conformance import (
     check_decision_conformance,
 )
@@ -140,6 +144,8 @@ __all__ = [
     "BundleSetEntry",
     "BundleSetReport",
     "check_bundle_set",
+    "SUMMARY_SCHEMA",
+    "render_record_set_summary",
     "DidDocumentCache",
     "EvidenceBundle",
     "ExecutionReceipt",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -1875,6 +1875,51 @@ def _cmd_verify_records(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def _cmd_audit_summary(args: argparse.Namespace) -> int:
+    """Render a directory of records as a one-page audit summary a regulator reads.
+
+    Runs the same keyless set check as ``verify-records`` and renders the
+    verdict, the record counts, and the findings as a page of plain Markdown:
+    what was checked, how many records conform, where the gaps are, and why the
+    answer needs no signing key. Writes to ``--out`` or stdout. Exit 0 iff the
+    set conforms and every file was readable, the same gate as ``verify-records``.
+    """
+    from vaara.attestation.receipt import check_record_set, render_record_set_summary
+
+    directory = Path(args.directory).expanduser()
+    if not directory.is_dir():
+        print(f"vaara audit-summary: not a directory: {directory}", file=sys.stderr)
+        return 2
+
+    paths = sorted(p for p in directory.glob(args.glob) if p.is_file())
+    if not paths:
+        print(f"vaara audit-summary: no files matched {args.glob!r} in {directory}",
+              file=sys.stderr)
+        return 2
+
+    parsed: list[tuple[str, Any]] = []
+    unreadable: list[tuple[str, str]] = []
+    for path in paths:
+        try:
+            parsed.append((path.name, json.loads(path.read_text(encoding="utf-8"))))
+        except (json.JSONDecodeError, OSError) as exc:
+            unreadable.append((path.name, str(exc)))
+
+    report = check_record_set(parsed)
+    page = render_record_set_summary(report)
+    if unreadable:
+        names = ", ".join(n for n, _ in unreadable)
+        page += f"\n> Note: {len(unreadable)} file(s) could not be read: {names}\n"
+
+    if args.out:
+        Path(args.out).expanduser().write_text(page, encoding="utf-8")
+        print(f"wrote audit summary to {args.out}", file=sys.stderr)
+    else:
+        print(page, end="")
+
+    return 0 if (report.conforms and not unreadable) else 1
+
+
 def _cmd_verify_bundles(args: argparse.Namespace) -> int:
     """Run the full lens stack over a whole directory of evidence bundles.
 
@@ -2821,6 +2866,27 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the full set conformance report as JSON",
     )
     pvrs.set_defaults(func=_cmd_verify_records)
+
+    pas = sub.add_parser(
+        "audit-summary",
+        help="Render a directory of SEP-2828 records as a one-page audit "
+             "summary a regulator reads: the verdict, the record counts, and "
+             "the findings as plain Markdown. The human-readable face of "
+             "verify-records. Keyless.",
+    )
+    pas.add_argument(
+        "directory",
+        help="Directory of JSON files, each claiming to be a SEP-2828 record",
+    )
+    pas.add_argument(
+        "--glob", default="*.json",
+        help="Glob for record files within the directory (default: *.json)",
+    )
+    pas.add_argument(
+        "--out", default=None,
+        help="Write the Markdown summary to this file instead of stdout",
+    )
+    pas.set_defaults(func=_cmd_audit_summary)
 
     pvbs = sub.add_parser(
         "verify-bundles",

--- a/tests/test_audit_summary.py
+++ b/tests/test_audit_summary.py
@@ -1,0 +1,143 @@
+"""The one-page audit summary and the `vaara audit-summary` command.
+
+The human-readable face of `verify-records`: the same keyless set check,
+rendered as a page of Markdown a regulator reads. Covers the renderer against
+the committed golden pages (byte-exact, deterministic), its structural
+guarantees, and the CLI end to end. Keyless, like the record check, so the
+suite runs in the base install.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vaara.attestation._audit_summary import SUMMARY_SCHEMA
+from vaara.attestation.receipt import check_record_set, render_record_set_summary
+from vaara.cli import main
+
+RECORD_SETS = Path(__file__).resolve().parent / "vectors" / "record_set_v0" / "sets"
+PAGES = Path(__file__).resolve().parent / "vectors" / "audit_summary_v0" / "pages"
+
+
+def _cases():
+    return sorted(p.stem for p in PAGES.glob("*.md"))
+
+
+def _load_set(name: str):
+    files = sorted((RECORD_SETS / name).glob("*.json"))
+    return [(p.name, json.loads(p.read_text())) for p in files]
+
+
+# ── Golden pages ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", _cases())
+def test_render_matches_golden_page(name):
+    page = render_record_set_summary(check_record_set(_load_set(name)))
+    assert page == (PAGES / f"{name}.md").read_text(encoding="utf-8")
+
+
+def test_at_least_four_golden_pages_present():
+    assert len(_cases()) >= 4
+
+
+def test_public_reexport_is_wired():
+    from vaara.attestation.receipt import render_record_set_summary as public
+    assert public is render_record_set_summary
+    assert SUMMARY_SCHEMA == "vaara-record-set-summary/1"
+
+
+# ── Deterministic and faithful ────────────────────────────────────────────────
+
+
+def test_render_is_deterministic():
+    records = _load_set("clean")
+    a = render_record_set_summary(check_record_set(records))
+    b = render_record_set_summary(check_record_set(records))
+    assert a == b  # no clock, no key: same set, same bytes
+
+
+def test_conforming_set_says_conforms_and_has_no_findings_section_body():
+    page = render_record_set_summary(check_record_set(_load_set("clean")))
+    assert "**Verdict: CONFORMS**" in page
+    assert "No cross-record findings." in page
+
+
+def test_nonconforming_set_names_the_required_finding():
+    page = render_record_set_summary(check_record_set(_load_set("duplicate_call")))
+    assert "**Verdict: NON-CONFORMING**" in page
+    assert "Required (these gate conformance):" in page
+    assert "duplicate_call" in page
+
+
+def test_advisory_gap_is_under_the_advisory_heading():
+    page = render_record_set_summary(check_record_set(_load_set("executed_gap")))
+    assert "Advisory (gaps that do not gate conformance):" in page
+    assert "executed_without_result_commitment" in page
+
+
+def test_nonconforming_record_is_listed_with_its_reason():
+    page = render_record_set_summary(check_record_set(_load_set("mixed_nonconforming")))
+    assert "## Non-conforming records" in page
+    assert "`bad.json`" in page
+
+
+def test_empty_set_renders_a_clean_page():
+    page = render_record_set_summary(check_record_set([]))
+    assert "No records were supplied." in page
+    assert "**Verdict: CONFORMS**" in page
+
+
+def test_custom_title_is_used():
+    page = render_record_set_summary(check_record_set([]), title="Quarterly review")
+    assert page.startswith("# Quarterly review\n")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def test_cli_clean_set_to_stdout(capsys):
+    rc = main(["audit-summary", str(RECORD_SETS / "clean")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == (PAGES / "clean.md").read_text(encoding="utf-8")
+
+
+def test_cli_nonconforming_set_exit_1(capsys):
+    rc = main(["audit-summary", str(RECORD_SETS / "duplicate_call")])
+    assert rc == 1
+    assert "NON-CONFORMING" in capsys.readouterr().out
+
+
+def test_cli_writes_to_out_file(tmp_path, capsys):
+    target = tmp_path / "summary.md"
+    rc = main(["audit-summary", str(RECORD_SETS / "clean"), "--out", str(target)])
+    assert rc == 0
+    assert target.read_text(encoding="utf-8") == (PAGES / "clean.md").read_text("utf-8")
+    assert "wrote audit summary" in capsys.readouterr().err
+
+
+def test_cli_not_a_directory(tmp_path, capsys):
+    rc = main(["audit-summary", str(tmp_path / "nope")])
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_cli_no_matching_files(tmp_path, capsys):
+    rc = main(["audit-summary", str(tmp_path)])
+    assert rc == 2
+    assert "no files matched" in capsys.readouterr().err
+
+
+def test_cli_unreadable_file_notes_and_gates(tmp_path, capsys):
+    (tmp_path / "good.json").write_text(
+        (RECORD_SETS / "clean" / "r1.json").read_text())
+    (tmp_path / "bad.json").write_text("{ not json")
+    rc = main(["audit-summary", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "could not be read" in out
+    assert "bad.json" in out

--- a/tests/vectors/audit_summary_v0/README.md
+++ b/tests/vectors/audit_summary_v0/README.md
@@ -1,0 +1,31 @@
+# Audit-summary golden pages, v0
+
+The one-page Markdown a regulator reads, rendered from a record-set check.
+`render_record_set_summary` turns a `RecordSetReport` into a plain page: the
+verdict, the record counts, and the findings. These vectors pin the exact
+bytes that page produces.
+
+The fixtures are the `record_set_v0` sets, reused: each set is checked with
+the keyless `check_record_set`, and the rendered page is committed under
+`pages/<case>.md`. The test renders each set and asserts byte-equality with
+its committed page.
+
+There is no separate Vaara-free re-implementation here, and that is the point.
+The summary is a rendering of a verdict, not a second judgement. The verdict it
+formats is already verified independently by `record_set_v0/_check_independent.py`
+(a Vaara-free checker that reproduces every count and finding from the schema
+alone). The golden bytes are this layer's contract: the page is deterministic,
+carrying no timestamp and no key, so the same set always renders the same page.
+
+## Layout
+
+```
+pages/<case>.md     the exact Markdown render_record_set_summary produces for
+                    the record_set_v0 set of the same name
+```
+
+## Regenerating
+
+The pages are generated from the renderer over the `record_set_v0` sets. If the
+renderer changes on purpose, re-render and commit the new pages; an accidental
+change shows up as a failing byte comparison.

--- a/tests/vectors/audit_summary_v0/pages/clean.md
+++ b/tests/vectors/audit_summary_v0/pages/clean.md
@@ -1,0 +1,21 @@
+# Execution-record conformance summary
+
+**Verdict: CONFORMS**
+
+2 records checked, 2 conform.
+
+## What was checked
+
+Each record was checked against the SEP-2828 execution-record schema for its type, decision or outcome, with no signing key: the wire shape and the record's own self-proving digest. Across the set, calls were checked for duplicates and decisions were paired with their outcomes.
+
+## Records
+
+- Outcomes: executed 1, refused 1
+
+## Findings
+
+No cross-record findings.
+
+---
+
+No signing key was used to produce this summary. Any party can reproduce every count and finding above from the records alone with `vaara verify-records`.

--- a/tests/vectors/audit_summary_v0/pages/decision_without_outcome.md
+++ b/tests/vectors/audit_summary_v0/pages/decision_without_outcome.md
@@ -1,0 +1,24 @@
+# Execution-record conformance summary
+
+**Verdict: CONFORMS**
+
+3 records checked, 3 conform.
+
+## What was checked
+
+Each record was checked against the SEP-2828 execution-record schema for its type, decision or outcome, with no signing key: the wire shape and the record's own self-proving digest. Across the set, calls were checked for duplicates and decisions were paired with their outcomes.
+
+## Records
+
+- Decisions: allow 1, escalate 1
+- Outcomes: executed 1
+
+## Findings
+
+Advisory (gaps that do not gate conformance):
+
+- **decision_without_outcome** — 1 allow/escalate decisions have no matching outcome record; an authorised action SHOULD leave a recorded outcome (decision_b.json)
+
+---
+
+No signing key was used to produce this summary. Any party can reproduce every count and finding above from the records alone with `vaara verify-records`.

--- a/tests/vectors/audit_summary_v0/pages/duplicate_call.md
+++ b/tests/vectors/audit_summary_v0/pages/duplicate_call.md
@@ -1,0 +1,23 @@
+# Execution-record conformance summary
+
+**Verdict: NON-CONFORMING**
+
+2 records checked, 2 conform.
+
+## What was checked
+
+Each record was checked against the SEP-2828 execution-record schema for its type, decision or outcome, with no signing key: the wire shape and the record's own self-proving digest. Across the set, calls were checked for duplicates and decisions were paired with their outcomes.
+
+## Records
+
+- Outcomes: executed 1, refused 1
+
+## Findings
+
+Required (these gate conformance):
+
+- **duplicate_call** — 2 outcome records pin the same call (attestationDigest sha256:6b23c0d5f35d1b11f9b683f0b0a617355deb11277d91ae091d399c655b87940d, nonce nonce-C); a call MUST be recorded once (r1.json, r2.json)
+
+---
+
+No signing key was used to produce this summary. Any party can reproduce every count and finding above from the records alone with `vaara verify-records`.

--- a/tests/vectors/audit_summary_v0/pages/executed_gap.md
+++ b/tests/vectors/audit_summary_v0/pages/executed_gap.md
@@ -1,0 +1,23 @@
+# Execution-record conformance summary
+
+**Verdict: CONFORMS**
+
+2 records checked, 2 conform.
+
+## What was checked
+
+Each record was checked against the SEP-2828 execution-record schema for its type, decision or outcome, with no signing key: the wire shape and the record's own self-proving digest. Across the set, calls were checked for duplicates and decisions were paired with their outcomes.
+
+## Records
+
+- Outcomes: executed 2
+
+## Findings
+
+Advisory (gaps that do not gate conformance):
+
+- **executed_without_result_commitment** — 1 executed records carry no resultCommitment; an executed action SHOULD commit to its result (r1.json)
+
+---
+
+No signing key was used to produce this summary. Any party can reproduce every count and finding above from the records alone with `vaara verify-records`.

--- a/tests/vectors/audit_summary_v0/pages/mixed_nonconforming.md
+++ b/tests/vectors/audit_summary_v0/pages/mixed_nonconforming.md
@@ -1,0 +1,25 @@
+# Execution-record conformance summary
+
+**Verdict: NON-CONFORMING**
+
+2 records checked, 1 conforms.
+
+## What was checked
+
+Each record was checked against the SEP-2828 execution-record schema for its type, decision or outcome, with no signing key: the wire shape and the record's own self-proving digest. Across the set, calls were checked for duplicates and decisions were paired with their outcomes.
+
+## Records
+
+- Outcomes: executed 1
+
+## Findings
+
+No cross-record findings.
+
+## Non-conforming records
+
+- `bad.json` (outcome): status_valid
+
+---
+
+No signing key was used to produce this summary. Any party can reproduce every count and finding above from the records alone with `vaara verify-records`.

--- a/tests/vectors/audit_summary_v0/pages/outcome_without_decision.md
+++ b/tests/vectors/audit_summary_v0/pages/outcome_without_decision.md
@@ -1,0 +1,24 @@
+# Execution-record conformance summary
+
+**Verdict: CONFORMS**
+
+3 records checked, 3 conform.
+
+## What was checked
+
+Each record was checked against the SEP-2828 execution-record schema for its type, decision or outcome, with no signing key: the wire shape and the record's own self-proving digest. Across the set, calls were checked for duplicates and decisions were paired with their outcomes.
+
+## Records
+
+- Decisions: allow 1
+- Outcomes: executed 1, refused 1
+
+## Findings
+
+Advisory (gaps that do not gate conformance):
+
+- **outcome_without_decision** — 1 outcome records have no matching decision record; a recorded action SHOULD trace to the decision that authorised it (outcome_b.json)
+
+---
+
+No signing key was used to produce this summary. Any party can reproduce every count and finding above from the records alone with `vaara verify-records`.

--- a/tests/vectors/audit_summary_v0/pages/proper_pair.md
+++ b/tests/vectors/audit_summary_v0/pages/proper_pair.md
@@ -1,0 +1,22 @@
+# Execution-record conformance summary
+
+**Verdict: CONFORMS**
+
+2 records checked, 2 conform.
+
+## What was checked
+
+Each record was checked against the SEP-2828 execution-record schema for its type, decision or outcome, with no signing key: the wire shape and the record's own self-proving digest. Across the set, calls were checked for duplicates and decisions were paired with their outcomes.
+
+## Records
+
+- Decisions: allow 1
+- Outcomes: executed 1
+
+## Findings
+
+No cross-record findings.
+
+---
+
+No signing key was used to produce this summary. Any party can reproduce every count and finding above from the records alone with `vaara verify-records`.


### PR DESCRIPTION
0.60 made Vaara the neutral checker of one record. This release adds the receiving side an auditor works from: point it at a whole directory of records or bundles and get the set-level answer, then read it as a page a regulator can follow.

A4, the one-page audit summary, is new in this PR. A1 (verify-records), A2 (the coverage critic), and A3 (verify-bundles) already landed on main since v0.60.0 and ship here under one version.

### New in this PR (A4)
- `vaara audit-summary DIR [--glob] [--out FILE]`: the human-readable face of `verify-records`. Renders the verdict, the record counts, and the findings as a one-page Markdown report a regulator reads. Deterministic and keyless: no timestamp, no signing key, so the same set always renders the same page.
- `render_record_set_summary` on the public `vaara.attestation.receipt` surface; `audit_summary_v0` golden pages over the `record_set_v0` sets.

### Released together (already on main)
- A1 `vaara verify-records`: set-level conformance over a directory of records.
- A2 the coverage critic: type-aware decision/outcome pairing.
- A3 `vaara verify-bundles`: the full lens stack over a directory of bundles.

### Release
- Version bumped to 0.61.0 across the seven manifests. CHANGELOG entry covers the whole workbench (A1 through A4).
- 1410 passed, 13 skipped, ruff clean, the new module mypy --strict clean.
