### PR TITLE
test(audit-summary): independent checker confirms the page matches the verdict

### DIFF
--- a/src/vaara/attestation/_audit_summary.py
+++ b/src/vaara/attestation/_audit_summary.py
@@ -86,13 +86,13 @@ def render_record_set_summary(
             lines.append("Required (these gate conformance):")
             lines.append("")
             for f in required:
-                lines.append(f"- **{f.id}** — {f.detail} ({_names(f.records)})")
+                lines.append(f"- **{f.id}**: {f.detail} ({_names(f.records)})")
             lines.append("")
         if advisory:
             lines.append("Advisory (gaps that do not gate conformance):")
             lines.append("")
             for f in advisory:
-                lines.append(f"- **{f.id}** — {f.detail} ({_names(f.records)})")
+                lines.append(f"- **{f.id}**: {f.detail} ({_names(f.records)})")
             lines.append("")
 
     nonconforming = [e for e in report.entries if not e.conforms]

--- a/tests/test_audit_summary.py
+++ b/tests/test_audit_summary.py
@@ -10,6 +10,8 @@ suite runs in the base install.
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -18,8 +20,9 @@ from vaara.attestation._audit_summary import SUMMARY_SCHEMA
 from vaara.attestation.receipt import check_record_set, render_record_set_summary
 from vaara.cli import main
 
+VECTORS = Path(__file__).resolve().parent / "vectors" / "audit_summary_v0"
 RECORD_SETS = Path(__file__).resolve().parent / "vectors" / "record_set_v0" / "sets"
-PAGES = Path(__file__).resolve().parent / "vectors" / "audit_summary_v0" / "pages"
+PAGES = VECTORS / "pages"
 
 
 def _cases():
@@ -42,6 +45,22 @@ def test_render_matches_golden_page(name):
 
 def test_at_least_four_golden_pages_present():
     assert len(_cases()) >= 4
+
+
+def test_independent_checker_confirms_pages_match_verdict():
+    # The Vaara-free checker re-derives each verdict from record_set_v0 and
+    # asserts the rendered page states it faithfully.
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_rendered_page_carries_no_em_dash():
+    for name in _cases():
+        page = render_record_set_summary(check_record_set(_load_set(name)))
+        assert "—" not in page  # em-dash is the AI tell; not in Vaara output
 
 
 def test_public_reexport_is_wired():

--- a/tests/vectors/audit_summary_v0/README.md
+++ b/tests/vectors/audit_summary_v0/README.md
@@ -10,18 +10,24 @@ the keyless `check_record_set`, and the rendered page is committed under
 `pages/<case>.md`. The test renders each set and asserts byte-equality with
 its committed page.
 
-There is no separate Vaara-free re-implementation here, and that is the point.
-The summary is a rendering of a verdict, not a second judgement. The verdict it
-formats is already verified independently by `record_set_v0/_check_independent.py`
-(a Vaara-free checker that reproduces every count and finding from the schema
-alone). The golden bytes are this layer's contract: the page is deterministic,
-carrying no timestamp and no key, so the same set always renders the same page.
+Two things are verified, on two levels. The golden bytes pin the exact page the
+renderer produces (a deterministic render carrying no timestamp and no key, so
+the same set always renders the same page). On top of that, `_check_independent.py`
+proves the page tells the truth: with no Vaara import it parses each golden page,
+pulls out the claims it makes (the verdict word, the counts, the finding ids and
+records, the non-conforming count), and asserts they equal what
+`record_set_v0/expected.json` independently says for the same case. So the
+verdict the regulator reads is confirmed to match the machine verdict by a party
+that re-derived it from the records alone. The conformance itself is reproduced
+from the SEP-2828 schema by `record_set_v0/_check_independent.py`.
 
 ## Layout
 
 ```
-pages/<case>.md     the exact Markdown render_record_set_summary produces for
-                    the record_set_v0 set of the same name
+pages/<case>.md          the exact Markdown render_record_set_summary produces
+                         for the record_set_v0 set of the same name
+_check_independent.py    stdlib only (re + json), no Vaara import: asserts each
+                         page's claims match record_set_v0's independent verdict
 ```
 
 ## Regenerating

--- a/tests/vectors/audit_summary_v0/_check_independent.py
+++ b/tests/vectors/audit_summary_v0/_check_independent.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Independent check that the regulator page tells the truth.
+
+The audit summary is a rendering, not a second judgement: every fact on the
+page comes from ``check_record_set``, whose verdict is already reproduced from
+the SEP-2828 schema with no Vaara import by ``record_set_v0/_check_independent.py``.
+What that leaves unproven is whether the *prose* faithfully states that verdict,
+or whether a renderer could quietly print CONFORMS over a non-conforming set.
+
+This checker closes that gap without importing Vaara. It reads each committed
+golden page as plain text, pulls out the claims it makes (the verdict word, the
+"N records checked, M conform" counts, the finding ids and their records under
+the Required and Advisory headings, and the count of non-conforming records),
+and asserts they equal what ``record_set_v0/expected.json`` independently says
+for the same case. The page is confirmed to match the machine verdict, by a
+party that re-derived that verdict from the records alone.
+
+Standard library only (re, json, pathlib). Run:
+``python tests/vectors/audit_summary_v0/_check_independent.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PAGES = HERE / "pages"
+EXPECTED = HERE.parent / "record_set_v0" / "expected.json"
+
+_VERDICT = re.compile(r"^\*\*Verdict: (CONFORMS|NON-CONFORMING)\*\*$", re.M)
+_COUNTS = re.compile(r"^(\d+) records? checked, (\d+) conforms?\.$", re.M)
+_FINDING_ID = re.compile(r"\*\*(.+?)\*\*")
+_TRAILING_PARENS = re.compile(r"\(([^()]+)\)\s*$")
+_NONCONFORMING = re.compile(r"^- `([^`]+)` \(")
+
+
+def _section(lines, header):
+    """The bullet lines under a `header`, skipping the blank line after it."""
+    out = []
+    if header not in lines:
+        return out
+    i = lines.index(header) + 1
+    while i < len(lines) and not lines[i].strip():  # skip blank(s) after header
+        i += 1
+    while i < len(lines) and lines[i].startswith("- "):
+        out.append(lines[i])
+        i += 1
+    return out
+
+
+def parse_page(text):
+    """Pull the claims a regulator would read off the page."""
+    lines = text.splitlines()
+    verdict_m = _VERDICT.search(text)
+    counts_m = _COUNTS.search(text)
+
+    findings = []
+    for severity, header in (
+        ("required", "Required (these gate conformance):"),
+        ("advisory", "Advisory (gaps that do not gate conformance):"),
+    ):
+        for line in _section(lines, header):
+            fid = _FINDING_ID.search(line)
+            recs = _TRAILING_PARENS.search(line)
+            if fid and recs:
+                names = sorted(r.strip() for r in recs.group(1).split(","))
+                findings.append({"id": fid.group(1), "severity": severity,
+                                 "records": names})
+
+    nonconforming = [m.group(1) for m in (_NONCONFORMING.match(ln) for ln in lines) if m]
+
+    return {
+        "verdict": verdict_m.group(1) if verdict_m else None,
+        "total": int(counts_m.group(1)) if counts_m else None,
+        "conforming": int(counts_m.group(2)) if counts_m else None,
+        "findings": sorted(findings, key=lambda f: (f["id"], f["records"])),
+        "nonconforming_count": len(nonconforming),
+    }
+
+
+def expected_claims(case):
+    """The same claims, derived from the independent record-set verdict."""
+    want_findings = sorted(
+        ({"id": f["id"], "severity": f["severity"], "records": sorted(f["records"])}
+         for f in case["findings"]),
+        key=lambda f: (f["id"], f["records"]),
+    )
+    return {
+        "verdict": "CONFORMS" if case["conforms"] else "NON-CONFORMING",
+        "total": case["total"],
+        "conforming": case["conforming"],
+        "findings": want_findings,
+        "nonconforming_count": case["total"] - case["conforming"],
+    }
+
+
+def main() -> int:
+    expected = json.loads(EXPECTED.read_text())
+    failures = 0
+    for name in sorted(p.stem for p in PAGES.glob("*.md")):
+        page = parse_page((PAGES / f"{name}.md").read_text())
+        want = expected_claims(expected[name])
+        ok = page == want
+        failures += 0 if ok else 1
+        print(f"[{'OK' if ok else 'FAIL'}] {name}: page says {page['verdict']}")
+        if not ok:
+            print("  want:", want)
+            print("  got :", page)
+    total = len(list(PAGES.glob("*.md")))
+    print(f"\n{total - failures}/{total} pages match the independent verdict.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/audit_summary_v0/pages/decision_without_outcome.md
+++ b/tests/vectors/audit_summary_v0/pages/decision_without_outcome.md
@@ -17,7 +17,7 @@ Each record was checked against the SEP-2828 execution-record schema for its typ
 
 Advisory (gaps that do not gate conformance):
 
-- **decision_without_outcome** — 1 allow/escalate decisions have no matching outcome record; an authorised action SHOULD leave a recorded outcome (decision_b.json)
+- **decision_without_outcome**: 1 allow/escalate decisions have no matching outcome record; an authorised action SHOULD leave a recorded outcome (decision_b.json)
 
 ---
 

--- a/tests/vectors/audit_summary_v0/pages/duplicate_call.md
+++ b/tests/vectors/audit_summary_v0/pages/duplicate_call.md
@@ -16,7 +16,7 @@ Each record was checked against the SEP-2828 execution-record schema for its typ
 
 Required (these gate conformance):
 
-- **duplicate_call** — 2 outcome records pin the same call (attestationDigest sha256:6b23c0d5f35d1b11f9b683f0b0a617355deb11277d91ae091d399c655b87940d, nonce nonce-C); a call MUST be recorded once (r1.json, r2.json)
+- **duplicate_call**: 2 outcome records pin the same call (attestationDigest sha256:6b23c0d5f35d1b11f9b683f0b0a617355deb11277d91ae091d399c655b87940d, nonce nonce-C); a call MUST be recorded once (r1.json, r2.json)
 
 ---
 

--- a/tests/vectors/audit_summary_v0/pages/executed_gap.md
+++ b/tests/vectors/audit_summary_v0/pages/executed_gap.md
@@ -16,7 +16,7 @@ Each record was checked against the SEP-2828 execution-record schema for its typ
 
 Advisory (gaps that do not gate conformance):
 
-- **executed_without_result_commitment** — 1 executed records carry no resultCommitment; an executed action SHOULD commit to its result (r1.json)
+- **executed_without_result_commitment**: 1 executed records carry no resultCommitment; an executed action SHOULD commit to its result (r1.json)
 
 ---
 

--- a/tests/vectors/audit_summary_v0/pages/outcome_without_decision.md
+++ b/tests/vectors/audit_summary_v0/pages/outcome_without_decision.md
@@ -17,7 +17,7 @@ Each record was checked against the SEP-2828 execution-record schema for its typ
 
 Advisory (gaps that do not gate conformance):
 
-- **outcome_without_decision** — 1 outcome records have no matching decision record; a recorded action SHOULD trace to the decision that authorised it (outcome_b.json)
+- **outcome_without_decision**: 1 outcome records have no matching decision record; a recorded action SHOULD trace to the decision that authorised it (outcome_b.json)
 
 ---
 


### PR DESCRIPTION
The audit-summary page is a rendering, so it shipped with golden-byte vectors but no Vaara-free second check, the way `verify-records` and `verify-bundles` have one. This closes that gap.

### Independent checker
`tests/vectors/audit_summary_v0/_check_independent.py` parses each golden page with no Vaara import, pulls out the claims it states (the verdict word, the counts, the finding ids and their records, the non-conforming count), and asserts they equal what `record_set_v0/expected.json` independently computes for the same case. The regulator page is now confirmed to tell the truth a party can re-derive from the records alone, not just to be byte-stable. The conformance underneath is already reproduced from the SEP-2828 schema by `record_set_v0`'s own checker.

### Em-dash out of the output
The findings line of the rendered page used an em-dash. A colon reads the same and the em-dash does not belong in Vaara's output. Swapped it, regenerated the four affected golden pages, added a test asserting no em-dash renders.

The verdict and every count are unchanged. 1412 passed, ruff clean, mypy --strict clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated formatting in audit summary markdown output to use colons instead of em dashes for improved consistency in finding entries.

* **Tests**
  * Added independent verification script to validate audit summary page rendering.
  * Extended test suite with additional validation checks beyond byte-level verification.

* **Documentation**
  * Updated audit summary test documentation to clarify verification methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->