### PR TITLE
v0.61.1: drop the em-dash from the audit-summary output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.61.1] - 2026-06-08
+
+### Fixed
+- `vaara audit-summary` no longer emits an em-dash in the findings line of the
+  rendered report; it uses a colon. Cosmetic only: the verdict, the counts, and
+  the findings are unchanged, and the page stays byte-deterministic.
+
+### Verification
+- Added a standalone checker for the audit-summary golden pages
+  (`tests/vectors/audit_summary_v0/_check_independent.py`) that parses each
+  rendered page with no Vaara import and asserts the verdict, counts, and
+  findings it states equal what the `record_set_v0` conformance vectors
+  independently compute. The regulator page is confirmed to state the same
+  verdict a neutral party derives from the records, not only to be byte-stable.
+
 ## [0.61.0] - 2026-06-08
 
 **Theme: the auditor's workbench. 0.60 made Vaara the neutral checker of one

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.61.0"
+version = "0.61.1"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.61.0",
+  "version": "0.61.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.61.0",
+      "version": "0.61.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.61.0",
+  "version": "0.61.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.61.0",
+      "version": "0.61.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.61.0"
+__version__ = "0.61.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Patch over v0.61.0. The findings line of the `vaara audit-summary` report rendered an em-dash, and published 0.61.0 carried it. An em-dash does not belong in Vaara's output, so this swaps it for a colon. Cosmetic only: the verdict, the counts, and the findings are unchanged and the page stays byte-deterministic.

The em-dash fix and the new audit-summary independent checker already landed on main (PR #215, `ba13d2a`); this PR only bumps the version across the seven manifests and adds the CHANGELOG entry so the fix reaches PyPI and npm.

1412 passed.
