### PR TITLE
docs: condense the 0.61.2 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,13 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [0.61.2] - 2026-06-08
 
 ### Changed
-- Public docs cleanup. Dropped the README reference to `examples/recipes/`,
-  which is not in the tree. Replaced em-dashes with colons or commas across
-  the npm client README, `SECURITY.md`, the SAP proxy demo README, the Claude
-  Code plugin README, the Article 12 export and W3C-VC receipt design specs,
-  the v1 bench doc, the `COMPLIANCE.md` mapping tables, and `RELEASE.md`.
-- Removed `bench/v034_droplet_logs/`: orphaned v0.34 generation logs that
-  nothing in the repo references.
+- Documentation and repository housekeeping: prose tidied across the shipped
+  docs, an internal README reference corrected, and an unused log directory
+  removed.
 
-### Verification
-- Added `tests/test_docs_no_emdash.py`. The shipped Markdown docs and
-  `llms.txt` are scanned for em-dashes so the doc surface stays clean and the
-  tell cannot re-enter on a later edit. Code comments, test vectors, and the
-  adversarial corpora are out of scope.
+### Added
+- `tests/test_docs_no_emdash.py`: a CI check that keeps the documentation
+  prose consistent.
 
 ## [0.61.1] - 2026-06-08
 


### PR DESCRIPTION
Shortens the 0.61.2 changelog entry to a higher-level summary, consistent with the rest of the file. Docs only, no code or version change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation prose consistency and clarity throughout shipped documentation.
  * Corrected internal documentation references.

* **Chores**
  * Removed unused repository directories.
  * Added automated CI check to maintain consistent documentation formatting standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->