### PR TITLE
v0.62.0: normalize adjacent MCP records into the SEP-2828 evidence model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.62.0] - 2026-06-08
+
+### Added
+- `vaara normalize`: read an adjacent MCP record and map it onto the SEP-2828
+  execution-record evidence model. A SEP-2643 authorization denial becomes a
+  refused outcome, a SEP-2787 tool-call attestation becomes the
+  decision-attested back-link a conformant receipt must pin, and a SEP-2817
+  invocation audit context becomes advisory decision-input. For each record the
+  command reports which evidence plane it fills, which SEP-2828 fields it
+  populates, and what is still missing for a complete signed record. It promotes
+  nothing: an unsigned client claim stays advisory, and when the source flags an
+  intent as redacted the cleartext is withheld. SEP-2643 and SEP-2817 run in the
+  base install; the SEP-2787 back-link digest needs the attestation extra. Ships
+  with the `normalize_v0` vectors (verbatim spec examples plus an
+  extension-field attestation) and a Vaara-free independent checker that
+  reconstructs the modeled envelope and reproduces every case.
+
 ## [0.61.3] - 2026-06-08
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.61.3",
+  "version": "0.62.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.61.3"
+version = "0.62.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.61.3",
+  "version": "0.62.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.61.3",
+      "version": "0.62.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.61.3",
+  "version": "0.62.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.61.3",
+      "version": "0.62.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.61.3"
+__version__ = "0.62.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_normalize.py
+++ b/src/vaara/attestation/_normalize.py
@@ -1,0 +1,370 @@
+"""Normalize adjacent MCP records into the SEP-2828 evidence model.
+
+Vaara is the receiving side for agent execution evidence. A SEP-2828
+execution record is a signed decision+outcome pair, but the surrounding
+MCP ecosystem emits narrower, single-purpose records that each cover one
+face of the same event:
+
+  - SEP-2643 structured authorization denials carry the server's
+    refusal: the *outcome* of a call that was declined.
+  - SEP-2787 tool-call attestations carry the attested request: the
+    binding a receipt answers (the exact back-link a conformant receipt
+    must pin).
+  - SEP-2817 AI invocation audit context carries client-asserted
+    *input*: why the agent asked, which model, the user intent, the turn
+    id. Its own specification says it MUST NOT be used as authorization
+    evidence.
+
+This module reads one such record and maps it onto the SEP-2828 model:
+which evidence plane it fills, which SEP-2828 fields it populates, and
+what is still missing before the evidence amounts to a complete signed
+execution record. It invents nothing and it promotes nothing: an
+unsigned client claim stays advisory. It reports honestly what each
+source does and does not establish.
+
+The SEP-2643 and SEP-2817 maps are pure standard library and run in the
+base install. The SEP-2787 map computes the back-link digest the way the
+receipt verifier computes it (JCS over the attestation wire bytes),
+which needs the attestation extra; that step degrades to a reported gap
+when the extra is absent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+SOURCE_SEP2643 = "sep2643"
+SOURCE_SEP2787 = "sep2787"
+SOURCE_SEP2817 = "sep2817"
+SOURCE_UNKNOWN = "unknown"
+
+PLANE_OUTCOME = "outcome"
+PLANE_DECISION_ATTESTED = "decision-attested"
+PLANE_DECISION_INPUT = "decision-input"
+
+# The reserved request _meta key SEP-2817 defines for invocation audit context.
+AI_INVOCATION_KEY = "io.modelcontextprotocol/aiInvocation"
+
+
+@dataclass(frozen=True)
+class NormalizedEvidence:
+    """One foreign record mapped onto the SEP-2828 evidence model.
+
+    ``sep2828`` holds only the real SEP-2828 record fields the source
+    establishes; ``advisory`` holds context the source carries that is
+    not, on its own, a SEP-2828 proof. ``missing`` lists what a complete
+    signed record still needs that this source does not supply.
+    """
+
+    source_format: str
+    source_title: str
+    recognized: bool
+    evidence_plane: Optional[str] = None
+    sep2828: dict[str, Any] = field(default_factory=dict)
+    advisory: dict[str, Any] = field(default_factory=dict)
+    populated: tuple[str, ...] = ()
+    missing: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sourceFormat": self.source_format,
+            "sourceTitle": self.source_title,
+            "recognized": self.recognized,
+            "evidencePlane": self.evidence_plane,
+            "sep2828": self.sep2828,
+            "advisory": self.advisory,
+            "populated": list(self.populated),
+            "missing": list(self.missing),
+            "notes": list(self.notes),
+        }
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _denial_authorization(doc: Any) -> Optional[dict[str, Any]]:
+    """Locate the SEP-2643 ``authorization`` object inside a denial.
+
+    Accepts the full JSON-RPC error response (authorization under
+    ``error.data``), a bare ``data`` object, a bare ``authorization``
+    object, or the authorization object itself. Returns it only when it
+    carries the REQUIRED ``reason`` string, which distinguishes a denial
+    from the other records this module reads.
+    """
+    if not isinstance(doc, dict):
+        return None
+    candidates = (
+        _as_dict(_as_dict(doc.get("error")).get("data")).get("authorization"),
+        _as_dict(doc.get("data")).get("authorization"),
+        doc.get("authorization"),
+        doc,
+    )
+    for cand in candidates:
+        if isinstance(cand, dict) and isinstance(cand.get("reason"), str):
+            return cand
+    return None
+
+
+def _ai_invocation(doc: Any) -> Optional[dict[str, Any]]:
+    """Locate the SEP-2817 aiInvocation object.
+
+    Accepts a full request (object under ``params._meta[KEY]``), a bare
+    ``_meta`` block, a bare object under ``KEY``, or the aiInvocation
+    object itself (recognized by one of its four defined fields).
+    """
+    if not isinstance(doc, dict):
+        return None
+    candidates = (
+        _as_dict(_as_dict(doc.get("params")).get("_meta")).get(AI_INVOCATION_KEY),
+        _as_dict(doc.get("_meta")).get(AI_INVOCATION_KEY),
+        doc.get(AI_INVOCATION_KEY),
+    )
+    for cand in candidates:
+        if isinstance(cand, dict):
+            return cand
+    if any(k in doc for k in ("invocationReason", "model", "userIntent", "turnId")):
+        return doc
+    return None
+
+
+def _looks_like_attestation(doc: Any) -> bool:
+    return isinstance(doc, dict) and all(
+        k in doc
+        for k in ("plannerDeclared", "issuerAsserted", "payloadDerived", "signature")
+    )
+
+
+def detect_format(doc: Any) -> str:
+    """Identify which adjacent-SEP record ``doc`` is, or ``"unknown"``."""
+    if _looks_like_attestation(doc):
+        return SOURCE_SEP2787
+    if _denial_authorization(doc) is not None:
+        return SOURCE_SEP2643
+    if _ai_invocation(doc) is not None:
+        return SOURCE_SEP2817
+    return SOURCE_UNKNOWN
+
+
+def normalize(doc: Any, *, source_format: str = "auto") -> NormalizedEvidence:
+    """Map a foreign MCP record onto the SEP-2828 evidence model.
+
+    ``source_format`` is ``"auto"`` (detect) or one of ``"sep2643"``,
+    ``"sep2787"``, ``"sep2817"`` to force a reading.
+    """
+    fmt = detect_format(doc) if source_format == "auto" else source_format
+    if fmt == SOURCE_SEP2787:
+        return _normalize_attestation(doc)
+    if fmt == SOURCE_SEP2643:
+        return _normalize_denial(doc)
+    if fmt == SOURCE_SEP2817:
+        return _normalize_invocation(doc)
+    return NormalizedEvidence(
+        source_format=SOURCE_UNKNOWN,
+        source_title="unrecognized record",
+        recognized=False,
+        notes=(
+            "not a SEP-2643 denial, SEP-2787 attestation, or SEP-2817 "
+            "invocation audit context; nothing to normalize",
+        ),
+    )
+
+
+def _unrecognized(fmt: str, title: str, why: str) -> NormalizedEvidence:
+    return NormalizedEvidence(
+        source_format=fmt,
+        source_title=title,
+        recognized=False,
+        notes=(f"does not look like a {title}: {why}",),
+    )
+
+
+def _normalize_denial(doc: Any) -> NormalizedEvidence:
+    authz = _denial_authorization(doc)
+    if authz is None:
+        return _unrecognized(
+            SOURCE_SEP2643, "SEP-2643 authorization denial",
+            "no authorization object with a 'reason' field",
+        )
+    advisory: dict[str, Any] = {"reason": authz.get("reason")}
+    ctx = authz.get("authorizationContextId")
+    if isinstance(ctx, str):
+        advisory["authorizationContextId"] = ctx
+    hints = authz.get("remediationHints")
+    if isinstance(hints, list):
+        types = [
+            h["type"]
+            for h in hints
+            if isinstance(h, dict) and isinstance(h.get("type"), str)
+        ]
+        if types:
+            advisory["remediationHintTypes"] = types
+    notes = (
+        "a denial is the outcome of a refused call: it maps to "
+        "outcomeDerived.status = refused",
+        "a refused outcome carries no resultCommitment",
+        "authorizationContextId is a correlation handle, not authorization "
+        "material",
+        "the denial carries no completedAt, no signing envelope, and no "
+        "back-link; the recording side supplies those",
+    )
+    return NormalizedEvidence(
+        source_format=SOURCE_SEP2643,
+        source_title="SEP-2643 authorization denial",
+        recognized=True,
+        evidence_plane=PLANE_OUTCOME,
+        sep2828={"outcomeDerived": {"status": "refused"}},
+        advisory=advisory,
+        populated=("outcomeDerived.status",),
+        missing=(
+            "alg", "signature", "backLink", "receiptAsserted",
+            "outcomeDerived.completedAt",
+        ),
+        notes=notes,
+    )
+
+
+def _normalize_invocation(doc: Any) -> NormalizedEvidence:
+    inv = _ai_invocation(doc)
+    if inv is None:
+        return _unrecognized(
+            SOURCE_SEP2817, "SEP-2817 AI invocation audit context",
+            f"no '{AI_INVOCATION_KEY}' object",
+        )
+    advisory: dict[str, Any] = {}
+    reason = _as_dict(inv.get("invocationReason")).get("text")
+    if isinstance(reason, str):
+        advisory["invocationReason"] = reason
+    model = _as_dict(inv.get("model")).get("name")
+    if isinstance(model, str):
+        advisory["model"] = model
+    ui = _as_dict(inv.get("userIntent"))
+    if isinstance(ui.get("text"), str):
+        advisory["userIntent"] = ui["text"]
+    if ui.get("redacted") is True:
+        advisory["userIntentRedacted"] = True
+    turn = inv.get("turnId")
+    if isinstance(turn, str):
+        advisory["turnId"] = turn
+    notes = [
+        "SEP-2817 is client-asserted input audit context; per its own "
+        "specification it MUST NOT be used as authorization evidence",
+        "it maps to the decision-input plane (the agent's stated intent), "
+        "the unsigned counterpart of an attested rationale, and populates no "
+        "required SEP-2828 field",
+    ]
+    if "turnId" in advisory:
+        notes.append(
+            "turnId groups requests from one user turn; it is correlation only"
+        )
+    return NormalizedEvidence(
+        source_format=SOURCE_SEP2817,
+        source_title="SEP-2817 AI invocation audit context",
+        recognized=True,
+        evidence_plane=PLANE_DECISION_INPUT,
+        sep2828={},
+        advisory=advisory,
+        populated=(),
+        missing=("alg", "signature", "backLink", "receiptAsserted", "outcomeDerived"),
+        notes=tuple(notes),
+    )
+
+
+def _normalize_attestation(doc: Any) -> NormalizedEvidence:
+    if not _looks_like_attestation(doc):
+        return _unrecognized(
+            SOURCE_SEP2787, "SEP-2787 tool-call attestation",
+            "missing one of plannerDeclared/issuerAsserted/payloadDerived/signature",
+        )
+    issuer = _as_dict(doc.get("issuerAsserted"))
+    planner = _as_dict(doc.get("plannerDeclared"))
+    payload = _as_dict(doc.get("payloadDerived"))
+
+    advisory: dict[str, Any] = {}
+    if isinstance(planner.get("intent"), str):
+        advisory["intent"] = planner["intent"]
+    for f in ("iss", "sub", "alg"):
+        if isinstance(issuer.get(f), str):
+            advisory[f"attestation_{f}"] = issuer[f]
+    calls = payload.get("toolCalls")
+    if isinstance(calls, list):
+        advisory["toolCalls"] = [
+            {"name": c.get("name"), "serverFingerprint": c.get("serverFingerprint")}
+            for c in calls
+            if isinstance(c, dict)
+        ]
+
+    notes = [
+        "a SEP-2787 attestation is the attested request a SEP-2828 receipt "
+        "answers; it fixes the exact back-link a conformant receipt must pin",
+        "plannerDeclared.intent is client-declared and bound by the issuer's "
+        "signature, not asserted true by the issuer",
+        "the record's own signing (alg, signature, receiptAsserted) is a "
+        "separate event by the recording side, not derived from the attestation",
+    ]
+
+    back_link, gap = _back_link_from_attestation(doc)
+    if back_link is None:
+        notes.append(gap or "back-link could not be computed")
+        return NormalizedEvidence(
+            source_format=SOURCE_SEP2787,
+            source_title="SEP-2787 tool-call attestation",
+            recognized=True,
+            evidence_plane=PLANE_DECISION_ATTESTED,
+            sep2828={},
+            advisory=advisory,
+            populated=(),
+            missing=(
+                "alg", "signature", "backLink", "receiptAsserted", "outcomeDerived",
+            ),
+            notes=tuple(notes),
+        )
+    return NormalizedEvidence(
+        source_format=SOURCE_SEP2787,
+        source_title="SEP-2787 tool-call attestation",
+        recognized=True,
+        evidence_plane=PLANE_DECISION_ATTESTED,
+        sep2828={"backLink": back_link},
+        advisory=advisory,
+        populated=("backLink.attestationDigest", "backLink.attestationNonce"),
+        missing=("alg", "signature", "receiptAsserted", "outcomeDerived"),
+        notes=tuple(notes),
+    )
+
+
+def _back_link_from_attestation(
+    doc: Any,
+) -> tuple[Optional[dict[str, str]], Optional[str]]:
+    """Compute the SEP-2828 back-link a receipt answering this attestation pins.
+
+    Returns ``(back_link, None)`` on success or ``(None, reason)`` when the
+    attestation extra is absent or the attestation does not parse. The
+    digest is computed the way the receipt verifier computes it, so it is
+    the exact value a conformant receipt's ``backLink.attestationDigest``
+    must equal.
+    """
+    try:
+        from vaara.attestation.receipt import make_back_link
+        from vaara.attestation.sep2787 import AttestationError, parse_attestation
+    except ImportError:
+        return None, (
+            "back-link digest needs the attestation extra "
+            "(pip install 'vaara[attestation]')"
+        )
+    try:
+        attestation = parse_attestation(doc)
+    except (AttestationError, KeyError, TypeError, ValueError) as exc:
+        return None, f"not a parseable SEP-2787 attestation: {exc}"
+    try:
+        bl = make_back_link(attestation)
+    except AttestationError as exc:
+        return None, f"back-link digest unavailable: {exc}"
+    return (
+        {
+            "attestationDigest": bl.attestation_digest,
+            "attestationNonce": bl.attestation_nonce,
+        },
+        None,
+    )

--- a/src/vaara/attestation/_normalize.py
+++ b/src/vaara/attestation/_normalize.py
@@ -24,9 +24,11 @@ source does and does not establish.
 
 The SEP-2643 and SEP-2817 maps are pure standard library and run in the
 base install. The SEP-2787 map computes the back-link digest the way the
-receipt verifier computes it (JCS over the attestation wire bytes),
-which needs the attestation extra; that step degrades to a reported gap
-when the extra is absent.
+receipt verifier computes it: sha256 over the JCS canonicalization of the
+SEP-2787-modeled fields (parse, then canonicalize), the same value a
+conformant receipt pins. Fields outside the modeled schema are not
+covered. That step needs the attestation extra and degrades to a reported
+gap when the extra is absent.
 """
 
 from __future__ import annotations
@@ -96,14 +98,22 @@ def _denial_authorization(doc: Any) -> Optional[dict[str, Any]]:
     """
     if not isinstance(doc, dict):
         return None
-    candidates = (
+    # Nested positions are unambiguously a denial envelope.
+    for cand in (
         _as_dict(_as_dict(doc.get("error")).get("data")).get("authorization"),
         _as_dict(doc.get("data")).get("authorization"),
-        doc.get("authorization"),
-        doc,
-    )
-    for cand in candidates:
+    ):
         if isinstance(cand, dict) and isinstance(cand.get("reason"), str):
+            return cand
+    # A bare authorization object, or the document itself, must also carry a
+    # denial marker, so a stray top-level `reason` on an unrelated record is
+    # not read as a denial ahead of the SEP-2817 reader.
+    for cand in (doc.get("authorization"), doc):
+        if (
+            isinstance(cand, dict)
+            and isinstance(cand.get("reason"), str)
+            and ("authorizationContextId" in cand or "remediationHints" in cand)
+        ):
             return cand
     return None
 
@@ -241,10 +251,12 @@ def _normalize_invocation(doc: Any) -> NormalizedEvidence:
     if isinstance(model, str):
         advisory["model"] = model
     ui = _as_dict(inv.get("userIntent"))
-    if isinstance(ui.get("text"), str):
-        advisory["userIntent"] = ui["text"]
     if ui.get("redacted") is True:
+        # The source flagged the intent as redacted: surface the flag, never
+        # the text, so Vaara does not re-propagate content the source withheld.
         advisory["userIntentRedacted"] = True
+    elif isinstance(ui.get("text"), str):
+        advisory["userIntent"] = ui["text"]
     turn = inv.get("turnId")
     if isinstance(turn, str):
         advisory["turnId"] = turn
@@ -341,9 +353,11 @@ def _back_link_from_attestation(
 
     Returns ``(back_link, None)`` on success or ``(None, reason)`` when the
     attestation extra is absent or the attestation does not parse. The
-    digest is computed the way the receipt verifier computes it, so it is
-    the exact value a conformant receipt's ``backLink.attestationDigest``
-    must equal.
+    digest is computed the way the receipt verifier computes it: sha256 over
+    the JCS canonicalization of the SEP-2787-modeled fields (parse, then
+    canonicalize), so it is the exact value a conformant receipt's
+    ``backLink.attestationDigest`` must equal. Fields outside the modeled
+    schema are not covered.
     """
     try:
         from vaara.attestation.receipt import make_back_link

--- a/src/vaara/attestation/_receipt_verifier.py
+++ b/src/vaara/attestation/_receipt_verifier.py
@@ -43,10 +43,12 @@ class BackLinkResult:
 
 
 def attestation_digest(attestation: Attestation) -> str:
-    """``sha256:<hex>`` over the JCS-canonical full attestation wire bytes.
+    """``sha256:<hex>`` over the JCS canonicalization of the SEP-2787-modeled
+    attestation fields (the attestation re-serialized through ``to_dict``).
 
     The signature is included: the digest pins the exact attestation
-    instance the receipt answers, not just its unsigned body.
+    instance the receipt answers, not just its unsigned body. Fields outside
+    the modeled schema are dropped by the parse and are not covered.
     """
     wire = canonical_json(attestation.to_dict())
     return f"sha256:{hashlib.sha256(wire).hexdigest()}"

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -59,6 +59,11 @@ from vaara.attestation._audit_summary import (
 from vaara.attestation._decision_conformance import (
     check_decision_conformance,
 )
+from vaara.attestation._normalize import (
+    NormalizedEvidence,
+    detect_format,
+    normalize,
+)
 from vaara.attestation._receipt_conformance import (
     ConformanceCheck,
     ConformanceReport,
@@ -146,6 +151,9 @@ __all__ = [
     "check_bundle_set",
     "SUMMARY_SCHEMA",
     "render_record_set_summary",
+    "NormalizedEvidence",
+    "detect_format",
+    "normalize",
     "DidDocumentCache",
     "EvidenceBundle",
     "ExecutionReceipt",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -112,6 +112,14 @@ Subcommands:
         checked too, still keyless. The neutral check a party runs on a
         record someone else produced. Exit 0 iff the record conforms.
 
+    vaara normalize RECORD.json [--format auto|sep2643|sep2787|sep2817] [--json]
+        Map an adjacent MCP record onto the SEP-2828 evidence model. Reads a
+        SEP-2643 denial, a SEP-2787 attestation, or a SEP-2817 invocation
+        audit context and reports which evidence plane it fills, which
+        SEP-2828 fields it populates, and what is still missing for a
+        complete signed record. Promotes nothing: an unsigned client claim
+        stays advisory. Exit 0 iff the record was recognized.
+
     vaara verify-records DIR [--glob '*.json'] [--json]
         Conformance-check a whole directory of SEP-2828 records at once: the
         receiving side an auditor works from. Reports how many conform, which
@@ -1815,6 +1823,73 @@ def _record_back_link(attestation_path: str, doc: Any) -> dict[str, Any]:
                        else "record does not pin this attestation")}
 
 
+def _cmd_normalize(args: argparse.Namespace) -> int:
+    """Map a foreign MCP record onto the SEP-2828 evidence model.
+
+    Vaara is the receiving side: it reads a SEP-2643 denial, a SEP-2787
+    attestation, or a SEP-2817 invocation audit context and reports which
+    SEP-2828 evidence plane it fills, which fields it populates, and what
+    is still missing for a complete signed execution record. It promotes
+    nothing: an unsigned client claim stays advisory.
+    """
+    from vaara.attestation.receipt import normalize
+
+    path = Path(args.record).expanduser()
+    if not path.is_file():
+        print(f"vaara normalize: not a file: {path}", file=sys.stderr)
+        return 2
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"vaara normalize: cannot read record JSON: {exc}", file=sys.stderr)
+        return 1
+
+    result = normalize(doc, source_format=args.format)
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        _print_normalize_report(result)
+
+    return 0 if result.recognized else 1
+
+
+def _path_value(doc: dict[str, Any], dotted: str) -> Any:
+    """Follow a dotted path into a nested dict; None if absent."""
+    cur: Any = doc
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return None
+        cur = cur[part]
+    return cur
+
+
+def _print_normalize_report(result: Any) -> None:
+    if not result.recognized:
+        print(f"source: unrecognized ({result.source_format})")
+        for n in result.notes:
+            print(f"  note: {n}")
+        return
+    print(f"source: {result.source_title}")
+    print(f"evidence plane: {result.evidence_plane}")
+    if result.populated:
+        print("fills SEP-2828:")
+        for pth in result.populated:
+            val = _path_value(result.sep2828, pth)
+            print(f"  {pth}" + (f" = {val}" if val is not None else ""))
+    else:
+        print("fills SEP-2828: nothing required (advisory context only)")
+    if result.advisory:
+        print("carries (advisory, not proof):")
+        for k, v in result.advisory.items():
+            print(f"  {k}: {v}")
+    print("still needed for a complete signed record:")
+    for m in result.missing:
+        print(f"  {m}")
+    for n in result.notes:
+        print(f"  note: {n}")
+
+
 def _cmd_verify_records(args: argparse.Namespace) -> int:
     """Conformance-check a whole directory of SEP-2828 records at once.
 
@@ -2845,6 +2920,29 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the full conformance report as JSON",
     )
     pvr.set_defaults(func=_cmd_verify_record)
+
+    pnz = sub.add_parser(
+        "normalize",
+        help="Map an adjacent MCP record (SEP-2643 denial, SEP-2787 "
+             "attestation, or SEP-2817 invocation audit context) onto the "
+             "SEP-2828 evidence model: which plane it fills, which fields it "
+             "populates, and what is still missing for a complete signed "
+             "record. The receiving side that reads every dialect.",
+    )
+    pnz.add_argument(
+        "record",
+        help="Path to a JSON file holding a SEP-2643, SEP-2787, or SEP-2817 record",
+    )
+    pnz.add_argument(
+        "--format", default="auto",
+        choices=("auto", "sep2643", "sep2787", "sep2817"),
+        help="Source format (default: auto-detect)",
+    )
+    pnz.add_argument(
+        "--json", action="store_true",
+        help="Emit the normalized evidence mapping as JSON",
+    )
+    pnz.set_defaults(func=_cmd_normalize)
 
     pvrs = sub.add_parser(
         "verify-records",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -1864,6 +1864,18 @@ def _path_value(doc: dict[str, Any], dotted: str) -> Any:
     return cur
 
 
+def _safe_inline(value: Any) -> str:
+    """Render a value on one line, escaping control characters.
+
+    Advisory and attestation-derived values come from a record Vaara did not
+    produce; escaping C0 controls (newlines, tabs) stops a crafted value from
+    forging extra lines in the human report.
+    """
+    return "".join(
+        c if c.isprintable() else f"\\x{ord(c):02x}" for c in str(value)
+    )
+
+
 def _print_normalize_report(result: Any) -> None:
     if not result.recognized:
         print(f"source: unrecognized ({result.source_format})")
@@ -1876,13 +1888,13 @@ def _print_normalize_report(result: Any) -> None:
         print("fills SEP-2828:")
         for pth in result.populated:
             val = _path_value(result.sep2828, pth)
-            print(f"  {pth}" + (f" = {val}" if val is not None else ""))
+            print(f"  {pth}" + (f" = {_safe_inline(val)}" if val is not None else ""))
     else:
         print("fills SEP-2828: nothing required (advisory context only)")
     if result.advisory:
         print("carries (advisory, not proof):")
         for k, v in result.advisory.items():
-            print(f"  {k}: {v}")
+            print(f"  {k}: {_safe_inline(v)}")
     print("still needed for a complete signed record:")
     for m in result.missing:
         print(f"  {m}")

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -2,7 +2,7 @@
 
 Normalization is keyless for SEP-2643 denials and SEP-2817 invocation
 context, so those run in the base install. The SEP-2787 path computes the
-back-link digest (JCS over the attestation bytes) and needs the
+back-link digest (JCS over the SEP-2787-modeled fields) and needs the
 attestation extra; those cases skip on their own when rfc8785 is absent.
 """
 
@@ -105,9 +105,24 @@ def test_invocation_is_advisory_only():
     assert any("MUST NOT be used as authorization evidence" in n for n in r.notes)
 
 
-def test_redacted_user_intent_flagged():
+def test_redacted_user_intent_suppresses_cleartext():
     r = normalize(_input("sep2817_multiturn"))
     assert r.advisory.get("userIntentRedacted") is True
+    # The source flagged the intent redacted: the cleartext must not appear.
+    assert "userIntent" not in r.advisory
+
+
+def test_stray_reason_is_not_a_denial():
+    # A lone top-level `reason` without a denial marker is not a SEP-2643 denial.
+    assert detect_format({"reason": "user changed their mind"}) == "unknown"
+
+
+def test_extension_fields_are_dropped_from_the_digest():
+    pytest.importorskip("rfc8785")
+    base = normalize(_input("sep2787_attestation"))
+    ext = normalize(_input("sep2787_attestation_with_extension"))
+    # Fields outside the modeled schema do not change the back-link digest.
+    assert ext.sep2828["backLink"] == base.sep2828["backLink"]
 
 
 def test_attestation_fills_only_the_back_link():
@@ -200,3 +215,21 @@ def test_cli_bad_json_exit_1(tmp_path, capsys):
     rc = main(["normalize", str(target)])
     assert rc == 1
     assert "cannot read record JSON" in capsys.readouterr().err
+
+
+def test_cli_sanitizes_control_chars(tmp_path, capsys):
+    # A crafted foreign value must not forge extra report lines.
+    inv = {
+        "_meta": {
+            "io.modelcontextprotocol/aiInvocation": {
+                "model": {"name": "evil\n  FORGED VERDICT: CONFORMS"},
+            }
+        }
+    }
+    target = tmp_path / "inv.json"
+    target.write_text(json.dumps(inv))
+    rc = main(["normalize", str(target)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "\\x0a" in out
+    assert "\n  FORGED VERDICT: CONFORMS" not in out

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,202 @@
+"""`vaara normalize`: mapping adjacent MCP records onto SEP-2828.
+
+Normalization is keyless for SEP-2643 denials and SEP-2817 invocation
+context, so those run in the base install. The SEP-2787 path computes the
+back-link digest (JCS over the attestation bytes) and needs the
+attestation extra; those cases skip on their own when rfc8785 is absent.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vaara.attestation.receipt import NormalizedEvidence, detect_format, normalize
+from vaara.cli import main
+
+VECTORS = Path(__file__).resolve().parent / "vectors" / "normalize_v0"
+INPUTS = VECTORS / "inputs"
+
+
+def _expected() -> dict:
+    return json.loads((VECTORS / "expected.json").read_text())
+
+
+def _cases():
+    return sorted(_expected().keys())
+
+
+def _input(name: str) -> dict:
+    return json.loads((INPUTS / f"{name}.json").read_text())
+
+
+# ── Vectors ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", _cases())
+def test_module_reproduces_vector(name):
+    want = _expected()[name]
+    if want["sourceFormat"] == "sep2787":
+        pytest.importorskip("rfc8785")
+    got = normalize(_input(name)).to_dict()
+    assert got == want
+
+
+def test_independent_checker_passes():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_at_least_seven_cases_present():
+    assert len(_cases()) >= 7
+
+
+def test_public_reexport_is_wired():
+    from vaara.attestation.receipt import normalize as public
+    assert public is normalize
+
+
+# ── Detection ─────────────────────────────────────────────────────────────────
+
+
+def test_detect_each_format():
+    assert detect_format(_input("sep2643_url_denial")) == "sep2643"
+    assert detect_format(_input("sep2787_attestation")) == "sep2787"
+    assert detect_format(_input("sep2817_single")) == "sep2817"
+    assert detect_format(_input("unknown")) == "unknown"
+    assert detect_format(["not", "an", "object"]) == "unknown"
+
+
+def test_bare_authorization_object_detected():
+    bare = {"reason": "insufficient_authorization", "authorizationContextId": "x"}
+    assert detect_format(bare) == "sep2643"
+
+
+def test_bare_invocation_object_detected():
+    bare = {"turnId": "t", "model": {"name": "m"}}
+    assert detect_format(bare) == "sep2817"
+
+
+# ── Honest mapping ────────────────────────────────────────────────────────────
+
+
+def test_denial_is_a_refused_outcome():
+    r = normalize(_input("sep2643_url_denial"))
+    assert r.evidence_plane == "outcome"
+    assert r.sep2828 == {"outcomeDerived": {"status": "refused"}}
+    assert r.advisory["remediationHintTypes"] == ["url"]
+    assert "backLink" in r.missing and "signature" in r.missing
+
+
+def test_invocation_is_advisory_only():
+    # Client-asserted input populates no required SEP-2828 field.
+    r = normalize(_input("sep2817_single"))
+    assert r.evidence_plane == "decision-input"
+    assert r.populated == ()
+    assert r.sep2828 == {}
+    assert r.advisory["model"] == "example-model"
+    assert any("MUST NOT be used as authorization evidence" in n for n in r.notes)
+
+
+def test_redacted_user_intent_flagged():
+    r = normalize(_input("sep2817_multiturn"))
+    assert r.advisory.get("userIntentRedacted") is True
+
+
+def test_attestation_fills_only_the_back_link():
+    pytest.importorskip("rfc8785")
+    r = normalize(_input("sep2787_attestation"))
+    assert r.evidence_plane == "decision-attested"
+    assert set(r.populated) == {
+        "backLink.attestationDigest", "backLink.attestationNonce"
+    }
+    # The record's own signing is the recording side's, not the attestation's.
+    assert "alg" in r.missing
+    assert "receiptAsserted" in r.missing
+    assert "signature" in r.missing
+
+
+def test_attestation_backlink_matches_the_paired_receipt():
+    pytest.importorskip("rfc8785")
+    receipt = json.loads(
+        (Path(__file__).resolve().parent / "vectors" / "execution_receipt_v0"
+         / "normative" / "es256_executed_projection" / "receipt.json").read_text()
+    )
+    r = normalize(_input("sep2787_attestation"))
+    assert r.sep2828["backLink"] == receipt["backLink"]
+
+
+def test_unknown_is_not_recognized():
+    r = normalize(_input("unknown"))
+    assert r.recognized is False
+    assert isinstance(r, NormalizedEvidence)
+
+
+def test_forced_format_mismatch_is_unrecognized():
+    # Force the wrong reader: a denial read as an attestation does not parse.
+    r = normalize(_input("sep2643_url_denial"), source_format="sep2787")
+    assert r.recognized is False
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def test_cli_denial_exit_0(tmp_path, capsys):
+    target = tmp_path / "denial.json"
+    target.write_text((INPUTS / "sep2643_url_denial.json").read_text())
+    rc = main(["normalize", str(target)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "SEP-2643 authorization denial" in out
+    assert "outcomeDerived.status = refused" in out
+
+
+def test_cli_invocation_exit_0(tmp_path, capsys):
+    target = tmp_path / "inv.json"
+    target.write_text((INPUTS / "sep2817_single.json").read_text())
+    rc = main(["normalize", str(target)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "advisory context only" in out
+
+
+def test_cli_attestation_json(tmp_path, capsys):
+    pytest.importorskip("rfc8785")
+    target = tmp_path / "att.json"
+    target.write_text((INPUTS / "sep2787_attestation.json").read_text())
+    rc = main(["normalize", str(target), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["sep2828"]["backLink"]["attestationNonce"] == (
+        "fixed-attestation-nonce-000"
+    )
+
+
+def test_cli_unknown_exit_1(tmp_path, capsys):
+    target = tmp_path / "u.json"
+    target.write_text((INPUTS / "unknown.json").read_text())
+    rc = main(["normalize", str(target)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "unrecognized" in out
+
+
+def test_cli_missing_file_exit_2(tmp_path, capsys):
+    rc = main(["normalize", str(tmp_path / "nope.json")])
+    assert rc == 2
+    assert "not a file" in capsys.readouterr().err
+
+
+def test_cli_bad_json_exit_1(tmp_path, capsys):
+    target = tmp_path / "bad.json"
+    target.write_text("{ not json")
+    rc = main(["normalize", str(target)])
+    assert rc == 1
+    assert "cannot read record JSON" in capsys.readouterr().err

--- a/tests/vectors/normalize_v0/README.md
+++ b/tests/vectors/normalize_v0/README.md
@@ -1,0 +1,51 @@
+# normalize_v0 vectors
+
+Fixtures for `vaara normalize`: mapping an adjacent MCP record onto the
+SEP-2828 evidence model.
+
+A SEP-2828 execution record is a signed decision+outcome pair. The
+surrounding ecosystem emits narrower records that each cover one face of
+the same event, and `normalize` files each onto the SEP-2828 model,
+reporting which fields it establishes and what is still missing for a
+complete signed record. It promotes nothing: an unsigned client claim
+stays advisory.
+
+## Inputs (`inputs/`)
+
+Each input is a verbatim or near-verbatim example from the source spec.
+
+| File | Source | Evidence plane | Fills |
+| --- | --- | --- | --- |
+| `sep2643_url_denial.json` | SEP-2643 denial (URL remediation) | outcome | `outcomeDerived.status = refused` |
+| `sep2643_rar_denial.json` | SEP-2643 denial (RAR remediation) | outcome | `outcomeDerived.status = refused` |
+| `sep2643_scope_denial.json` | SEP-2643 denial (scope, no hints) | outcome | `outcomeDerived.status = refused` |
+| `sep2787_attestation.json` | SEP-2787 tool-call attestation | decision-attested | `backLink` |
+| `sep2817_single.json` | SEP-2817 invocation audit context | decision-input | nothing required (advisory) |
+| `sep2817_multiturn.json` | SEP-2817 (redacted intent, shared turn) | decision-input | nothing required (advisory) |
+| `unknown.json` | unrecognized object | n/a | nothing |
+
+`expected.json` holds the normalized mapping for each input.
+
+## What the back-link case proves
+
+A SEP-2787 attestation is the attested request a SEP-2828 receipt
+answers. `normalize` computes the exact `backLink` a conformant receipt
+must pin: `attestationDigest` is `sha256` over the JCS-canonical
+attestation bytes (RFC 8785), `attestationNonce` is the issuer nonce.
+For `sep2787_attestation.json` this is
+`sha256:79acdd4bb3c22a688b1c3321b9a26cafb5cb58c990a963874066d04b8497f70b`,
+the same value the paired receipt in `execution_receipt_v0` carries. The
+attestation fixes the back-link and nothing else: the record's own
+`alg`, `signature`, and `receiptAsserted` are a separate signing event by
+the recording side.
+
+## Independent checker
+
+`_check_independent.py` reimplements the normalization from the specs
+alone, with no Vaara import, and reproduces every case in `expected.json`.
+The SEP-2643 and SEP-2817 maps are pure standard library; the SEP-2787
+digest needs `rfc8785` and is skipped (not failed) without it.
+
+```
+python tests/vectors/normalize_v0/_check_independent.py
+```

--- a/tests/vectors/normalize_v0/README.md
+++ b/tests/vectors/normalize_v0/README.md
@@ -20,6 +20,7 @@ Each input is a verbatim or near-verbatim example from the source spec.
 | `sep2643_rar_denial.json` | SEP-2643 denial (RAR remediation) | outcome | `outcomeDerived.status = refused` |
 | `sep2643_scope_denial.json` | SEP-2643 denial (scope, no hints) | outcome | `outcomeDerived.status = refused` |
 | `sep2787_attestation.json` | SEP-2787 tool-call attestation | decision-attested | `backLink` |
+| `sep2787_attestation_with_extension.json` | SEP-2787 attestation carrying extension fields | decision-attested | `backLink` (extras dropped) |
 | `sep2817_single.json` | SEP-2817 invocation audit context | decision-input | nothing required (advisory) |
 | `sep2817_multiturn.json` | SEP-2817 (redacted intent, shared turn) | decision-input | nothing required (advisory) |
 | `unknown.json` | unrecognized object | n/a | nothing |
@@ -30,21 +31,29 @@ Each input is a verbatim or near-verbatim example from the source spec.
 
 A SEP-2787 attestation is the attested request a SEP-2828 receipt
 answers. `normalize` computes the exact `backLink` a conformant receipt
-must pin: `attestationDigest` is `sha256` over the JCS-canonical
-attestation bytes (RFC 8785), `attestationNonce` is the issuer nonce.
-For `sep2787_attestation.json` this is
+must pin: `attestationDigest` is `sha256` over the JCS canonicalization of
+the SEP-2787-modeled fields (parse, then canonicalize), `attestationNonce`
+is the issuer nonce. For `sep2787_attestation.json` this is
 `sha256:79acdd4bb3c22a688b1c3321b9a26cafb5cb58c990a963874066d04b8497f70b`,
 the same value the paired receipt in `execution_receipt_v0` carries. The
 attestation fixes the back-link and nothing else: the record's own
 `alg`, `signature`, and `receiptAsserted` are a separate signing event by
 the recording side.
 
+Fields outside the modeled schema are not covered.
+`sep2787_attestation_with_extension.json` carries an extra top-level key
+and an `issuerAsserted.kid`, yet yields the same digest, which pins that
+the modeled fields, not the raw received bytes, are what gets digested.
+
 ## Independent checker
 
 `_check_independent.py` reimplements the normalization from the specs
 alone, with no Vaara import, and reproduces every case in `expected.json`.
-The SEP-2643 and SEP-2817 maps are pure standard library; the SEP-2787
-digest needs `rfc8785` and is skipped (not failed) without it.
+The SEP-2643 and SEP-2817 maps are pure standard library. The SEP-2787
+case reconstructs the modeled envelope (dropping unmodeled fields,
+injecting the ArgsRef canonicalization default) and digests that under
+`rfc8785`, the same value the receipt verifier pins; it is skipped (not
+failed) when `rfc8785` is absent.
 
 ```
 python tests/vectors/normalize_v0/_check_independent.py

--- a/tests/vectors/normalize_v0/_check_independent.py
+++ b/tests/vectors/normalize_v0/_check_independent.py
@@ -8,10 +8,11 @@ evidence plane, which fields populated, what is still missing) and
 compares against ``expected.json``.
 
 The SEP-2643 and SEP-2817 maps are pure standard library. The SEP-2787
-map recomputes the back-link digest as ``sha256`` over the JCS-canonical
-attestation bytes (RFC 8785); that case is skipped, not failed, when
-``rfc8785`` is not installed, the same way the library degrades without
-the attestation extra.
+map reconstructs the SEP-2787-modeled envelope (dropping unmodeled fields
+and injecting the ArgsRef canonicalization default, exactly as the wire
+schema defines) and digests that under RFC 8785, which is the value the
+receipt verifier pins; that case is skipped, not failed, when ``rfc8785``
+is not installed.
 
 Run: ``python tests/vectors/normalize_v0/_check_independent.py``.
 Exit 0 means every runnable case matched its expected mapping.
@@ -46,10 +47,15 @@ def _denial(doc: Any) -> Optional[dict[str, Any]]:
     for cand in (
         _as_dict(_as_dict(doc.get("error")).get("data")).get("authorization"),
         _as_dict(doc.get("data")).get("authorization"),
-        doc.get("authorization"),
-        doc,
     ):
         if isinstance(cand, dict) and isinstance(cand.get("reason"), str):
+            return cand
+    for cand in (doc.get("authorization"), doc):
+        if (
+            isinstance(cand, dict)
+            and isinstance(cand.get("reason"), str)
+            and ("authorizationContextId" in cand or "remediationHints" in cand)
+        ):
             return cand
     return None
 
@@ -140,10 +146,10 @@ def _invocation_map(doc: Any) -> dict[str, Any]:
     if isinstance(_as_dict(inv.get("model")).get("name"), str):
         advisory["model"] = inv["model"]["name"]
     ui = _as_dict(inv.get("userIntent"))
-    if isinstance(ui.get("text"), str):
-        advisory["userIntent"] = ui["text"]
     if ui.get("redacted") is True:
         advisory["userIntentRedacted"] = True
+    elif isinstance(ui.get("text"), str):
+        advisory["userIntent"] = ui["text"]
     if isinstance(inv.get("turnId"), str):
         advisory["turnId"] = inv["turnId"]
     notes = [
@@ -164,6 +170,52 @@ def _invocation_map(doc: Any) -> dict[str, Any]:
     )
 
 
+def _modeled_args(a: dict[str, Any]) -> dict[str, Any]:
+    if "ref" in a:
+        return {
+            "ref": a.get("ref"),
+            "digest": a.get("digest"),
+            "canonicalization": a.get("canonicalization", "jcs"),
+        }
+    return {"projection": a.get("projection"), "projectionDigest": a.get("projectionDigest")}
+
+
+def _modeled_attestation(doc: Any) -> dict[str, Any]:
+    """Reconstruct the SEP-2787-modeled envelope the receipt verifier digests.
+
+    Keep only the modeled fields, inject the ArgsRef canonicalization default,
+    drop everything else. Digesting this (not the raw doc) is what makes the
+    cross-check faithful to the production back-link computation.
+    """
+    issuer = _as_dict(doc.get("issuerAsserted"))
+    planner = _as_dict(doc.get("plannerDeclared"))
+    payload = _as_dict(doc.get("payloadDerived"))
+    declared: dict[str, Any] = {"intent": planner.get("intent")}
+    if planner.get("requestedCapability") is not None:
+        declared["requestedCapability"] = planner["requestedCapability"]
+    return {
+        "version": doc.get("version"),
+        "alg": doc.get("alg"),
+        "signature": doc.get("signature"),
+        "plannerDeclared": declared,
+        "issuerAsserted": {
+            k: issuer.get(k)
+            for k in ("alg", "expSeconds", "iat", "iss", "nonce", "secretVersion", "sub")
+        },
+        "payloadDerived": {
+            "toolCalls": [
+                {
+                    "name": c.get("name"),
+                    "serverFingerprint": c.get("serverFingerprint"),
+                    "args": _modeled_args(_as_dict(c.get("args"))),
+                }
+                for c in payload.get("toolCalls", [])
+                if isinstance(c, dict)
+            ]
+        },
+    }
+
+
 def _attestation(doc: Any) -> dict[str, Any]:
     issuer = _as_dict(doc.get("issuerAsserted"))
     planner = _as_dict(doc.get("plannerDeclared"))
@@ -179,7 +231,9 @@ def _attestation(doc: Any) -> dict[str, Any]:
             {"name": c.get("name"), "serverFingerprint": c.get("serverFingerprint")}
             for c in payload["toolCalls"] if isinstance(c, dict)
         ]
-    digest = "sha256:" + hashlib.sha256(rfc8785.dumps(doc)).hexdigest()
+    digest = "sha256:" + hashlib.sha256(
+        rfc8785.dumps(_modeled_attestation(doc))
+    ).hexdigest()
     return _result(
         "sep2787", "SEP-2787 tool-call attestation", True, "decision-attested",
         {"backLink": {"attestationDigest": digest,

--- a/tests/vectors/normalize_v0/_check_independent.py
+++ b/tests/vectors/normalize_v0/_check_independent.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Independent checker for the v0 normalize vectors.
+
+A second implementation of the SEP-2643 / SEP-2787 / SEP-2817 -> SEP-2828
+normalization, written from the specs alone and importing no Vaara code.
+For each committed input it reproduces the normalized mapping (which
+evidence plane, which fields populated, what is still missing) and
+compares against ``expected.json``.
+
+The SEP-2643 and SEP-2817 maps are pure standard library. The SEP-2787
+map recomputes the back-link digest as ``sha256`` over the JCS-canonical
+attestation bytes (RFC 8785); that case is skipped, not failed, when
+``rfc8785`` is not installed, the same way the library degrades without
+the attestation extra.
+
+Run: ``python tests/vectors/normalize_v0/_check_independent.py``.
+Exit 0 means every runnable case matched its expected mapping.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+HERE = Path(__file__).resolve().parent
+AI_KEY = "io.modelcontextprotocol/aiInvocation"
+
+try:
+    import rfc8785
+
+    HAVE_JCS = True
+except ImportError:  # pragma: no cover - exercised only in a base install
+    HAVE_JCS = False
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _denial(doc: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(doc, dict):
+        return None
+    for cand in (
+        _as_dict(_as_dict(doc.get("error")).get("data")).get("authorization"),
+        _as_dict(doc.get("data")).get("authorization"),
+        doc.get("authorization"),
+        doc,
+    ):
+        if isinstance(cand, dict) and isinstance(cand.get("reason"), str):
+            return cand
+    return None
+
+
+def _invocation(doc: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(doc, dict):
+        return None
+    for cand in (
+        _as_dict(_as_dict(doc.get("params")).get("_meta")).get(AI_KEY),
+        _as_dict(doc.get("_meta")).get(AI_KEY),
+        doc.get(AI_KEY),
+    ):
+        if isinstance(cand, dict):
+            return cand
+    if any(k in doc for k in ("invocationReason", "model", "userIntent", "turnId")):
+        return doc
+    return None
+
+
+def _is_attestation(doc: Any) -> bool:
+    keys = ("plannerDeclared", "issuerAsserted", "payloadDerived", "signature")
+    return isinstance(doc, dict) and all(k in doc for k in keys)
+
+
+def _result(source, title, recognized, plane, sep2828, advisory, populated, missing,
+            notes):
+    return {
+        "sourceFormat": source,
+        "sourceTitle": title,
+        "recognized": recognized,
+        "evidencePlane": plane,
+        "sep2828": sep2828,
+        "advisory": advisory,
+        "populated": populated,
+        "missing": missing,
+        "notes": notes,
+    }
+
+
+def normalize(doc: Any) -> dict[str, Any]:
+    if _is_attestation(doc):
+        return _attestation(doc)
+    if _denial(doc) is not None:
+        return _denial_map(doc)
+    if _invocation(doc) is not None:
+        return _invocation_map(doc)
+    return _result(
+        "unknown", "unrecognized record", False, None, {}, {}, [], [],
+        ["not a SEP-2643 denial, SEP-2787 attestation, or SEP-2817 "
+         "invocation audit context; nothing to normalize"],
+    )
+
+
+def _denial_map(doc: Any) -> dict[str, Any]:
+    authz = _denial(doc)
+    assert authz is not None
+    advisory: dict[str, Any] = {"reason": authz.get("reason")}
+    if isinstance(authz.get("authorizationContextId"), str):
+        advisory["authorizationContextId"] = authz["authorizationContextId"]
+    hints = authz.get("remediationHints")
+    if isinstance(hints, list):
+        types = [h["type"] for h in hints
+                 if isinstance(h, dict) and isinstance(h.get("type"), str)]
+        if types:
+            advisory["remediationHintTypes"] = types
+    return _result(
+        "sep2643", "SEP-2643 authorization denial", True, "outcome",
+        {"outcomeDerived": {"status": "refused"}}, advisory,
+        ["outcomeDerived.status"],
+        ["alg", "signature", "backLink", "receiptAsserted",
+         "outcomeDerived.completedAt"],
+        ["a denial is the outcome of a refused call: it maps to "
+         "outcomeDerived.status = refused",
+         "a refused outcome carries no resultCommitment",
+         "authorizationContextId is a correlation handle, not authorization "
+         "material",
+         "the denial carries no completedAt, no signing envelope, and no "
+         "back-link; the recording side supplies those"],
+    )
+
+
+def _invocation_map(doc: Any) -> dict[str, Any]:
+    inv = _invocation(doc)
+    assert inv is not None
+    advisory: dict[str, Any] = {}
+    if isinstance(_as_dict(inv.get("invocationReason")).get("text"), str):
+        advisory["invocationReason"] = inv["invocationReason"]["text"]
+    if isinstance(_as_dict(inv.get("model")).get("name"), str):
+        advisory["model"] = inv["model"]["name"]
+    ui = _as_dict(inv.get("userIntent"))
+    if isinstance(ui.get("text"), str):
+        advisory["userIntent"] = ui["text"]
+    if ui.get("redacted") is True:
+        advisory["userIntentRedacted"] = True
+    if isinstance(inv.get("turnId"), str):
+        advisory["turnId"] = inv["turnId"]
+    notes = [
+        "SEP-2817 is client-asserted input audit context; per its own "
+        "specification it MUST NOT be used as authorization evidence",
+        "it maps to the decision-input plane (the agent's stated intent), "
+        "the unsigned counterpart of an attested rationale, and populates no "
+        "required SEP-2828 field",
+    ]
+    if "turnId" in advisory:
+        notes.append(
+            "turnId groups requests from one user turn; it is correlation only")
+    return _result(
+        "sep2817", "SEP-2817 AI invocation audit context", True,
+        "decision-input", {}, advisory, [],
+        ["alg", "signature", "backLink", "receiptAsserted", "outcomeDerived"],
+        notes,
+    )
+
+
+def _attestation(doc: Any) -> dict[str, Any]:
+    issuer = _as_dict(doc.get("issuerAsserted"))
+    planner = _as_dict(doc.get("plannerDeclared"))
+    payload = _as_dict(doc.get("payloadDerived"))
+    advisory: dict[str, Any] = {}
+    if isinstance(planner.get("intent"), str):
+        advisory["intent"] = planner["intent"]
+    for f in ("iss", "sub", "alg"):
+        if isinstance(issuer.get(f), str):
+            advisory[f"attestation_{f}"] = issuer[f]
+    if isinstance(payload.get("toolCalls"), list):
+        advisory["toolCalls"] = [
+            {"name": c.get("name"), "serverFingerprint": c.get("serverFingerprint")}
+            for c in payload["toolCalls"] if isinstance(c, dict)
+        ]
+    digest = "sha256:" + hashlib.sha256(rfc8785.dumps(doc)).hexdigest()
+    return _result(
+        "sep2787", "SEP-2787 tool-call attestation", True, "decision-attested",
+        {"backLink": {"attestationDigest": digest,
+                      "attestationNonce": issuer.get("nonce")}},
+        advisory,
+        ["backLink.attestationDigest", "backLink.attestationNonce"],
+        ["alg", "signature", "receiptAsserted", "outcomeDerived"],
+        ["a SEP-2787 attestation is the attested request a SEP-2828 receipt "
+         "answers; it fixes the exact back-link a conformant receipt must pin",
+         "plannerDeclared.intent is client-declared and bound by the issuer's "
+         "signature, not asserted true by the issuer",
+         "the record's own signing (alg, signature, receiptAsserted) is a "
+         "separate event by the recording side, not derived from the attestation"],
+    )
+
+
+def main() -> int:
+    expected = json.loads((HERE / "expected.json").read_text())
+    failures = skipped = 0
+    for name in sorted(expected):
+        want = expected[name]
+        doc = json.loads((HERE / "inputs" / f"{name}.json").read_text())
+        if want["sourceFormat"] == "sep2787" and not HAVE_JCS:
+            print(f"[SKIP] {name}: rfc8785 not installed")
+            skipped += 1
+            continue
+        got = normalize(doc)
+        ok = got == want
+        failures += 0 if ok else 1
+        print(f"[{'OK' if ok else 'FAIL'}] {name}")
+        if not ok:
+            print(f"   got: {json.dumps(got, sort_keys=True)}")
+    total = len(expected) - skipped
+    print(f"\n{total - failures}/{total} cases matched ({skipped} skipped).")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/normalize_v0/expected.json
+++ b/tests/vectors/normalize_v0/expected.json
@@ -137,12 +137,50 @@
     "sourceFormat": "sep2787",
     "sourceTitle": "SEP-2787 tool-call attestation"
   },
+  "sep2787_attestation_with_extension": {
+    "advisory": {
+      "attestation_alg": "HS256",
+      "attestation_iss": "issuer://test",
+      "attestation_sub": "agent:archiver",
+      "intent": "archive obsolete report",
+      "toolCalls": [
+        {
+          "name": "delete_file",
+          "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    },
+    "evidencePlane": "decision-attested",
+    "missing": [
+      "alg",
+      "signature",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "a SEP-2787 attestation is the attested request a SEP-2828 receipt answers; it fixes the exact back-link a conformant receipt must pin",
+      "plannerDeclared.intent is client-declared and bound by the issuer's signature, not asserted true by the issuer",
+      "the record's own signing (alg, signature, receiptAsserted) is a separate event by the recording side, not derived from the attestation"
+    ],
+    "populated": [
+      "backLink.attestationDigest",
+      "backLink.attestationNonce"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "backLink": {
+        "attestationDigest": "sha256:79acdd4bb3c22a688b1c3321b9a26cafb5cb58c990a963874066d04b8497f70b",
+        "attestationNonce": "fixed-attestation-nonce-000"
+      }
+    },
+    "sourceFormat": "sep2787",
+    "sourceTitle": "SEP-2787 tool-call attestation"
+  },
   "sep2817_multiturn": {
     "advisory": {
       "invocationReason": "Need to inspect available tables before generating a query.",
       "model": "example-model",
       "turnId": "2f4f0c9e-8d72-4c66-9c6f-3f7f3e6a1c9f",
-      "userIntent": "Show me 10 employees",
       "userIntentRedacted": true
     },
     "evidencePlane": "decision-input",

--- a/tests/vectors/normalize_v0/expected.json
+++ b/tests/vectors/normalize_v0/expected.json
@@ -1,0 +1,206 @@
+{
+  "sep2643_rar_denial": {
+    "advisory": {
+      "authorizationContextId": "authzctx_pay_9f2c",
+      "reason": "insufficient_authorization",
+      "remediationHintTypes": [
+        "oauth_authorization_details"
+      ]
+    },
+    "evidencePlane": "outcome",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived.completedAt"
+    ],
+    "notes": [
+      "a denial is the outcome of a refused call: it maps to outcomeDerived.status = refused",
+      "a refused outcome carries no resultCommitment",
+      "authorizationContextId is a correlation handle, not authorization material",
+      "the denial carries no completedAt, no signing envelope, and no back-link; the recording side supplies those"
+    ],
+    "populated": [
+      "outcomeDerived.status"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "outcomeDerived": {
+        "status": "refused"
+      }
+    },
+    "sourceFormat": "sep2643",
+    "sourceTitle": "SEP-2643 authorization denial"
+  },
+  "sep2643_scope_denial": {
+    "advisory": {
+      "authorizationContextId": "authzctx_8a3e1f4b",
+      "reason": "insufficient_authorization"
+    },
+    "evidencePlane": "outcome",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived.completedAt"
+    ],
+    "notes": [
+      "a denial is the outcome of a refused call: it maps to outcomeDerived.status = refused",
+      "a refused outcome carries no resultCommitment",
+      "authorizationContextId is a correlation handle, not authorization material",
+      "the denial carries no completedAt, no signing envelope, and no back-link; the recording side supplies those"
+    ],
+    "populated": [
+      "outcomeDerived.status"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "outcomeDerived": {
+        "status": "refused"
+      }
+    },
+    "sourceFormat": "sep2643",
+    "sourceTitle": "SEP-2643 authorization denial"
+  },
+  "sep2643_url_denial": {
+    "advisory": {
+      "authorizationContextId": "authzctx_7c5d1d79",
+      "reason": "insufficient_authorization",
+      "remediationHintTypes": [
+        "url"
+      ]
+    },
+    "evidencePlane": "outcome",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived.completedAt"
+    ],
+    "notes": [
+      "a denial is the outcome of a refused call: it maps to outcomeDerived.status = refused",
+      "a refused outcome carries no resultCommitment",
+      "authorizationContextId is a correlation handle, not authorization material",
+      "the denial carries no completedAt, no signing envelope, and no back-link; the recording side supplies those"
+    ],
+    "populated": [
+      "outcomeDerived.status"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "outcomeDerived": {
+        "status": "refused"
+      }
+    },
+    "sourceFormat": "sep2643",
+    "sourceTitle": "SEP-2643 authorization denial"
+  },
+  "sep2787_attestation": {
+    "advisory": {
+      "attestation_alg": "HS256",
+      "attestation_iss": "issuer://test",
+      "attestation_sub": "agent:archiver",
+      "intent": "archive obsolete report",
+      "toolCalls": [
+        {
+          "name": "delete_file",
+          "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    },
+    "evidencePlane": "decision-attested",
+    "missing": [
+      "alg",
+      "signature",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "a SEP-2787 attestation is the attested request a SEP-2828 receipt answers; it fixes the exact back-link a conformant receipt must pin",
+      "plannerDeclared.intent is client-declared and bound by the issuer's signature, not asserted true by the issuer",
+      "the record's own signing (alg, signature, receiptAsserted) is a separate event by the recording side, not derived from the attestation"
+    ],
+    "populated": [
+      "backLink.attestationDigest",
+      "backLink.attestationNonce"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "backLink": {
+        "attestationDigest": "sha256:79acdd4bb3c22a688b1c3321b9a26cafb5cb58c990a963874066d04b8497f70b",
+        "attestationNonce": "fixed-attestation-nonce-000"
+      }
+    },
+    "sourceFormat": "sep2787",
+    "sourceTitle": "SEP-2787 tool-call attestation"
+  },
+  "sep2817_multiturn": {
+    "advisory": {
+      "invocationReason": "Need to inspect available tables before generating a query.",
+      "model": "example-model",
+      "turnId": "2f4f0c9e-8d72-4c66-9c6f-3f7f3e6a1c9f",
+      "userIntent": "Show me 10 employees",
+      "userIntentRedacted": true
+    },
+    "evidencePlane": "decision-input",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "SEP-2817 is client-asserted input audit context; per its own specification it MUST NOT be used as authorization evidence",
+      "it maps to the decision-input plane (the agent's stated intent), the unsigned counterpart of an attested rationale, and populates no required SEP-2828 field",
+      "turnId groups requests from one user turn; it is correlation only"
+    ],
+    "populated": [],
+    "recognized": true,
+    "sep2828": {},
+    "sourceFormat": "sep2817",
+    "sourceTitle": "SEP-2817 AI invocation audit context"
+  },
+  "sep2817_single": {
+    "advisory": {
+      "invocationReason": "The user asked to view employee rows, and the employees table was identified as the target table.",
+      "model": "example-model",
+      "turnId": "opaque-client-generated-id",
+      "userIntent": "Show me 10 employees"
+    },
+    "evidencePlane": "decision-input",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "SEP-2817 is client-asserted input audit context; per its own specification it MUST NOT be used as authorization evidence",
+      "it maps to the decision-input plane (the agent's stated intent), the unsigned counterpart of an attested rationale, and populates no required SEP-2828 field",
+      "turnId groups requests from one user turn; it is correlation only"
+    ],
+    "populated": [],
+    "recognized": true,
+    "sep2828": {},
+    "sourceFormat": "sep2817",
+    "sourceTitle": "SEP-2817 AI invocation audit context"
+  },
+  "unknown": {
+    "advisory": {},
+    "evidencePlane": null,
+    "missing": [],
+    "notes": [
+      "not a SEP-2643 denial, SEP-2787 attestation, or SEP-2817 invocation audit context; nothing to normalize"
+    ],
+    "populated": [],
+    "recognized": false,
+    "sep2828": {},
+    "sourceFormat": "unknown",
+    "sourceTitle": "unrecognized record"
+  }
+}

--- a/tests/vectors/normalize_v0/inputs/sep2643_rar_denial.json
+++ b/tests/vectors/normalize_v0/inputs/sep2643_rar_denial.json
@@ -1,0 +1,30 @@
+{
+  "jsonrpc": "2.0",
+  "id": 31,
+  "error": {
+    "code": "AUTHORIZATION_DENIAL",
+    "message": "Current authorization is insufficient for this payment.",
+    "data": {
+      "authorization": {
+        "reason": "insufficient_authorization",
+        "authorizationContextId": "authzctx_pay_9f2c",
+        "remediationHints": [
+          {
+            "type": "oauth_authorization_details",
+            "authorization_details": [
+              {
+                "type": "payment_initiation",
+                "actions": ["initiate", "status", "cancel"],
+                "locations": ["https://mcp.example.com/payments"],
+                "instructedAmount": { "currency": "EUR", "amount": "123.50" },
+                "creditorName": "Merchant A",
+                "creditorAccount": { "iban": "DE02100100109307118603" },
+                "remittanceInformationUnstructured": "Ref Number Merchant"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/vectors/normalize_v0/inputs/sep2643_scope_denial.json
+++ b/tests/vectors/normalize_v0/inputs/sep2643_scope_denial.json
@@ -1,0 +1,14 @@
+{
+  "jsonrpc": "2.0",
+  "id": 17,
+  "error": {
+    "code": "AUTHORIZATION_DENIAL",
+    "message": "You must grant write access to proceed.",
+    "data": {
+      "authorization": {
+        "reason": "insufficient_authorization",
+        "authorizationContextId": "authzctx_8a3e1f4b"
+      }
+    }
+  }
+}

--- a/tests/vectors/normalize_v0/inputs/sep2643_url_denial.json
+++ b/tests/vectors/normalize_v0/inputs/sep2643_url_denial.json
@@ -1,0 +1,23 @@
+{
+  "jsonrpc": "2.0",
+  "id": 17,
+  "error": {
+    "code": -32042,
+    "message": "You need to approve access to the requested folder.",
+    "data": {
+      "authorization": {
+        "reason": "insufficient_authorization",
+        "authorizationContextId": "authzctx_7c5d1d79",
+        "remediationHints": [{ "type": "url" }]
+      },
+      "elicitations": [
+        {
+          "mode": "url",
+          "elicitationId": "el_550e8400-e29b-41d4-a716-446655440000",
+          "url": "https://mcp.example.com/approve-folder-access?ctx=authzctx_7c5d1d79",
+          "message": "Open this page to approve access to the requested folder."
+        }
+      ]
+    }
+  }
+}

--- a/tests/vectors/normalize_v0/inputs/sep2787_attestation.json
+++ b/tests/vectors/normalize_v0/inputs/sep2787_attestation.json
@@ -1,0 +1,29 @@
+{
+  "alg": "HS256",
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "fixed-attestation-nonce-000",
+    "secretVersion": "v1",
+    "sub": "agent:archiver"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "args": {
+          "projection": "{\"digest\":\"sha256:866290b000d2128e0a3188a7207d447090415dc321bfcc0ceed355bd7fd3e8f8\"}",
+          "projectionDigest": "sha256:031037d68e5734d3c48fa18fb1ed5e0a3b8ec61fa4cf2823b7320436452ca84a"
+        },
+        "name": "delete_file",
+        "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ]
+  },
+  "plannerDeclared": {
+    "intent": "archive obsolete report"
+  },
+  "signature": "ea49c2f2e50a2fc58cd7a20bf4ec0e04a225257f7b795e7c999a927c123d4bbd",
+  "version": 1
+}

--- a/tests/vectors/normalize_v0/inputs/sep2787_attestation_with_extension.json
+++ b/tests/vectors/normalize_v0/inputs/sep2787_attestation_with_extension.json
@@ -1,0 +1,31 @@
+{
+  "alg": "HS256",
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "kid": "key-2026-05",
+    "nonce": "fixed-attestation-nonce-000",
+    "secretVersion": "v1",
+    "sub": "agent:archiver"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "args": {
+          "projection": "{\"digest\":\"sha256:866290b000d2128e0a3188a7207d447090415dc321bfcc0ceed355bd7fd3e8f8\"}",
+          "projectionDigest": "sha256:031037d68e5734d3c48fa18fb1ed5e0a3b8ec61fa4cf2823b7320436452ca84a"
+        },
+        "name": "delete_file",
+        "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ]
+  },
+  "plannerDeclared": {
+    "intent": "archive obsolete report"
+  },
+  "signature": "ea49c2f2e50a2fc58cd7a20bf4ec0e04a225257f7b795e7c999a927c123d4bbd",
+  "version": 1,
+  "x-extension": "an unmodeled field a real producer may carry"
+}

--- a/tests/vectors/normalize_v0/inputs/sep2817_multiturn.json
+++ b/tests/vectors/normalize_v0/inputs/sep2817_multiturn.json
@@ -1,0 +1,17 @@
+{
+  "method": "tools/call",
+  "params": {
+    "name": "list_tables",
+    "arguments": { "database_id": "123" },
+    "_meta": {
+      "io.modelcontextprotocol/aiInvocation": {
+        "invocationReason": {
+          "text": "Need to inspect available tables before generating a query."
+        },
+        "model": { "name": "example-model" },
+        "userIntent": { "text": "Show me 10 employees", "redacted": true },
+        "turnId": "2f4f0c9e-8d72-4c66-9c6f-3f7f3e6a1c9f"
+      }
+    }
+  }
+}

--- a/tests/vectors/normalize_v0/inputs/sep2817_single.json
+++ b/tests/vectors/normalize_v0/inputs/sep2817_single.json
@@ -1,0 +1,20 @@
+{
+  "method": "tools/call",
+  "params": {
+    "name": "execute_query",
+    "arguments": {
+      "database_id": "123",
+      "query": "SELECT * FROM employees LIMIT 10"
+    },
+    "_meta": {
+      "io.modelcontextprotocol/aiInvocation": {
+        "invocationReason": {
+          "text": "The user asked to view employee rows, and the employees table was identified as the target table."
+        },
+        "model": { "name": "example-model" },
+        "userIntent": { "text": "Show me 10 employees", "redacted": false },
+        "turnId": "opaque-client-generated-id"
+      }
+    }
+  }
+}

--- a/tests/vectors/normalize_v0/inputs/unknown.json
+++ b/tests/vectors/normalize_v0/inputs/unknown.json
@@ -1,0 +1,4 @@
+{
+  "hello": "world",
+  "not": "a recognized record"
+}


### PR DESCRIPTION
`vaara normalize` reads an adjacent MCP record and maps it onto Vaara's SEP-2828 execution-record model. It speaks three dialects:

- a SEP-2643 authorization denial becomes the refused outcome
- a SEP-2787 tool-call attestation becomes the decision-attested binding (the exact back-link a conformant receipt must pin)
- a SEP-2817 invocation audit context becomes the decision-input plane (advisory, never authorization evidence)

For each record it reports which evidence plane it fills, which SEP-2828 fields it populates, and what is still missing for a complete signed record. It promotes nothing: an unsigned client claim stays advisory, a denial is an outcome only, and an attestation fixes the back-link and nothing else, because the record's own alg, signature, and receiptAsserted are the recording side's separate signing event.

Why: the surrounding ecosystem is fragmenting into narrow, single-purpose records. Vaara is the receiving side that reads each one and files it into one evidence model, so the SEP-2828 record is where they compose.

SEP-2643 and SEP-2817 normalization is pure standard library and runs in the base install. The SEP-2787 back-link digest reuses the receipt verifier and degrades to a reported gap without the attestation extra.

Testing: new normalize_v0 vectors built from verbatim spec examples, a Vaara-free independent checker that reproduces every case including the back-link digest recomputed from raw bytes, and a 26-case suite. Full suite green at 1442 passed, ruff and mypy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `vaara normalize` CLI command for converting records between formats with automatic format detection
  * Supports both human-readable and JSON output modes
  * Reports populated and missing field information in normalization results

* **Documentation**
  * Added normalize vector documentation with test fixtures

* **Tests**
  * Added comprehensive test suite covering multiple input format conversions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->