### PR TITLE
v0.63.0: conformance-statement, prove SEP-2828 conformance against the published corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.63.0] - 2026-06-09
+
+### Added
+- `vaara conformance-statement`: the self-test a producer runs to prove SEP-2828
+  conformance against the published corpus instead of asking to be trusted. It
+  confirms the corpus bytes match `MANIFEST.json`, re-runs this implementation's
+  keyless conformance check over every corpus fixture and confirms it reproduces
+  the verdict the corpus records, optionally runs the producer's own records
+  through the same set check, and prints one statement that names the exact
+  corpus version and corpusDigest it was checked against. Keyless and
+  deterministic: no signing key and no clock, so anyone holding the same corpus
+  re-runs the command and reaches the same verdict. Ships with the
+  `conformance_statement_v0` vectors and a Vaara-free independent checker that
+  re-derives every claim and confirms the statement states it faithfully.
+  Markdown or `--json`; runs in the base install.
+
 ## [0.62.0] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ vaara audit-summary  ./records --out summary.md
 - `verify-bundles` runs the full six-lens `verify-bundle` over every bundle and reports per-lens pass counts and how many bundles authenticated.
 - `audit-summary` renders the conformance verdict for a directory of records as a Markdown page an auditor reads directly. The page states what was checked and every count, and records that any party can reproduce it from the records alone.
 
+### Prove conformance
+
+A producer who claims its records are SEP-2828 records can prove it against the published conformance corpus instead of asking to be trusted:
+
+```bash
+vaara conformance-statement --corpus conformance/sep2828 --records ./records
+```
+
+The command prints one statement. It confirms the corpus bytes match their manifest, re-runs this implementation's keyless conformance check over every corpus fixture to confirm it reproduces the verdict the corpus records, and runs your own records through the same set check. The statement names the exact corpus version and corpusDigest it was checked against, so the claim pins a fixed byte set rather than a moving target. Keyless and deterministic: anyone holding the same corpus re-runs the command and reaches the same verdict.
+
 ## Benchmarks
 
 Held-out test recall **84.7%** (95% Wilson [82.4, 86.7]) at a **4.1%** false-positive rate, and **1.2%** FPR on benign tool calls under live injection pressure. The hot-path rule scorer adds 140 µs mean / 210 µs p99 per call on commodity CPU. Every figure is reproducible end-to-end via `make bench`.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.62.0"
+version = "0.63.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/scripts/build_conformance_statement_vectors.py
+++ b/scripts/build_conformance_statement_vectors.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Regenerate the conformance-statement golden vectors from the live corpus.
+
+The ``conformance_statement_v0`` vectors pin what ``vaara conformance-statement``
+produces when run against the published corpus under ``conformance/sep2828`` and
+the emitter records committed beside them. Because the statement names the exact
+corpus byte set (version plus corpusDigest), the goldens move whenever the
+corpus does; this script regenerates them so the test ``test_conformance_statement``
+stays a drift guard rather than a chore.
+
+It writes, for three scenarios, the structured statement (``expected.json``) and
+the rendered Markdown page (``pages/<scenario>.md``):
+
+* ``selftest_only`` - no emitter records, just the corpus self-test.
+* ``clean`` - emitter records that conform.
+* ``flawed`` - emitter records with one non-conforming record.
+* ``duplicate`` - records that each conform but fail a required set property
+  (two outcomes pin one call), so the set does not conform.
+
+Run: ``python scripts/build_conformance_statement_vectors.py``. Commit the
+result; the test fails if the committed goldens drift from this output or from
+the independent re-derivation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from vaara.attestation.receipt import (
+    build_conformance_statement,
+    render_conformance_statement,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+CORPUS = REPO / "conformance" / "sep2828"
+VECTORS = REPO / "tests" / "vectors" / "conformance_statement_v0"
+EMITTER = VECTORS / "emitter_records"
+PAGES = VECTORS / "pages"
+
+SCENARIOS = ["selftest_only", "clean", "flawed", "duplicate"]
+
+
+def _load_records(scenario: str) -> list[tuple[str, object]] | None:
+    if scenario == "selftest_only":
+        return None
+    paths = sorted((EMITTER / scenario).glob("*.json"))
+    return [(p.name, json.loads(p.read_text(encoding="utf-8"))) for p in paths]
+
+
+def build() -> None:
+    PAGES.mkdir(parents=True, exist_ok=True)
+    expected: dict[str, object] = {}
+    for scenario in SCENARIOS:
+        statement = build_conformance_statement(CORPUS, records=_load_records(scenario))
+        expected[scenario] = statement.to_dict()
+        (PAGES / f"{scenario}.md").write_text(
+            render_conformance_statement(statement), encoding="utf-8"
+        )
+    text = json.dumps(expected, indent=2, sort_keys=True) + "\n"
+    (VECTORS / "expected.json").write_text(text, encoding="utf-8")
+    print(f"wrote {len(SCENARIOS)} scenarios to {VECTORS.relative_to(REPO)}")
+
+
+if __name__ == "__main__":
+    build()
+    sys.exit(0)

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.62.0",
+  "version": "0.63.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.62.0",
+      "version": "0.63.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.62.0",
+  "version": "0.63.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.62.0",
+      "version": "0.63.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.62.0"
+__version__ = "0.63.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_conformance_statement.py
+++ b/src/vaara/attestation/_conformance_statement.py
@@ -1,0 +1,526 @@
+"""Conformance self-test and statement for the published SEP-2828 corpus.
+
+An emitter that claims SEP-2828 conformance answers "trust us" with "prove it
+against the neutral suite". This builds that proof. It runs this
+implementation's keyless conformance check over the published conformance
+corpus, confirms the bytes match their manifest, optionally runs the emitter's
+own records through the same set-level check, and produces one statement that
+names the exact corpus byte set it was checked against.
+
+The statement has three parts:
+
+* **Corpus integrity** - every fixture file's SHA-256 matches ``MANIFEST.json``
+  and the single ``corpusDigest`` recomputes, so the statement pins the
+  published bytes rather than a moving target.
+* **Self-test** - the running implementation's conformance check reproduces
+  every verdict the corpus records in each suite's ``expected.json``. This is
+  the "prove it": the tool agrees with the neutral suite, case for case.
+* **Records** (optional) - the emitter's own records run through the same
+  keyless set check, with the verdict reported beside the self-test.
+
+Deterministic and keyless. There is no clock: an ``as_of`` date is echoed
+verbatim when the caller supplies one and is never read from the system, so the
+same inputs render the same statement byte for byte. The whole check needs no
+signing key, which is what lets a third party reproduce it.
+
+Pure standard library; importable without the ``attestation`` extra.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+from vaara.attestation._receipt_conformance import check_record_conformance
+from vaara.attestation._record_set_conformance import check_record_set
+from vaara.attestation._record_set_findings import SetFinding
+
+STATEMENT_SCHEMA = "sep2828-conformance-statement"
+STATEMENT_SCHEMA_VERSION = 1
+
+
+class ConformanceCorpusError(ValueError):
+    """The corpus directory is missing the manifest the statement is built from."""
+
+
+# ── Result records ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CorpusIntegrity:
+    """Does the corpus on disk match the byte set its manifest pins?"""
+
+    name: str
+    spec: str
+    version: str
+    corpus_digest: str
+    file_count: int
+    verified: bool
+    problems: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "spec": self.spec,
+            "version": self.version,
+            "corpusDigest": self.corpus_digest,
+            "fileCount": self.file_count,
+            "verified": self.verified,
+            "problems": list(self.problems),
+        }
+
+
+@dataclass(frozen=True)
+class SuiteResult:
+    """How many of one suite's recorded verdicts this implementation reproduced."""
+
+    name: str
+    runnable: bool
+    cases: int
+    reproduced: int
+    mismatches: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "runnable": self.runnable,
+            "cases": self.cases,
+            "reproduced": self.reproduced,
+            "mismatches": list(self.mismatches),
+        }
+
+
+@dataclass(frozen=True)
+class SelfTest:
+    """Did this implementation reproduce every verdict the corpus records?"""
+
+    conforms: bool
+    cases: int
+    reproduced: int
+    suites: tuple[SuiteResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "conforms": self.conforms,
+            "cases": self.cases,
+            "reproduced": self.reproduced,
+            "suites": [s.to_dict() for s in self.suites],
+        }
+
+
+@dataclass(frozen=True)
+class RecordsResult:
+    """The keyless set verdict over the emitter's own records."""
+
+    conforms: bool
+    total: int
+    conforming: int
+    findings: tuple[SetFinding, ...]
+    nonconforming: tuple[tuple[str, tuple[str, ...]], ...]
+    unreadable: tuple[tuple[str, str], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "conforms": self.conforms,
+            "total": self.total,
+            "conforming": self.conforming,
+            "findings": [
+                {"id": f.id, "severity": f.severity, "records": list(f.records)}
+                for f in self.findings
+            ],
+            "nonconforming": [
+                {"name": n, "requiredFailed": list(rf)} for n, rf in self.nonconforming
+            ],
+            "unreadable": [{"name": n, "error": e} for n, e in self.unreadable],
+        }
+
+
+@dataclass(frozen=True)
+class ConformanceStatement:
+    """A reproducible claim of SEP-2828 conformance against a named corpus."""
+
+    corpus: CorpusIntegrity
+    self_test: SelfTest
+    records: Optional[RecordsResult]
+    conforms: bool
+    as_of: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": STATEMENT_SCHEMA,
+            "schemaVersion": STATEMENT_SCHEMA_VERSION,
+            "conforms": self.conforms,
+            "asOf": self.as_of,
+            "corpus": self.corpus.to_dict(),
+            "selfTest": self.self_test.to_dict(),
+            "records": self.records.to_dict() if self.records is not None else None,
+        }
+
+
+# ── Corpus integrity ──────────────────────────────────────────────────────────
+
+
+def _load_manifest(corpus_dir: Path) -> dict[str, Any]:
+    manifest_path = corpus_dir / "MANIFEST.json"
+    if not manifest_path.is_file():
+        raise ConformanceCorpusError(
+            f"no MANIFEST.json in {corpus_dir}; point --corpus at a published "
+            "SEP-2828 conformance corpus directory"
+        )
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ConformanceCorpusError(f"cannot read MANIFEST.json: {exc}") from exc
+    if not isinstance(data, dict) or "suites" not in data or "files" not in data:
+        raise ConformanceCorpusError("MANIFEST.json is not a corpus manifest")
+    return data
+
+
+def _file_digests(corpus_dir: Path, suites: Sequence[str]) -> dict[str, str]:
+    """SHA-256 of every fixture under each suite, keyed by POSIX relpath.
+
+    Mirrors the corpus builder: ``__pycache__`` and ``.pyc`` are skipped so the
+    digest set is the source fixtures only, never a local test artefact.
+    """
+    out: dict[str, str] = {}
+    for suite in suites:
+        for path in sorted((corpus_dir / suite).rglob("*")):
+            if not path.is_file():
+                continue
+            if "__pycache__" in path.parts or path.suffix == ".pyc":
+                continue
+            rel = path.relative_to(corpus_dir).as_posix()
+            out[rel] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    return out
+
+
+def _corpus_digest(files: dict[str, str]) -> str:
+    """One digest over the whole set: SHA-256 of the sorted ``<hex>  <path>`` list."""
+    lines = [f"{files[k].split(':', 1)[1]}  {k}" for k in sorted(files)]
+    blob = ("\n".join(lines) + "\n").encode("utf-8")
+    return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+def verify_corpus_integrity(corpus_dir: Path, manifest: dict[str, Any]) -> CorpusIntegrity:
+    """Confirm the corpus bytes on disk match what its manifest pins.
+
+    Recomputes every file digest and the single ``corpusDigest`` and compares
+    them to the manifest. ``verified`` is true iff the file set, every digest,
+    and the corpus digest all match. Needs no key: anyone holding the files can
+    reproduce this.
+    """
+    suites: list[str] = list(manifest["suites"])
+    want: dict[str, str] = dict(manifest["files"])
+    got = _file_digests(corpus_dir, suites)
+
+    problems: list[str] = []
+    for rel in sorted(set(want) | set(got)):
+        if rel not in got:
+            problems.append(f"missing file: {rel}")
+        elif rel not in want:
+            problems.append(f"unexpected file: {rel}")
+        elif want[rel] != got[rel]:
+            problems.append(f"digest mismatch: {rel}")
+
+    want_corpus = str(manifest.get("corpusDigest", ""))
+    got_corpus = _corpus_digest(got)
+    if want_corpus != got_corpus:
+        problems.append(f"corpusDigest mismatch: manifest {want_corpus} != computed {got_corpus}")
+
+    return CorpusIntegrity(
+        name=str(manifest.get("corpus", "")),
+        spec=str(manifest.get("spec", "")),
+        version=str(manifest.get("version", "")),
+        corpus_digest=want_corpus,
+        file_count=len(got),
+        verified=not problems,
+        problems=tuple(problems),
+    )
+
+
+# ── Self-test ─────────────────────────────────────────────────────────────────
+
+
+def _record_suite_result(name: str, suite_dir: Path, expected: dict[str, Any]) -> SuiteResult:
+    """Reproduce each per-record verdict and compare to the suite's expected.json."""
+    mismatches: list[str] = []
+    for case in sorted(expected):
+        doc = json.loads((suite_dir / "records" / f"{case}.json").read_text(encoding="utf-8"))
+        report = check_record_conformance(doc)
+        got = {
+            "conforms": report.conforms,
+            "requiredFailed": sorted(report.required_failed),
+            "advisories": sorted(report.advisories),
+        }
+        if got != _normalise_record_expected(expected[case]):
+            mismatches.append(case)
+    cases = len(expected)
+    return SuiteResult(name, True, cases, cases - len(mismatches), tuple(sorted(mismatches)))
+
+
+def _set_suite_result(name: str, suite_dir: Path, expected: dict[str, Any]) -> SuiteResult:
+    """Reproduce each set verdict and compare to the suite's expected.json."""
+    mismatches: list[str] = []
+    for case in sorted(expected):
+        files = sorted((suite_dir / "sets" / case).glob("*.json"))
+        records = [(p.name, json.loads(p.read_text(encoding="utf-8"))) for p in files]
+        report = check_record_set(records)
+        got = {
+            "conforms": report.conforms,
+            "total": report.total,
+            "conforming": report.conforming,
+            "statusCounts": dict(report.status_counts),
+            "verdictCounts": dict(report.verdict_counts),
+            "findings": [
+                {"id": f.id, "severity": f.severity, "records": list(f.records)}
+                for f in report.findings
+            ],
+        }
+        if got != _normalise_set_expected(expected[case]):
+            mismatches.append(case)
+    cases = len(expected)
+    return SuiteResult(name, True, cases, cases - len(mismatches), tuple(sorted(mismatches)))
+
+
+def _normalise_record_expected(case: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "conforms": case["conforms"],
+        "requiredFailed": sorted(case.get("requiredFailed", [])),
+        "advisories": sorted(case.get("advisories", [])),
+    }
+
+
+def _normalise_set_expected(case: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "conforms": case["conforms"],
+        "total": case["total"],
+        "conforming": case["conforming"],
+        "statusCounts": dict(case.get("statusCounts", {})),
+        "verdictCounts": dict(case.get("verdictCounts", {})),
+        "findings": [
+            {"id": f["id"], "severity": f["severity"], "records": sorted(f["records"])}
+            for f in sorted(
+                case.get("findings", []), key=lambda f: (f["id"], sorted(f["records"]))
+            )
+        ],
+    }
+
+
+def run_self_test(corpus_dir: Path, manifest: dict[str, Any]) -> SelfTest:
+    """Reproduce every recorded verdict the corpus carries, suite by suite.
+
+    A suite is run by its shape: a ``records/`` directory means a per-record
+    suite, a ``sets/`` directory means a set-level suite. A suite the runner
+    cannot place is reported as not runnable and fails the self-test honestly,
+    rather than being silently skipped.
+    """
+    results: list[SuiteResult] = []
+    for name in manifest["suites"]:
+        suite_dir = corpus_dir / name
+        expected_path = suite_dir / "expected.json"
+        if not expected_path.is_file():
+            results.append(SuiteResult(name, False, 0, 0, ("no expected.json",)))
+            continue
+        expected = json.loads(expected_path.read_text(encoding="utf-8"))
+        if (suite_dir / "records").is_dir():
+            results.append(_record_suite_result(name, suite_dir, expected))
+        elif (suite_dir / "sets").is_dir():
+            results.append(_set_suite_result(name, suite_dir, expected))
+        else:
+            results.append(SuiteResult(name, False, len(expected), 0, ("unknown suite shape",)))
+
+    cases = sum(s.cases for s in results)
+    reproduced = sum(s.reproduced for s in results)
+    conforms = bool(results) and all(s.runnable and not s.mismatches for s in results)
+    return SelfTest(conforms, cases, reproduced, tuple(results))
+
+
+# ── Records ───────────────────────────────────────────────────────────────────
+
+
+def _records_result(
+    records: Sequence[tuple[str, Any]], unreadable: Sequence[tuple[str, str]]
+) -> RecordsResult:
+    report = check_record_set(records)
+    nonconforming = tuple(
+        (e.name, e.required_failed) for e in report.entries if not e.conforms
+    )
+    return RecordsResult(
+        conforms=report.conforms and not unreadable,
+        total=report.total,
+        conforming=report.conforming,
+        findings=report.findings,
+        nonconforming=nonconforming,
+        unreadable=tuple(unreadable),
+    )
+
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+
+def build_conformance_statement(
+    corpus_dir: Path,
+    *,
+    records: Optional[Sequence[tuple[str, Any]]] = None,
+    unreadable: Sequence[tuple[str, str]] = (),
+    as_of: Optional[str] = None,
+) -> ConformanceStatement:
+    """Build a conformance statement for ``corpus_dir``.
+
+    Verifies the corpus integrity, runs the self-test, and (when ``records`` is
+    given) the keyless set check over the emitter's own records. The statement
+    conforms iff the corpus bytes verify, the self-test reproduced every verdict,
+    and any supplied records conform. Raises :class:`ConformanceCorpusError`
+    when the directory holds no readable corpus manifest.
+    """
+    manifest = _load_manifest(corpus_dir)
+    corpus = verify_corpus_integrity(corpus_dir, manifest)
+    self_test = run_self_test(corpus_dir, manifest)
+
+    records_result = (
+        _records_result(records, unreadable) if records is not None else None
+    )
+
+    conforms = (
+        corpus.verified
+        and self_test.conforms
+        and (records_result is None or records_result.conforms)
+    )
+    return ConformanceStatement(corpus, self_test, records_result, conforms, as_of)
+
+
+# ── Render ────────────────────────────────────────────────────────────────────
+
+_HOW = (
+    "This statement is keyless and reproducible. Anyone holding the same corpus "
+    "version can re-run `vaara conformance-statement` and reach the same verdict. "
+    "It covers the wire schema, the record's self-proving digest, and the "
+    "cross-record set properties; it is not signature verification, issuer trust, "
+    "or time-anchor verification, which need external material and are checked "
+    "separately."
+)
+
+
+def render_conformance_statement(statement: ConformanceStatement) -> str:
+    """Render a conformance statement as a one-page Markdown document.
+
+    Deterministic: the page depends only on ``statement`` (no clock unless the
+    caller passed an ``as_of`` date, which is echoed verbatim), so the same
+    inputs render byte-identical every time.
+    """
+    c = statement.corpus
+    verdict = "CONFORMS" if statement.conforms else "NON-CONFORMING"
+    lines: list[str] = ["# SEP-2828 conformance statement", ""]
+    lines.append(f"**Statement: {verdict}**")
+    lines.append("")
+    lines.append(
+        f"Checked against corpus `{_safe(c.name)}` version {_safe(c.version)} "
+        f"(corpusDigest `{_safe(c.corpus_digest)}`)."
+    )
+    if statement.as_of is not None:
+        lines.append(f"As of {_safe(statement.as_of)}.")
+    lines.append("")
+
+    lines.append("## Corpus integrity")
+    lines.append("")
+    if c.verified:
+        lines.append(
+            f"Verified: all {c.file_count} fixture files match `MANIFEST.json` "
+            "and the corpusDigest recomputes."
+        )
+    else:
+        lines.append(f"NOT verified: {len(c.problems)} problem(s) with the corpus bytes.")
+        for p in c.problems:
+            lines.append(f"- {_safe(p)}")
+    lines.append("")
+
+    st = statement.self_test
+    lines.append("## Self-test")
+    lines.append("")
+    state = "reproduced" if st.conforms else "did NOT reproduce"
+    lines.append(
+        f"This implementation's keyless conformance check {state} "
+        f"{st.reproduced} of {st.cases} recorded verdicts."
+    )
+    lines.append("")
+    for s in st.suites:
+        if not s.runnable:
+            lines.append(f"- `{s.name}`: not runnable ({_names(s.mismatches)})")
+        else:
+            tail = "" if not s.mismatches else f"; mismatched {_names(s.mismatches)}"
+            lines.append(f"- `{s.name}`: {s.reproduced}/{s.cases} reproduced{tail}")
+    lines.append("")
+
+    if statement.records is not None:
+        _render_records(statement.records, lines)
+
+    lines.append("---")
+    lines.append("")
+    lines.append(_HOW)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _render_records(r: RecordsResult, lines: list[str]) -> None:
+    lines.append("## Your records")
+    lines.append("")
+    rv = "CONFORM" if r.conforms else "do NOT conform"
+    if r.total == 0:
+        lines.append("No records were supplied to this run.")
+    else:
+        lines.append(
+            f"{r.total} record{_s(r.total)} checked, {r.conforming} "
+            f"conform{'s' if r.conforming == 1 else ''}; your records {rv}."
+        )
+    lines.append("")
+
+    if r.findings:
+        required = [f for f in r.findings if f.severity == "required"]
+        advisory = [f for f in r.findings if f.severity == "advisory"]
+        if required:
+            lines.append("Required (these gate conformance):")
+            lines.append("")
+            for f in required:
+                lines.append(f"- **{f.id}**: {_safe(f.detail)} ({_names(f.records)})")
+            lines.append("")
+        if advisory:
+            lines.append("Advisory (gaps that do not gate conformance):")
+            lines.append("")
+            for f in advisory:
+                lines.append(f"- **{f.id}**: {_safe(f.detail)} ({_names(f.records)})")
+            lines.append("")
+
+    if r.nonconforming:
+        lines.append("Non-conforming records:")
+        lines.append("")
+        for name, rf in r.nonconforming:
+            why = ", ".join(rf) if rf else "did not conform"
+            lines.append(f"- `{_safe(name)}`: {why}")
+        lines.append("")
+
+    if r.unreadable:
+        names = ", ".join(_safe(n) for n, _ in r.unreadable)
+        lines.append(f"> Note: {len(r.unreadable)} file(s) could not be read: {names}")
+        lines.append("")
+
+
+def _s(n: int) -> str:
+    return "" if n == 1 else "s"
+
+
+def _names(records: Sequence[str]) -> str:
+    # Record names can be foreign (a filename under --records, a corpus case
+    # name); escape control characters so a crafted name cannot forge a line.
+    return ", ".join(_safe(n) for n in records)
+
+
+def _safe(value: str) -> str:
+    """Escape C0 control characters so a foreign value cannot forge a line.
+
+    Record names and an ``as_of`` value can come from outside the corpus; this
+    keeps a crafted newline from injecting extra Markdown lines into the page.
+    """
+    return "".join(ch if ch.isprintable() else f"\\x{ord(ch):02x}" for ch in value)

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -56,6 +56,18 @@ from vaara.attestation._audit_summary import (
     SUMMARY_SCHEMA,
     render_record_set_summary,
 )
+from vaara.attestation._conformance_statement import (
+    STATEMENT_SCHEMA,
+    ConformanceCorpusError,
+    ConformanceStatement,
+    CorpusIntegrity,
+    RecordsResult,
+    SelfTest,
+    SuiteResult,
+    build_conformance_statement,
+    render_conformance_statement,
+    verify_corpus_integrity,
+)
 from vaara.attestation._decision_conformance import (
     check_decision_conformance,
 )
@@ -151,6 +163,16 @@ __all__ = [
     "check_bundle_set",
     "SUMMARY_SCHEMA",
     "render_record_set_summary",
+    "STATEMENT_SCHEMA",
+    "ConformanceCorpusError",
+    "ConformanceStatement",
+    "CorpusIntegrity",
+    "RecordsResult",
+    "SelfTest",
+    "SuiteResult",
+    "build_conformance_statement",
+    "render_conformance_statement",
+    "verify_corpus_integrity",
     "NormalizedEvidence",
     "detect_format",
     "normalize",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -127,6 +127,16 @@ Subcommands:
         call recorded twice, an executed action that committed no result).
         Keyless. Exit 0 iff every record conforms and no required gap fired.
 
+    vaara conformance-statement [--corpus DIR] [--records DIR] [--as-of DATE]
+            [--out FILE] [--json]
+        Self-test this implementation against the published SEP-2828
+        conformance corpus and print one reproducible statement: the corpus
+        bytes match their manifest, every recorded verdict was reproduced, and
+        (with --records) your own records conform. Names the exact corpus byte
+        set (version plus corpusDigest), so the claim pins a fixed suite rather
+        than a moving target. The answer to "trust us": prove it against the
+        neutral suite. Keyless. Exit 0 iff the statement conforms.
+
     vaara build-bundle (--receipt RECEIPT.json | --from-dir DIR) [piece flags]
             [--out BUNDLE.json]
         Assemble a complete evidence bundle on disk from the issuer's
@@ -2007,6 +2017,69 @@ def _cmd_audit_summary(args: argparse.Namespace) -> int:
     return 0 if (report.conforms and not unreadable) else 1
 
 
+def _cmd_conformance_statement(args: argparse.Namespace) -> int:
+    """Self-test this implementation against the published corpus and state the result.
+
+    The answer to "trust us": run this implementation's keyless conformance
+    check over the published SEP-2828 corpus, confirm the bytes match their
+    manifest, optionally run the emitter's own records through the same set
+    check, and print one reproducible statement that names the exact corpus
+    byte set. Exit 0 iff the statement conforms (corpus verifies, the self-test
+    reproduced every verdict, and any supplied records conform).
+    """
+    from vaara.attestation.receipt import (
+        ConformanceCorpusError,
+        build_conformance_statement,
+        render_conformance_statement,
+    )
+
+    corpus = Path(args.corpus).expanduser()
+    if not corpus.is_dir():
+        print(f"vaara conformance-statement: not a corpus directory: {corpus}",
+              file=sys.stderr)
+        return 2
+
+    records: list[tuple[str, Any]] | None = None
+    unreadable: list[tuple[str, str]] = []
+    if args.records is not None:
+        records_dir = Path(args.records).expanduser()
+        if not records_dir.is_dir():
+            print(f"vaara conformance-statement: not a directory: {records_dir}",
+                  file=sys.stderr)
+            return 2
+        paths = sorted(p for p in records_dir.glob(args.glob) if p.is_file())
+        if not paths:
+            print(f"vaara conformance-statement: no files matched {args.glob!r} in "
+                  f"{records_dir}", file=sys.stderr)
+            return 2
+        records = []
+        for path in paths:
+            try:
+                records.append((path.name, json.loads(path.read_text(encoding="utf-8"))))
+            except (json.JSONDecodeError, OSError) as exc:
+                unreadable.append((path.name, str(exc)))
+
+    try:
+        statement = build_conformance_statement(
+            corpus, records=records, unreadable=unreadable, as_of=args.as_of
+        )
+    except ConformanceCorpusError as exc:
+        print(f"vaara conformance-statement: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(statement.to_dict(), indent=2))
+    else:
+        page = render_conformance_statement(statement)
+        if args.out:
+            Path(args.out).expanduser().write_text(page, encoding="utf-8")
+            print(f"wrote conformance statement to {args.out}", file=sys.stderr)
+        else:
+            print(page, end="")
+
+    return 0 if statement.conforms else 1
+
+
 def _cmd_verify_bundles(args: argparse.Namespace) -> int:
     """Run the full lens stack over a whole directory of evidence bundles.
 
@@ -2997,6 +3070,41 @@ def build_parser() -> argparse.ArgumentParser:
         help="Write the Markdown summary to this file instead of stdout",
     )
     pas.set_defaults(func=_cmd_audit_summary)
+
+    pcs = sub.add_parser(
+        "conformance-statement",
+        help="Self-test this implementation against the published SEP-2828 "
+             "conformance corpus and print one reproducible statement: corpus "
+             "bytes match the manifest, every recorded verdict was reproduced, "
+             "and (with --records) your own records conform. The answer to "
+             "'trust us': prove it against the neutral suite. Keyless.",
+    )
+    pcs.add_argument(
+        "--corpus", default="conformance/sep2828",
+        help="Path to the published conformance corpus directory "
+             "(default: conformance/sep2828)",
+    )
+    pcs.add_argument(
+        "--records", default=None,
+        help="Directory of your own SEP-2828 records to check against the corpus",
+    )
+    pcs.add_argument(
+        "--glob", default="*.json",
+        help="Glob for record files within --records (default: *.json)",
+    )
+    pcs.add_argument(
+        "--as-of", default=None, dest="as_of",
+        help="A date echoed verbatim into the statement (never read from a clock)",
+    )
+    pcs.add_argument(
+        "--out", default=None,
+        help="Write the Markdown statement to this file instead of stdout",
+    )
+    pcs.add_argument(
+        "--json", action="store_true",
+        help="Emit the full statement as JSON instead of Markdown",
+    )
+    pcs.set_defaults(func=_cmd_conformance_statement)
 
     pvbs = sub.add_parser(
         "verify-bundles",

--- a/tests/test_conformance_statement.py
+++ b/tests/test_conformance_statement.py
@@ -1,0 +1,255 @@
+"""The conformance statement and the `vaara conformance-statement` command.
+
+B2 of the widening plan: the self-test an emitter runs to prove SEP-2828
+conformance against the published corpus rather than ask to be trusted. Covers
+the builder and renderer against the committed goldens (deterministic, keyless),
+the real corpus self-test, the Vaara-free independent checker, and the CLI end
+to end. Keyless, so the suite runs in the base install.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vaara.attestation.receipt import (
+    STATEMENT_SCHEMA,
+    ConformanceCorpusError,
+    build_conformance_statement,
+    render_conformance_statement,
+)
+from vaara.cli import main
+
+REPO = Path(__file__).resolve().parent.parent
+CORPUS = REPO / "conformance" / "sep2828"
+VECTORS = Path(__file__).resolve().parent / "vectors" / "conformance_statement_v0"
+EMITTER = VECTORS / "emitter_records"
+PAGES = VECTORS / "pages"
+EXPECTED = json.loads((VECTORS / "expected.json").read_text(encoding="utf-8"))
+
+SCENARIO_RECORDS = {
+    "selftest_only": None, "clean": "clean", "flawed": "flawed", "duplicate": "duplicate",
+}
+
+
+def _records(scenario: str):
+    sub = SCENARIO_RECORDS[scenario]
+    if sub is None:
+        return None
+    return [(p.name, json.loads(p.read_text())) for p in sorted((EMITTER / sub).glob("*.json"))]
+
+
+def _build(scenario: str):
+    return build_conformance_statement(CORPUS, records=_records(scenario))
+
+
+# ── Goldens ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("scenario", sorted(SCENARIO_RECORDS))
+def test_statement_matches_golden_json(scenario):
+    assert _build(scenario).to_dict() == EXPECTED[scenario]
+
+
+@pytest.mark.parametrize("scenario", sorted(SCENARIO_RECORDS))
+def test_render_matches_golden_page(scenario):
+    page = render_conformance_statement(_build(scenario))
+    assert page == (PAGES / f"{scenario}.md").read_text(encoding="utf-8")
+
+
+def test_all_scenarios_present():
+    assert sorted(p.stem for p in PAGES.glob("*.md")) == [
+        "clean", "duplicate", "flawed", "selftest_only"
+    ]
+
+
+def test_independent_checker_confirms_statements():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_public_reexport_is_wired():
+    from vaara.attestation.receipt import build_conformance_statement as public
+    assert public is build_conformance_statement
+    assert STATEMENT_SCHEMA == "sep2828-conformance-statement"
+
+
+# ── Real corpus self-test ─────────────────────────────────────────────────────
+
+
+def test_real_corpus_self_test_reproduces_every_verdict():
+    statement = build_conformance_statement(CORPUS)
+    assert statement.corpus.verified
+    assert statement.self_test.conforms
+    assert statement.self_test.reproduced == statement.self_test.cases
+    assert statement.conforms  # no records supplied, so corpus + self-test decide it
+
+
+def test_self_test_covers_both_published_suites():
+    statement = build_conformance_statement(CORPUS)
+    names = {s.name for s in statement.self_test.suites}
+    assert names == {"record_conformance_v0", "record_set_v0"}
+    assert all(s.runnable and not s.mismatches for s in statement.self_test.suites)
+
+
+def test_clean_records_conform_and_flawed_do_not():
+    assert _build("clean").records.conforms
+    flawed = _build("flawed").records
+    assert not flawed.conforms
+    assert flawed.conforming < flawed.total
+    assert flawed.nonconforming  # the non-conforming record is named
+
+
+def test_duplicate_set_gate_each_record_conforms_but_set_does_not():
+    # Every record is individually well-formed, so the verdict turns on a
+    # required cross-record property: two outcomes pinning one call.
+    statement = _build("duplicate")
+    records = statement.records
+    assert records.conforming == records.total  # each record conforms on its own
+    assert not records.conforms  # but the set does not
+    assert any(f.id == "duplicate_call" and f.severity == "required" for f in records.findings)
+    assert not statement.conforms
+
+
+# ── Deterministic and faithful ────────────────────────────────────────────────
+
+
+def test_render_is_deterministic():
+    a = render_conformance_statement(build_conformance_statement(CORPUS))
+    b = render_conformance_statement(build_conformance_statement(CORPUS))
+    assert a == b  # no clock, no key: same inputs, same bytes
+
+
+def test_as_of_is_echoed_verbatim_not_from_a_clock():
+    statement = build_conformance_statement(CORPUS, as_of="2026-06-08")
+    page = render_conformance_statement(statement)
+    assert statement.as_of == "2026-06-08"
+    assert "As of 2026-06-08." in page
+
+
+def test_as_of_default_is_omitted():
+    page = render_conformance_statement(build_conformance_statement(CORPUS))
+    assert "As of " not in page
+
+
+def test_statement_names_the_exact_corpus_byte_set():
+    page = render_conformance_statement(build_conformance_statement(CORPUS))
+    manifest = json.loads((CORPUS / "MANIFEST.json").read_text())
+    assert manifest["corpusDigest"] in page
+    assert manifest["version"] in page
+
+
+# ── Tampered corpus ───────────────────────────────────────────────────────────
+
+
+def _copy_corpus(dst: Path) -> Path:
+    shutil.copytree(CORPUS, dst)
+    return dst
+
+
+def test_tampered_fixture_breaks_integrity_and_gates(tmp_path):
+    corpus = _copy_corpus(tmp_path / "corpus")
+    victim = corpus / "record_conformance_v0" / "records" / "conforming_refused_no_commitment.json"
+    victim.write_text(victim.read_text() + "\n", encoding="utf-8")  # one byte changes the digest
+    statement = build_conformance_statement(corpus)
+    assert not statement.corpus.verified
+    assert statement.corpus.problems
+    assert not statement.conforms  # a tampered corpus cannot yield a conforming statement
+
+
+def test_extra_file_in_corpus_is_an_integrity_problem(tmp_path):
+    corpus = _copy_corpus(tmp_path / "corpus")
+    (corpus / "record_set_v0" / "sets" / "clean" / "rogue.json").write_text("{}", "utf-8")
+    statement = build_conformance_statement(corpus)
+    assert not statement.corpus.verified
+    assert any("unexpected file" in p for p in statement.corpus.problems)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def test_cli_default_corpus_to_stdout(capsys):
+    rc = main(["conformance-statement", "--corpus", str(CORPUS)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == (PAGES / "selftest_only.md").read_text(encoding="utf-8")
+
+
+def test_cli_clean_records_conform(capsys):
+    rc = main(["conformance-statement", "--corpus", str(CORPUS),
+               "--records", str(EMITTER / "clean")])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert out == (PAGES / "clean.md").read_text(encoding="utf-8")
+
+
+def test_cli_flawed_records_exit_1(capsys):
+    rc = main(["conformance-statement", "--corpus", str(CORPUS),
+               "--records", str(EMITTER / "flawed")])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "NON-CONFORMING" in out
+
+
+def test_cli_json_output(capsys):
+    rc = main(["conformance-statement", "--corpus", str(CORPUS), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload == EXPECTED["selftest_only"]
+
+
+def test_cli_writes_to_out_file(tmp_path, capsys):
+    target = tmp_path / "statement.md"
+    rc = main(["conformance-statement", "--corpus", str(CORPUS), "--out", str(target)])
+    assert rc == 0
+    assert target.read_text(encoding="utf-8") == (PAGES / "selftest_only.md").read_text("utf-8")
+    assert "wrote conformance statement" in capsys.readouterr().err
+
+
+def test_cli_corpus_not_a_directory(tmp_path, capsys):
+    rc = main(["conformance-statement", "--corpus", str(tmp_path / "nope")])
+    assert rc == 2
+    assert "not a corpus directory" in capsys.readouterr().err
+
+
+def test_cli_corpus_without_manifest(tmp_path, capsys):
+    rc = main(["conformance-statement", "--corpus", str(tmp_path)])
+    assert rc == 2
+    assert "no MANIFEST.json" in capsys.readouterr().err
+
+
+def test_cli_records_not_a_directory(tmp_path, capsys):
+    rc = main(["conformance-statement", "--corpus", str(CORPUS),
+               "--records", str(tmp_path / "nope")])
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_cli_records_no_matching_files(tmp_path, capsys):
+    rc = main(["conformance-statement", "--corpus", str(CORPUS), "--records", str(tmp_path)])
+    assert rc == 2
+    assert "no files matched" in capsys.readouterr().err
+
+
+def test_cli_unreadable_record_gates(tmp_path, capsys):
+    (tmp_path / "good.json").write_text(
+        (EMITTER / "clean" / "decision.json").read_text(), "utf-8")
+    (tmp_path / "bad.json").write_text("{ not json", "utf-8")
+    rc = main(["conformance-statement", "--corpus", str(CORPUS), "--records", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "could not be read" in out
+    assert "bad.json" in out
+
+
+def test_missing_manifest_raises_corpus_error(tmp_path):
+    with pytest.raises(ConformanceCorpusError):
+        build_conformance_statement(tmp_path)

--- a/tests/vectors/conformance_statement_v0/README.md
+++ b/tests/vectors/conformance_statement_v0/README.md
@@ -1,0 +1,46 @@
+# Conformance-statement vectors, v0
+
+Fixtures for `vaara conformance-statement`: the self-test an emitter runs to
+prove SEP-2828 conformance against the published corpus instead of asking to be
+trusted. The command checks the corpus bytes against their manifest, reproduces
+every recorded verdict with this implementation's keyless check, optionally runs
+the emitter's own records through the same set check, and prints one
+reproducible statement that names the exact corpus byte set (version plus
+corpusDigest).
+
+These goldens pin what the command produces against the real corpus under
+`conformance/sep2828`, so they move whenever that corpus does. Regenerate them
+with `python scripts/build_conformance_statement_vectors.py`.
+
+## Layout
+
+```
+emitter_records/<scenario>/   the emitter's own SEP-2828 records for a scenario
+expected.json                 {scenario: statement.to_dict()}
+pages/<scenario>.md           the rendered Markdown statement (deterministic)
+_check_independent.py         stdlib only, no Vaara import
+```
+
+## Scenarios
+
+- `selftest_only`: no emitter records, just the corpus self-test. Conforms.
+- `clean`: emitter records that conform (a decision and its outcome). Conforms.
+- `flawed`: emitter records with one non-conforming record. NON-CONFORMING,
+  even though the corpus self-test passes, because the supplied records do not
+  all conform.
+
+The `clean` and `flawed` records are byte copies of the `proper_pair` and
+`mixed_nonconforming` sets from the `record_set_v0` vectors, so their set
+verdict is already independently fixed there.
+
+## Verifying
+
+```
+python tests/vectors/conformance_statement_v0/_check_independent.py
+```
+
+The checker re-derives every claim each statement makes (corpus integrity by
+recomputing the digests, the self-test by running the corpus's own neutral
+runner, the records verdict with a second implementation of the set check) and
+asserts both the golden page and `expected.json` state exactly that. Exit 0
+means every statement is true under the independent derivation.

--- a/tests/vectors/conformance_statement_v0/_check_independent.py
+++ b/tests/vectors/conformance_statement_v0/_check_independent.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Independent check that the conformance statement tells the truth.
+
+The statement claims three things: the corpus bytes match their manifest, this
+implementation reproduced every recorded verdict, and the emitter's own records
+conform. A renderer could print CONFORMS over any of those without it being so.
+This checker closes that gap without importing Vaara.
+
+It re-derives each claim from the real corpus and the committed emitter records:
+
+* corpus integrity, by recomputing every file digest and the corpusDigest;
+* self-test, by running the corpus's own Vaara-free runner (``run.py``) and
+  confirming the neutral suite reproduces every case the statement counts;
+* the emitter records verdict, with a second implementation of the SEP-2828
+  set check (per-record conformance plus the required unique-call property that
+  gates it) written from the schema alone.
+
+Then it parses each committed golden page and the structured ``expected.json``
+and asserts both state exactly what this independent derivation found. Standard
+library only (hashlib, json, re, subprocess). Run:
+``python tests/vectors/conformance_statement_v0/_check_independent.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]
+CORPUS = REPO / "conformance" / "sep2828"
+EMITTER = HERE / "emitter_records"
+PAGES = HERE / "pages"
+
+VALID_ALGS = {"HS256", "ES256", "RS256"}
+VALID_STATUSES = {"executed", "refused", "errored"}
+VALID_VERDICTS = {"allow", "block", "escalate"}
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+HEX_RE = re.compile(r"^[0-9a-f]+$")
+
+SCENARIO_RECORDS = {
+    "selftest_only": None, "clean": "clean", "flawed": "flawed", "duplicate": "duplicate",
+}
+
+
+# ── Independent corpus + self-test derivation ─────────────────────────────────
+
+
+def _file_digests(suites):
+    out = {}
+    for suite in suites:
+        for path in sorted((CORPUS / suite).rglob("*")):
+            if not path.is_file() or "__pycache__" in path.parts or path.suffix == ".pyc":
+                continue
+            rel = path.relative_to(CORPUS).as_posix()
+            out[rel] = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    return out
+
+
+def _corpus_digest(files):
+    lines = [f"{files[k].split(':', 1)[1]}  {k}" for k in sorted(files)]
+    return "sha256:" + hashlib.sha256(("\n".join(lines) + "\n").encode("utf-8")).hexdigest()
+
+
+def corpus_facts():
+    """Recompute the corpus identity and integrity from the bytes on disk."""
+    manifest = json.loads((CORPUS / "MANIFEST.json").read_text())
+    files = _file_digests(manifest["suites"])
+    verified = files == manifest["files"] and _corpus_digest(files) == manifest["corpusDigest"]
+    return {
+        "name": manifest["corpus"],
+        "version": manifest["version"],
+        "corpusDigest": manifest["corpusDigest"],
+        "fileCount": len(files),
+        "verified": verified,
+        "suites": list(manifest["suites"]),
+    }
+
+
+def self_test_facts(suites):
+    """Per-suite case counts, corroborated by the corpus's own neutral runner."""
+    runner = subprocess.run([sys.executable, "run.py"], cwd=CORPUS,
+                            capture_output=True, text=True)
+    reproduces_all = runner.returncode == 0 and "PASS: all" in runner.stdout
+    per_suite = {}
+    for suite in suites:
+        cases = len(json.loads((CORPUS / suite / "expected.json").read_text()))
+        per_suite[suite] = (cases, cases if reproduces_all else 0)
+    return reproduces_all, per_suite
+
+
+# ── Independent SEP-2828 set check (second implementation) ────────────────────
+
+
+def _classify(doc):
+    if not isinstance(doc, dict):
+        return "unknown"
+    has_d, has_o = isinstance(doc.get("decisionDerived"), dict), isinstance(
+        doc.get("outcomeDerived"), dict)
+    return "decision" if has_d and not has_o else "outcome" if has_o and not has_d else "unknown"
+
+
+def _envelope_ok(doc, asserted_key):
+    if doc.get("version") != 1 or doc.get("alg") not in VALID_ALGS:
+        return False
+    sig = doc.get("signature")
+    if not (isinstance(sig, str) and HEX_RE.match(sig) and len(sig) % 2 == 0):
+        return False
+    bl = doc.get("backLink")
+    if not (isinstance(bl, dict) and isinstance(bl.get("attestationDigest"), str)
+            and DIGEST_RE.match(bl["attestationDigest"])
+            and isinstance(bl.get("attestationNonce"), str)):
+        return False
+    a = doc.get(asserted_key)
+    if not isinstance(a, dict) or any(
+            f not in a for f in ("alg", "iat", "iss", "nonce", "secretVersion", "sub")):
+        return False
+    return a.get("alg") == doc.get("alg")
+
+
+def _conforms(doc, kind):
+    if kind == "decision":
+        if not _envelope_ok(doc, "issuerAsserted"):
+            return False
+        dd = doc["decisionDerived"]
+        return dd.get("decision") in VALID_VERDICTS and isinstance(dd.get("decidedAt"), str)
+    if not _envelope_ok(doc, "receiptAsserted"):
+        return False
+    od = doc["outcomeDerived"]
+    if od.get("status") not in VALID_STATUSES or not isinstance(od.get("completedAt"), str):
+        return False
+    rc = od.get("resultCommitment")
+    if isinstance(rc, dict) and "projection" in rc:
+        proj, pdg = rc.get("projection"), rc.get("projectionDigest")
+        if not (isinstance(proj, str) and isinstance(pdg, str)):
+            return False
+        if "sha256:" + hashlib.sha256(proj.encode("utf-8")).hexdigest() != pdg:
+            return False
+    return True
+
+
+def records_facts(scenario):
+    """The set verdict for one emitter-records scenario, or None when there are none.
+
+    Mirrors the conformance gate: every record conforms to its type's schema and
+    no required cross-record property fails. The one required set property is
+    unique calls (two outcome records pinning one call is a duplicate); pairing
+    and coverage gaps are advisory and do not gate the verdict.
+    """
+    sub = SCENARIO_RECORDS[scenario]
+    if sub is None:
+        return None
+    docs = [(p.name, json.loads(p.read_text())) for p in sorted((EMITTER / sub).glob("*.json"))]
+    conforming = 0
+    outcomes = []
+    for _name, d in docs:
+        kind = _classify(d)
+        if kind in ("decision", "outcome") and _conforms(d, kind):
+            conforming += 1
+            if kind == "outcome":
+                outcomes.append(d)
+    by_call = {}
+    for d in outcomes:
+        bl = d["backLink"]
+        key = (bl["attestationDigest"], bl["attestationNonce"])
+        by_call[key] = by_call.get(key, 0) + 1
+    duplicate = any(count > 1 for count in by_call.values())
+    return {
+        "total": len(docs),
+        "conforming": conforming,
+        "conforms": conforming == len(docs) and not duplicate,
+    }
+
+
+# ── Page parsing ──────────────────────────────────────────────────────────────
+
+_VERDICT = re.compile(r"^\*\*Statement: (CONFORMS|NON-CONFORMING)\*\*$", re.M)
+_CORPUS = re.compile(
+    r"^Checked against corpus `(.+?)` version (\S+) \(corpusDigest `(sha256:[0-9a-f]{64})`\)\.$",
+    re.M)
+_VERIFIED = re.compile(r"^Verified: all (\d+) fixture files match", re.M)
+_SUITE = re.compile(r"^- `(\S+?)`: (\d+)/(\d+) reproduced", re.M)
+_RECORDS = re.compile(
+    r"^(\d+) records? checked, (\d+) conforms?; your records (CONFORM|do NOT conform)\.$", re.M)
+
+
+def parse_page(text):
+    verdict = _VERDICT.search(text)
+    corpus = _CORPUS.search(text)
+    verified = _VERIFIED.search(text)
+    suites = {m.group(1): (int(m.group(3)), int(m.group(2))) for m in _SUITE.finditer(text)}
+    rec = _RECORDS.search(text)
+    return {
+        "verdict": verdict.group(1) if verdict else None,
+        "corpus": (corpus.group(1), corpus.group(2), corpus.group(3)) if corpus else None,
+        "verifiedCount": int(verified.group(1)) if verified else None,
+        "suites": suites,
+        "has_records": "## Your records" in text,
+        "records": (int(rec.group(1)), int(rec.group(2)), rec.group(3) == "CONFORM")
+        if rec else None,
+    }
+
+
+# ── Cross-check ───────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    corpus = corpus_facts()
+    reproduces_all, per_suite = self_test_facts(corpus["suites"])
+    expected = json.loads((HERE / "expected.json").read_text())
+    failures = 0
+
+    for scenario in sorted(SCENARIO_RECORDS):
+        rec = records_facts(scenario)
+        want_verdict = "CONFORMS" if (
+            corpus["verified"] and reproduces_all and (rec is None or rec["conforms"])
+        ) else "NON-CONFORMING"
+
+        page = parse_page((PAGES / f"{scenario}.md").read_text())
+        problems = []
+        if page["verdict"] != want_verdict:
+            problems.append(f"verdict {page['verdict']} != {want_verdict}")
+        if page["corpus"] != (corpus["name"], corpus["version"], corpus["corpusDigest"]):
+            problems.append(f"corpus identity {page['corpus']}")
+        want_count = corpus["fileCount"] if corpus["verified"] else None
+        if page["verifiedCount"] != want_count:
+            problems.append(f"verified count {page['verifiedCount']} != {want_count}")
+        if page["suites"] != per_suite:
+            problems.append(f"suite counts {page['suites']} != {per_suite}")
+        if (rec is None) == page["has_records"]:
+            problems.append(f"records section presence wrong (rec={rec})")
+        if rec is not None and page["records"] != (
+                rec["total"], rec["conforming"], rec["conforms"]):
+            problems.append(f"records line {page['records']} != {rec}")
+
+        # The structured expected.json must agree with the same derivation.
+        exp = expected[scenario]
+        if exp["conforms"] != (want_verdict == "CONFORMS"):
+            problems.append("expected.json conforms disagrees")
+        if exp["corpus"]["corpusDigest"] != corpus["corpusDigest"]:
+            problems.append("expected.json corpusDigest disagrees")
+        if exp["selfTest"]["reproduced"] != sum(r for _c, r in per_suite.values()):
+            problems.append("expected.json selfTest reproduced disagrees")
+        if (exp["records"] is None) != (rec is None):
+            problems.append("expected.json records presence disagrees")
+        if rec is not None and exp["records"]["conforms"] != rec["conforms"]:
+            problems.append("expected.json records conforms disagrees")
+
+        ok = not problems
+        failures += 0 if ok else 1
+        print(f"[{'OK' if ok else 'FAIL'}] {scenario}: page says {page['verdict']}")
+        for p in problems:
+            print(f"    {p}")
+
+    total = len(SCENARIO_RECORDS)
+    print(f"\n{total - failures}/{total} statements match the independent derivation.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/conformance_statement_v0/emitter_records/clean/decision.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/clean/decision.json
@@ -1,0 +1,21 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "226d2a3c2998ecbd0366ac8080e27b5ce255e2680c8178fa478f69dceac571fb",
+  "version": 1
+}

--- a/tests/vectors/conformance_statement_v0/emitter_records/clean/outcome.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/clean/outcome.json
@@ -1,0 +1,26 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "decisionDigest": "sha256:bc1a28955291e73f991374b6ba5a72be528db6049ed2f53042d6d429fbe9ac9b",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "f4b87ef796407eef8d6644ca001a616deb09838b4d2584a809c4fbb4ee3c9db6",
+  "version": 1
+}

--- a/tests/vectors/conformance_statement_v0/emitter_records/duplicate/r1.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/duplicate/r1.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:6b23c0d5f35d1b11f9b683f0b0a617355deb11277d91ae091d399c655b87940d",
+    "attestationNonce": "nonce-C"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"ok\":true}",
+      "projectionDigest": "sha256:4062edaf750fb8074e7e83e0c9028c94e32468a8b6f1614774328ef045150f93"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-C",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/conformance_statement_v0/emitter_records/duplicate/r2.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/duplicate/r2.json
@@ -1,0 +1,21 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:6b23c0d5f35d1b11f9b683f0b0a617355deb11277d91ae091d399c655b87940d",
+    "attestationNonce": "nonce-C"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "status": "refused"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-C",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/conformance_statement_v0/emitter_records/flawed/bad.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/flawed/bad.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:f67ab10ad4e4c53121b6a5fe4da9c10ddee905b978d3788d2723d7bfacbe28a9",
+    "attestationNonce": "nonce-F"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"x\":1}",
+      "projectionDigest": "sha256:5041bf1f713df204784353e82f6a4a535931cb64f1f4b4a5aeaffcb720918b22"
+    },
+    "status": "frobnicated"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-F",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/conformance_statement_v0/emitter_records/flawed/good.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/flawed/good.json
@@ -1,0 +1,25 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:f67ab10ad4e4c53121b6a5fe4da9c10ddee905b978d3788d2723d7bfacbe28a9",
+    "attestationNonce": "nonce-F"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-05-29T10:00:00Z",
+    "resultCommitment": {
+      "projection": "{\"ok\":true}",
+      "projectionDigest": "sha256:4062edaf750fb8074e7e83e0c9028c94e32468a8b6f1614774328ef045150f93"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "ES256",
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "rnonce-F",
+    "secretVersion": "v1",
+    "sub": "agent:x"
+  },
+  "signature": "abababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababababab",
+  "version": 1
+}

--- a/tests/vectors/conformance_statement_v0/expected.json
+++ b/tests/vectors/conformance_statement_v0/expected.json
@@ -1,0 +1,187 @@
+{
+  "clean": {
+    "asOf": null,
+    "conforms": true,
+    "corpus": {
+      "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
+      "fileCount": 32,
+      "name": "sep2828-execution-record-conformance",
+      "problems": [],
+      "spec": "SEP-2828",
+      "verified": true,
+      "version": "1.0.0"
+    },
+    "records": {
+      "conforming": 2,
+      "conforms": true,
+      "findings": [],
+      "nonconforming": [],
+      "total": 2,
+      "unreadable": []
+    },
+    "schema": "sep2828-conformance-statement",
+    "schemaVersion": 1,
+    "selfTest": {
+      "cases": 17,
+      "conforms": true,
+      "reproduced": 17,
+      "suites": [
+        {
+          "cases": 10,
+          "mismatches": [],
+          "name": "record_conformance_v0",
+          "reproduced": 10,
+          "runnable": true
+        },
+        {
+          "cases": 7,
+          "mismatches": [],
+          "name": "record_set_v0",
+          "reproduced": 7,
+          "runnable": true
+        }
+      ]
+    }
+  },
+  "duplicate": {
+    "asOf": null,
+    "conforms": false,
+    "corpus": {
+      "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
+      "fileCount": 32,
+      "name": "sep2828-execution-record-conformance",
+      "problems": [],
+      "spec": "SEP-2828",
+      "verified": true,
+      "version": "1.0.0"
+    },
+    "records": {
+      "conforming": 2,
+      "conforms": false,
+      "findings": [
+        {
+          "id": "duplicate_call",
+          "records": [
+            "r1.json",
+            "r2.json"
+          ],
+          "severity": "required"
+        }
+      ],
+      "nonconforming": [],
+      "total": 2,
+      "unreadable": []
+    },
+    "schema": "sep2828-conformance-statement",
+    "schemaVersion": 1,
+    "selfTest": {
+      "cases": 17,
+      "conforms": true,
+      "reproduced": 17,
+      "suites": [
+        {
+          "cases": 10,
+          "mismatches": [],
+          "name": "record_conformance_v0",
+          "reproduced": 10,
+          "runnable": true
+        },
+        {
+          "cases": 7,
+          "mismatches": [],
+          "name": "record_set_v0",
+          "reproduced": 7,
+          "runnable": true
+        }
+      ]
+    }
+  },
+  "flawed": {
+    "asOf": null,
+    "conforms": false,
+    "corpus": {
+      "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
+      "fileCount": 32,
+      "name": "sep2828-execution-record-conformance",
+      "problems": [],
+      "spec": "SEP-2828",
+      "verified": true,
+      "version": "1.0.0"
+    },
+    "records": {
+      "conforming": 1,
+      "conforms": false,
+      "findings": [],
+      "nonconforming": [
+        {
+          "name": "bad.json",
+          "requiredFailed": [
+            "status_valid"
+          ]
+        }
+      ],
+      "total": 2,
+      "unreadable": []
+    },
+    "schema": "sep2828-conformance-statement",
+    "schemaVersion": 1,
+    "selfTest": {
+      "cases": 17,
+      "conforms": true,
+      "reproduced": 17,
+      "suites": [
+        {
+          "cases": 10,
+          "mismatches": [],
+          "name": "record_conformance_v0",
+          "reproduced": 10,
+          "runnable": true
+        },
+        {
+          "cases": 7,
+          "mismatches": [],
+          "name": "record_set_v0",
+          "reproduced": 7,
+          "runnable": true
+        }
+      ]
+    }
+  },
+  "selftest_only": {
+    "asOf": null,
+    "conforms": true,
+    "corpus": {
+      "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
+      "fileCount": 32,
+      "name": "sep2828-execution-record-conformance",
+      "problems": [],
+      "spec": "SEP-2828",
+      "verified": true,
+      "version": "1.0.0"
+    },
+    "records": null,
+    "schema": "sep2828-conformance-statement",
+    "schemaVersion": 1,
+    "selfTest": {
+      "cases": 17,
+      "conforms": true,
+      "reproduced": 17,
+      "suites": [
+        {
+          "cases": 10,
+          "mismatches": [],
+          "name": "record_conformance_v0",
+          "reproduced": 10,
+          "runnable": true
+        },
+        {
+          "cases": 7,
+          "mismatches": [],
+          "name": "record_set_v0",
+          "reproduced": 7,
+          "runnable": true
+        }
+      ]
+    }
+  }
+}

--- a/tests/vectors/conformance_statement_v0/pages/clean.md
+++ b/tests/vectors/conformance_statement_v0/pages/clean.md
@@ -1,0 +1,24 @@
+# SEP-2828 conformance statement
+
+**Statement: CONFORMS**
+
+Checked against corpus `sep2828-execution-record-conformance` version 1.0.0 (corpusDigest `sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a`).
+
+## Corpus integrity
+
+Verified: all 32 fixture files match `MANIFEST.json` and the corpusDigest recomputes.
+
+## Self-test
+
+This implementation's keyless conformance check reproduced 17 of 17 recorded verdicts.
+
+- `record_conformance_v0`: 10/10 reproduced
+- `record_set_v0`: 7/7 reproduced
+
+## Your records
+
+2 records checked, 2 conform; your records CONFORM.
+
+---
+
+This statement is keyless and reproducible. Anyone holding the same corpus version can re-run `vaara conformance-statement` and reach the same verdict. It covers the wire schema, the record's self-proving digest, and the cross-record set properties; it is not signature verification, issuer trust, or time-anchor verification, which need external material and are checked separately.

--- a/tests/vectors/conformance_statement_v0/pages/duplicate.md
+++ b/tests/vectors/conformance_statement_v0/pages/duplicate.md
@@ -1,0 +1,28 @@
+# SEP-2828 conformance statement
+
+**Statement: NON-CONFORMING**
+
+Checked against corpus `sep2828-execution-record-conformance` version 1.0.0 (corpusDigest `sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a`).
+
+## Corpus integrity
+
+Verified: all 32 fixture files match `MANIFEST.json` and the corpusDigest recomputes.
+
+## Self-test
+
+This implementation's keyless conformance check reproduced 17 of 17 recorded verdicts.
+
+- `record_conformance_v0`: 10/10 reproduced
+- `record_set_v0`: 7/7 reproduced
+
+## Your records
+
+2 records checked, 2 conform; your records do NOT conform.
+
+Required (these gate conformance):
+
+- **duplicate_call**: 2 outcome records pin the same call (attestationDigest sha256:6b23c0d5f35d1b11f9b683f0b0a617355deb11277d91ae091d399c655b87940d, nonce nonce-C); a call MUST be recorded once (r1.json, r2.json)
+
+---
+
+This statement is keyless and reproducible. Anyone holding the same corpus version can re-run `vaara conformance-statement` and reach the same verdict. It covers the wire schema, the record's self-proving digest, and the cross-record set properties; it is not signature verification, issuer trust, or time-anchor verification, which need external material and are checked separately.

--- a/tests/vectors/conformance_statement_v0/pages/flawed.md
+++ b/tests/vectors/conformance_statement_v0/pages/flawed.md
@@ -1,0 +1,28 @@
+# SEP-2828 conformance statement
+
+**Statement: NON-CONFORMING**
+
+Checked against corpus `sep2828-execution-record-conformance` version 1.0.0 (corpusDigest `sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a`).
+
+## Corpus integrity
+
+Verified: all 32 fixture files match `MANIFEST.json` and the corpusDigest recomputes.
+
+## Self-test
+
+This implementation's keyless conformance check reproduced 17 of 17 recorded verdicts.
+
+- `record_conformance_v0`: 10/10 reproduced
+- `record_set_v0`: 7/7 reproduced
+
+## Your records
+
+2 records checked, 1 conforms; your records do NOT conform.
+
+Non-conforming records:
+
+- `bad.json`: status_valid
+
+---
+
+This statement is keyless and reproducible. Anyone holding the same corpus version can re-run `vaara conformance-statement` and reach the same verdict. It covers the wire schema, the record's self-proving digest, and the cross-record set properties; it is not signature verification, issuer trust, or time-anchor verification, which need external material and are checked separately.

--- a/tests/vectors/conformance_statement_v0/pages/selftest_only.md
+++ b/tests/vectors/conformance_statement_v0/pages/selftest_only.md
@@ -1,0 +1,20 @@
+# SEP-2828 conformance statement
+
+**Statement: CONFORMS**
+
+Checked against corpus `sep2828-execution-record-conformance` version 1.0.0 (corpusDigest `sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a`).
+
+## Corpus integrity
+
+Verified: all 32 fixture files match `MANIFEST.json` and the corpusDigest recomputes.
+
+## Self-test
+
+This implementation's keyless conformance check reproduced 17 of 17 recorded verdicts.
+
+- `record_conformance_v0`: 10/10 reproduced
+- `record_set_v0`: 7/7 reproduced
+
+---
+
+This statement is keyless and reproducible. Anyone holding the same corpus version can re-run `vaara conformance-statement` and reach the same verdict. It covers the wire schema, the record's self-proving digest, and the cross-record set properties; it is not signature verification, issuer trust, or time-anchor verification, which need external material and are checked separately.


### PR DESCRIPTION
Adds `vaara conformance-statement`: the self-test a producer runs to prove SEP-2828 conformance against the published corpus instead of asking to be trusted.

The command runs three checks and prints one statement:
- the corpus bytes match `MANIFEST.json` and the corpusDigest recomputes,
- this implementation's keyless conformance check reproduces every verdict the corpus records in each suite's `expected.json`,
- with `--records`, the producer's own records conform under the same set check.

The statement names the exact corpus version and corpusDigest it was checked against, so the claim pins a fixed byte set. Keyless and deterministic: no signing key and no clock, so anyone holding the same corpus re-runs the command and reaches the same verdict.

Ships the `conformance_statement_v0` vectors (four scenarios: self-test only, conforming records, a non-conforming record, and a set that fails the required duplicate-call property) and a Vaara-free independent checker that re-derives every claim and confirms both the rendered page and the structured output state it faithfully.

An adversarial review ran over the diff before this PR. It found and fixed control-character escaping on foreign values rendered into the statement (corpus metadata, record names), and strengthened the independent checker to implement the required set-level gate.

1478 passed, ruff clean, mypy clean. Runs in the base install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `conformance-statement` command for validating SEP-2828 conformance against the published corpus.
  * Keyless, deterministic self-testing capability with support for Markdown and JSON output formats.
  * Validate custom record sets with conformance analysis and detailed reporting of results.

* **Chores**
  * Version bumped to 0.63.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->