### PR TITLE
feat: verify-handoffs / verify-enforcements, batch over a directory of evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+- `vaara verify-handoffs` and `vaara verify-enforcements`: the set-level forms of
+  `verify-handoff` and `verify-enforcement`, for an auditor holding a directory
+  of evidence rather than one file. `verify-handoffs` runs the handoff lens over
+  every package and rolls up how many records verify under their rotated-out
+  keys, how many are anchor-corroborated rather than resting on the signature
+  alone, and how many had their producer identity pinned. `verify-enforcements`
+  binds a directory of records to their SEV-SNP reports, discovering each triple
+  by stem (`NAME.record.json` with `NAME.report.bin` and `NAME.vcek.pem`), and
+  rolls up how many bind to a confidential VM, the per-tier tally, and whether
+  any pinned a vetted launch image. Each set is `ok` only when every item
+  verifies for the chosen mode; a coverage note (no producer pinned, no image
+  pinned) is advisory and does not gate, mirroring `verify-bundles`. New
+  `check_handoff_set` / `check_enforcement_set` with `handoff_set_v0` and
+  `enforcement_set_v0` conformance vectors, each with a Vaara-free checker that
+  reproduces the roll-up by composing the single-verb suite's own evaluator.
+
 ## [0.66.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,14 +142,20 @@ It needs no signing key and no attestation. The check is the wire schema plus th
 When the evidence is a folder of records or bundles rather than one file, each single-file command above has a set-level form that runs over a whole directory:
 
 ```bash
-vaara verify-records ./records
-vaara verify-bundles ./bundles
-vaara audit-summary  ./records --out summary.md
+vaara verify-records      ./records
+vaara verify-bundles      ./bundles
+vaara verify-handoffs     ./handoffs
+vaara verify-enforcements ./enforced
+vaara audit-summary       ./records --out summary.md
 ```
 
 - `verify-records` checks every record for SEP-2828 conformance, then checks the set as a whole: it flags a call recorded twice, an authorised decision with no matching outcome, and an executed action that committed no result. Keyless, like `verify-record`.
 - `verify-bundles` runs the full six-lens `verify-bundle` over every bundle and reports per-lens pass counts and how many bundles authenticated.
+- `verify-handoffs` runs `verify-handoff` over a directory of cross-org packages and reports how many records verify under their rotated-out keys, how many are anchor-corroborated rather than resting on the signature alone, and how many had their producer pinned.
+- `verify-enforcements` runs `verify-enforcement` over a directory of records and their SEV-SNP reports (discovered by stem: `NAME.record.json` with `NAME.report.bin` and `NAME.vcek.pem`), reporting how many bind to a confidential VM, the per-tier tally, and whether any pinned a vetted launch image.
 - `audit-summary` renders the conformance verdict for a directory of records as a Markdown page an auditor reads directly. The page states what was checked and every count, and records that any party can reproduce it from the records alone.
+
+Each set form is `ok` only when every item verifies for the chosen mode; a coverage note (no producer pinned, no image pinned) is advisory and does not gate. Vaara-free checkers in `tests/vectors/handoff_set_v0/` and `tests/vectors/enforcement_set_v0/` reproduce every roll-up.
 
 ### Prove conformance
 

--- a/src/vaara/attestation/_enforcement_set.py
+++ b/src/vaara/attestation/_enforcement_set.py
@@ -1,0 +1,180 @@
+"""Enforcement verification over a whole directory of (record, report, VCEK) triples.
+
+``verify_enforcement`` binds one signed SEP-2828 record to one SEV-SNP report.
+An auditor who receives a pile of enforced records, one report and VCEK per
+record, asks the batch question: across the whole set, how many bind to a
+confidential VM, and at what tier? ``check_enforcement_set`` is the receiving
+side of that, the batch twin of :func:`verify_enforcement` and the enforcement
+analogue of :func:`check_bundle_set`.
+
+Each triple is run through :func:`verify_enforcement`. The set then rolls up:
+
+* **Pass count.** How many triples are ``ok`` for the chosen mode. A triple
+  whose report does not parse, whose signature fails, or whose ``REPORT_DATA``
+  does not bind is a failing entry that gates the set, never a silent drop.
+* **Tier tally.** How many landed at each tier (``unverified`` / ``bound`` /
+  ``measurement_pinned``). The tier ``attested`` is reserved for the future
+  KDS-chained release and is never emitted in v0, so it never appears here.
+* **Pinning coverage.** How many records pinned a launch measurement. The
+  coverage note (advisory) fires when no record in the set pinned an image:
+  the whole set bound to *a* CVM but never to a *vetted* one, the enforcement
+  analogue of the lens coverage gap.
+
+The set is ``ok`` iff every triple loaded and every loaded triple verified for
+the chosen mode; the pinning coverage note is advisory and does not gate. Like
+the single verb, this needs the crypto the binding uses, so it runs only with
+the attestation extra installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+from vaara.attestation._enforcement import verify_enforcement
+from vaara.attestation.tee import TEEAttestationError
+
+ENFORCEMENT_SET_SCHEMA_NAME = "sep2828-enforcement-set"
+ENFORCEMENT_SET_SCHEMA_VERSION = 1
+
+# The tiers a v0 verdict can carry, in ascending order. ``attested`` is
+# deliberately absent: it is reserved for the chain-rooted future tier and is
+# never emitted, so it is not a key the tally pre-seeds.
+TIER_NAMES = ("unverified", "bound", "measurement_pinned")
+
+
+@dataclass(frozen=True)
+class EnforcementSetEntry:
+    """Per-triple verdict inside a set.
+
+    ``loaded`` is False when the triple could not be evaluated at all (an
+    unreadable report, a malformed VCEK, a record that will not canonicalise);
+    then ``error`` names why and ``tier`` is ``unverified``. Otherwise ``ok``,
+    ``tier``, and ``bound`` come from the enforcement verdict.
+    """
+
+    name: str
+    loaded: bool
+    ok: bool
+    tier: str
+    bound: bool
+    measurement_basis: str
+    error: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "loaded": self.loaded,
+            "ok": self.ok,
+            "tier": self.tier,
+            "bound": self.bound,
+            "measurementBasis": self.measurement_basis,
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class EnforcementSetReport:
+    """Outcome of binding a whole set of records to SEV-SNP reports."""
+
+    ok: bool
+    strict: bool
+    total: int
+    loaded: int
+    passed: int
+    bound: int
+    measurement_pinned: int
+    tier_counts: dict[str, int]
+    entries: tuple[EnforcementSetEntry, ...]
+    pinning_gap: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": ENFORCEMENT_SET_SCHEMA_NAME,
+            "schemaVersion": ENFORCEMENT_SET_SCHEMA_VERSION,
+            "ok": self.ok,
+            "strict": self.strict,
+            "total": self.total,
+            "loaded": self.loaded,
+            "passed": self.passed,
+            "bound": self.bound,
+            "measurementPinned": self.measurement_pinned,
+            "tierCounts": dict(self.tier_counts),
+            "pinningGap": self.pinning_gap,
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+
+def check_enforcement_set(
+    triples: Sequence[tuple[str, Any, bytes, bytes]],
+    *,
+    expected_measurement: Optional[str] = None,
+    strict: bool = False,
+) -> EnforcementSetReport:
+    """Bind a set of ``(name, record, report_bytes, vcek_pem)`` triples.
+
+    Each triple is run through :func:`verify_enforcement`. The set rolls up the
+    pass count, the per-tier tally, and the pinning coverage. Never raises on a
+    bad triple: a report that will not parse, a malformed VCEK, or a record that
+    will not canonicalise becomes a failing entry that gates the set. The set is
+    ``ok`` iff every triple loaded and every loaded triple verified for the
+    chosen mode. The pinning gap (no record pinned a measurement) is advisory.
+    """
+    entries: list[EnforcementSetEntry] = []
+    tier_counts: dict[str, int] = {name: 0 for name in TIER_NAMES}
+    loaded = 0
+    passed = 0
+    bound = 0
+    measurement_pinned = 0
+
+    for name, record, report_bytes, vcek_pem in triples:
+        try:
+            verdict = verify_enforcement(
+                record, report_bytes, vcek_pem,
+                expected_measurement=expected_measurement, strict=strict,
+            )
+        except (TEEAttestationError, ValueError, KeyError, TypeError) as exc:
+            entries.append(
+                EnforcementSetEntry(
+                    name, False, False, "unverified", False, "unpinned", str(exc)
+                )
+            )
+            continue
+
+        loaded += 1
+        # A future tier outside the v0 set would still be counted, never dropped.
+        tier_counts[verdict.tier] = tier_counts.get(verdict.tier, 0) + 1
+        if verdict.bound:
+            bound += 1
+        if verdict.measurement_basis == "pinned":
+            measurement_pinned += 1
+        if verdict.ok:
+            passed += 1
+        entries.append(
+            EnforcementSetEntry(
+                name=name,
+                loaded=True,
+                ok=verdict.ok,
+                tier=verdict.tier,
+                bound=verdict.bound,
+                measurement_basis=verdict.measurement_basis,
+                error=None,
+            )
+        )
+
+    all_loaded = all(e.loaded for e in entries)
+    all_ok = all(e.ok for e in entries if e.loaded)
+    pinning_gap = loaded > 0 and measurement_pinned == 0
+
+    return EnforcementSetReport(
+        ok=all_loaded and all_ok,
+        strict=strict,
+        total=len(entries),
+        loaded=loaded,
+        passed=passed,
+        bound=bound,
+        measurement_pinned=measurement_pinned,
+        tier_counts=tier_counts,
+        entries=tuple(entries),
+        pinning_gap=pinning_gap,
+    )

--- a/src/vaara/attestation/_handoff_set.py
+++ b/src/vaara/attestation/_handoff_set.py
@@ -1,0 +1,182 @@
+"""Handoff verification over a whole directory of cross-org packages.
+
+``verify_handoff`` checks one self-contained handoff package: one org's record,
+handed to another org's regulator. A regulator who receives a pile of packages,
+from one provider or several, asks the batch question: across the whole set, how
+many records verify offline under their rotated-out keys, and how many are
+anchor-corroborated rather than resting on the signature alone?
+``check_handoff_set`` is the receiving side of that, the batch twin of
+:func:`verify_handoff` and the handoff analogue of :func:`check_bundle_set`.
+
+Each package is run through :func:`verify_handoff`. The set then rolls up:
+
+* **Pass count.** How many packages are ``ok`` for the chosen mode. A document
+  that does not parse into a package is a failing entry that gates the set,
+  never a silent drop.
+* **Tier tally.** How many records reached ``verifiable`` (signature binds to a
+  listed key, inside its window, not revoked) and how many reached
+  ``corroborated`` (an enclosed eIDAS anchor predates retirement and
+  revocation). The gap between the two is the part of the set whose record
+  authenticity rests on the signature alone.
+* **Pinning coverage.** How many packages had their producer identity pinned
+  against a trusted DID document. The coverage note (advisory) fires when no
+  package in the set was pinned: every record's authenticity rests on a
+  self-asserted identity, the handoff analogue of the lens coverage gap.
+
+The set is ``ok`` iff every document loaded and every loaded package verified
+for the chosen mode; the coverage note is advisory and does not gate. Like the
+single verb, this needs the crypto the record lens uses, so it runs only with
+the attestation extra installed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
+
+from vaara.attestation._handoff import verify_handoff
+
+HANDOFF_SET_SCHEMA_NAME = "sep2828-handoff-set"
+HANDOFF_SET_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class HandoffSetEntry:
+    """Per-package verdict inside a set.
+
+    ``loaded`` is False when the document did not parse into a handoff package;
+    then ``error`` names why and the tier booleans are False. Otherwise ``ok``,
+    ``verifiable``, ``corroborated``, and ``producer_identity_basis`` come from
+    the handoff verdict.
+    """
+
+    name: str
+    loaded: bool
+    ok: bool
+    verifiable: bool
+    corroborated: bool
+    producer_identity_basis: str
+    producer: Optional[str]
+    error: Optional[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "loaded": self.loaded,
+            "ok": self.ok,
+            "verifiable": self.verifiable,
+            "corroborated": self.corroborated,
+            "producerIdentityBasis": self.producer_identity_basis,
+            "producer": self.producer,
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class HandoffSetReport:
+    """Outcome of verifying a set of cross-org handoff packages."""
+
+    ok: bool
+    strict: bool
+    total: int
+    loaded: int
+    passed: int
+    verifiable: int
+    corroborated: int
+    pinned: int
+    entries: tuple[HandoffSetEntry, ...]
+    pinning_gap: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": HANDOFF_SET_SCHEMA_NAME,
+            "schemaVersion": HANDOFF_SET_SCHEMA_VERSION,
+            "ok": self.ok,
+            "strict": self.strict,
+            "total": self.total,
+            "loaded": self.loaded,
+            "passed": self.passed,
+            "verifiable": self.verifiable,
+            "corroborated": self.corroborated,
+            "pinned": self.pinned,
+            "pinningGap": self.pinning_gap,
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+
+def check_handoff_set(
+    packages: Sequence[tuple[str, Any, Optional[str]]],
+    *,
+    trusted_did_document: Optional[dict[str, Any]] = None,
+    strict: bool = False,
+) -> HandoffSetReport:
+    """Verify a set of ``(name, document, anchor_attested_time)`` packages.
+
+    Each document is run through :func:`verify_handoff` with the per-package
+    anchor time the caller resolved (None when the package carries no verified
+    anchor). The set rolls up the pass count, the verifiable / corroborated
+    tiers, and the producer-identity pinning. Never raises on a malformed
+    document: it becomes a failing entry that gates the set. The set is ``ok``
+    iff every document loaded and every loaded package verified for the chosen
+    mode. The pinning gap (no package pinned its producer) is advisory.
+    """
+    entries: list[HandoffSetEntry] = []
+    loaded = 0
+    passed = 0
+    verifiable = 0
+    corroborated = 0
+    pinned = 0
+
+    for name, doc, anchor_time in packages:
+        try:
+            verdict = verify_handoff(
+                doc, anchor_attested_time=anchor_time,
+                trusted_did_document=trusted_did_document, strict=strict,
+            )
+        except ValueError as exc:
+            entries.append(
+                HandoffSetEntry(
+                    name, False, False, False, False,
+                    "self_asserted_unpinned", None, str(exc)
+                )
+            )
+            continue
+
+        loaded += 1
+        if verdict.verifiable:
+            verifiable += 1
+        if verdict.corroborated:
+            corroborated += 1
+        if verdict.producer_identity_basis == "pinned":
+            pinned += 1
+        if verdict.ok:
+            passed += 1
+        entries.append(
+            HandoffSetEntry(
+                name=name,
+                loaded=True,
+                ok=verdict.ok,
+                verifiable=verdict.verifiable,
+                corroborated=verdict.corroborated,
+                producer_identity_basis=verdict.producer_identity_basis,
+                producer=verdict.producer,
+                error=None,
+            )
+        )
+
+    all_loaded = all(e.loaded for e in entries)
+    all_ok = all(e.ok for e in entries if e.loaded)
+    pinning_gap = loaded > 0 and pinned == 0
+
+    return HandoffSetReport(
+        ok=all_loaded and all_ok,
+        strict=strict,
+        total=len(entries),
+        loaded=loaded,
+        passed=passed,
+        verifiable=verifiable,
+        corroborated=corroborated,
+        pinned=pinned,
+        entries=tuple(entries),
+        pinning_gap=pinning_gap,
+    )

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -77,12 +77,24 @@ from vaara.attestation._enforcement import (
     bind_record_to_report_data,
     verify_enforcement,
 )
+from vaara.attestation._enforcement_set import (
+    ENFORCEMENT_SET_SCHEMA_NAME,
+    EnforcementSetEntry,
+    EnforcementSetReport,
+    check_enforcement_set,
+)
 from vaara.attestation._handoff import (
     ComponentDigest,
     HandoffVerdict,
     build_handoff,
     sign_manifest,
     verify_handoff,
+)
+from vaara.attestation._handoff_set import (
+    HANDOFF_SET_SCHEMA_NAME,
+    HandoffSetEntry,
+    HandoffSetReport,
+    check_handoff_set,
 )
 from vaara.attestation._key_history import (
     KeyHistory,
@@ -178,10 +190,18 @@ __all__ = [
     "EnforcementVerdict",
     "bind_record_to_report_data",
     "verify_enforcement",
+    "ENFORCEMENT_SET_SCHEMA_NAME",
+    "EnforcementSetEntry",
+    "EnforcementSetReport",
+    "check_enforcement_set",
     "HandoffVerdict",
     "build_handoff",
     "sign_manifest",
     "verify_handoff",
+    "HANDOFF_SET_SCHEMA_NAME",
+    "HandoffSetEntry",
+    "HandoffSetReport",
+    "check_handoff_set",
     "check_record_conformance",
     "check_decision_conformance",
     "RecordSetEntry",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -151,6 +151,24 @@ Subcommands:
         call recorded twice, an executed action that committed no result).
         Keyless. Exit 0 iff every record conforms and no required gap fired.
 
+    vaara verify-handoffs DIR [--glob '*.json'] [--trusted-did-document DOC.json]
+            [--strict] [--no-anchor] [--json]
+        Verify a whole directory of cross-org handoff packages at once: the
+        batch twin of verify-handoff. Reports how many records verify offline
+        under their rotated-out keys, how many are anchor-corroborated rather
+        than resting on the signature alone, and how many had their producer
+        identity pinned. Requires the attestation extra. Exit 0 iff every
+        package verifies for the chosen mode.
+
+    vaara verify-enforcements DIR [--glob '*.record.json']
+            [--expected-measurement HEX] [--strict] [--json]
+        Bind a whole directory of (record, report, VCEK) triples at once: the
+        batch twin of verify-enforcement. Triples are discovered by stem
+        (NAME.record.json with NAME.report.bin and NAME.vcek.pem). Reports how
+        many bind to a confidential VM, the per-tier tally, and whether any
+        pinned a vetted launch image. Requires the attestation extra. Exit 0
+        iff every triple binds for the chosen mode.
+
     vaara conformance-statement [--corpus DIR] [--records DIR] [--as-of DATE]
             [--out FILE] [--json]
         Self-test this implementation against the published SEP-2828
@@ -2558,6 +2576,200 @@ def _cmd_verify_bundles(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def _cmd_verify_handoffs(args: argparse.Namespace) -> int:
+    """Verify a whole directory of cross-org handoff packages at once.
+
+    The batch twin of ``verify-handoff``: a regulator points this at a pile of
+    packages, from one provider or several, and gets the roll-up a single-file
+    check cannot give. How many records verify offline under their rotated-out
+    keys, how many are anchor-corroborated rather than resting on the signature
+    alone, and how many had their producer identity pinned. Each package's
+    enclosed anchor is resolved independently (``--no-anchor`` skips it for all);
+    a single out-of-band attested time cannot stand in for a whole set, so this
+    has no ``--anchored-time``. Requires the attestation extra.
+    """
+    try:
+        from vaara.attestation.receipt import check_handoff_set
+    except ImportError:
+        print(_ATTESTATION_HINT, file=sys.stderr)
+        return 2
+
+    directory = Path(args.directory).expanduser()
+    if not directory.is_dir():
+        print(f"vaara verify-handoffs: not a directory: {directory}", file=sys.stderr)
+        return 2
+
+    paths = sorted(p for p in directory.glob(args.glob) if p.is_file())
+    if not paths:
+        print(f"vaara verify-handoffs: no files matched {args.glob!r} in {directory}",
+              file=sys.stderr)
+        return 2
+
+    try:
+        trusted = (
+            _load_json_file(args.trusted_did_document, "trusted DID document")
+            if args.trusted_did_document else None
+        )
+    except ValueError as exc:
+        print(f"vaara verify-handoffs: {exc}", file=sys.stderr)
+        return 1
+
+    packages: list[tuple[str, Any, Optional[str]]] = []
+    unreadable: list[tuple[str, str]] = []
+    for path in paths:
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            unreadable.append((path.name, str(exc)))
+            continue
+        anchor_time, note = _resolve_handoff_anchor_time(args, doc)
+        if note is not None:
+            print(f"vaara verify-handoffs: {path.name}: {note}", file=sys.stderr)
+        packages.append((path.name, doc, anchor_time))
+
+    report = check_handoff_set(
+        packages, trusted_did_document=trusted, strict=args.strict
+    )
+    ok = report.ok and not unreadable
+
+    if args.json:
+        out: dict[str, Any] = report.to_dict()
+        out["ok"] = ok
+        out["unreadable"] = [{"name": n, "error": e} for n, e in unreadable]
+        print(json.dumps(out, indent=2))
+    else:
+        verdict = "OK" if ok else "FAILED"
+        mode = "  [strict]" if report.strict else ""
+        print(f"handoff set: {verdict}{mode}  ({report.passed}/{report.total} verify, "
+              f"{report.corroborated} corroborated)")
+        print(f"  verifiable: {report.verifiable}   corroborated: "
+              f"{report.corroborated}   producer pinned: {report.pinned}")
+        if report.pinning_gap:
+            print("  coverage gap: no package pinned its producer identity "
+                  "(every record's authenticity is self-asserted)")
+        for entry in report.entries:
+            if not entry.loaded:
+                print(f"  [FAIL] {entry.name}: not a valid handoff package "
+                      f"({_safe_inline(entry.error or '')})")
+            elif not entry.ok:
+                tier = "corroborated" if entry.corroborated else (
+                    "verifiable" if entry.verifiable else "not verifiable")
+                print(f"  [FAIL] {entry.name}: {tier}, "
+                      f"identity {entry.producer_identity_basis}")
+        for name, exc in unreadable:
+            print(f"  [FAIL] {name}: unreadable ({exc})")
+
+    return 0 if ok else 1
+
+
+def _cmd_verify_enforcements(args: argparse.Namespace) -> int:
+    """Bind a whole directory of (record, report, VCEK) triples at once.
+
+    The batch twin of ``verify-enforcement``: an auditor points this at a
+    directory of enforced records and gets the roll-up. How many bind to a
+    confidential VM, at what tier, and whether any pinned a vetted launch image.
+    Triples are discovered by stem: ``NAME.record.json`` pairs with
+    ``NAME.report.bin`` and ``NAME.vcek.pem``. A record missing either companion
+    is a failing entry, never a silent skip. Requires the attestation extra.
+    """
+    try:
+        import rfc8785  # noqa: F401
+        from cryptography.hazmat.primitives.asymmetric import ec  # noqa: F401
+
+        from vaara.attestation.receipt import check_enforcement_set
+    except ImportError:
+        print(_ATTESTATION_HINT, file=sys.stderr)
+        return 2
+
+    directory = Path(args.directory).expanduser()
+    if not directory.is_dir():
+        print(f"vaara verify-enforcements: not a directory: {directory}",
+              file=sys.stderr)
+        return 2
+
+    expected = args.expected_measurement
+    if expected is not None:
+        try:
+            raw = bytes.fromhex(expected.strip())
+        except ValueError:
+            print("vaara verify-enforcements: --expected-measurement is not valid hex",
+                  file=sys.stderr)
+            return 1
+        if len(raw) != 48:
+            print("vaara verify-enforcements: --expected-measurement must be 48 "
+                  "bytes (96 hex chars, an SHA-384 launch measurement)",
+                  file=sys.stderr)
+            return 1
+
+    records = sorted(p for p in directory.glob(args.glob) if p.is_file())
+    if not records:
+        print(f"vaara verify-enforcements: no files matched {args.glob!r} in "
+              f"{directory}", file=sys.stderr)
+        return 2
+
+    triples: list[tuple[str, Any, bytes, bytes]] = []
+    missing: list[tuple[str, str]] = []
+    for record_path in records:
+        # NAME.record.json -> NAME; the glob default ends in .record.json, but a
+        # custom glob may not, so fall back to the full stem.
+        if record_path.name.endswith(".record.json"):
+            stem = record_path.name[: -len(".record.json")]
+        else:
+            stem = record_path.stem
+        report_path = directory / f"{stem}.report.bin"
+        vcek_path = directory / f"{stem}.vcek.pem"
+        try:
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            missing.append((record_path.name, f"unreadable record ({exc})"))
+            continue
+        if not report_path.is_file():
+            missing.append((record_path.name, f"no companion {report_path.name}"))
+            continue
+        if not vcek_path.is_file():
+            missing.append((record_path.name, f"no companion {vcek_path.name}"))
+            continue
+        try:
+            report_bytes = report_path.read_bytes()
+            vcek_pem = vcek_path.read_bytes()
+        except OSError as exc:
+            missing.append((record_path.name, f"cannot read companion ({exc})"))
+            continue
+        triples.append((stem, record, report_bytes, vcek_pem))
+
+    report = check_enforcement_set(
+        triples, expected_measurement=expected, strict=args.strict
+    )
+    ok = report.ok and not missing
+
+    if args.json:
+        out: dict[str, Any] = report.to_dict()
+        out["ok"] = ok
+        out["incomplete"] = [{"name": n, "error": e} for n, e in missing]
+        print(json.dumps(out, indent=2))
+    else:
+        verdict = "OK" if ok else "FAILED"
+        mode = "  [strict]" if report.strict else ""
+        print(f"enforcement set: {verdict}{mode}  ({report.passed}/{report.total} bind, "
+              f"{report.measurement_pinned} measurement-pinned)")
+        tally = ", ".join(f"{t}: {n}" for t, n in report.tier_counts.items() if n)
+        if tally:
+            print(f"  tiers: {tally}")
+        if report.pinning_gap:
+            print("  coverage gap: no record pinned a launch measurement "
+                  "(the set bound to a CVM, never to a vetted image)")
+        for entry in report.entries:
+            if not entry.loaded:
+                print(f"  [FAIL] {entry.name}: {_safe_inline(entry.error or '')}")
+            elif not entry.ok:
+                print(f"  [FAIL] {entry.name}: tier {entry.tier}, "
+                      f"measurement {entry.measurement_basis}")
+        for name, exc in missing:
+            print(f"  [FAIL] {name}: {exc}")
+
+    return 0 if ok else 1
+
+
 def _cmd_build_bundle(args: argparse.Namespace) -> int:
     """Assemble an evidence bundle on disk from the issuer's pieces.
 
@@ -3515,6 +3727,46 @@ def build_parser() -> argparse.ArgumentParser:
     )
     pvh.set_defaults(func=_cmd_verify_handoff)
 
+    pvhs = sub.add_parser(
+        "verify-handoffs",
+        help="Verify a whole directory of cross-org handoff packages at once. "
+             "The batch twin of verify-handoff: how many records verify offline "
+             "under their rotated-out keys, how many are anchor-corroborated "
+             "rather than resting on the signature alone, and how many had their "
+             "producer identity pinned. Requires the attestation extra.",
+    )
+    pvhs.add_argument(
+        "directory",
+        help="Directory of cross-org handoff package JSON documents",
+    )
+    pvhs.add_argument(
+        "--glob", default="*.json",
+        help="Glob for handoff files within the directory (default: *.json)",
+    )
+    pvhs.add_argument(
+        "--trusted-did-document", default=None, dest="trusted_did_document",
+        help="Path to the DID document you independently trust as the "
+             "producer's; pins producer identity across the whole set",
+    )
+    pvhs.add_argument(
+        "--strict", action="store_true",
+        help="Regulator-grade: every package must be corroborated, with a "
+             "recorded window, an affirmative revocation source, and a pinned "
+             "producer identity",
+    )
+    pvhs.add_argument(
+        "--no-anchor", action="store_true", dest="no_anchor",
+        help="Do not verify any enclosed time anchor (report each record "
+             "without corroboration)",
+    )
+    pvhs.add_argument(
+        "--json", action="store_true",
+        help="Emit the full set verdict report as JSON",
+    )
+    # _resolve_handoff_anchor_time reads args.anchored_time; the batch has no
+    # single out-of-band time, so it is always None here.
+    pvhs.set_defaults(func=_cmd_verify_handoffs, anchored_time=None)
+
     pve = sub.add_parser(
         "verify-enforcement",
         help="Check whether a SEV-SNP attestation report binds a signed SEP-2828 "
@@ -3556,6 +3808,43 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the full enforcement verdict as JSON",
     )
     pve.set_defaults(func=_cmd_verify_enforcement)
+
+    pves = sub.add_parser(
+        "verify-enforcements",
+        help="Bind a whole directory of (record, report, VCEK) triples at once. "
+             "The batch twin of verify-enforcement: how many records bind to a "
+             "confidential VM, at what tier, and whether any pinned a vetted "
+             "launch image. Triples are discovered by stem: NAME.record.json "
+             "pairs with NAME.report.bin and NAME.vcek.pem. Requires the "
+             "attestation extra.",
+    )
+    pves.add_argument(
+        "directory",
+        help="Directory of NAME.record.json records with NAME.report.bin and "
+             "NAME.vcek.pem companions",
+    )
+    pves.add_argument(
+        "--glob", default="*.record.json",
+        help="Glob for record files within the directory (default: "
+             "*.record.json)",
+    )
+    pves.add_argument(
+        "--expected-measurement", default=None, dest="expected_measurement",
+        help="Pin every report's launch measurement (96 hex chars / 48 bytes) "
+             "against an independently vetted value; a mismatch fails that "
+             "record",
+    )
+    pves.add_argument(
+        "--strict", action="store_true",
+        help="Regulator-grade: every record must reach the chain-rooted attested "
+             "tier, which v0 cannot yet reach, so a strict pass is honestly "
+             "unavailable",
+    )
+    pves.add_argument(
+        "--json", action="store_true",
+        help="Emit the full set verdict report as JSON",
+    )
+    pves.set_defaults(func=_cmd_verify_enforcements)
 
     pbh = sub.add_parser(
         "build-handoff",

--- a/tests/test_enforcement_set.py
+++ b/tests/test_enforcement_set.py
@@ -1,0 +1,251 @@
+"""Batch enforcement verification and the `vaara verify-enforcements` command.
+
+The batch twin of `verify-enforcement`: an auditor points the tool at a
+directory of (record, report, VCEK) triples and gets the roll-up a single-file
+check cannot give. Covers the `enforcement_set_v0` vectors through both Vaara
+and the standalone Vaara-free checker, the module behaviour (the per-tier tally,
+the pinning-coverage gap, gating on a non-binding triple), and the CLI end to
+end including stem-based triple discovery. Runs the binding crypto, so the suite
+skips when the attestation extra is absent.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+for _mod in ("rfc8785", "cryptography"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            "attestation extra not installed (pip install 'vaara[attestation]')",
+            allow_module_level=True,
+        )
+
+from cryptography.hazmat.primitives import serialization  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric import ec  # noqa: E402
+
+from vaara.attestation.receipt import (  # noqa: E402
+    ENFORCEMENT_SET_SCHEMA_NAME,
+    check_enforcement_set,
+)
+from vaara.cli import main  # noqa: E402
+
+VECTORS = Path(__file__).resolve().parent / "vectors" / "enforcement_set_v0"
+SIBLING = Path(__file__).resolve().parent / "vectors" / "enforcement_attestation_v0"
+
+SUMMARY_KEYS = (
+    "ok", "strict", "total", "loaded", "passed", "bound",
+    "measurementPinned", "tierCounts", "pinningGap",
+)
+
+
+def _jwk_to_pem(jwk: dict) -> bytes:
+    def _i(v: str) -> int:
+        return int.from_bytes(base64.urlsafe_b64decode(v + "=" * (-len(v) % 4)), "big")
+
+    pub = ec.EllipticCurvePublicNumbers(
+        _i(jwk["x"]), _i(jwk["y"]), ec.SECP384R1()).public_key()
+    return pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def _cases() -> dict:
+    return {c["name"]: c
+            for c in json.loads((SIBLING / "cases.json").read_text())["cases"]}
+
+
+def _sets() -> dict:
+    return json.loads((VECTORS / "sets.json").read_text())["sets"]
+
+
+def _expected() -> dict:
+    return json.loads((VECTORS / "expected.json").read_text())
+
+
+def _triples_for(spec: dict, cases: dict):
+    out = []
+    for case_name in spec["cases"]:
+        case = cases[case_name]
+        out.append((
+            case_name,
+            case["record"],
+            base64.b64decode(case["report_b64"]),
+            _jwk_to_pem(case["vcek_jwk"]),
+        ))
+    return out
+
+
+# ── Vectors ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", sorted(_expected().keys()))
+def test_module_reproduces_vector_rollup(name):
+    cases, sets, want = _cases(), _sets(), _expected()[name]
+    spec = sets[name]
+    report = check_enforcement_set(
+        _triples_for(spec, cases),
+        expected_measurement=spec["expected_measurement"],
+        strict=spec["strict"],
+    )
+    got = {k: report.to_dict()[k] for k in SUMMARY_KEYS}
+    assert got == want
+
+
+def test_independent_checker_passes():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_public_reexport_is_wired():
+    from vaara.attestation.receipt import check_enforcement_set as public
+    assert public is check_enforcement_set
+
+
+# ── Unit behaviour ────────────────────────────────────────────────────────────
+
+
+def test_clean_set_passes_without_pinning_gap_when_measurement_pinned():
+    cases, sets = _cases(), _sets()
+    spec = sets["all_bound"]
+    report = check_enforcement_set(
+        _triples_for(spec, cases),
+        expected_measurement=spec["expected_measurement"], strict=False)
+    assert report.ok
+    assert report.passed == report.total == 2
+    assert report.pinning_gap is False
+
+
+def test_unpinned_set_passes_but_flags_the_pinning_gap():
+    cases = _cases()
+    report = check_enforcement_set(_triples_for(_sets()["unpinned_only"], cases))
+    assert report.ok  # bound is enough for a default-mode pass
+    assert report.measurement_pinned == 0
+    assert report.pinning_gap is True  # advisory, did not gate
+
+
+def test_a_non_binding_triple_gates_the_set():
+    cases = _cases()
+    report = check_enforcement_set(_triples_for(_sets()["mixed_failure"], cases))
+    assert not report.ok
+    assert report.passed == 1
+    failing = [e for e in report.entries if not e.ok]
+    assert len(failing) == 2  # bad signature + report bound to another record
+
+
+def test_strict_is_unreachable_even_for_a_clean_pinned_set():
+    cases, sets = _cases(), _sets()
+    spec = sets["strict_unreachable"]
+    report = check_enforcement_set(
+        _triples_for(spec, cases),
+        expected_measurement=spec["expected_measurement"], strict=True)
+    assert not report.ok  # no validated VCEK chain in v0
+    assert report.measurement_pinned == 1  # pinned, yet strict still fails
+
+
+def test_malformed_triple_is_a_failing_entry_not_a_raise():
+    cases = _cases()
+    good = _triples_for(_sets()["unpinned_only"], cases)[0]
+    # A report that will not parse yields an unverified verdict (no raise), so
+    # this is a failing entry that gates rather than an exception.
+    bad = ("broken", {"version": 1}, b"too short", good[3])
+    report = check_enforcement_set([good, bad])
+    assert not report.ok
+    broken = next(e for e in report.entries if e.name == "broken")
+    assert broken.ok is False
+
+
+def test_attested_tier_never_appears_in_v0():
+    cases, sets = _cases(), _sets()
+    report = check_enforcement_set(
+        _triples_for(sets["all_bound"], cases),
+        expected_measurement=sets["all_bound"]["expected_measurement"])
+    assert "attested" not in report.tier_counts
+
+
+def test_empty_set_is_ok_without_a_pinning_gap():
+    report = check_enforcement_set([])
+    assert report.ok and report.total == 0
+    assert report.pinning_gap is False  # no loaded record means no gap to flag
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def _materialize(tmp_path: Path, case_names: list[str]) -> Path:
+    """Write NAME.record.json / NAME.report.bin / NAME.vcek.pem triples."""
+    cases = _cases()
+    for name in case_names:
+        case = cases[name]
+        (tmp_path / f"{name}.record.json").write_text(json.dumps(case["record"]))
+        (tmp_path / f"{name}.report.bin").write_bytes(
+            base64.b64decode(case["report_b64"]))
+        (tmp_path / f"{name}.vcek.pem").write_bytes(_jwk_to_pem(case["vcek_jwk"]))
+    return tmp_path
+
+
+def test_cli_clean_set_exit_0(tmp_path, capsys):
+    _materialize(tmp_path, ["clean_bound"])
+    rc = main(["verify-enforcements", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "OK" in out and "1/1 bind" in out
+
+
+def test_cli_failing_set_exit_1(tmp_path, capsys):
+    _materialize(tmp_path, ["clean_bound", "bad_signature"])
+    rc = main(["verify-enforcements", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAILED" in out
+    assert "bad_signature" in out
+
+
+def test_cli_json_output(tmp_path, capsys):
+    _materialize(tmp_path, ["clean_bound"])
+    rc = main(["verify-enforcements", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["schema"] == ENFORCEMENT_SET_SCHEMA_NAME
+    assert payload["incomplete"] == []
+
+
+def test_cli_missing_companion_gates(tmp_path, capsys):
+    _materialize(tmp_path, ["clean_bound"])
+    (tmp_path / "clean_bound.vcek.pem").unlink()  # drop one companion
+    rc = main(["verify-enforcements", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["ok"] is False
+    assert payload["incomplete"][0]["name"] == "clean_bound.record.json"
+    assert "vcek.pem" in payload["incomplete"][0]["error"]
+
+
+def test_cli_not_a_directory(tmp_path, capsys):
+    rc = main(["verify-enforcements", str(tmp_path / "nope")])
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_cli_no_matching_files(tmp_path, capsys):
+    rc = main(["verify-enforcements", str(tmp_path)])
+    assert rc == 2
+    assert "no files matched" in capsys.readouterr().err
+
+
+def test_cli_bad_expected_measurement(tmp_path, capsys):
+    _materialize(tmp_path, ["clean_bound"])
+    rc = main(["verify-enforcements", str(tmp_path),
+               "--expected-measurement", "xyz"])
+    assert rc == 1
+    assert "not valid hex" in capsys.readouterr().err

--- a/tests/test_handoff_set.py
+++ b/tests/test_handoff_set.py
@@ -1,0 +1,229 @@
+"""Batch handoff verification and the `vaara verify-handoffs` command.
+
+The batch twin of `verify-handoff`: a regulator points the tool at a directory
+of cross-org packages and gets the roll-up a single-file check cannot give.
+Covers the `handoff_set_v0` vectors through both Vaara and the standalone
+Vaara-free checker, the module behaviour (the verifiable / corroborated tiers,
+the producer-pin coverage gap, gating and strict mode), and the CLI end to end.
+Runs the record-lens crypto, so the suite skips when the attestation extra is
+absent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+for _mod in ("rfc8785", "cryptography"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            "attestation extra not installed (pip install 'vaara[attestation]')",
+            allow_module_level=True,
+        )
+
+from vaara.attestation.receipt import (  # noqa: E402
+    HANDOFF_SET_SCHEMA_NAME,
+    check_handoff_set,
+)
+from vaara.cli import main  # noqa: E402
+
+VECTORS = Path(__file__).resolve().parent / "vectors" / "handoff_set_v0"
+SIBLING = Path(__file__).resolve().parent / "vectors" / "cross_org_handoff_v0"
+
+SUMMARY_KEYS = (
+    "ok", "strict", "total", "loaded", "passed", "verifiable",
+    "corroborated", "pinned", "pinningGap",
+)
+
+
+def _cases() -> dict:
+    return {c["name"]: c
+            for c in json.loads((SIBLING / "cases.json").read_text())["cases"]}
+
+
+def _sets() -> dict:
+    return json.loads((VECTORS / "sets.json").read_text())["sets"]
+
+
+def _expected() -> dict:
+    return json.loads((VECTORS / "expected.json").read_text())
+
+
+def _packages_for(spec: dict, cases: dict):
+    out = []
+    for case_name in spec["cases"]:
+        case = cases[case_name]
+        package = case["package"]
+        anchor_present = package.get("evidence", {}).get("anchor") is not None
+        anchor_time = case.get("anchoredTime") if anchor_present else None
+        out.append((case_name, package, anchor_time))
+    return out
+
+
+def _trusted_for(spec: dict, cases: dict):
+    if spec["trusted_from_case"] is None:
+        return None
+    return cases[spec["trusted_from_case"]]["trustedDidDocument"]
+
+
+# ── Vectors ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", sorted(_expected().keys()))
+def test_module_reproduces_vector_rollup(name):
+    cases, sets, want = _cases(), _sets(), _expected()[name]
+    spec = sets[name]
+    report = check_handoff_set(
+        _packages_for(spec, cases),
+        trusted_did_document=_trusted_for(spec, cases),
+        strict=spec["strict"],
+    )
+    got = {k: report.to_dict()[k] for k in SUMMARY_KEYS}
+    assert got == want
+
+
+def test_independent_checker_passes():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_public_reexport_is_wired():
+    from vaara.attestation.receipt import check_handoff_set as public
+    assert public is check_handoff_set
+
+
+# ── Unit behaviour ────────────────────────────────────────────────────────────
+
+
+def test_verifiable_set_passes_and_flags_the_pinning_gap():
+    cases = _cases()
+    report = check_handoff_set(_packages_for(_sets()["all_verifiable"], cases))
+    assert report.ok
+    assert report.verifiable == 2
+    assert report.corroborated == 1
+    assert report.pinned == 0
+    assert report.pinning_gap is True  # advisory, did not gate
+
+
+def test_a_failing_package_gates_the_set():
+    cases = _cases()
+    report = check_handoff_set(_packages_for(_sets()["with_failure"], cases))
+    assert not report.ok
+    assert report.passed == 1
+    failing = [e for e in report.entries if not e.ok]
+    assert len(failing) == 1
+
+
+def test_strict_with_pin_passes_and_lifts_the_gap():
+    cases, sets = _cases(), _sets()
+    spec = sets["strict_pinned"]
+    report = check_handoff_set(
+        _packages_for(spec, cases),
+        trusted_did_document=_trusted_for(spec, cases), strict=True)
+    assert report.ok
+    assert report.pinned == 1
+    assert report.pinning_gap is False
+
+
+def test_strict_without_pin_fails():
+    cases = _cases()
+    report = check_handoff_set(_packages_for(_sets()["strict_unmet"], cases),
+                               strict=True)
+    assert not report.ok  # corroborated but self-asserted identity
+    assert report.corroborated == 1
+
+
+def test_malformed_document_is_a_failing_entry_not_a_raise():
+    cases = _cases()
+    good = _packages_for(_sets()["all_verifiable"], cases)[0]
+    report = check_handoff_set([good, ("broken", {"not": "a package"}, None)])
+    assert not report.ok
+    broken = next(e for e in report.entries if e.name == "broken")
+    assert broken.loaded is False
+    assert broken.ok is False
+    assert broken.error is not None
+    assert report.loaded == 1
+
+
+def test_empty_set_is_ok_without_a_pinning_gap():
+    report = check_handoff_set([])
+    assert report.ok and report.total == 0
+    assert report.pinning_gap is False
+
+
+def test_report_to_dict_shape():
+    cases = _cases()
+    d = check_handoff_set(_packages_for(_sets()["all_verifiable"], cases)).to_dict()
+    assert d["schema"] == HANDOFF_SET_SCHEMA_NAME
+    assert d["ok"] is True
+    assert all({"name", "loaded", "ok", "verifiable"} <= set(e) for e in d["entries"])
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def _materialize(tmp_path: Path, case_names: list[str]) -> Path:
+    """Write each case's package as NAME.json in a directory."""
+    cases = _cases()
+    for name in case_names:
+        (tmp_path / f"{name}.json").write_text(json.dumps(cases[name]["package"]))
+    return tmp_path
+
+
+def test_cli_clean_set_exit_0(tmp_path, capsys):
+    # --no-anchor keeps this offline: the enclosed RFC 3161 token is not the
+    # subject of this check, the batch roll-up is.
+    _materialize(tmp_path, ["clean_no_anchor"])
+    rc = main(["verify-handoffs", str(tmp_path), "--no-anchor"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "OK" in out and "1/1 verify" in out
+
+
+def test_cli_failing_set_exit_1(tmp_path, capsys):
+    _materialize(tmp_path, ["clean_no_anchor", "signed_after_retirement"])
+    rc = main(["verify-handoffs", str(tmp_path), "--no-anchor"])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAILED" in out
+    assert "signed_after_retirement.json" in out
+
+
+def test_cli_json_reports_the_pinning_gap(tmp_path, capsys):
+    _materialize(tmp_path, ["clean_no_anchor"])
+    rc = main(["verify-handoffs", str(tmp_path), "--no-anchor", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["schema"] == HANDOFF_SET_SCHEMA_NAME
+    assert payload["pinningGap"] is True
+    assert payload["unreadable"] == []
+
+
+def test_cli_not_a_directory(tmp_path, capsys):
+    rc = main(["verify-handoffs", str(tmp_path / "nope")])
+    assert rc == 2
+    assert "not a directory" in capsys.readouterr().err
+
+
+def test_cli_no_matching_files(tmp_path, capsys):
+    rc = main(["verify-handoffs", str(tmp_path)])
+    assert rc == 2
+    assert "no files matched" in capsys.readouterr().err
+
+
+def test_cli_unreadable_file_gates(tmp_path, capsys):
+    _materialize(tmp_path, ["clean_no_anchor"])
+    (tmp_path / "bad.json").write_text("{ not json")
+    rc = main(["verify-handoffs", str(tmp_path), "--no-anchor", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["ok"] is False
+    assert [u["name"] for u in payload["unreadable"]] == ["bad.json"]

--- a/tests/vectors/enforcement_set_v0/README.md
+++ b/tests/vectors/enforcement_set_v0/README.md
@@ -1,0 +1,42 @@
+# Enforcement-set vectors, v0
+
+Fixtures for the batch enforcement check on a directory of (record, report,
+VCEK) triples: what `vaara verify-enforcements` produces. Where
+`enforcement_attestation_v0` asks "does this one report bind this one record to
+a CVM", these vectors ask the question that only shows up across a pile of
+enforced records: how many bind, at what tier, and did any pin a vetted launch
+image?
+
+A set is a list of `enforcement_attestation_v0` case names plus the mode the
+batch applies uniformly (one `expected_measurement`, one `strict` flag). These
+vectors add no new crypto: they reuse the single suite's committed cases, group
+them into sets, and record the roll-up `check_enforcement_set` produces:
+
+- **Pass count** how many triples are `ok` for the chosen mode.
+- **Tier tally** how many landed at each tier (`unverified` / `bound` /
+  `measurement_pinned`). The chain-rooted `attested` tier is reserved for the
+  future KDS-chained release and never appears in v0.
+- **Bound count** how many had `REPORT_DATA` carry `sha512(jcs(record))`,
+  independent of whether the signature or measurement checks passed.
+- **Pinning coverage** how many pinned a launch measurement. `pinningGap` is
+  advisory and fires when no record in the set pinned an image: the set bound to
+  a CVM but never to a vetted one. It does not gate.
+
+The set is `ok` iff every triple loaded and every loaded triple verified for the
+chosen mode. Strict is unreachable in v0 (no validated VCEK chain), so a strict
+set never passes.
+
+## Layout
+
+```
+sets.json              {case: {cases: [name...], expected_measurement, strict}}
+expected.json          {case: {ok, strict, total, loaded, passed, bound,
+                               measurementPinned, tierCounts, pinningGap}}
+_generate.py           rebuilds sets.json + expected.json from the single suite
+_check_independent.py  reuses the enforcement_attestation_v0 evaluator, no
+                       Vaara import, and reproduces the roll-up
+```
+
+The cases live in the sibling `enforcement_attestation_v0` suite; these vectors
+reference them by name rather than copying the report bytes. Like the single
+suite, they need the attestation extra (`pip install 'vaara[attestation]'`).

--- a/tests/vectors/enforcement_set_v0/_check_independent.py
+++ b/tests/vectors/enforcement_set_v0/_check_independent.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Independent checker for the enforcement_set_v0 vectors.
+
+Imports only the standard library plus the single-verb suite's own Vaara-free
+evaluator. It does not import Vaara. A set is a list of
+``enforcement_attestation_v0`` case names plus the mode the batch applies
+uniformly. For each set this checker:
+
+1. Runs every referenced case through the single suite's ``_evaluate`` (the
+   Vaara-free reproduction of one ``verify_enforcement`` verdict), re-applying
+   the set-level ``expected_measurement`` and ``strict`` so each verdict is
+   judged under the batch's mode, not the single case's.
+2. Rolls the per-case verdicts up the same way ``check_enforcement_set`` does:
+   the pass count, the per-tier tally, the bound and measurement-pinned counts,
+   and the pinning-coverage gap (no case pinned a measurement).
+
+The summary is compared against ``expected.json``. The single suite already
+proves each verdict Vaara-free; this proves the roll-up Vaara-free, so the chain
+from report bytes to set verdict never touches Vaara. Run:
+``python tests/vectors/enforcement_set_v0/_check_independent.py``.
+Exit code 0 means every set matched its expected summary.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SIBLING = HERE.parent / "enforcement_attestation_v0"
+
+TIER_NAMES = ("unverified", "bound", "measurement_pinned")
+SUMMARY_KEYS = (
+    "ok", "strict", "total", "loaded", "passed", "bound",
+    "measurementPinned", "tierCounts", "pinningGap",
+)
+
+
+def _load_single_evaluator():
+    spec = importlib.util.spec_from_file_location(
+        "_enforcement_single_checker", SIBLING / "_check_independent.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - import guard
+        raise RuntimeError("cannot load the single-verb checker")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod._evaluate
+
+
+def _rollup(verdicts: list[dict], *, strict: bool) -> dict:
+    """Reproduce check_enforcement_set's summary from per-case verdicts.
+
+    Every referenced case is well-formed here, so each verdict loaded; an
+    unloadable triple (a CLI-only concern: a missing companion file) is not
+    reachable from committed cases and is exercised by the in-process test.
+    """
+    total = len(verdicts)
+    loaded = total
+    passed = sum(1 for v in verdicts if v["ok"])
+    bound = sum(1 for v in verdicts if v["bound"])
+    measurement_pinned = sum(
+        1 for v in verdicts if v["measurement_basis"] == "pinned")
+    tier_counts = {name: 0 for name in TIER_NAMES}
+    for v in verdicts:
+        tier_counts[v["tier"]] = tier_counts.get(v["tier"], 0) + 1
+    return {
+        "ok": passed == total,
+        "strict": strict,
+        "total": total,
+        "loaded": loaded,
+        "passed": passed,
+        "bound": bound,
+        "measurementPinned": measurement_pinned,
+        "tierCounts": tier_counts,
+        "pinningGap": loaded > 0 and measurement_pinned == 0,
+    }
+
+
+def main() -> int:
+    evaluate = _load_single_evaluator()
+    cases = {c["name"]: c
+             for c in json.loads((SIBLING / "cases.json").read_text())["cases"]}
+    sets = json.loads((HERE / "sets.json").read_text())["sets"]
+    expected = json.loads((HERE / "expected.json").read_text())
+
+    failures = []
+    for set_name, spec in sets.items():
+        verdicts = []
+        for case_name in spec["cases"]:
+            case = dict(cases[case_name])
+            # Re-apply the set-level mode: the batch judges every case under one
+            # expected_measurement and one strict flag, not the single case's.
+            case["expected_measurement"] = spec["expected_measurement"]
+            case["strict"] = spec["strict"]
+            verdicts.append(evaluate(case))
+        got = _rollup(verdicts, strict=spec["strict"])
+        want = {k: expected[set_name][k] for k in SUMMARY_KEYS}
+        if {k: got[k] for k in SUMMARY_KEYS} != want:
+            failures.append(f"{set_name}:\n    expected {want}\n    got      {got}")
+        else:
+            print(f"{set_name}: OK ok={got['ok']} passed={got['passed']}/{got['total']} "
+                  f"pinned={got['measurementPinned']} gap={got['pinningGap']}")
+
+    if failures:
+        print("\nFAIL:\n  " + "\n  ".join(failures))
+        return 1
+    print("\nall enforcement_set_v0 sets matched")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/enforcement_set_v0/_generate.py
+++ b/tests/vectors/enforcement_set_v0/_generate.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Generate the enforcement_set_v0 vectors from the single-verb corpus.
+
+A set is a list of ``enforcement_attestation_v0`` case names. This script does
+not invent new crypto: it reuses that suite's committed cases (each a record,
+a SEV-SNP report, and a VCEK JWK), groups them into sets, and records the
+roll-up ``check_enforcement_set`` produces. ``expected.json`` is the committed
+truth the in-process test (Vaara) and ``_check_independent.py`` (Vaara-free)
+both reproduce.
+
+Run: ``python tests/vectors/enforcement_set_v0/_generate.py``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from vaara.attestation.receipt import check_enforcement_set
+
+HERE = Path(__file__).resolve().parent
+SIBLING = HERE.parent / "enforcement_attestation_v0"
+
+# Each set names cases from the single-verb suite, plus the set-level mode the
+# batch applies uniformly (expected_measurement, strict). Cases that pin a
+# measurement only do so when the set pins the matching value, mirroring how the
+# single verb takes --expected-measurement as a verifier-side input.
+SETS: dict[str, dict] = {
+    # Two clean binds, one of them pinned when the set pins its measurement:
+    # passes, and the pinned one lifts the pinning-coverage gap.
+    "all_bound": {
+        "cases": ["clean_bound", "pinned_measurement_match"],
+        "expected_measurement": (
+            "0102030405060708090a0b0c0d0e0f10"
+            "1112131415161718191a1b1c1d1e1f20"
+            "2122232425262728292a2b2c2d2e2f30"
+        ),
+        "strict": False,
+    },
+    # One clean bind, no pin: passes, but every record bound to a CVM without a
+    # vetted image, so the pinning gap fires (advisory, does not gate).
+    "unpinned_only": {
+        "cases": ["clean_bound"],
+        "expected_measurement": None,
+        "strict": False,
+    },
+    # A clean bind alongside a bad signature and a report bound to another
+    # record: the set fails, one entry passes.
+    "mixed_failure": {
+        "cases": ["clean_bound", "bad_signature", "bound_to_different_record"],
+        "expected_measurement": None,
+        "strict": False,
+    },
+    # Nothing binds: a truncated report and a wrong signature algorithm.
+    "all_unverified": {
+        "cases": ["truncated_report", "wrong_signature_algo"],
+        "expected_measurement": None,
+        "strict": False,
+    },
+    # Strict is unreachable in v0 (no validated KDS chain), so even a clean
+    # pinned bind does not pass strict.
+    "strict_unreachable": {
+        "cases": ["pinned_measurement_match"],
+        "expected_measurement": (
+            "0102030405060708090a0b0c0d0e0f10"
+            "1112131415161718191a1b1c1d1e1f20"
+            "2122232425262728292a2b2c2d2e2f30"
+        ),
+        "strict": True,
+    },
+}
+
+SUMMARY_KEYS = (
+    "ok", "strict", "total", "loaded", "passed", "bound",
+    "measurementPinned", "tierCounts", "pinningGap",
+)
+
+
+def _jwk_to_pem(jwk: dict) -> bytes:
+    def _i(v: str) -> int:
+        return int.from_bytes(base64.urlsafe_b64decode(v + "=" * (-len(v) % 4)), "big")
+
+    pub = ec.EllipticCurvePublicNumbers(
+        _i(jwk["x"]), _i(jwk["y"]), ec.SECP384R1()).public_key()
+    return pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def main() -> int:
+    cases = {c["name"]: c
+             for c in json.loads((SIBLING / "cases.json").read_text())["cases"]}
+    expected: dict[str, dict] = {}
+    for set_name, spec in SETS.items():
+        triples = []
+        for case_name in spec["cases"]:
+            case = cases[case_name]
+            triples.append((
+                case_name,
+                case["record"],
+                base64.b64decode(case["report_b64"]),
+                _jwk_to_pem(case["vcek_jwk"]),
+            ))
+        report = check_enforcement_set(
+            triples,
+            expected_measurement=spec["expected_measurement"],
+            strict=spec["strict"],
+        )
+        d = report.to_dict()
+        expected[set_name] = {k: d[k] for k in SUMMARY_KEYS}
+
+    sets_doc = {
+        "sets": {
+            name: {
+                "cases": spec["cases"],
+                "expected_measurement": spec["expected_measurement"],
+                "strict": spec["strict"],
+            }
+            for name, spec in SETS.items()
+        }
+    }
+    (HERE / "sets.json").write_text(json.dumps(sets_doc, indent=2, sort_keys=True) + "\n")
+    (HERE / "expected.json").write_text(
+        json.dumps(expected, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {len(SETS)} sets to sets.json and expected.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/enforcement_set_v0/expected.json
+++ b/tests/vectors/enforcement_set_v0/expected.json
@@ -1,0 +1,77 @@
+{
+  "all_bound": {
+    "bound": 2,
+    "loaded": 2,
+    "measurementPinned": 2,
+    "ok": true,
+    "passed": 2,
+    "pinningGap": false,
+    "strict": false,
+    "tierCounts": {
+      "bound": 0,
+      "measurement_pinned": 2,
+      "unverified": 0
+    },
+    "total": 2
+  },
+  "all_unverified": {
+    "bound": 1,
+    "loaded": 2,
+    "measurementPinned": 0,
+    "ok": false,
+    "passed": 0,
+    "pinningGap": true,
+    "strict": false,
+    "tierCounts": {
+      "bound": 0,
+      "measurement_pinned": 0,
+      "unverified": 2
+    },
+    "total": 2
+  },
+  "mixed_failure": {
+    "bound": 2,
+    "loaded": 3,
+    "measurementPinned": 0,
+    "ok": false,
+    "passed": 1,
+    "pinningGap": true,
+    "strict": false,
+    "tierCounts": {
+      "bound": 1,
+      "measurement_pinned": 0,
+      "unverified": 2
+    },
+    "total": 3
+  },
+  "strict_unreachable": {
+    "bound": 1,
+    "loaded": 1,
+    "measurementPinned": 1,
+    "ok": false,
+    "passed": 0,
+    "pinningGap": false,
+    "strict": true,
+    "tierCounts": {
+      "bound": 0,
+      "measurement_pinned": 1,
+      "unverified": 0
+    },
+    "total": 1
+  },
+  "unpinned_only": {
+    "bound": 1,
+    "loaded": 1,
+    "measurementPinned": 0,
+    "ok": true,
+    "passed": 1,
+    "pinningGap": true,
+    "strict": false,
+    "tierCounts": {
+      "bound": 1,
+      "measurement_pinned": 0,
+      "unverified": 0
+    },
+    "total": 1
+  }
+}

--- a/tests/vectors/enforcement_set_v0/sets.json
+++ b/tests/vectors/enforcement_set_v0/sets.json
@@ -1,0 +1,43 @@
+{
+  "sets": {
+    "all_bound": {
+      "cases": [
+        "clean_bound",
+        "pinned_measurement_match"
+      ],
+      "expected_measurement": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f30",
+      "strict": false
+    },
+    "all_unverified": {
+      "cases": [
+        "truncated_report",
+        "wrong_signature_algo"
+      ],
+      "expected_measurement": null,
+      "strict": false
+    },
+    "mixed_failure": {
+      "cases": [
+        "clean_bound",
+        "bad_signature",
+        "bound_to_different_record"
+      ],
+      "expected_measurement": null,
+      "strict": false
+    },
+    "strict_unreachable": {
+      "cases": [
+        "pinned_measurement_match"
+      ],
+      "expected_measurement": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f30",
+      "strict": true
+    },
+    "unpinned_only": {
+      "cases": [
+        "clean_bound"
+      ],
+      "expected_measurement": null,
+      "strict": false
+    }
+  }
+}

--- a/tests/vectors/handoff_set_v0/README.md
+++ b/tests/vectors/handoff_set_v0/README.md
@@ -1,0 +1,43 @@
+# Handoff-set vectors, v0
+
+Fixtures for the batch handoff check on a directory of cross-org packages: what
+`vaara verify-handoffs` produces. Where `cross_org_handoff_v0` asks "does this
+one package verify offline under its rotated-out key", these vectors ask the
+question that only shows up across a pile of packages, from one provider or
+several: how many records verify, how many are anchor-corroborated rather than
+resting on the signature alone, and how many had their producer identity pinned?
+
+A set is a list of `cross_org_handoff_v0` case names plus the mode the batch
+applies uniformly: one `strict` flag and one optional trusted DID document the
+set pins every package against. These vectors add no new crypto: they reuse the
+single suite's committed packages, group them into sets, and record the roll-up
+`check_handoff_set` produces:
+
+- **Pass count** how many packages are `ok` for the chosen mode.
+- **Verifiable / corroborated** how many records reached each tier. The gap
+  between them is the part of the set whose authenticity rests on the signature
+  alone, with no anchor.
+- **Pinned count** how many had their producer pinned against the trusted
+  document. `pinningGap` is advisory and fires when no package was pinned: every
+  record's authenticity rests on a self-asserted identity. It does not gate.
+
+The set is `ok` iff every document loaded and every loaded package verified for
+the chosen mode. A single out-of-band identity reference applies to the whole
+set, so only packages whose bound key appears in it pin.
+
+## Layout
+
+```
+sets.json              {case: {cases: [name...], strict, trusted_from_case}}
+expected.json          {case: {ok, strict, total, loaded, passed, verifiable,
+                               corroborated, pinned, pinningGap}}
+_generate.py           rebuilds sets.json + expected.json from the single suite
+_check_independent.py  reuses the cross_org_handoff_v0 evaluator, no Vaara
+                       import, and reproduces the roll-up
+```
+
+The packages live in the sibling `cross_org_handoff_v0` suite; these vectors
+reference them by name. Each package's anchor time is taken from its case's
+pre-verified `anchoredTime`; the RFC 3161 token itself is not re-verified here,
+exactly as in the single suite. Like it, they need the attestation extra
+(`pip install 'vaara[attestation]'`).

--- a/tests/vectors/handoff_set_v0/_check_independent.py
+++ b/tests/vectors/handoff_set_v0/_check_independent.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Independent checker for the handoff_set_v0 vectors.
+
+Imports only the standard library plus the single-verb suite's own Vaara-free
+evaluator. It does not import Vaara. A set is a list of
+``cross_org_handoff_v0`` case names plus the mode the batch applies uniformly:
+``strict`` and an optional set-level trusted DID document. For each set this
+checker:
+
+1. Runs every referenced case through the single suite's ``_evaluate`` (the
+   Vaara-free reproduction of one ``verify_handoff`` verdict), re-applying the
+   set-level ``strict`` and the one trusted document the batch pins every
+   package against, while keeping each package's own pre-verified anchor time.
+2. Rolls the per-case verdicts up the same way ``check_handoff_set`` does: the
+   pass count, the verifiable and corroborated tiers, the producer-pin count,
+   and the pinning-coverage gap (no package pinned its producer).
+
+The summary is compared against ``expected.json``. The single suite already
+proves each verdict Vaara-free; this proves the roll-up Vaara-free, so the chain
+from package bytes to set verdict never touches Vaara. Run:
+``python tests/vectors/handoff_set_v0/_check_independent.py``.
+Exit code 0 means every set matched its expected summary.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SIBLING = HERE.parent / "cross_org_handoff_v0"
+
+SUMMARY_KEYS = (
+    "ok", "strict", "total", "loaded", "passed", "verifiable",
+    "corroborated", "pinned", "pinningGap",
+)
+
+
+def _load_single_evaluator():
+    spec = importlib.util.spec_from_file_location(
+        "_handoff_single_checker", SIBLING / "_check_independent.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - import guard
+        raise RuntimeError("cannot load the single-verb checker")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod._evaluate
+
+
+def _rollup(verdicts: list[dict], *, strict: bool) -> dict:
+    total = len(verdicts)
+    loaded = total
+    passed = sum(1 for v in verdicts if v["ok"])
+    verifiable = sum(1 for v in verdicts if v["verifiable"])
+    corroborated = sum(1 for v in verdicts if v["corroborated"])
+    pinned = sum(1 for v in verdicts
+                 if v["producer_identity_basis"] == "pinned")
+    return {
+        "ok": passed == total,
+        "strict": strict,
+        "total": total,
+        "loaded": loaded,
+        "passed": passed,
+        "verifiable": verifiable,
+        "corroborated": corroborated,
+        "pinned": pinned,
+        "pinningGap": loaded > 0 and pinned == 0,
+    }
+
+
+def main() -> int:
+    evaluate = _load_single_evaluator()
+    cases = {c["name"]: c
+             for c in json.loads((SIBLING / "cases.json").read_text())["cases"]}
+    sets = json.loads((HERE / "sets.json").read_text())["sets"]
+    expected = json.loads((HERE / "expected.json").read_text())
+
+    failures = []
+    for set_name, spec in sets.items():
+        trusted = None
+        if spec["trusted_from_case"] is not None:
+            trusted = cases[spec["trusted_from_case"]]["trustedDidDocument"]
+        verdicts = []
+        for case_name in spec["cases"]:
+            case = dict(cases[case_name])
+            # Re-apply the set-level mode: one strict flag and one trusted
+            # document across the whole set; keep the package's own anchor time.
+            case["strict"] = spec["strict"]
+            if trusted is not None:
+                case["trustedDidDocument"] = trusted
+            else:
+                case.pop("trustedDidDocument", None)
+            verdicts.append(evaluate(case))
+        got = _rollup(verdicts, strict=spec["strict"])
+        want = {k: expected[set_name][k] for k in SUMMARY_KEYS}
+        if {k: got[k] for k in SUMMARY_KEYS} != want:
+            failures.append(f"{set_name}:\n    expected {want}\n    got      {got}")
+        else:
+            print(f"{set_name}: OK ok={got['ok']} passed={got['passed']}/{got['total']} "
+                  f"corroborated={got['corroborated']} pinned={got['pinned']}")
+
+    if failures:
+        print("\nFAIL:\n  " + "\n  ".join(failures))
+        return 1
+    print("\nall handoff_set_v0 sets matched")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/handoff_set_v0/_generate.py
+++ b/tests/vectors/handoff_set_v0/_generate.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Generate the handoff_set_v0 vectors from the single-verb corpus.
+
+A set is a list of ``cross_org_handoff_v0`` case names plus the mode the batch
+applies uniformly: ``strict`` and an optional set-level trusted DID document
+(named by a case whose ``trustedDidDocument`` is reused). This script reuses the
+single suite's committed packages, groups them into sets, and records the
+roll-up ``check_handoff_set`` produces. Each package's anchor time is taken from
+its case's pre-verified ``anchoredTime`` (the timeanchor token itself is not
+re-verified here, exactly as the single suite does). ``expected.json`` is the
+committed truth the in-process test (Vaara) and ``_check_independent.py``
+(Vaara-free) both reproduce.
+
+Run: ``python tests/vectors/handoff_set_v0/_generate.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaara.attestation.receipt import check_handoff_set
+
+HERE = Path(__file__).resolve().parent
+SIBLING = HERE.parent / "cross_org_handoff_v0"
+
+# Each set names cases from the single-verb suite, the set-level strict flag, and
+# (optionally) the case whose trustedDidDocument the batch pins every package
+# against. A single out-of-band identity reference applies to the whole set, so
+# only packages whose bound key appears in it pin.
+SETS: dict[str, dict] = {
+    # Two clean default-mode records, one anchor-corroborated. Passes; no
+    # producer is pinned (no trusted document), so the pinning gap fires.
+    "all_verifiable": {
+        "cases": ["clean_no_anchor", "corroborated"],
+        "strict": False,
+        "trusted_from_case": None,
+    },
+    # A clean record beside one signed after the key retired: the set fails.
+    "with_failure": {
+        "cases": ["clean_no_anchor", "signed_after_retirement"],
+        "strict": False,
+        "trusted_from_case": None,
+    },
+    # Strict, with the producer pinned against a trusted archive: a corroborated,
+    # pinned record passes the regulator-grade bar.
+    "strict_pinned": {
+        "cases": ["pinned_corroborated"],
+        "strict": True,
+        "trusted_from_case": "pinned_corroborated",
+    },
+    # Strict without a trusted document: a corroborated record still fails strict
+    # because its producer identity is self-asserted.
+    "strict_unmet": {
+        "cases": ["corroborated"],
+        "strict": True,
+        "trusted_from_case": None,
+    },
+}
+
+SUMMARY_KEYS = (
+    "ok", "strict", "total", "loaded", "passed", "verifiable",
+    "corroborated", "pinned", "pinningGap",
+)
+
+
+def main() -> int:
+    cases = {c["name"]: c
+             for c in json.loads((SIBLING / "cases.json").read_text())["cases"]}
+    expected: dict[str, dict] = {}
+    for set_name, spec in SETS.items():
+        trusted = None
+        if spec["trusted_from_case"] is not None:
+            trusted = cases[spec["trusted_from_case"]]["trustedDidDocument"]
+        packages = []
+        for case_name in spec["cases"]:
+            case = cases[case_name]
+            package = case["package"]
+            anchor_present = package.get("evidence", {}).get("anchor") is not None
+            anchor_time = case.get("anchoredTime") if anchor_present else None
+            packages.append((case_name, package, anchor_time))
+        report = check_handoff_set(
+            packages, trusted_did_document=trusted, strict=spec["strict"])
+        d = report.to_dict()
+        expected[set_name] = {k: d[k] for k in SUMMARY_KEYS}
+
+    sets_doc = {
+        "sets": {
+            name: {
+                "cases": spec["cases"],
+                "strict": spec["strict"],
+                "trusted_from_case": spec["trusted_from_case"],
+            }
+            for name, spec in SETS.items()
+        }
+    }
+    (HERE / "sets.json").write_text(json.dumps(sets_doc, indent=2, sort_keys=True) + "\n")
+    (HERE / "expected.json").write_text(
+        json.dumps(expected, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {len(SETS)} sets to sets.json and expected.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/handoff_set_v0/expected.json
+++ b/tests/vectors/handoff_set_v0/expected.json
@@ -1,0 +1,46 @@
+{
+  "all_verifiable": {
+    "corroborated": 1,
+    "loaded": 2,
+    "ok": true,
+    "passed": 2,
+    "pinned": 0,
+    "pinningGap": true,
+    "strict": false,
+    "total": 2,
+    "verifiable": 2
+  },
+  "strict_pinned": {
+    "corroborated": 1,
+    "loaded": 1,
+    "ok": true,
+    "passed": 1,
+    "pinned": 1,
+    "pinningGap": false,
+    "strict": true,
+    "total": 1,
+    "verifiable": 1
+  },
+  "strict_unmet": {
+    "corroborated": 1,
+    "loaded": 1,
+    "ok": false,
+    "passed": 0,
+    "pinned": 0,
+    "pinningGap": true,
+    "strict": true,
+    "total": 1,
+    "verifiable": 1
+  },
+  "with_failure": {
+    "corroborated": 0,
+    "loaded": 2,
+    "ok": false,
+    "passed": 1,
+    "pinned": 0,
+    "pinningGap": true,
+    "strict": false,
+    "total": 2,
+    "verifiable": 1
+  }
+}

--- a/tests/vectors/handoff_set_v0/sets.json
+++ b/tests/vectors/handoff_set_v0/sets.json
@@ -1,0 +1,34 @@
+{
+  "sets": {
+    "all_verifiable": {
+      "cases": [
+        "clean_no_anchor",
+        "corroborated"
+      ],
+      "strict": false,
+      "trusted_from_case": null
+    },
+    "strict_pinned": {
+      "cases": [
+        "pinned_corroborated"
+      ],
+      "strict": true,
+      "trusted_from_case": "pinned_corroborated"
+    },
+    "strict_unmet": {
+      "cases": [
+        "corroborated"
+      ],
+      "strict": true,
+      "trusted_from_case": null
+    },
+    "with_failure": {
+      "cases": [
+        "clean_no_anchor",
+        "signed_after_retirement"
+      ],
+      "strict": false,
+      "trusted_from_case": null
+    }
+  }
+}


### PR DESCRIPTION
The set-level forms of `verify-handoff` and `verify-enforcement`, for an auditor holding a directory of evidence rather than one file. They mirror the existing `verify-bundles` batch surface.

- `verify-handoffs DIR` runs `verify-handoff` over every package and rolls up how many records verify under their rotated-out keys, how many are anchor-corroborated rather than resting on the signature alone, and how many had their producer identity pinned.
- `verify-enforcements DIR` binds a directory of records to their SEV-SNP reports, discovering each triple by stem (`NAME.record.json` with `NAME.report.bin` and `NAME.vcek.pem`), and rolls up how many bind to a confidential VM, the per-tier tally, and whether any pinned a vetted launch image.

Each set is `ok` only when every item verifies for the chosen mode; a coverage note (no producer pinned, no image pinned) is advisory and does not gate.

New `check_handoff_set` / `check_enforcement_set` plus `handoff_set_v0` and `enforcement_set_v0` conformance vectors. Each vector suite reuses the single-verb corpus by reference (no new crypto fixtures) and ships a Vaara-free checker that reproduces the roll-up by composing the single suite's own evaluator, so the chain from bytes to set verdict never touches Vaara.

Lands in Unreleased; the version is unchanged. 1607 passed, ruff and mypy --strict clean on the new modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `vaara verify-handoffs` command for batch verification of handoff packages across directories with rollup metrics.
  * Added `vaara verify-enforcements` command for batch verification of enforcement evidence sets with comprehensive coverage indicators.
  * Set-level verification now reports metrics including key rotation, anchor corroboration, producer identity pinning, and enforcement binding assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->