### PR TITLE
feat: export-article12 folds in cross-org handoff and confidential-VM enforcement evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 ## [Unreleased]
 
 ### Added
+- The Article 12 regulator pack now folds in cross-org handoff (Article 26(6))
+  and confidential-VM enforcement evidence, and verifies a full directory of
+  records in one pass. One deployer command produces one package coherent across
+  Article 12 (the signed record-keeping trail), Article 19 (existence in time
+  under the eIDAS anchor), and Article 26(6) (the records a deployer hands its
+  own regulator), with an optional "where it ran" confidential-VM attestation
+  alongside. It is a more complete pack, not a certificate: the eIDAS time
+  anchor stays the only un-forgeable component, a handoff is corroborated only
+  with a verified anchor and pinned only against a trusted DID document, and an
+  enforcement binding is never "attested" (the VCEK chain to AMD's root is not
+  validated in this release).
+- `vaara trail export-article12 --handoffs <dir> --enforcements <dir>` (also
+  `--handoff <pkg.json>`, repeatable): fold verified handoff packages and
+  confidential-VM enforcement bindings into the regulator package as sidecars
+  under `evidence/`, with the roll-up in `evidence/attestations_summary.json`
+  and a report section mapping them to Article 26(6) custody and the
+  confidential-VM "where enforcement ran" evidence. Each attachment is verified
+  at export; one that does not verify fails the export closed, so the package
+  never ships evidence it cannot back. `--trusted-did-document` pins handoff
+  producer identity out of band, `--expected-measurement` pins enforcement
+  launch images. New `article12_fold_v0` conformance vectors with a Vaara-free
+  checker that reproduces every folded verdict from the bytes inside the package.
 - `vaara verify-handoffs` and `vaara verify-enforcements`: the set-level forms of
   `verify-handoff` and `verify-enforcement`, for an auditor holding a directory
   of evidence rather than one file. `verify-handoffs` runs the handoff lens over

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ trail.anchor_head(RFC3161TimeAnchorClient("https://freetsa.org/tsr"))
 
 The anchor also folds into the one-command regulator package: `vaara trail export-article12 --anchor-tsa https://freetsa.org/tsr` writes the timestamp beside the signed trail as Article 19 existence-in-time evidence, and `vaara trail verify-anchor --zip <package>.zip` checks it offline.
 
+The same command folds in cross-org handoff and confidential-VM enforcement evidence as verified sidecars: `vaara trail export-article12 --anchor-tsa <url> --handoffs ./handoffs --enforcements ./enforced` adds the records a deployer hands its own regulator (Article 26(6)) and "where enforcement ran" attestations under `evidence/`, with a roll-up in the report. Each attachment is verified at export and one that does not verify fails the export, so the package never ships evidence it cannot back. It is a more complete pack, not a certificate: the eIDAS anchor stays the only un-forgeable component, a handoff is corroborated only with a verified anchor, and an enforcement binding is never "attested" in this release.
+
 ## Install
 
 ```bash

--- a/docs/design/article12-export-spec.md
+++ b/docs/design/article12-export-spec.md
@@ -170,3 +170,80 @@ The two features compose; build threshold first.
 - Auto-submission to any regulator intake portal.
 - Per-article legal interpretation beyond the static obligation checklist
   (semantic-correctness layer; stays human-owned per the trust model).
+
+## Folding SEP-2828 evidence as sidecars (the fold)
+
+The package can carry verified SEP-2828 evidence beside the trail: cross-org
+handoff packages (Article 26(6) deployer custody) and confidential-VM
+enforcement bindings ("where it ran"). One deployer command then produces one
+package coherent across Article 12 (the signed trail), Article 19 (the eIDAS
+anchor), and Article 26(6) (the handoff records), with an optional
+confidential-VM attestation alongside.
+
+### The architectural seam
+
+Article 12 export operates on the **audit trail** (the hash-chained
+`AuditRecord` trail, the governance plane). Handoff and enforcement operate on
+**SEP-2828 execution records** (the attestation plane). These are two planes.
+The fold attaches SEP-2828 evidence as verified sidecars to the trail package;
+it does not claim the trail records are SEP-2828 records, and it does not bring
+the sidecars under the trail signature. The sidecars are content-addressed
+SEP-2828 records, verified at export.
+
+### Layout
+
+```
+evidence/handoff/<name>.json
+evidence/enforcement/<name>.{record.json,report.bin,vcek.pem}
+evidence/attestations_summary.json
+```
+
+`attestations_summary.json` carries the roll-up `check_handoff_set` /
+`check_enforcement_set` produce, plus the verifier-side inputs used at export
+(per-package anchor times, the trusted DID document, the expected measurement),
+so the folded evidence re-verifies offline from the package alone. The report
+gains a "Cross-org handoff and enforcement evidence" section mapping the counts
+to Article 26(6) custody and the confidential-VM "where enforcement ran"
+evidence, each with the honesty note verbatim.
+
+### Verified at export, fail closed
+
+Each attachment is verified before any bytes are written, in default mode, by
+the same `check_handoff_set` / `check_enforcement_set` the verify verbs use. A
+single attachment that does not verify raises and writes no package: v0 never
+ships evidence it cannot back, and there is no `--skip-invalid`.
+
+### Honesty model (the brand applies)
+
+- The eIDAS time anchor stays the **only** un-forgeable component of the package.
+- A handoff is `verifiable` when the signature binds to a listed key inside its
+  window and not revoked; it is `corroborated` only with a verified anchor that
+  predates retirement, and `pinned` only against a `--trusted-did-document`. It
+  is never silently upgraded.
+- An enforcement binding is never "attested" in v0: `vcek_chain_basis` stays
+  `caller_supplied_unverified` and `enforcement_logic_basis` stays
+  `not_established`. `--expected-measurement` pins a launch image; the
+  `attested` tier and a strict pass are reserved for the future KDS-chained tier.
+
+### Conformance
+
+`article12_fold_v0` vectors fold named subsets of the `cross_org_handoff_v0` and
+`enforcement_attestation_v0` corpora into a real package and pin the roll-up and
+`evidence/` membership. The Vaara-free checker reproduces every folded verdict
+from the same bytes folded into the zip (not a re-snapshot), composing the two
+single-verb suites' own evaluators.
+
+### CLI
+
+```
+vaara trail export-article12 --trail t.jsonl --key signer.pem --out pack.zip \
+    --anchor-tsa https://freetsa.org/tsr \
+    --handoff one.json --handoffs ./handoffs \
+    --enforcements ./enforced \
+    --trusted-did-document issuer-did.json \
+    --expected-measurement <96-hex>
+```
+
+`--handoff` is repeatable for single packages; `--handoffs` globs `*.json` in a
+directory; `--enforcements` discovers `NAME.record.json` + `NAME.report.bin` +
+`NAME.vcek.pem` triples by stem. Folding needs the attestation extra.

--- a/src/vaara/audit/article12_export.py
+++ b/src/vaara/audit/article12_export.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import json
 import zipfile
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Optional, Sequence, Union
 
 if TYPE_CHECKING:
     from vaara.audit.timeanchor import TimeAnchor
@@ -63,6 +63,150 @@ def _records_from_zip(zip_path: Path) -> tuple[list[AuditRecord], dict]:
     return records, manifest
 
 
+def _member_base(name: str) -> str:
+    """A safe zip-member base from a caller-supplied attachment name.
+
+    Strips any directory components so a hostile name cannot fold a file
+    outside ``evidence/``. The result is used to build ``evidence/.../<base>``
+    paths; an empty result is rejected by the caller.
+    """
+    return Path(str(name)).name
+
+
+def _prepare_folded_evidence(
+    handoffs: "Optional[Sequence[tuple[str, dict, Optional[str]]]]",
+    enforcements: "Optional[Sequence[tuple[str, dict, bytes, bytes]]]",
+    *,
+    trusted_did_document: Optional[dict],
+    expected_measurement: Optional[str],
+) -> "tuple[Optional[dict], Optional[dict], list[tuple[str, bytes]]]":
+    """Verify the optional SEP-2828 attachments and stage them for folding.
+
+    Returns ``(report_attestations, summary_doc, files)``:
+
+    * ``report_attestations`` is the counts-only roll-up handed to the report
+      builder (``None`` when nothing is folded).
+    * ``summary_doc`` is the self-describing ``attestations_summary.json`` body,
+      carrying the full set verdicts plus the verifier-side inputs (per-package
+      anchor times, the trusted DID document, the expected measurement) so the
+      folded evidence re-verifies offline from the package alone.
+    * ``files`` are ``(zip_member, bytes)`` pairs to fold under ``evidence/``.
+
+    Fails closed: every attachment is verified here in default mode, and a
+    single attachment that does not verify raises :class:`ValueError` naming the
+    offender. The package never ships evidence it cannot back. Needs the
+    attestation extra; a missing extra raises :class:`ImportError`.
+    """
+    if not handoffs and not enforcements:
+        return None, None, []
+
+    from vaara.attestation.receipt import (
+        check_enforcement_set,
+        check_handoff_set,
+    )
+
+    report_attestations: dict = {}
+    summary: dict = {
+        "schema": "vaara-article12-attestations",
+        "schemaVersion": 1,
+        "handoff": {"present": False},
+        "enforcement": {"present": False},
+    }
+    files: list[tuple[str, bytes]] = []
+    seen: set[str] = set()
+
+    def _fold(member: str, body: bytes) -> None:
+        if member in seen:
+            raise ValueError(f"duplicate folded evidence path: {member!r}")
+        seen.add(member)
+        files.append((member, body))
+
+    if handoffs:
+        h_report = check_handoff_set(
+            handoffs, trusted_did_document=trusted_did_document, strict=False,
+        )
+        if not h_report.ok:
+            bad = [
+                f"{e.name} ({e.error or 'did not verify'})"
+                for e in h_report.entries if not e.ok
+            ]
+            raise ValueError(
+                "handoff attachment(s) failed verification, refusing to fold: "
+                + "; ".join(bad)
+            )
+        anchored_times: dict[str, Optional[str]] = {}
+        for name, doc, anchor_time in handoffs:
+            base = _member_base(name)
+            if base.endswith(".json"):
+                base = base[: -len(".json")]
+            if not base:
+                raise ValueError(f"empty handoff attachment name: {name!r}")
+            _fold(
+                f"evidence/handoff/{base}.json",
+                json.dumps(doc, indent=2, sort_keys=True).encode("utf-8"),
+            )
+            # Key by the folded base, not the raw name, so the anchor time maps
+            # to the file an offline reader sees in the zip.
+            anchored_times[base] = anchor_time
+        summary["handoff"] = {
+            "present": True,
+            "strict": h_report.strict,
+            "trustedDidDocument": trusted_did_document,
+            "anchoredTimes": anchored_times,
+            "report": h_report.to_dict(),
+        }
+        report_attestations["handoff"] = {
+            "total": h_report.total,
+            "passed": h_report.passed,
+            "verifiable": h_report.verifiable,
+            "corroborated": h_report.corroborated,
+            "pinned": h_report.pinned,
+            "pinning_gap": h_report.pinning_gap,
+            "strict": h_report.strict,
+        }
+
+    if enforcements:
+        e_report = check_enforcement_set(
+            enforcements, expected_measurement=expected_measurement, strict=False,
+        )
+        if not e_report.ok:
+            bad = [
+                f"{e.name} ({e.error or 'did not verify'})"
+                for e in e_report.entries if not e.ok
+            ]
+            raise ValueError(
+                "enforcement attachment(s) failed verification, refusing to "
+                "fold: " + "; ".join(bad)
+            )
+        for name, record, report_bytes, vcek_pem in enforcements:
+            base = _member_base(name)
+            if not base:
+                raise ValueError(f"empty enforcement attachment name: {name!r}")
+            _fold(
+                f"evidence/enforcement/{base}.record.json",
+                json.dumps(record, indent=2, sort_keys=True).encode("utf-8"),
+            )
+            _fold(f"evidence/enforcement/{base}.report.bin", report_bytes)
+            _fold(f"evidence/enforcement/{base}.vcek.pem", vcek_pem)
+        summary["enforcement"] = {
+            "present": True,
+            "strict": e_report.strict,
+            "expectedMeasurement": expected_measurement,
+            "report": e_report.to_dict(),
+        }
+        report_attestations["enforcement"] = {
+            "total": e_report.total,
+            "passed": e_report.passed,
+            "bound": e_report.bound,
+            "measurement_pinned": e_report.measurement_pinned,
+            "tier_counts": dict(e_report.tier_counts),
+            "pinning_gap": e_report.pinning_gap,
+            "strict": e_report.strict,
+        }
+
+    return report_attestations, summary, files
+
+
 def export_article12(
     trail,
     out_path: Union[str, Path],
@@ -74,6 +218,10 @@ def export_article12(
     system_meta: Optional[dict] = None,
     period: Optional[tuple] = None,
     time_anchor: "Optional[TimeAnchor]" = None,
+    handoffs: "Optional[Sequence[tuple[str, dict, Optional[str]]]]" = None,
+    enforcements: "Optional[Sequence[tuple[str, dict, bytes, bytes]]]" = None,
+    trusted_did_document: Optional[dict] = None,
+    expected_measurement: Optional[str] = None,
     fmt: str = "md",
     agent_id: str = "",
 ) -> ExportResult:
@@ -92,12 +240,35 @@ def export_article12(
     in as ``time_anchor.json`` and surfaced in the report as Article 19
     existence-in-time evidence, independent of the signing key.
 
+    ``handoffs`` and ``enforcements`` fold verified SEP-2828 evidence in as
+    sidecars under ``evidence/``: cross-org handoff packages (Article 26(6)
+    deployer custody) as ``(name, document, anchor_attested_time)`` tuples, and
+    confidential-VM enforcement bindings as ``(name, record, report_bytes,
+    vcek_pem)`` tuples, mirroring ``check_handoff_set`` / ``check_enforcement_set``.
+    ``trusted_did_document`` pins handoff producer identity out of band;
+    ``expected_measurement`` pins enforcement launch images. Each attachment is
+    verified at export in default mode and a single one that does not verify
+    raises :class:`ValueError`: the package never ships evidence it cannot back.
+    The roll-up is written as ``evidence/attestations_summary.json`` and
+    surfaced in the report; folding these needs the attestation extra. The
+    eIDAS anchor stays the only un-forgeable component, and the report says so.
+
     Returns the underlying :class:`ExportResult` (its ``manifest`` covers the
     signed core; the Article 12 files are folded in afterwards).
     """
     if fmt not in ("md", "html"):
         raise ValueError(f"fmt must be 'md' or 'html', got {fmt!r}")
     out_path = Path(out_path)
+
+    # Verify the optional SEP-2828 attachments up front, before any bytes are
+    # written, so a bad attachment fails closed without leaving a partial zip.
+    report_attestations, attestations_summary, folded_files = (
+        _prepare_folded_evidence(
+            handoffs, enforcements,
+            trusted_did_document=trusted_did_document,
+            expected_measurement=expected_measurement,
+        )
+    )
 
     threshold_mode = signers is not None or threshold_k is not None
     if threshold_mode:
@@ -138,7 +309,7 @@ def export_article12(
 
     report = build_article12_report(
         records, manifest, system_meta=system_meta, period=period,
-        time_anchor=anchor_dict,
+        time_anchor=anchor_dict, attestations=report_attestations,
     )
 
     report_name = f"article12_report.{fmt}"
@@ -157,5 +328,14 @@ def export_article12(
                 "time_anchor.json",
                 json.dumps(anchor_dict, indent=2, sort_keys=True).encode("utf-8"),
             )
+        if attestations_summary is not None:
+            zf.writestr(
+                "evidence/attestations_summary.json",
+                json.dumps(
+                    attestations_summary, indent=2, sort_keys=True
+                ).encode("utf-8"),
+            )
+            for member, body in folded_files:
+                zf.writestr(member, body)
 
     return result

--- a/src/vaara/audit/article12_report.py
+++ b/src/vaara/audit/article12_report.py
@@ -26,6 +26,83 @@ from vaara.audit.trail import AuditRecord, EventType
 
 SCHEMA_VERSION = "vaara-article12/1.0"
 
+# Honesty notes for the folded SEP-2828 attestations. These are the brand: a
+# handoff is only corroborated when an eIDAS anchor predates the key's
+# retirement, and only pinned against an out-of-band trusted DID document; an
+# enforcement binding is never "attested" in this release. The eIDAS time
+# anchor stays the only un-forgeable component of the package, and the report
+# says so plainly rather than letting a folded sidecar read as proof.
+HANDOFF_BASIS_NOTE = (
+    "A handoff is verifiable when the record's signature binds to a key the "
+    "archived DID document lists, inside that key's validity window, and the "
+    "key was not revoked before issuance. It is corroborated only when an "
+    "enclosed eIDAS time anchor predates the key's retirement and revocation. "
+    "Producer identity is pinned only when checked against a DID document "
+    "trusted out of band; otherwise it is self-asserted. Where a record is "
+    "neither corroborated nor pinned, its authenticity rests on the signature "
+    "against a self-asserted identity."
+)
+ENFORCEMENT_BASIS_NOTE = (
+    "An enforcement binding proves a SEV-SNP attestation report carries this "
+    "record's digest in REPORT_DATA. It is not attested in this release: the "
+    "VCEK certificate chain to AMD's root is not validated "
+    "(vcek_chain_basis=caller_supplied_unverified), and binding a report to a "
+    "record does not prove the record came from the image's decision path "
+    "(enforcement_logic_basis=not_established). A binding pins a launch "
+    "measurement only when a vetted value was supplied. The eIDAS time anchor "
+    "remains the only un-forgeable component of this package."
+)
+
+
+def _build_attestations_block(attestations: Optional[dict]) -> dict:
+    """Shape the folded-attestation summary for the report dict.
+
+    ``attestations`` is the pre-computed roll-up the export layer hands in
+    (counts and basis flags from ``check_handoff_set`` /
+    ``check_enforcement_set``); this module stays crypto-free. Returns a block
+    that is always present so the rendered report can state plainly when no
+    attestations were folded.
+    """
+    attestations = attestations or {}
+    handoff = attestations.get("handoff")
+    enforcement = attestations.get("enforcement")
+    articles: list[str] = []
+    if handoff:
+        articles.append("26(6)")
+    block: dict = {
+        "folded": bool(handoff or enforcement),
+        "articles": articles,
+    }
+    if handoff:
+        block["handoff"] = {
+            "present": True,
+            "packages": handoff.get("total", 0),
+            "verifiable": handoff.get("verifiable", 0),
+            "corroborated": handoff.get("corroborated", 0),
+            "producer_pinned": handoff.get("pinned", 0),
+            "passed": handoff.get("passed", 0),
+            "strict": bool(handoff.get("strict", False)),
+            "pinning_gap": bool(handoff.get("pinning_gap", False)),
+            "basis": HANDOFF_BASIS_NOTE,
+        }
+    else:
+        block["handoff"] = {"present": False}
+    if enforcement:
+        block["enforcement"] = {
+            "present": True,
+            "bindings": enforcement.get("total", 0),
+            "bound": enforcement.get("bound", 0),
+            "measurement_pinned": enforcement.get("measurement_pinned", 0),
+            "tier_counts": dict(enforcement.get("tier_counts", {})),
+            "passed": enforcement.get("passed", 0),
+            "strict": bool(enforcement.get("strict", False)),
+            "pinning_gap": bool(enforcement.get("pinning_gap", False)),
+            "basis": ENFORCEMENT_BASIS_NOTE,
+        }
+    else:
+        block["enforcement"] = {"present": False}
+    return block
+
 # Static Article 12 / 26(5) obligation checklist. Each entry names a duty and
 # the event types whose presence in the trail evidences it. The mapping is a
 # structural aid, not a legal opinion: it shows which logs speak to which
@@ -119,6 +196,7 @@ def build_article12_report(
     system_meta: Optional[dict] = None,
     period: Optional[tuple] = None,
     time_anchor: Optional[dict] = None,
+    attestations: Optional[dict] = None,
 ) -> dict:
     """Build the Article 12 report dict from a trail and its export manifest.
 
@@ -132,6 +210,10 @@ def build_article12_report(
     serialised with ``to_dict()``: an external trusted timestamp over the
     signed trail head, evidencing Article 19 existence-in-time independently of
     the signing key. Its chain-head binding is checked by the caller.
+    ``attestations`` is an optional pre-computed roll-up of folded SEP-2828
+    evidence (cross-org handoff packages, confidential-VM enforcement
+    bindings); the export layer verifies and counts them, this builder only
+    shapes and renders the summary, with the honesty notes verbatim.
     """
     system_meta = dict(system_meta or {})
     in_scope = [r for r in records if _in_period(r.timestamp, period)]
@@ -289,6 +371,7 @@ def build_article12_report(
             if time_anchor
             else {"anchored": False}
         ),
+        "attestations": _build_attestations_block(attestations),
     }
 
 
@@ -442,11 +525,83 @@ def render_report_md(report: dict) -> str:
         )
     out.append("")
 
+    _render_attestations_md(out, report.get("attestations") or {"folded": False})
+
     out.append("## How to verify")
     out.append("")
     out.append(verify_instructions_text(report))
     out.append("")
     return "\n".join(out)
+
+
+def _render_attestations_md(out: list, att: dict) -> None:
+    """Render the folded SEP-2828 attestations section, if any.
+
+    Always emits the heading so the package is self-describing: when nothing
+    was folded it states that plainly rather than leaving a regulator to wonder
+    whether handoff or enforcement evidence was meant to be present.
+    """
+    out.append("## Cross-org handoff and enforcement evidence")
+    out.append("")
+    if not att.get("folded"):
+        out.append(
+            "No cross-org handoff or confidential-VM enforcement evidence is "
+            "folded into this package. The Article 12 record-keeping above "
+            "stands on its own. Attach handoff packages or enforcement bindings "
+            "with: vaara trail export-article12 --handoffs <dir> "
+            "--enforcements <dir>."
+        )
+        out.append("")
+        return
+
+    handoff = att.get("handoff") or {"present": False}
+    if handoff.get("present"):
+        strict = " [strict]" if handoff.get("strict") else ""
+        out.append(f"### Cross-org handoff custody (Article 26(6)){strict}")
+        out.append("")
+        out.append(_md_table(["Field", "Value"], [
+            ["Packages folded", handoff.get("packages", 0)],
+            ["Verify under rotated-out key", handoff.get("passed", 0)],
+            ["Verifiable", handoff.get("verifiable", 0)],
+            ["Anchor-corroborated", handoff.get("corroborated", 0)],
+            ["Producer pinned (out of band)", handoff.get("producer_pinned", 0)],
+        ]))
+        out.append("")
+        if handoff.get("pinning_gap"):
+            out.append(
+                "Coverage note: no package pinned its producer identity against "
+                "a trusted DID document, so every record's authenticity is "
+                "self-asserted (advisory, does not gate)."
+            )
+            out.append("")
+        out.append(handoff["basis"])
+        out.append("")
+
+    enforcement = att.get("enforcement") or {"present": False}
+    if enforcement.get("present"):
+        strict = " [strict]" if enforcement.get("strict") else ""
+        out.append(f"### Where enforcement ran (confidential VM){strict}")
+        out.append("")
+        out.append(_md_table(["Field", "Value"], [
+            ["Bindings folded", enforcement.get("bindings", 0)],
+            ["Bound to a CVM report", enforcement.get("bound", 0)],
+            ["Launch measurement pinned", enforcement.get("measurement_pinned", 0)],
+        ]))
+        tiers = enforcement.get("tier_counts") or {}
+        tally = ", ".join(f"{t}: {n}" for t, n in tiers.items() if n)
+        if tally:
+            out.append("")
+            out.append(f"Tiers: {tally}.")
+        out.append("")
+        if enforcement.get("pinning_gap"):
+            out.append(
+                "Coverage note: no binding pinned a launch measurement, so the "
+                "set bound to a confidential VM but never to a vetted image "
+                "(advisory, does not gate)."
+            )
+            out.append("")
+        out.append(enforcement["basis"])
+        out.append("")
 
 
 def render_report_html(report: dict) -> str:
@@ -475,6 +630,7 @@ def verify_instructions_text(report: dict) -> str:
     s = report["record_keeping_summary"]
     threshold = report["cover"].get("threshold")
     anchor = report.get("time_anchor") or {"anchored": False}
+    att = report.get("attestations") or {"folded": False}
     lines = [
         "How to verify this Article 12 package",
         "",
@@ -516,10 +672,48 @@ def verify_instructions_text(report: dict) -> str:
             f"     {anchor.get('chain_head_hash', '')}",
         ]
         step += 1
+    if att.get("folded"):
+        handoff = att.get("handoff") or {"present": False}
+        enforcement = att.get("enforcement") or {"present": False}
+        lines += [
+            "",
+            f"{step}. Re-verify the folded SEP-2828 evidence from the bytes in "
+            "evidence/.",
+            "   These sidecars are verified at export and fail the export if "
+            "they do not",
+            "   verify; re-check them independently:",
+        ]
+        if handoff.get("present"):
+            lines += [
+                "     vaara verify-handoffs evidence/handoff",
+                "   or the Vaara-free checker in "
+                "tests/vectors/cross_org_handoff_v0/.",
+            ]
+        if enforcement.get("present"):
+            lines += [
+                "     vaara verify-enforcements evidence/enforcement",
+                "   or the Vaara-free checker in "
+                "tests/vectors/enforcement_attestation_v0/.",
+            ]
+        lines += [
+            "   The roll-up in evidence/attestations_summary.json must match "
+            "what you",
+            "   reproduce. A handoff is not corroborated without a verified "
+            "anchor, and an",
+            "   enforcement binding is not attested: the VCEK chain to AMD's "
+            "root is not",
+            "   validated in this release. The eIDAS time anchor stays the only "
+            "un-forgeable",
+            "   component of this package.",
+        ]
+        step += 1
     lines += [
         "",
         "The signature covers trail.jsonl and manifest.json. This report and",
         "article12_summary.json are a derived, human-readable view bound to the",
         "signed trail by the trail_sha256 above. They are not themselves signed.",
+        "The folded evidence/ sidecars are content-addressed SEP-2828 records, "
+        "verified",
+        "at export; they are not covered by the trail signature.",
     ]
     return "\n".join(lines)

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -771,10 +771,31 @@ def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
             if rec.record_hash:
                 trail._last_hash = rec.record_hash
 
+    # Folding handoff / enforcement evidence needs the attestation extra (the
+    # crypto the record and binding lenses use). Fail fast with the install
+    # hint rather than deep inside the export.
+    fold_requested = bool(args.handoff or args.handoffs or args.enforcements)
+    if fold_requested:
+        try:
+            import rfc8785  # noqa: F401
+
+            from vaara.attestation.receipt import (  # noqa: F401
+                check_enforcement_set,
+                check_handoff_set,
+            )
+        except ImportError:
+            print(_ATTESTATION_HINT, file=sys.stderr)
+            return 2
+
     out = Path(args.out).expanduser()
     out.parent.mkdir(parents=True, exist_ok=True)
 
+    handoffs = enforcements = None
     try:
+        if fold_requested:
+            handoffs, enforcements, trusted, expected = _collect_fold_attachments(args)
+        else:
+            trusted, expected = None, None
         time_anchor = _obtain_time_anchor(args, trail)
         result = export_article12(
             trail,
@@ -783,6 +804,10 @@ def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
             system_meta=system_meta,
             period=period,
             time_anchor=time_anchor,
+            handoffs=handoffs,
+            enforcements=enforcements,
+            trusted_did_document=trusted,
+            expected_measurement=expected,
             fmt=args.format,
             agent_id=args.agent_id or "",
         )
@@ -796,6 +821,10 @@ def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
     print(f"  report:       article12_report.{args.format}")
     if time_anchor is not None:
         print(f"  time anchor:  {time_anchor.anchored_time} ({time_anchor.backend})")
+    if handoffs:
+        print(f"  handoff:      {len(handoffs)} package(s) folded (Article 26(6))")
+    if enforcements:
+        print(f"  enforcement:  {len(enforcements)} binding(s) folded")
     return 0 if result.chain_intact else 1
 
 
@@ -1991,20 +2020,20 @@ def _print_retained_report(r: Any) -> None:
     print(f"  {_safe_inline(r.reason)}")
 
 
-def _resolve_handoff_anchor_time(
-    args: argparse.Namespace, doc: Any
+def _resolve_package_anchor_time(
+    doc: Any, *, anchored_time: Optional[str] = None, no_anchor: bool = False,
 ) -> "tuple[Optional[str], Optional[str]]":
     """Return (anchored_time, note) for a handoff package's enclosed anchor.
 
-    ``--anchored-time`` (a time the regulator verified out of band) wins. Else,
+    ``anchored_time`` (a time the regulator verified out of band) wins. Else,
     if the package carries an anchor and the timeanchor extra is installed, the
     RFC 3161 token is verified and its attested time returned. A missing extra
     or a token that does not verify yields no time and a note: the record stays
     verifiable, not corroborated, never silently upgraded.
     """
-    if args.anchored_time is not None:
-        return args.anchored_time, None
-    if args.no_anchor:
+    if anchored_time is not None:
+        return anchored_time, None
+    if no_anchor:
         return None, None
     evidence = doc.get("evidence") if isinstance(doc, dict) else None
     anchor = evidence.get("anchor") if isinstance(evidence, dict) else None
@@ -2022,6 +2051,154 @@ def _resolve_handoff_anchor_time(
     except (ValueError, KeyError, TypeError, TimeAnchorError) as exc:
         return None, f"the enclosed time anchor did not verify: {exc}"
     return attested.isoformat(), None
+
+
+def _resolve_handoff_anchor_time(
+    args: argparse.Namespace, doc: Any
+) -> "tuple[Optional[str], Optional[str]]":
+    """Args wrapper over :func:`_resolve_package_anchor_time` for verify-handoffs."""
+    return _resolve_package_anchor_time(
+        doc, anchored_time=args.anchored_time, no_anchor=args.no_anchor,
+    )
+
+
+def _load_handoff_docs(
+    paths: "list[Path]", *,
+    anchored_time: Optional[str] = None, no_anchor: bool = False,
+    on_note: "Optional[Any]" = None,
+) -> "tuple[list[tuple[Path, Any, Optional[str]]], list[tuple[str, str]]]":
+    """Load handoff packages from disk and resolve each enclosed anchor.
+
+    Shared by ``verify-handoffs`` and the ``export-article12`` fold: reads every
+    path, resolves the anchor time (out-of-band override, else the enclosed
+    RFC 3161 token), and returns ``(path, doc, anchor_time)`` for each readable
+    package plus an ``unreadable`` list. Callers pick the entry name (file name
+    vs stem). ``on_note(name, note)`` is called for any anchor-resolution note.
+    """
+    loaded: list[tuple[Path, Any, Optional[str]]] = []
+    unreadable: list[tuple[str, str]] = []
+    for path in paths:
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            unreadable.append((path.name, str(exc)))
+            continue
+        anchor_time, note = _resolve_package_anchor_time(
+            doc, anchored_time=anchored_time, no_anchor=no_anchor,
+        )
+        if note is not None and on_note is not None:
+            on_note(path.name, note)
+        loaded.append((path, doc, anchor_time))
+    return loaded, unreadable
+
+
+def _discover_enforcement_triples(
+    record_paths: "list[Path]", directory: Path,
+) -> "tuple[list[tuple[str, Any, bytes, bytes]], list[tuple[str, str]]]":
+    """Discover ``(stem, record, report_bytes, vcek_pem)`` triples by stem.
+
+    Shared by ``verify-enforcements`` and the ``export-article12`` fold:
+    ``NAME.record.json`` pairs with ``NAME.report.bin`` and ``NAME.vcek.pem`` in
+    the same directory. A record missing either companion, or an unreadable
+    file, becomes a failing entry in the returned ``missing`` list, never a
+    silent skip.
+    """
+    triples: list[tuple[str, Any, bytes, bytes]] = []
+    missing: list[tuple[str, str]] = []
+    for record_path in record_paths:
+        if record_path.name.endswith(".record.json"):
+            stem = record_path.name[: -len(".record.json")]
+        else:
+            stem = record_path.stem
+        report_path = directory / f"{stem}.report.bin"
+        vcek_path = directory / f"{stem}.vcek.pem"
+        try:
+            record = json.loads(record_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            missing.append((record_path.name, f"unreadable record ({exc})"))
+            continue
+        if not report_path.is_file():
+            missing.append((record_path.name, f"no companion {report_path.name}"))
+            continue
+        if not vcek_path.is_file():
+            missing.append((record_path.name, f"no companion {vcek_path.name}"))
+            continue
+        try:
+            report_bytes = report_path.read_bytes()
+            vcek_pem = vcek_path.read_bytes()
+        except OSError as exc:
+            missing.append((record_path.name, f"cannot read companion ({exc})"))
+            continue
+        triples.append((stem, record, report_bytes, vcek_pem))
+    return triples, missing
+
+
+def _collect_fold_attachments(
+    args: argparse.Namespace,
+) -> "tuple[Optional[list], Optional[list], Optional[Any], Optional[str]]":
+    """Load the SEP-2828 attachments for the ``export-article12`` fold.
+
+    Returns ``(handoffs, enforcements, trusted_did_document,
+    expected_measurement)``, any of which may be ``None``. Single ``--handoff``
+    files and a ``--handoffs`` directory both feed the handoff list (entry name
+    = file stem, matching the verify verbs' stem discovery). Raises
+    :class:`ValueError` on any load failure (a missing file, an unreadable
+    package, an incomplete enforcement triple, a bad measurement hex) so the
+    fold fails closed before the package is written.
+    """
+    handoffs: Optional[list] = None
+    enforcements: Optional[list] = None
+    trusted: Optional[Any] = None
+    expected = args.expected_measurement
+
+    hpaths: list[Path] = []
+    for f in (args.handoff or []):
+        p = Path(f).expanduser()
+        if not p.is_file():
+            raise ValueError(f"handoff package not found: {p}")
+        hpaths.append(p)
+    if args.handoffs:
+        d = Path(args.handoffs).expanduser()
+        if not d.is_dir():
+            raise ValueError(f"--handoffs is not a directory: {d}")
+        hpaths += sorted(p for p in d.glob("*.json") if p.is_file())
+    if hpaths:
+        loaded, unreadable = _load_handoff_docs(
+            hpaths,
+            on_note=lambda name, note: print(
+                f"vaara export-article12: {name}: {note}", file=sys.stderr),
+        )
+        if unreadable:
+            joined = "; ".join(f"{n} ({e})" for n, e in unreadable)
+            raise ValueError(f"unreadable handoff package(s): {joined}")
+        handoffs = [(p.stem, doc, t) for p, doc, t in loaded]
+
+    if args.enforcements:
+        d = Path(args.enforcements).expanduser()
+        if not d.is_dir():
+            raise ValueError(f"--enforcements is not a directory: {d}")
+        recs = sorted(p for p in d.glob("*.record.json") if p.is_file())
+        triples, missing = _discover_enforcement_triples(recs, d)
+        if missing:
+            joined = "; ".join(f"{n} ({e})" for n, e in missing)
+            raise ValueError(f"incomplete enforcement triple(s): {joined}")
+        enforcements = triples
+
+    if args.trusted_did_document:
+        trusted = _load_json_file(args.trusted_did_document, "trusted DID document")
+
+    if expected is not None:
+        try:
+            raw = bytes.fromhex(expected.strip())
+        except ValueError:
+            raise ValueError("--expected-measurement is not valid hex") from None
+        if len(raw) != 48:
+            raise ValueError(
+                "--expected-measurement must be 48 bytes (96 hex chars, an "
+                "SHA-384 launch measurement)")
+        expected = expected.strip()
+
+    return handoffs, enforcements, trusted, expected
 
 
 def _cmd_verify_handoff(args: argparse.Namespace) -> int:
@@ -2614,18 +2791,14 @@ def _cmd_verify_handoffs(args: argparse.Namespace) -> int:
         print(f"vaara verify-handoffs: {exc}", file=sys.stderr)
         return 1
 
-    packages: list[tuple[str, Any, Optional[str]]] = []
-    unreadable: list[tuple[str, str]] = []
-    for path in paths:
-        try:
-            doc = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            unreadable.append((path.name, str(exc)))
-            continue
-        anchor_time, note = _resolve_handoff_anchor_time(args, doc)
-        if note is not None:
-            print(f"vaara verify-handoffs: {path.name}: {note}", file=sys.stderr)
-        packages.append((path.name, doc, anchor_time))
+    loaded, unreadable = _load_handoff_docs(
+        paths, anchored_time=args.anchored_time, no_anchor=args.no_anchor,
+        on_note=lambda name, note: print(
+            f"vaara verify-handoffs: {name}: {note}", file=sys.stderr),
+    )
+    packages: list[tuple[str, Any, Optional[str]]] = [
+        (p.name, doc, t) for p, doc, t in loaded
+    ]
 
     report = check_handoff_set(
         packages, trusted_did_document=trusted, strict=args.strict
@@ -2707,35 +2880,7 @@ def _cmd_verify_enforcements(args: argparse.Namespace) -> int:
               f"{directory}", file=sys.stderr)
         return 2
 
-    triples: list[tuple[str, Any, bytes, bytes]] = []
-    missing: list[tuple[str, str]] = []
-    for record_path in records:
-        # NAME.record.json -> NAME; the glob default ends in .record.json, but a
-        # custom glob may not, so fall back to the full stem.
-        if record_path.name.endswith(".record.json"):
-            stem = record_path.name[: -len(".record.json")]
-        else:
-            stem = record_path.stem
-        report_path = directory / f"{stem}.report.bin"
-        vcek_path = directory / f"{stem}.vcek.pem"
-        try:
-            record = json.loads(record_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            missing.append((record_path.name, f"unreadable record ({exc})"))
-            continue
-        if not report_path.is_file():
-            missing.append((record_path.name, f"no companion {report_path.name}"))
-            continue
-        if not vcek_path.is_file():
-            missing.append((record_path.name, f"no companion {vcek_path.name}"))
-            continue
-        try:
-            report_bytes = report_path.read_bytes()
-            vcek_pem = vcek_path.read_bytes()
-        except OSError as exc:
-            missing.append((record_path.name, f"cannot read companion ({exc})"))
-            continue
-        triples.append((stem, record, report_bytes, vcek_pem))
+    triples, missing = _discover_enforcement_triples(records, directory)
 
     report = check_enforcement_set(
         triples, expected_measurement=expected, strict=args.strict
@@ -3215,6 +3360,33 @@ def build_parser() -> argparse.ArgumentParser:
         "--anchor-file", default=None, metavar="PATH",
         help="Fold in a pre-fetched time anchor (TimeAnchor JSON over the "
              "trail head) instead of fetching one.",
+    )
+    pa12.add_argument(
+        "--handoff", action="append", default=None, metavar="PKG.json",
+        help="Fold a verified cross-org handoff package (Article 26(6)) in as a "
+             "sidecar. Repeatable. Each is verified at export; one that does not "
+             "verify fails the export. Needs the attestation extra.",
+    )
+    pa12.add_argument(
+        "--handoffs", default=None, metavar="DIR",
+        help="Fold every handoff package matching *.json in this directory.",
+    )
+    pa12.add_argument(
+        "--enforcements", default=None, metavar="DIR",
+        help="Fold confidential-VM enforcement bindings from this directory "
+             "(NAME.record.json + NAME.report.bin + NAME.vcek.pem triples). "
+             "Each is verified at export; one that does not bind fails the "
+             "export.",
+    )
+    pa12.add_argument(
+        "--trusted-did-document", default=None, metavar="DOC.json",
+        help="DID document trusted out of band, used to pin handoff producer "
+             "identity. Without it, producer identity stays self-asserted.",
+    )
+    pa12.add_argument(
+        "--expected-measurement", default=None, metavar="HEX",
+        help="Vetted SHA-384 launch measurement (96 hex chars) to pin folded "
+             "enforcement bindings against.",
     )
     pa12.set_defaults(func=_cmd_trail_export_article12)
 

--- a/tests/test_article12_fold.py
+++ b/tests/test_article12_fold.py
@@ -1,0 +1,216 @@
+"""Tests for the Article 12 regulator-package fold.
+
+``export_article12`` attaches verified SEP-2828 evidence as sidecars under
+``evidence/``: cross-org handoff packages (Article 26(6)) and confidential-VM
+enforcement bindings. These tests prove the fold lands the right bytes, carries
+the honest roll-up, fails closed on a bad attachment, leaves the signed core and
+the Article 19 anchor intact, and that every folded verdict reproduces both
+against the standalone set checkers and Vaara-free from the zip bytes.
+
+See ``docs/design/article12-export-spec.md`` and the ``article12_fold_v0``
+vectors.
+"""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
+from vaara.attestation._enforcement import verify_enforcement
+from vaara.attestation._handoff import verify_handoff
+from vaara.attestation.receipt import check_enforcement_set, check_handoff_set
+from vaara.audit.article12_export import export_article12
+from vaara.audit.verify import verify_signed
+
+VEC = Path(__file__).resolve().parent / "vectors" / "article12_fold_v0"
+EXPECTED = json.loads((VEC / "expected.json").read_text())
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+GEN = _load(VEC / "_generate.py", "_a12_fold_gen")
+EXPORT_TEST = _load(
+    Path(__file__).parent / "test_article12_export.py", "_a12_export_test")
+
+HCASES = {c["name"]: c
+          for c in json.loads((GEN.HANDOFF / "cases.json").read_text())["cases"]}
+ECASES = {c["name"]: c
+          for c in json.loads((GEN.ENFORCEMENT / "cases.json").read_text())["cases"]}
+
+
+def _build(scenario: str, tmp_path: Path) -> Path:
+    return GEN._build(GEN.SCENARIOS[scenario], HCASES, ECASES, tmp_path)
+
+
+def _handoff_tuples(cases):
+    out = []
+    for name in cases:
+        case = HCASES[name]
+        pkg = case["package"]
+        anchored = pkg.get("evidence", {}).get("anchor") is not None
+        out.append((name, pkg, case.get("anchoredTime") if anchored else None))
+    return out
+
+
+def _enforcement_tuples(cases):
+    out = []
+    for name in cases:
+        case = ECASES[name]
+        out.append((name, case["record"], base64.b64decode(case["report_b64"]),
+                    GEN._jwk_to_pem(case["vcek_jwk"])))
+    return out
+
+
+@pytest.mark.parametrize("scenario", ["full", "pinned_handoff", "enforcement_only"])
+def test_membership_and_rollup(scenario, tmp_path):
+    out = _build(scenario, tmp_path)
+    with zipfile.ZipFile(out) as zf:
+        members = sorted(m for m in zf.namelist() if m.startswith("evidence/"))
+        summary = json.loads(zf.read("evidence/attestations_summary.json"))
+    exp = EXPECTED[scenario]
+    assert members == exp["evidence_members"]
+    if "handoff" in exp:
+        rep = summary["handoff"]["report"]
+        assert {k: rep[k] for k in GEN.HANDOFF_KEYS} == exp["handoff"]
+    if "enforcement" in exp:
+        rep = summary["enforcement"]["report"]
+        assert {k: rep[k] for k in GEN.ENFORCEMENT_KEYS} == exp["enforcement"]
+
+
+def test_signed_core_still_verifies(tmp_path):
+    # Folding evidence in via append mode must not disturb the signed trail.
+    assert verify_signed(_build("full", tmp_path)).ok
+
+
+def test_report_section_and_honesty_notes(tmp_path):
+    out = _build("full", tmp_path)
+    with zipfile.ZipFile(out) as zf:
+        md = zf.read("article12_report.md").decode("utf-8")
+    assert "## Cross-org handoff and enforcement evidence" in md
+    assert "Article 26(6)" in md
+    assert "Where enforcement ran (confidential VM)" in md
+    assert "not attested in this release" in md
+    assert "caller_supplied_unverified" in md
+    assert "only un-forgeable component" in md
+    # The em-dash is the one house no-go in shipped prose.
+    assert "—" not in md
+
+
+def test_rollup_matches_standalone_set_checkers(tmp_path):
+    out = _build("full", tmp_path)
+    with zipfile.ZipFile(out) as zf:
+        summary = json.loads(zf.read("evidence/attestations_summary.json"))
+    h = check_handoff_set(
+        _handoff_tuples(["clean_no_anchor", "corroborated"]),
+        trusted_did_document=None, strict=False).to_dict()
+    assert {k: summary["handoff"]["report"][k] for k in GEN.HANDOFF_KEYS} == \
+        {k: h[k] for k in GEN.HANDOFF_KEYS}
+    e = check_enforcement_set(
+        _enforcement_tuples(["clean_bound", "pinned_measurement_match"]),
+        expected_measurement=GEN.SCENARIOS["full"]["enforcement"]["expected_measurement"],
+        strict=False).to_dict()
+    assert {k: summary["enforcement"]["report"][k] for k in GEN.ENFORCEMENT_KEYS} == \
+        {k: e[k] for k in GEN.ENFORCEMENT_KEYS}
+
+
+def test_independent_checker_reproduces_from_zip(tmp_path):
+    out = _build("full", tmp_path)
+    proc = subprocess.run(
+        [sys.executable, str(VEC / "_check_independent.py"), str(out)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_folded_handoff_verifies_from_zip_bytes(tmp_path):
+    # The v0.62 trap: re-verify each attachment FROM the folded bytes.
+    out = _build("full", tmp_path)
+    with zipfile.ZipFile(out) as zf:
+        summary = json.loads(zf.read("evidence/attestations_summary.json"))
+        for member in [n for n in zf.namelist()
+                       if n.startswith("evidence/handoff/") and n.endswith(".json")]:
+            base = member[len("evidence/handoff/"):-len(".json")]
+            doc = json.loads(zf.read(member))
+            attested = summary["handoff"]["anchoredTimes"].get(base)
+            assert verify_handoff(doc, anchor_attested_time=attested).ok
+
+
+def test_folded_enforcement_binds_from_zip_bytes(tmp_path):
+    out = _build("full", tmp_path)
+    with zipfile.ZipFile(out) as zf:
+        summary = json.loads(zf.read("evidence/attestations_summary.json"))
+        meas = summary["enforcement"]["expectedMeasurement"]
+        for member in [n for n in zf.namelist() if n.endswith(".record.json")]:
+            base = member[len("evidence/enforcement/"):-len(".record.json")]
+            record = json.loads(zf.read(member))
+            report_bytes = zf.read(f"evidence/enforcement/{base}.report.bin")
+            vcek_pem = zf.read(f"evidence/enforcement/{base}.vcek.pem")
+            v = verify_enforcement(
+                record, report_bytes, vcek_pem, expected_measurement=meas)
+            assert v.ok and v.bound
+
+
+def test_fail_closed_bad_handoff(tmp_path):
+    spec = GEN.FAIL_CLOSED["bad_handoff"]["handoff"]
+    out = tmp_path / "bad.zip"
+    with pytest.raises(ValueError, match="signed_after_retirement"):
+        export_article12(
+            GEN._trail(), out, signer_key=GEN._key(tmp_path),
+            handoffs=_handoff_tuples(spec["cases"]))
+    assert not out.exists()
+
+
+def test_fail_closed_bad_enforcement(tmp_path):
+    spec = GEN.FAIL_CLOSED["bad_enforcement"]["enforcement"]
+    out = tmp_path / "bad.zip"
+    with pytest.raises(ValueError, match="bad_signature"):
+        export_article12(
+            GEN._trail(), out, signer_key=GEN._key(tmp_path),
+            enforcements=_enforcement_tuples(spec["cases"]),
+            expected_measurement=spec["expected_measurement"])
+    assert not out.exists()
+
+
+def test_anchor_and_fold_coexist(tmp_path):
+    # The Article 19 time anchor and the folded SEP-2828 evidence live together.
+    pytest.importorskip("asn1crypto")
+    trail = EXPORT_TEST._make_trail()
+    anchor = EXPORT_TEST._anchor_over_trail(trail)
+    out = tmp_path / "both.zip"
+    export_article12(
+        trail, out, signer_key=GEN._key(tmp_path), time_anchor=anchor,
+        handoffs=_handoff_tuples(["clean_no_anchor", "corroborated"]))
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+        md = zf.read("article12_report.md").decode("utf-8")
+    assert "time_anchor.json" in names
+    assert any(n.startswith("evidence/handoff/") for n in names)
+    assert "External time anchor (Article 19)" in md
+    assert "## Cross-org handoff and enforcement evidence" in md
+    assert verify_signed(out).ok
+
+
+def test_no_attachments_states_none_folded(tmp_path):
+    out = tmp_path / "plain.zip"
+    export_article12(GEN._trail(), out, signer_key=GEN._key(tmp_path))
+    with zipfile.ZipFile(out) as zf:
+        names = set(zf.namelist())
+        md = zf.read("article12_report.md").decode("utf-8")
+    assert not any(n.startswith("evidence/") for n in names)
+    assert "No cross-org handoff or confidential-VM enforcement evidence is folded" \
+        in md

--- a/tests/vectors/article12_fold_v0/README.md
+++ b/tests/vectors/article12_fold_v0/README.md
@@ -1,0 +1,42 @@
+# article12_fold_v0
+
+Conformance vectors for the EU AI Act Article 12 regulator-package **fold**:
+`vaara trail export-article12` attaching verified SEP-2828 evidence as sidecars
+under `evidence/`. Cross-org handoff packages (Article 26(6) deployer custody)
+and confidential-VM enforcement bindings ("where it ran") are verified at export
+and folded alongside the signed trail, the Article 19 time anchor, and the
+record-keeping report.
+
+These vectors do not invent new crypto. They reuse the committed corpora next
+door, `cross_org_handoff_v0` and `enforcement_attestation_v0`, fold named
+subsets into a real package, and pin the roll-up the package carries in
+`evidence/attestations_summary.json`.
+
+## Files
+
+- `fold.json`: the scenarios. Each names handoff cases, enforcement cases, and
+  the verifier-side inputs the fold applies (a trusted DID document to pin
+  handoff producer identity, an expected launch measurement to pin enforcement).
+  `fail_closed` names scenarios whose attachment does not verify, which must
+  abort the export with no package written.
+- `expected.json`: for each producing scenario, the folded `evidence/`
+  membership and the handoff / enforcement roll-up the package carries.
+- `_generate.py`: builds each package with `export_article12` (reusing each
+  package's pre-verified anchor time, exactly as `handoff_set_v0` does) and
+  records `expected.json`. No zip is committed: it carries a fresh signature and
+  a runtime `.vcek.pem`. The test rebuilds it in a temp directory.
+- `_check_independent.py <package.zip>`: the Vaara-free checker. It opens a
+  produced package and reproduces every folded verdict from the **same bytes
+  folded into the zip**, composing the two single-verb suites' own `_evaluate`
+  functions, then asserts each reproduced roll-up equals the one the package
+  claims. It never imports Vaara.
+
+## Honesty model
+
+The fold never upgrades a verdict. A handoff is corroborated only with a
+verified anchor and pinned only against a trusted DID document; an enforcement
+binding is never "attested" (the VCEK chain to AMD's root is not validated). The
+eIDAS time anchor stays the only un-forgeable component of the package, and the
+report says so. An attachment that does not verify fails the export closed.
+
+Regenerate with `python tests/vectors/article12_fold_v0/_generate.py`.

--- a/tests/vectors/article12_fold_v0/_check_independent.py
+++ b/tests/vectors/article12_fold_v0/_check_independent.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Independent checker for the article12_fold_v0 vectors.
+
+Reads a produced Article 12 package zip and reproduces every folded attestation
+verdict WITHOUT importing Vaara, from the same bytes folded into the zip (not a
+re-snapshot of the source fixtures). It imports only the standard library,
+``cryptography``, and the two single-verb suites' own Vaara-free checkers
+(``cross_org_handoff_v0`` and ``enforcement_attestation_v0``). For the package:
+
+1. Read ``evidence/attestations_summary.json`` (the roll-up the package claims).
+2. For each ``evidence/handoff/<name>.json``, rebuild the single-verb case from
+   the folded package bytes plus the summary's recorded anchor time, trusted DID
+   document, and strict flag; run the handoff checker; reproduce the handoff
+   roll-up the same way ``check_handoff_set`` does.
+3. For each ``evidence/enforcement/<name>`` triple, read the folded
+   ``.record.json`` / ``.report.bin`` / ``.vcek.pem``, convert the VCEK PEM back
+   to the JWK the checker takes, run the enforcement checker under the summary's
+   expected measurement and strict flag, and reproduce that roll-up.
+4. Assert each reproduced roll-up equals the one folded into the package.
+
+The chain from folded bytes to set verdict never touches Vaara. Run:
+``python tests/vectors/article12_fold_v0/_check_independent.py <package.zip>``.
+Exit code 0 means every folded verdict reproduced and matched.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+HERE = Path(__file__).resolve().parent
+HANDOFF = HERE.parent / "cross_org_handoff_v0"
+ENFORCEMENT = HERE.parent / "enforcement_attestation_v0"
+
+HANDOFF_KEYS = ("ok", "strict", "total", "loaded", "passed", "verifiable",
+                "corroborated", "pinned", "pinningGap")
+ENFORCEMENT_KEYS = ("ok", "strict", "total", "loaded", "passed", "bound",
+                    "measurementPinned", "tierCounts", "pinningGap")
+TIER_NAMES = ("unverified", "bound", "measurement_pinned")
+
+
+def _load_single_checker(path: Path, mod_name: str):
+    """Load a single-verb suite's Vaara-free ``_evaluate`` from its checker."""
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    if spec is None or spec.loader is None:  # pragma: no cover - import guard
+        raise RuntimeError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return getattr(mod, "_evaluate")
+
+
+def _b64url(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _pem_to_jwk(pem: bytes) -> dict:
+    """Recover the P-384 JWK the enforcement checker takes from a VCEK PEM."""
+    pub = load_pem_public_key(pem)
+    nums = pub.public_numbers()  # type: ignore[attr-defined]
+    size = (nums.curve.key_size + 7) // 8
+    return {
+        "kty": "EC", "crv": "P-384",
+        "x": _b64url(nums.x.to_bytes(size, "big")),
+        "y": _b64url(nums.y.to_bytes(size, "big")),
+    }
+
+
+def _handoff_rollup(verdicts: list, *, strict: bool) -> dict:
+    total = len(verdicts)
+    passed = sum(1 for v in verdicts if v["ok"])
+    pinned = sum(1 for v in verdicts if v["producer_identity_basis"] == "pinned")
+    return {
+        "ok": passed == total, "strict": strict, "total": total, "loaded": total,
+        "passed": passed,
+        "verifiable": sum(1 for v in verdicts if v["verifiable"]),
+        "corroborated": sum(1 for v in verdicts if v["corroborated"]),
+        "pinned": pinned, "pinningGap": total > 0 and pinned == 0,
+    }
+
+
+def _enforcement_rollup(verdicts: list, *, strict: bool) -> dict:
+    total = len(verdicts)
+    passed = sum(1 for v in verdicts if v["ok"])
+    pinned = sum(1 for v in verdicts if v["measurement_basis"] == "pinned")
+    tier_counts = {name: 0 for name in TIER_NAMES}
+    for v in verdicts:
+        tier_counts[v["tier"]] = tier_counts.get(v["tier"], 0) + 1
+    return {
+        "ok": passed == total, "strict": strict, "total": total, "loaded": total,
+        "passed": passed, "bound": sum(1 for v in verdicts if v["bound"]),
+        "measurementPinned": pinned, "tierCounts": tier_counts,
+        "pinningGap": total > 0 and pinned == 0,
+    }
+
+
+def _check_zip(zip_path: Path) -> list:
+    failures: list = []
+    judge_handoff = _load_single_checker(
+        HANDOFF / "_check_independent.py", "_h_single")
+    judge_enforcement = _load_single_checker(
+        ENFORCEMENT / "_check_independent.py", "_e_single")
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = set(zf.namelist())
+        summary = json.loads(zf.read("evidence/attestations_summary.json"))
+
+        h = summary["handoff"]
+        if h["present"]:
+            strict = h["strict"]
+            verdicts = []
+            members = sorted(
+                n for n in names
+                if n.startswith("evidence/handoff/") and n.endswith(".json"))
+            for member in members:
+                base = member[len("evidence/handoff/"):-len(".json")]
+                doc = json.loads(zf.read(member))
+                case = {"package": doc, "strict": strict,
+                        "anchoredTime": h["anchoredTimes"].get(base)}
+                if h.get("trustedDidDocument") is not None:
+                    case["trustedDidDocument"] = h["trustedDidDocument"]
+                verdicts.append(judge_handoff(case))
+            got = _handoff_rollup(verdicts, strict=strict)
+            want = {k: h["report"][k] for k in HANDOFF_KEYS}
+            if {k: got[k] for k in HANDOFF_KEYS} != want:
+                failures.append(f"handoff:\n    folded {want}\n    reproduced {got}")
+            else:
+                print(f"handoff: OK ok={got['ok']} verifiable={got['verifiable']} "
+                      f"corroborated={got['corroborated']} pinned={got['pinned']}")
+
+        e = summary["enforcement"]
+        if e["present"]:
+            strict = e["strict"]
+            verdicts = []
+            records = sorted(
+                n for n in names
+                if n.startswith("evidence/enforcement/")
+                and n.endswith(".record.json"))
+            for member in records:
+                base = member[len("evidence/enforcement/"):-len(".record.json")]
+                record = json.loads(zf.read(member))
+                report_bytes = zf.read(f"evidence/enforcement/{base}.report.bin")
+                vcek_pem = zf.read(f"evidence/enforcement/{base}.vcek.pem")
+                case = {"record": record,
+                        "report_b64": base64.b64encode(report_bytes).decode("ascii"),
+                        "vcek_jwk": _pem_to_jwk(vcek_pem),
+                        "expected_measurement": e["expectedMeasurement"],
+                        "strict": strict}
+                verdicts.append(judge_enforcement(case))
+            got = _enforcement_rollup(verdicts, strict=strict)
+            want = {k: e["report"][k] for k in ENFORCEMENT_KEYS}
+            if {k: got[k] for k in ENFORCEMENT_KEYS} != want:
+                failures.append(
+                    f"enforcement:\n    folded {want}\n    reproduced {got}")
+            else:
+                print(f"enforcement: OK ok={got['ok']} bound={got['bound']} "
+                      f"pinned={got['measurementPinned']}")
+    return failures
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: _check_independent.py <article12_package.zip>", file=sys.stderr)
+        return 2
+    failures = _check_zip(Path(sys.argv[1]))
+    if failures:
+        print("\nFAIL:\n  " + "\n  ".join(failures))
+        return 1
+    print("\nall folded attestations reproduced Vaara-free from the zip bytes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/article12_fold_v0/_generate.py
+++ b/tests/vectors/article12_fold_v0/_generate.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Generate the article12_fold_v0 vectors from the single-verb corpora.
+
+The Article 12 fold attaches verified SEP-2828 evidence as sidecars inside the
+regulator package: cross-org handoff packages (Article 26(6)) and
+confidential-VM enforcement bindings, each verified at export and folded under
+``evidence/``. This script does not invent new crypto. It reuses the committed
+``cross_org_handoff_v0`` and ``enforcement_attestation_v0`` cases, folds named
+subsets into a real package with :func:`export_article12`, and records the
+roll-up the package carries in ``evidence/attestations_summary.json`` plus the
+``evidence/`` membership. ``expected.json`` is the committed truth the
+in-process test (Vaara) and ``_check_independent.py`` (Vaara-free, reading the
+folded bytes back out of the zip) both reproduce.
+
+No zip is committed: it carries a fresh signature and a runtime ``.vcek.pem``.
+The test rebuilds it in a temp dir and runs the Vaara-free checker over it.
+
+Run: ``python tests/vectors/article12_fold_v0/_generate.py``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import tempfile
+import zipfile
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vaara.audit.article12_export import export_article12
+from vaara.audit.trail import AuditTrail
+from vaara.taxonomy.actions import ActionRequest, create_default_registry
+
+HERE = Path(__file__).resolve().parent
+HANDOFF = HERE.parent / "cross_org_handoff_v0"
+ENFORCEMENT = HERE.parent / "enforcement_attestation_v0"
+
+# Scenarios that produce a package, named by the evidence they fold and the
+# verifier-side inputs the fold applies. ``trusted_from_case`` pins handoff
+# producer identity against that case's archived DID document.
+SCENARIOS: dict[str, dict] = {
+    # A handoff with no anchor beside an anchor-corroborated one, plus two
+    # enforcement binds, one pinned to its launch measurement. The handoff set
+    # pins no producer (pinning gap); the enforcement set pins one image.
+    "full": {
+        "handoff": {"cases": ["clean_no_anchor", "corroborated"],
+                    "trusted_from_case": None},
+        "enforcement": {"cases": ["clean_bound", "pinned_measurement_match"],
+                        "expected_measurement": (
+                            "0102030405060708090a0b0c0d0e0f10"
+                            "1112131415161718191a1b1c1d1e1f20"
+                            "2122232425262728292a2b2c2d2e2f30")},
+    },
+    # A single handoff pinned against a trusted DID document: producer pinned,
+    # no pinning gap, anchor-corroborated.
+    "pinned_handoff": {
+        "handoff": {"cases": ["pinned_corroborated"],
+                    "trusted_from_case": "pinned_corroborated"},
+        "enforcement": None,
+    },
+    # Enforcement only, unpinned: binds to a CVM but to no vetted image, so the
+    # enforcement pinning gap fires (advisory, does not gate).
+    "enforcement_only": {
+        "handoff": None,
+        "enforcement": {"cases": ["clean_bound"], "expected_measurement": None},
+    },
+}
+
+# Scenarios that must FAIL the export (fail closed): an attachment that does not
+# verify aborts the whole package, no zip written. Exercised by the test.
+FAIL_CLOSED: dict[str, dict] = {
+    "bad_handoff": {
+        "handoff": {"cases": ["clean_no_anchor", "signed_after_retirement"],
+                    "trusted_from_case": None},
+        "enforcement": None,
+    },
+    "bad_enforcement": {
+        "handoff": None,
+        "enforcement": {"cases": ["clean_bound", "bad_signature"],
+                        "expected_measurement": None},
+    },
+}
+
+HANDOFF_KEYS = ("ok", "strict", "total", "loaded", "passed", "verifiable",
+                "corroborated", "pinned", "pinningGap")
+ENFORCEMENT_KEYS = ("ok", "strict", "total", "loaded", "passed", "bound",
+                    "measurementPinned", "tierCounts", "pinningGap")
+
+_REGISTRY = create_default_registry()
+_TX = _REGISTRY.get("tx.transfer")
+
+
+def _jwk_to_pem(jwk: dict) -> bytes:
+    def _i(v: str) -> int:
+        return int.from_bytes(base64.urlsafe_b64decode(v + "=" * (-len(v) % 4)), "big")
+    pub = ec.EllipticCurvePublicNumbers(
+        _i(jwk["x"]), _i(jwk["y"]), ec.SECP384R1()).public_key()
+    return pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def _trail() -> AuditTrail:
+    trail = AuditTrail()
+    for i in range(2):
+        req = ActionRequest(agent_id=f"agent-{i}", tool_name="send_funds",
+                            action_type=_TX, parameters={"to": f"0x{i}", "amount": i})
+        action_id = trail.record_action_requested(req)
+        trail.record_decision(action_id, f"agent-{i}", "send_funds", "allow", "t", 0.5)
+        trail.record_execution(action_id, f"agent-{i}", "send_funds", {"ok": True})
+        trail.record_outcome(action_id, f"agent-{i}", "send_funds", "success")
+    return trail
+
+
+def _key(d: Path) -> Path:
+    k = Ed25519PrivateKey.generate()
+    p = d / "signer.pem"
+    p.write_bytes(k.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption()))
+    return p
+
+
+def _build(spec: dict, hcases: dict, ecases: dict, work: Path) -> Path:
+    """Fold one scenario into a real package and return the zip path."""
+    handoffs = None
+    enforcements = None
+    trusted = None
+    expected_measurement = None
+
+    if spec["handoff"]:
+        h = spec["handoff"]
+        handoffs = []
+        for name in h["cases"]:
+            case = hcases[name]
+            package = case["package"]
+            anchored = package.get("evidence", {}).get("anchor") is not None
+            handoffs.append(
+                (name, package, case.get("anchoredTime") if anchored else None))
+        if h["trusted_from_case"] is not None:
+            trusted = hcases[h["trusted_from_case"]]["trustedDidDocument"]
+
+    if spec["enforcement"]:
+        e = spec["enforcement"]
+        enforcements = []
+        for name in e["cases"]:
+            case = ecases[name]
+            enforcements.append((
+                name, case["record"], base64.b64decode(case["report_b64"]),
+                _jwk_to_pem(case["vcek_jwk"])))
+        expected_measurement = e["expected_measurement"]
+
+    out = work / "pack.zip"
+    if out.exists():
+        out.unlink()
+    export_article12(
+        _trail(), out, signer_key=_key(work),
+        handoffs=handoffs, enforcements=enforcements,
+        trusted_did_document=trusted, expected_measurement=expected_measurement)
+    return out
+
+
+def main() -> int:
+    hcases = {c["name"]: c
+              for c in json.loads((HANDOFF / "cases.json").read_text())["cases"]}
+    ecases = {c["name"]: c
+              for c in json.loads((ENFORCEMENT / "cases.json").read_text())["cases"]}
+
+    expected: dict[str, dict] = {}
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        for name, spec in SCENARIOS.items():
+            zip_path = _build(spec, hcases, ecases, work)
+            with zipfile.ZipFile(zip_path) as zf:
+                members = sorted(m for m in zf.namelist() if m.startswith("evidence/"))
+                summary = json.loads(zf.read("evidence/attestations_summary.json"))
+            entry: dict = {"evidence_members": members}
+            if summary["handoff"]["present"]:
+                rep = summary["handoff"]["report"]
+                entry["handoff"] = {k: rep[k] for k in HANDOFF_KEYS}
+            if summary["enforcement"]["present"]:
+                rep = summary["enforcement"]["report"]
+                entry["enforcement"] = {k: rep[k] for k in ENFORCEMENT_KEYS}
+            expected[name] = entry
+
+    fold_doc = {"scenarios": SCENARIOS, "fail_closed": FAIL_CLOSED}
+    (HERE / "fold.json").write_text(json.dumps(fold_doc, indent=2, sort_keys=True) + "\n")
+    (HERE / "expected.json").write_text(
+        json.dumps(expected, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {len(SCENARIOS)} scenarios to fold.json and expected.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/article12_fold_v0/expected.json
+++ b/tests/vectors/article12_fold_v0/expected.json
@@ -1,0 +1,81 @@
+{
+  "enforcement_only": {
+    "enforcement": {
+      "bound": 1,
+      "loaded": 1,
+      "measurementPinned": 0,
+      "ok": true,
+      "passed": 1,
+      "pinningGap": true,
+      "strict": false,
+      "tierCounts": {
+        "bound": 1,
+        "measurement_pinned": 0,
+        "unverified": 0
+      },
+      "total": 1
+    },
+    "evidence_members": [
+      "evidence/attestations_summary.json",
+      "evidence/enforcement/clean_bound.record.json",
+      "evidence/enforcement/clean_bound.report.bin",
+      "evidence/enforcement/clean_bound.vcek.pem"
+    ]
+  },
+  "full": {
+    "enforcement": {
+      "bound": 2,
+      "loaded": 2,
+      "measurementPinned": 2,
+      "ok": true,
+      "passed": 2,
+      "pinningGap": false,
+      "strict": false,
+      "tierCounts": {
+        "bound": 0,
+        "measurement_pinned": 2,
+        "unverified": 0
+      },
+      "total": 2
+    },
+    "evidence_members": [
+      "evidence/attestations_summary.json",
+      "evidence/enforcement/clean_bound.record.json",
+      "evidence/enforcement/clean_bound.report.bin",
+      "evidence/enforcement/clean_bound.vcek.pem",
+      "evidence/enforcement/pinned_measurement_match.record.json",
+      "evidence/enforcement/pinned_measurement_match.report.bin",
+      "evidence/enforcement/pinned_measurement_match.vcek.pem",
+      "evidence/handoff/clean_no_anchor.json",
+      "evidence/handoff/corroborated.json"
+    ],
+    "handoff": {
+      "corroborated": 1,
+      "loaded": 2,
+      "ok": true,
+      "passed": 2,
+      "pinned": 0,
+      "pinningGap": true,
+      "strict": false,
+      "total": 2,
+      "verifiable": 2
+    }
+  },
+  "pinned_handoff": {
+    "evidence_members": [
+      "evidence/attestations_summary.json",
+      "evidence/handoff/pinned_corroborated.json"
+    ],
+    "handoff": {
+      "corroborated": 1,
+      "loaded": 1,
+      "ok": true,
+      "passed": 1,
+      "pinned": 1,
+      "pinningGap": false,
+      "strict": false,
+      "total": 1,
+      "verifiable": 1
+    }
+  }
+}

--- a/tests/vectors/article12_fold_v0/fold.json
+++ b/tests/vectors/article12_fold_v0/fold.json
@@ -1,0 +1,60 @@
+{
+  "fail_closed": {
+    "bad_enforcement": {
+      "enforcement": {
+        "cases": [
+          "clean_bound",
+          "bad_signature"
+        ],
+        "expected_measurement": null
+      },
+      "handoff": null
+    },
+    "bad_handoff": {
+      "enforcement": null,
+      "handoff": {
+        "cases": [
+          "clean_no_anchor",
+          "signed_after_retirement"
+        ],
+        "trusted_from_case": null
+      }
+    }
+  },
+  "scenarios": {
+    "enforcement_only": {
+      "enforcement": {
+        "cases": [
+          "clean_bound"
+        ],
+        "expected_measurement": null
+      },
+      "handoff": null
+    },
+    "full": {
+      "enforcement": {
+        "cases": [
+          "clean_bound",
+          "pinned_measurement_match"
+        ],
+        "expected_measurement": "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f30"
+      },
+      "handoff": {
+        "cases": [
+          "clean_no_anchor",
+          "corroborated"
+        ],
+        "trusted_from_case": null
+      }
+    },
+    "pinned_handoff": {
+      "enforcement": null,
+      "handoff": {
+        "cases": [
+          "pinned_corroborated"
+        ],
+        "trusted_from_case": "pinned_corroborated"
+      }
+    }
+  }
+}


### PR DESCRIPTION
The Article 12 regulator pack now folds in cross-org handoff (Article 26(6)) and confidential-VM enforcement evidence, and verifies a full directory of records in one pass.

One deployer command produces one package coherent across Article 12 (the signed record-keeping trail), Article 19 (existence in time under the eIDAS anchor), and Article 26(6) (the records a deployer hands its own regulator), with an optional "where enforcement ran" confidential-VM attestation alongside.

## What this adds

`vaara trail export-article12 --handoffs <dir> --enforcements <dir>` (also `--handoff <pkg.json>`, repeatable) folds verified SEP-2828 evidence in as sidecars under `evidence/`:

```
evidence/handoff/<name>.json
evidence/enforcement/<name>.{record.json,report.bin,vcek.pem}
evidence/attestations_summary.json
```

The report gains a "Cross-org handoff and enforcement evidence" section mapping the roll-up to Article 26(6) custody and the confidential-VM evidence. `--trusted-did-document` pins handoff producer identity out of band; `--expected-measurement` pins enforcement launch images.

## Fail closed

Each attachment is verified at export, before any bytes are written, by the same `check_handoff_set` / `check_enforcement_set` the verify verbs use. A single attachment that does not verify aborts the export with no package written. There is no `--skip-invalid` in v0: the pack never ships evidence it cannot back.

## The seam, respected

Article 12 export operates on the audit trail (governance plane). Handoff and enforcement are SEP-2828 records (attestation plane), folded as verified sidecars, not pretended to be trail records, and not brought under the trail signature.

## Honesty model (unchanged)

A more complete pack, not a certificate. The eIDAS time anchor stays the only un-forgeable component. A handoff is corroborated only with a verified anchor and pinned only against a trusted DID document. An enforcement binding is never "attested" in this release (the VCEK chain to AMD's root is not validated; `vcek_chain_basis` stays `caller_supplied_unverified`, `enforcement_logic_basis` stays `not_established`).

## Tests

`article12_fold_v0` vectors reuse the `cross_org_handoff_v0` and `enforcement_attestation_v0` corpora; the Vaara-free checker reproduces every folded verdict from the same bytes folded into the zip (the v0.62 trap). The `verify-handoffs` / `verify-enforcements` load and stem-discovery logic is factored into shared helpers reused by the fold. 1620 passed, ruff clean.

Lands to main unreleased. Ships as 0.67.0 together with the already-merged batch surfaces (verify-handoffs / verify-enforcements), one coherent Article 12 release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Article 12 export now packages verified cross-org handoff and confidential-VM enforcement evidence as sidecars within the exported package.
  * New CLI options enable including handoff and enforcement attachments during export with pinning support.
  * Evidence attachments are verified during export with fail-closed behavior (invalid evidence prevents export).
  * Export includes attestation summaries and evidence mapping for regulator review.

* **Documentation**
  * Added specifications and conformance vectors for independent offline verification of folded evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->