### PR TITLE
v0.67.0: Article 12 pack folds in cross-org handoff and confidential-VM enforcement evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.67.0] - 2026-06-09
 
 ### Added
 - The Article 12 regulator pack now folds in cross-org handoff (Article 26(6))

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.66.0",
+  "version": "0.67.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.66.0"
+version = "0.67.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.66.0",
+  "version": "0.67.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.66.0",
+  "version": "0.67.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.66.0",
+      "version": "0.67.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.66.0"
+__version__ = "0.67.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Release 0.67.0. Bundles the export-article12 fold (PR #228) with the already-merged verify-handoffs / verify-enforcements batch surfaces (PR #227) into one coherent Article 12 release.

The Article 12 regulator pack now folds in cross-org handoff (Article 26(6)) and confidential-VM enforcement evidence, and verifies a full directory of records in one pass.

Version bumped to 0.67.0 across pyproject, `__init__`, clients/ts, and the two MCP server manifests; CHANGELOG Unreleased rolled to 0.67.0. The Release workflow lifts the `## [0.67.0]` section into the GitHub Release body.