### PR TITLE
feat: no-2787 fallback binds a named projection, not the whole _meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   rpelevin on modelcontextprotocol#2852.
 
 ### Added
-- The no-SEP-2787 fallback case in the `decision_pairing_v0` corpus now commits
-  the observed `tools/call` request envelope as a first-class fixture input, so
-  an independent reader recomputes the back-link digest instead of trusting a
-  stored value. A replayed envelope with different arguments recomputes to a
-  different digest and does not bind. `vaara.attestation.decision`
-  `.request_envelope_digest` and `.verify_decision_fallback_binding` implement
-  the recompute in the reference verifier.
+- The no-SEP-2787 fallback back-link now binds a **named, versioned projection**
+  of the request envelope (the `tools/call` `name`+`arguments` plus the
+  `_meta.authorization_binding` block carrying the per-call `nonce` and
+  `projectionVersion`), not the whole observed `_meta`. Observation-local and
+  transport-local `_meta` (progress tokens, trace context, UI hints, fields a
+  gateway adds or strips) is excluded, so a gateway view and a provider view of
+  the same call project to the same digest; changing the bound params or the
+  binding block breaks the back-link; an absent or malformed binding block fails
+  closed instead of widening the preimage to the whole `_meta`.
+  `vaara.attestation.decision` adds `fallback_projection`,
+  `MalformedFallbackBindingError`, and `FALLBACK_PROJECTION_V1`;
+  `request_envelope_digest` and `verify_decision_fallback_binding` implement the
+  projection and fail-closed contract in the reference verifier. The
+  `decision_pairing_v0` corpus carries the provider, gateway, replayed,
+  tampered-binding, and no-binding envelopes as first-class fixture inputs, and
+  the Vaara-free checker reproduces every verdict. Refines the no-2787 fallback
+  shape discussed on modelcontextprotocol#2867.
 
 ## [0.67.0] - 2026-06-09
 

--- a/docs/sep/sep-server-execution-record.md
+++ b/docs/sep/sep-server-execution-record.md
@@ -179,10 +179,29 @@ following top-level fields.
 
 If no SEP-2787 attestation exists for the call (the deployment does not run
 2787), the server MUST instead bind the request by setting `attestationDigest` to
-`sha256:<hex>` over the JCS-canonical encoding of the request envelope it
-observed (the `tools/call` params plus `_meta`), and set `attestationNonce` to a
-server-chosen per-call nonce. The binding is to the request **instance**, not
-only its content.
+`sha256:<hex>` over the JCS-canonical encoding of a **named, versioned
+projection** of the request envelope, not the whole observed `_meta`. The
+projection commits to exactly:
+
+- the `tools/call` `name` and `arguments` (the call params that bind to the
+  decision);
+- the named binding block `_meta.authorization_binding`, which carries the
+  server-chosen per-call `nonce` and the `projectionVersion` in force (this
+  release: `sep2828-fallback/1`).
+
+Every other `_meta` field is observation-local or transport-local (progress
+tokens, trace context, UI hints, unrelated SEP blocks, fields a gateway can
+legitimately add or strip) and MUST be excluded, so a gateway view and a
+provider view of the same call project to the same digest. The server sets
+`attestationNonce` to echo `_meta.authorization_binding.nonce`. The binding is to
+the request **instance**, not only its content.
+
+A verifier reconstructs the same named projection from the same named fields and
+compares the digest. If the projection cannot be reconstructed (the
+`authorization_binding` block is absent, malformed, missing its `nonce`, or
+carries an unsupported `projectionVersion`), the fallback case is **not
+conformant** and the verifier MUST fail closed rather than widen the preimage to
+the whole `_meta`.
 
 **`decisionDerived`** carries the decision and the basis for it:
 
@@ -250,8 +269,8 @@ hold:
   not only content-binding: two byte-identical calls produce two attestations
   with distinct nonces and therefore distinct `attestationDigest` values, so a
   record cannot be replayed against a different instance of the same call. In the
-  no-attestation fallback, the shared `backLink` is over the request envelope
-  instead, and Check A anchors on that.
+  no-attestation fallback, the shared `backLink` is over the named request
+  envelope projection instead, and Check A anchors on that.
 - **Check B (outcome-to-decision digest, the normative pairing).** The outcome
   record's `outcomeDerived.decisionDigest` equals `sha256:<hex>` over the JCS
   canonical full wire bytes of *this* decision record. Check A alone admits a

--- a/src/vaara/attestation/_decision_verifier.py
+++ b/src/vaara/attestation/_decision_verifier.py
@@ -25,6 +25,7 @@ from vaara.attestation._decision_types import DecisionRecord
 from vaara.attestation._receipt_types import ExecutionReceipt
 from vaara.attestation._receipt_verifier import (
     BACK_LINK_MISMATCH,
+    FALLBACK_BINDING_MALFORMED,
     BackLinkResult,
     attestation_digest,
 )
@@ -66,18 +67,93 @@ def verify_decision_back_link(
     return BackLinkResult(ok=True)
 
 
-def request_envelope_digest(request_envelope: Mapping[str, Any]) -> str:
-    """``sha256:<hex>`` over the JCS canonicalization of an observed request
-    envelope (the ``tools/call`` params plus ``_meta``).
+# The named projection version that a no-SEP-2787 fallback digest commits
+# to. It is carried in the envelope's binding block and reconstructed by the
+# verifier, so a future projection rule is a new version, not a silent change.
+FALLBACK_PROJECTION_V1 = "sep2828-fallback/1"
 
-    This is the no-SEP-2787 fallback preimage: when a deployment does not
-    run 2787, the decision back-link binds the request instance by this
-    digest instead of an attestation digest (SEP-2828 backLink, fallback
-    path). The binding is to the request instance the server observed, so
-    a re-presented envelope whose arguments differ recomputes to a
-    different digest and does not bind.
+# The named binding block under ``_meta`` whose contents are authoritative for
+# the fallback digest. Everything else under ``_meta`` is excluded.
+_AUTHORIZATION_BINDING = "authorization_binding"
+
+
+class MalformedFallbackBindingError(ValueError):
+    """A no-SEP-2787 request envelope has no reconstructable fallback
+    projection: the named ``_meta.authorization_binding`` block is absent,
+    not an object, missing its ``nonce``, or carries an unsupported
+    ``projectionVersion``, or the ``tools/call`` ``name``/``arguments`` are
+    missing.
+
+    Per SEP-2828 the fallback case is then not conformant. Verifiers fail
+    closed on this rather than widening the preimage to the whole ``_meta``,
+    which would make observation-local material the authority boundary.
     """
-    wire = canonical_json(dict(request_envelope))
+
+
+def fallback_projection(request_envelope: Mapping[str, Any]) -> dict[str, Any]:
+    """The named, versioned projection a no-SEP-2787 fallback digest commits to.
+
+    Reconstructs a fixed object from only the fields that bind a decision to
+    its originating ``tools/call``:
+
+    - ``name`` and ``arguments`` (the canonical call params);
+    - the named ``_meta.authorization_binding`` block (the server's per-call
+      binding ``nonce`` and ``projectionVersion``).
+
+    Everything else under ``_meta`` is observation-local or transport-local
+    (progress tokens, trace context, UI hints, unrelated SEP blocks, fields a
+    gateway can legitimately add or strip) and is excluded, so a gateway view
+    and a provider view of the same call project to the same bytes. Raises
+    ``MalformedFallbackBindingError`` if the binding block is absent or
+    malformed: the fallback never silently widens to the whole ``_meta``.
+    """
+    meta = request_envelope.get("_meta")
+    if not isinstance(meta, Mapping):
+        raise MalformedFallbackBindingError(
+            "request envelope has no _meta object"
+        )
+    binding = meta.get(_AUTHORIZATION_BINDING)
+    if not isinstance(binding, Mapping):
+        raise MalformedFallbackBindingError(
+            f"_meta.{_AUTHORIZATION_BINDING} is absent or not an object"
+        )
+    if binding.get("projectionVersion") != FALLBACK_PROJECTION_V1:
+        raise MalformedFallbackBindingError(
+            "unsupported fallback projectionVersion: "
+            f"{binding.get('projectionVersion')!r}"
+        )
+    nonce = binding.get("nonce")
+    if not isinstance(nonce, str) or not nonce:
+        raise MalformedFallbackBindingError(
+            f"_meta.{_AUTHORIZATION_BINDING}.nonce is absent or not a string"
+        )
+    if "name" not in request_envelope or "arguments" not in request_envelope:
+        raise MalformedFallbackBindingError(
+            "request envelope is missing tools/call name or arguments"
+        )
+    return {
+        "projection": FALLBACK_PROJECTION_V1,
+        "name": request_envelope["name"],
+        "arguments": request_envelope["arguments"],
+        "authorizationBinding": dict(binding),
+    }
+
+
+def request_envelope_digest(request_envelope: Mapping[str, Any]) -> str:
+    """``sha256:<hex>`` over the JCS canonicalization of the named fallback
+    projection of a request envelope (see ``fallback_projection``).
+
+    This is the no-SEP-2787 fallback preimage: when a deployment does not run
+    2787, the decision back-link binds the request instance by this digest
+    instead of an attestation digest (SEP-2828 backLink, fallback path). The
+    digest commits to the bound call params and the named binding block only,
+    so a re-presented envelope whose arguments or binding block differ
+    recomputes to a different digest and does not bind, while transport-local
+    ``_meta`` a gateway adds or strips does not change it. Raises
+    ``MalformedFallbackBindingError`` if the binding block cannot be
+    reconstructed.
+    """
+    wire = canonical_json(fallback_projection(request_envelope))
     return f"sha256:{hashlib.sha256(wire).hexdigest()}"
 
 
@@ -86,20 +162,28 @@ def verify_decision_fallback_binding(
     *,
     request_envelope: Mapping[str, Any],
 ) -> BackLinkResult:
-    """Confirm a decision record's back-link pins ``request_envelope``.
+    """Confirm a decision record's back-link pins ``request_envelope`` under
+    the no-SEP-2787 fallback projection.
 
-    The no-SEP-2787 counterpart to ``verify_decision_back_link``:
-    recomputes the digest over the JCS-canonical request envelope and
-    compares it, constant-time, to the record's
-    ``backLink.attestationDigest``. The nonce is server-chosen and is not
-    derivable from the envelope alone, so it is not checked here; callers
-    that record the server nonce inside ``_meta`` get it under the digest
-    for free.
+    The no-SEP-2787 counterpart to ``verify_decision_back_link``: recomputes
+    the digest over the named projection (bound call params plus the
+    ``_meta.authorization_binding`` block) and compares it, constant-time, to
+    the record's ``backLink.attestationDigest``; then confirms the back-link's
+    ``attestationNonce`` echoes the binding block's ``nonce``, mirroring the
+    attestation path's nonce echo. A malformed or absent binding block fails
+    closed (``ok=False``, ``fallback_binding_malformed``), never widening the
+    preimage to the whole ``_meta``.
     """
-    expected_digest = request_envelope_digest(request_envelope)
+    try:
+        expected_digest = request_envelope_digest(request_envelope)
+    except MalformedFallbackBindingError:
+        return BackLinkResult(ok=False, reason=FALLBACK_BINDING_MALFORMED)
     if not hmac.compare_digest(
         record.back_link.attestation_digest, expected_digest
     ):
+        return BackLinkResult(ok=False, reason=BACK_LINK_MISMATCH)
+    binding_nonce = request_envelope["_meta"][_AUTHORIZATION_BINDING]["nonce"]
+    if record.back_link.attestation_nonce != binding_nonce:
         return BackLinkResult(ok=False, reason=BACK_LINK_MISMATCH)
     return BackLinkResult(ok=True)
 

--- a/src/vaara/attestation/_receipt_verifier.py
+++ b/src/vaara/attestation/_receipt_verifier.py
@@ -25,6 +25,9 @@ from vaara.attestation._sep2787_canonical import canonical_json
 from vaara.attestation._sep2787_types import Attestation
 
 BACK_LINK_MISMATCH: Literal["back_link_mismatch"] = "back_link_mismatch"
+FALLBACK_BINDING_MALFORMED: Literal["fallback_binding_malformed"] = (
+    "fallback_binding_malformed"
+)
 
 
 @dataclass(frozen=True)
@@ -34,12 +37,15 @@ class BackLinkResult:
     ``ok`` is True iff the receipt's ``backLink`` pins the given
     attestation: the digest matches the attestation's canonical wire
     bytes AND the nonce matches the attestation's issuer nonce.
-    ``reason`` is None on success or ``"back_link_mismatch"`` on
-    failure.
+    ``reason`` is None on success, ``"back_link_mismatch"`` when the
+    digest or nonce disagree, or ``"fallback_binding_malformed"`` when a
+    no-SEP-2787 fallback envelope has no reconstructable binding block.
     """
 
     ok: bool
-    reason: Optional[Literal["back_link_mismatch"]] = None
+    reason: Optional[
+        Literal["back_link_mismatch", "fallback_binding_malformed"]
+    ] = None
 
 
 def attestation_digest(attestation: Attestation) -> str:

--- a/src/vaara/attestation/decision.py
+++ b/src/vaara/attestation/decision.py
@@ -45,8 +45,11 @@ from vaara.attestation._decision_types import (
     decision_record_from_dict as parse_decision_record,
 )
 from vaara.attestation._decision_verifier import (
+    FALLBACK_PROJECTION_V1,
     AmbiguousSupersessionError,
+    MalformedFallbackBindingError,
     decision_digest,
+    fallback_projection,
     records_paired,
     request_envelope_digest,
     superseding_decision,
@@ -61,6 +64,7 @@ from vaara.attestation._receipt_verifier import (
 )
 
 __all__ = [
+    "FALLBACK_PROJECTION_V1",
     "AmbiguousSupersessionError",
     "BackLink",
     "BackLinkResult",
@@ -68,9 +72,11 @@ __all__ = [
     "DecisionRecord",
     "DecisionVerdict",
     "IssuerAsserted",
+    "MalformedFallbackBindingError",
     "attestation_digest",
     "decision_digest",
     "emit_decision_record",
+    "fallback_projection",
     "make_back_link",
     "parse_decision_record",
     "records_paired",

--- a/tests/test_decision_pairing_vectors.py
+++ b/tests/test_decision_pairing_vectors.py
@@ -42,25 +42,104 @@ def test_at_least_six_cases_present():
 
 
 def test_vaara_verifier_reproduces_fallback_binding():
-    """The Vaara reference verifier recomputes the no-2787 fallback binding
-    from the committed request envelope, and rejects a replayed envelope
-    whose arguments differ. This mirrors the independent checker's
-    fallback_binding_ok / replayed_binding_ok verdicts."""
+    """The Vaara reference verifier reproduces the no-2787 named-projection
+    fallback binding over the committed envelopes, covering the projection
+    rule's obligations: a provider view binds; a gateway view with different
+    transport-local _meta binds to the same digest; changed bound params or a
+    changed binding block break the back-link; an absent binding block fails
+    closed instead of digesting the whole _meta."""
     import json
 
     from vaara.attestation.decision import (
+        fallback_projection,
         parse_decision_record,
+        request_envelope_digest,
         verify_decision_fallback_binding,
+    )
+    from vaara.attestation._receipt_verifier import (
+        FALLBACK_BINDING_MALFORMED,
     )
 
     case = VECTORS / "normative" / "fallback_envelope_binding"
     decision = parse_decision_record(
         json.loads((case / "decision.json").read_text()))
-    env = json.loads((case / "request_envelope.json").read_text())
-    env_replayed = json.loads(
-        (case / "request_envelope_replayed.json").read_text())
 
+    def env(name: str) -> dict:
+        return json.loads((case / name).read_text())
+
+    provider = env("request_envelope.json")
+    gateway = env("request_envelope_gateway_view.json")
+
+    # Provider view binds; gateway view binds to the same digest despite
+    # carrying different non-binding _meta (rpelevin test 1).
     assert verify_decision_fallback_binding(
-        decision, request_envelope=env).ok is True
+        decision, request_envelope=provider).ok is True
     assert verify_decision_fallback_binding(
-        decision, request_envelope=env_replayed).ok is False
+        decision, request_envelope=gateway).ok is True
+    assert request_envelope_digest(provider) == request_envelope_digest(gateway)
+    # The digest comes from the named projection, not the whole _meta.
+    assert fallback_projection(provider) == fallback_projection(gateway)
+
+    # Changed bound params (test 3) and a changed binding block (test 2) each
+    # break the back-link.
+    replayed = verify_decision_fallback_binding(
+        decision, request_envelope=env("request_envelope_replayed.json"))
+    assert replayed.ok is False
+    tampered = verify_decision_fallback_binding(
+        decision, request_envelope=env("request_envelope_tampered_binding.json"))
+    assert tampered.ok is False
+
+    # An absent binding block fails closed with a distinct reason, rather than
+    # widening the preimage to the whole _meta (test 4).
+    malformed = verify_decision_fallback_binding(
+        decision, request_envelope=env("request_envelope_no_binding.json"))
+    assert malformed.ok is False
+    assert malformed.reason == FALLBACK_BINDING_MALFORMED
+
+
+def test_fallback_projection_excludes_transport_local_meta():
+    """The projection digest is invariant to non-binding _meta a gateway can
+    add or strip, and raises on an unreconstructable binding block."""
+    from vaara.attestation.decision import (
+        MalformedFallbackBindingError,
+        request_envelope_digest,
+    )
+
+    base = {
+        "name": "query_table",
+        "arguments": {"table": "employees", "limit": 10},
+        "_meta": {
+            "authorization_binding": {
+                "nonce": "n-1",
+                "projectionVersion": "sep2828-fallback/1",
+            },
+        },
+    }
+    with_noise = {
+        "name": "query_table",
+        "arguments": {"table": "employees", "limit": 10},
+        "_meta": {
+            "authorization_binding": {
+                "nonce": "n-1",
+                "projectionVersion": "sep2828-fallback/1",
+            },
+            "io.modelcontextprotocol/progressToken": "p-9",
+            "trace": {"spanId": "abc"},
+        },
+    }
+    assert request_envelope_digest(base) == request_envelope_digest(with_noise)
+
+    # Unsupported projection version and a missing block both fail closed.
+    bad_version = json_copy(base)
+    bad_version["_meta"]["authorization_binding"]["projectionVersion"] = "x/9"
+    with pytest.raises(MalformedFallbackBindingError):
+        request_envelope_digest(bad_version)
+    no_block = {"name": "query_table", "arguments": {}, "_meta": {}}
+    with pytest.raises(MalformedFallbackBindingError):
+        request_envelope_digest(no_block)
+
+
+def json_copy(obj):
+    import json
+
+    return json.loads(json.dumps(obj))

--- a/tests/vectors/decision_pairing_v0/README.md
+++ b/tests/vectors/decision_pairing_v0/README.md
@@ -44,12 +44,18 @@ published; the ES256 fixture is verified against the stored public key.
 - `substituted_decision_under_shared_attestation`: a second decision is
   substituted under the same attestation. Check A passes, Check B fails.
 - `fallback_envelope_binding`: the no-attestation fallback path. The
-  back-link digest is recomputed over the committed
-  `request_envelope.json` (the `tools/call` params plus `_meta`), so an
-  independent reader reproduces the binding rather than trusting a stored
-  digest. `request_envelope_replayed.json` is the same tool with different
-  arguments: it recomputes to a different digest and does not bind
-  (`replayed_binding_ok` is false).
+  back-link digest is recomputed over a named, versioned projection of the
+  committed `request_envelope.json` (the `tools/call` `name`+`arguments`
+  plus the `_meta.authorization_binding` block), not the whole `_meta`, so
+  an independent reader reproduces the binding rather than trusting a stored
+  digest. `request_envelope_gateway_view.json` carries different
+  transport-local `_meta` yet projects to the same digest
+  (`gateway_view_matches_provider_digest`). `request_envelope_replayed.json`
+  changes the bound arguments and `request_envelope_tampered_binding.json`
+  changes the binding block: each recomputes to a different digest and does
+  not bind. `request_envelope_no_binding.json` has no binding block and
+  fails closed (`malformed_binding_fails_closed`) instead of digesting the
+  whole `_meta`.
 - `supersession_equal_decidedat_tie`: two distinct decisions with equal
   `decidedAt` under one back-link and no explicit ordering field. The
   expected `supersession` verdict is `ambiguous`: a conformant verifier

--- a/tests/vectors/decision_pairing_v0/_check_independent.py
+++ b/tests/vectors/decision_pairing_v0/_check_independent.py
@@ -80,17 +80,58 @@ def verify_back_link(record: dict, attestation: dict) -> bool:
     return bl["attestationNonce"] == attestation["issuerAsserted"]["nonce"]
 
 
+FALLBACK_PROJECTION_V1 = "sep2828-fallback/1"
+
+
+def fallback_projection(envelope: dict):
+    """Reconstruct the named, versioned no-SEP-2787 projection from a request
+    envelope, or None if it cannot be reconstructed. The preimage is only the
+    tools/call name+arguments plus the named _meta.authorization_binding block;
+    every other _meta field (trace context, progress tokens, UI hints, fields a
+    gateway adds or strips) is excluded, so a gateway and a provider view of the
+    same call project to identical bytes."""
+    meta = envelope.get("_meta")
+    if not isinstance(meta, dict):
+        return None
+    binding = meta.get("authorization_binding")
+    if not isinstance(binding, dict):
+        return None
+    if binding.get("projectionVersion") != FALLBACK_PROJECTION_V1:
+        return None
+    nonce = binding.get("nonce")
+    if not isinstance(nonce, str) or not nonce:
+        return None
+    if "name" not in envelope or "arguments" not in envelope:
+        return None
+    return {
+        "projection": FALLBACK_PROJECTION_V1,
+        "name": envelope["name"],
+        "arguments": envelope["arguments"],
+        "authorizationBinding": dict(binding),
+    }
+
+
+def fallback_digest(envelope: dict):
+    """The no-2787 fallback digest over the named projection, or None if the
+    binding block cannot be reconstructed."""
+    proj = fallback_projection(envelope)
+    return None if proj is None else _sha256_hex(_jcs(proj))
+
+
 def verify_fallback_binding(record: dict, envelope: dict) -> bool:
-    """No-SEP-2787 path: the back-link digest is over the JCS-canonical
-    request envelope (the tools/call params plus _meta) the server observed.
-    Recompute it from the committed envelope rather than trusting the stored
-    digest, and confirm the server nonce recorded under _meta matches."""
+    """No-SEP-2787 path: the back-link digest is over the named, versioned
+    projection of the request envelope, not the whole _meta. Recompute it from
+    the committed envelope rather than trusting the stored digest, confirm the
+    back-link nonce echoes the binding block nonce, and fail closed when the
+    binding block is absent or malformed."""
+    proj = fallback_projection(envelope)
+    if proj is None:
+        return False
     bl = record["backLink"]
-    expected = _sha256_hex(_jcs(envelope))
-    if not hmac.compare_digest(bl["attestationDigest"], expected):
+    if not hmac.compare_digest(bl["attestationDigest"], _sha256_hex(_jcs(proj))):
         return False
     return bl["attestationNonce"] == envelope["_meta"][
-        "io.modelcontextprotocol/serverNonce"]
+        "authorization_binding"]["nonce"]
 
 
 def decision_digest(decision: dict) -> str:
@@ -177,6 +218,19 @@ def _verdicts(case: Path, expected: dict) -> dict:
         elif key == "replayed_binding_ok":
             got[key] = verify_fallback_binding(
                 dec, _load(case, "request_envelope_replayed.json"))
+        elif key == "gateway_view_binding_ok":
+            got[key] = verify_fallback_binding(
+                dec, _load(case, "request_envelope_gateway_view.json"))
+        elif key == "gateway_view_matches_provider_digest":
+            got[key] = (
+                fallback_digest(_load(case, "request_envelope_gateway_view.json"))
+                == fallback_digest(_load(case, "request_envelope.json")))
+        elif key == "tampered_binding_ok":
+            got[key] = verify_fallback_binding(
+                dec, _load(case, "request_envelope_tampered_binding.json"))
+        elif key == "malformed_binding_fails_closed":
+            got[key] = verify_fallback_binding(
+                dec, _load(case, "request_envelope_no_binding.json")) is False
         else:
             raise ValueError(f"unknown expected key: {key!r}")
     return got

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/decision.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/decision.json
@@ -1,7 +1,7 @@
 {
   "alg": "HS256",
   "backLink": {
-    "attestationDigest": "sha256:2b22dcace44e2e6e004db0a484ea587086d2ecf83107094db55b16244620c8e6",
+    "attestationDigest": "sha256:80eb071ee11a6430ecced0055f09f9570e30cd328fa757871c5a9f29ffa42247",
     "attestationNonce": "server-chosen-nonce-001"
   },
   "decisionDerived": {
@@ -20,6 +20,6 @@
     "secretVersion": "v1",
     "sub": "agent:reader"
   },
-  "signature": "34507ab3469f00941946e710d0e8d75eb81132888ad4d593d95c1eafdf70a209",
+  "signature": "4a3cfa73a705ffa9e6eba12441c401bba901aa69b912df6f969a5392cfe3bbc3",
   "version": 1
 }

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/expected.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/expected.json
@@ -1,8 +1,12 @@
 {
   "decision_signature_ok": true,
   "fallback_binding_ok": true,
-  "note": "no SEP-2787 attestation: the backLink digest is recomputed over the JCS-canonical request envelope (tools/call params plus _meta); a re-presented envelope with different arguments recomputes to a different digest and does not bind.",
+  "gateway_view_binding_ok": true,
+  "gateway_view_matches_provider_digest": true,
+  "malformed_binding_fails_closed": true,
+  "note": "no SEP-2787 attestation: the backLink digest is over a named, versioned projection (the tools/call name and arguments plus the _meta.authorization_binding block), not the whole _meta. A gateway and a provider view of the same call carry different transport-local _meta yet project to the same digest; changing the bound params or the binding block breaks the back-link; an absent binding block fails closed instead of digesting the whole _meta.",
   "receipt_signature_ok": true,
   "records_paired": true,
-  "replayed_binding_ok": false
+  "replayed_binding_ok": false,
+  "tampered_binding_ok": false
 }

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt.json
@@ -1,12 +1,12 @@
 {
   "alg": "HS256",
   "backLink": {
-    "attestationDigest": "sha256:2b22dcace44e2e6e004db0a484ea587086d2ecf83107094db55b16244620c8e6",
+    "attestationDigest": "sha256:80eb071ee11a6430ecced0055f09f9570e30cd328fa757871c5a9f29ffa42247",
     "attestationNonce": "server-chosen-nonce-001"
   },
   "outcomeDerived": {
     "completedAt": "2026-06-01T10:00:00Z",
-    "decisionDigest": "sha256:e7454ef07be275812a3d1016f4809b8bd2c1f75993e835bfd9c8a6edd5d182c5",
+    "decisionDigest": "sha256:02013b96b66b06a8db32fd188616f9b20d1991c650d3e431239370602896702c",
     "resultCommitment": {
       "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
       "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
@@ -21,6 +21,6 @@
     "secretVersion": "v1",
     "sub": "agent:reader"
   },
-  "signature": "d2a6dc12da3020c99d25289c6f2fd8d8de9ff7ef9b27d7f62435433acb582b81",
+  "signature": "1b9965420896d5185a817e075cdd19b35db157fedd671ea3036bdabd6db63561",
   "version": 1
 }

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_gateway_view.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_gateway_view.json
@@ -4,7 +4,8 @@
       "nonce": "server-chosen-nonce-001",
       "projectionVersion": "sep2828-fallback/1"
     },
-    "io.modelcontextprotocol/serverTraceId": "trace-provider-7f3a"
+    "io.modelcontextprotocol/progressToken": "p-7",
+    "io.modelcontextprotocol/uiHint": "table-preview"
   },
   "arguments": {
     "limit": 10,

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_no_binding.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_no_binding.json
@@ -1,9 +1,5 @@
 {
   "_meta": {
-    "authorization_binding": {
-      "nonce": "server-chosen-nonce-001",
-      "projectionVersion": "sep2828-fallback/1"
-    },
     "io.modelcontextprotocol/serverTraceId": "trace-provider-7f3a"
   },
   "arguments": {

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_replayed.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_replayed.json
@@ -1,6 +1,10 @@
 {
   "_meta": {
-    "io.modelcontextprotocol/serverNonce": "server-chosen-nonce-001"
+    "authorization_binding": {
+      "nonce": "server-chosen-nonce-001",
+      "projectionVersion": "sep2828-fallback/1"
+    },
+    "io.modelcontextprotocol/serverTraceId": "trace-provider-7f3a"
   },
   "arguments": {
     "limit": 1000,

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_tampered_binding.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_tampered_binding.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "authorization_binding": {
-      "nonce": "server-chosen-nonce-001",
+      "nonce": "attacker-swapped-nonce-999",
       "projectionVersion": "sep2828-fallback/1"
     },
     "io.modelcontextprotocol/serverTraceId": "trace-provider-7f3a"


### PR DESCRIPTION
## What

The no-SEP-2787 fallback back-link bound the **whole** observed request envelope (`tools/call` params plus the entire `_meta`). That makes observation-local material the authority boundary: a gateway and a provider view of the same call, differing only in transport-local `_meta` (progress tokens, trace context, UI hints, fields a gateway adds or strips), produce different digests, and one of them fails to bind.

This binds a **named, versioned projection** instead. The preimage commits to exactly:
- the `tools/call` `name` and `arguments`;
- the named `_meta.authorization_binding` block (per-call `nonce` + `projectionVersion`, `sep2828-fallback/1`).

Every other `_meta` field is excluded. A gateway view and a provider view now project to the same digest; changing the bound params or the binding block breaks the back-link; an absent or malformed binding block **fails closed** instead of widening the preimage to the whole `_meta`.

## Why

Refines the no-2787 fallback shape as it converged on modelcontextprotocol#2867 (the projection should name specific fields, exclude transport-local `_meta`, version the projection, and fail closed if it cannot be reconstructed). The previous Unreleased shape (#230) hashed the whole envelope, which diverges from that.

## Surface

- `vaara.attestation.decision`: adds `fallback_projection`, `MalformedFallbackBindingError`, `FALLBACK_PROJECTION_V1`. `request_envelope_digest` and `verify_decision_fallback_binding` now implement the projection + fail-closed contract (verify-only; no emit-side caller).
- `decision_pairing_v0` corpus carries provider, gateway, replayed, tampered-binding, and no-binding envelopes; the Vaara-free `_check_independent.py` reproduces every verdict.
- SEP doc fallback clause + CHANGELOG Unreleased updated.

## Tests

Covers the five obligations from the thread: gateway/provider parity, changed params break, changed binding block breaks, missing block fails closed, 2787 path unaffected. `1622 passed, 13 skipped`; ruff + mypy clean on the changed modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fallback binding validation using a named, versioned projection of request envelopes to ensure consistent digest computation and better security guarantees when primary attestations are unavailable.

* **Bug Fixes**
  * Improved fallback back-link verification to fail securely when authorization binding blocks are missing or malformed, with explicit nonce validation.

* **Tests**
  * Expanded test coverage with new scenarios for gateway views, replayed bindings, tampered bindings, and missing binding blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->