### PR TITLE
feat: fallback projection version rides on the signed record, not the envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,22 +21,25 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 - The no-SEP-2787 fallback back-link now binds a **named, versioned projection**
-  of the request envelope (the `tools/call` `name`+`arguments` plus the
-  `_meta.authorization_binding` block carrying the per-call `nonce` and
-  `projectionVersion`), not the whole observed `_meta`. Observation-local and
-  transport-local `_meta` (progress tokens, trace context, UI hints, fields a
-  gateway adds or strips) is excluded, so a gateway view and a provider view of
-  the same call project to the same digest; changing the bound params or the
-  binding block breaks the back-link; an absent or malformed binding block fails
-  closed instead of widening the preimage to the whole `_meta`.
-  `vaara.attestation.decision` adds `fallback_projection`,
-  `MalformedFallbackBindingError`, and `FALLBACK_PROJECTION_V1`;
-  `request_envelope_digest` and `verify_decision_fallback_binding` implement the
-  projection and fail-closed contract in the reference verifier. The
-  `decision_pairing_v0` corpus carries the provider, gateway, replayed,
-  tampered-binding, and no-binding envelopes as first-class fixture inputs, and
-  the Vaara-free checker reproduces every verdict. Refines the no-2787 fallback
-  shape discussed on modelcontextprotocol#2867.
+  of the request envelope, not the whole observed `_meta`. The preimage is an
+  allowlist: exactly the `tools/call` `name`+`arguments` plus the
+  `_meta.authorization_binding` block (the per-call `nonce`), and nothing else.
+  Every other `_meta` field is excluded by construction, so a gateway view and a
+  provider view of the same call project to the same digest; changing the bound
+  params or the binding block breaks the back-link; an absent binding block fails
+  closed instead of widening the preimage to the whole `_meta`. The signed record
+  names the projection version it used in a new `backLink.fallbackProjection`
+  field, so a verifier reconstructs the same projection deterministically from
+  trusted data and a later projection revision is an explicit new version rather
+  than a silent reinterpretation. `vaara.attestation.decision` adds
+  `fallback_projection`, `MalformedFallbackBindingError`, and
+  `FALLBACK_PROJECTION_V1`; `request_envelope_digest`,
+  `verify_decision_fallback_binding`, and the shared `BackLink` carry the version
+  and the fail-closed contract in the reference verifier. The `decision_pairing_v0`
+  corpus carries the provider, gateway, replayed, tampered-binding, and
+  no-binding envelopes as first-class fixture inputs, and the Vaara-free checker
+  reproduces every verdict. Refines the no-2787 fallback shape as it converged on
+  modelcontextprotocol#2867.
 
 ## [0.67.0] - 2026-06-09
 

--- a/docs/sep/sep-server-execution-record.md
+++ b/docs/sep/sep-server-execution-record.md
@@ -174,34 +174,42 @@ following top-level fields.
 
 | Field              | Type   | Required | Description                                                                          |
 | ------------------ | ------ | -------- | ------------------------------------------------------------------------------------ |
-| `attestationDigest`| string | yes      | `sha256:<hex>` over the JCS-canonical full SEP-2787 attestation wire bytes, signature included. Pins the exact attestation instance. |
-| `attestationNonce` | string | yes      | Echoes the attestation's `issuerAsserted.nonce` for fast correlation.                |
+| `attestationDigest`| string | yes      | `sha256:<hex>` over the JCS-canonical full SEP-2787 attestation wire bytes, signature included. Pins the exact attestation instance. In the no-2787 fallback (below) it is over the named request-envelope projection instead. |
+| `attestationNonce` | string | yes      | Echoes the attestation's `issuerAsserted.nonce` for fast correlation. In the fallback it echoes `_meta.authorization_binding.nonce`. |
+| `fallbackProjection`| string | no       | Present only in the no-2787 fallback: names the projection version `attestationDigest` was computed under (this release: `sep2828-fallback/1`). Absent on the attestation path. |
 
 If no SEP-2787 attestation exists for the call (the deployment does not run
 2787), the server MUST instead bind the request by setting `attestationDigest` to
 `sha256:<hex>` over the JCS-canonical encoding of a **named, versioned
 projection** of the request envelope, not the whole observed `_meta`. The
-projection commits to exactly:
+projection is an allowlist: it contains exactly
 
 - the `tools/call` `name` and `arguments` (the call params that bind to the
   decision);
 - the named binding block `_meta.authorization_binding`, which carries the
-  server-chosen per-call `nonce` and the `projectionVersion` in force (this
-  release: `sep2828-fallback/1`).
+  server-chosen per-call `nonce`;
 
-Every other `_meta` field is observation-local or transport-local (progress
-tokens, trace context, UI hints, unrelated SEP blocks, fields a gateway can
-legitimately add or strip) and MUST be excluded, so a gateway view and a
-provider view of the same call project to the same digest. The server sets
-`attestationNonce` to echo `_meta.authorization_binding.nonce`. The binding is to
-the request **instance**, not only its content.
+and nothing else. Every other `_meta` field is excluded by construction, so a
+gateway view and a provider view of the same call, differing only in
+observation-local or transport-local `_meta` (progress tokens, trace context, UI
+hints, unrelated SEP blocks, fields a gateway can legitimately add or strip),
+project to the same digest. The rule is stated as inclusion rather than a deny
+list because a deny list can never be complete: the moment a gateway adds a field
+nobody enumerated, a deny-everything-listed rule would drift.
 
-A verifier reconstructs the same named projection from the same named fields and
-compares the digest. If the projection cannot be reconstructed (the
-`authorization_binding` block is absent, malformed, missing its `nonce`, or
-carries an unsupported `projectionVersion`), the fallback case is **not
-conformant** and the verifier MUST fail closed rather than widen the preimage to
-the whole `_meta`.
+The server sets `attestationNonce` to echo `_meta.authorization_binding.nonce`,
+and MUST name the projection version it used in `backLink.fallbackProjection`.
+The binding is to the request **instance**, not only its content.
+
+A verifier reads the version from the signed record's `backLink.fallbackProjection`
+(so reconstruction is deterministic from trusted data, and a later projection
+revision is an explicit new version rather than a silent reinterpretation),
+reconstructs the same named projection from the same named fields of the observed
+envelope, and compares the digest. If the record names no projection version or
+an unsupported one, or the projection cannot be reconstructed (the
+`authorization_binding` block is absent, malformed, or missing its `nonce`), the
+fallback case is **not conformant** and the verifier MUST fail closed rather than
+widen the preimage to the whole `_meta`.
 
 **`decisionDerived`** carries the decision and the basis for it:
 

--- a/src/vaara/attestation/_decision_verifier.py
+++ b/src/vaara/attestation/_decision_verifier.py
@@ -67,22 +67,25 @@ def verify_decision_back_link(
     return BackLinkResult(ok=True)
 
 
-# The named projection version that a no-SEP-2787 fallback digest commits
-# to. It is carried in the envelope's binding block and reconstructed by the
-# verifier, so a future projection rule is a new version, not a silent change.
+# The named projection version a no-SEP-2787 fallback digest commits to. The
+# signed record names which version it used (backLink.fallbackProjection), so a
+# verifier reconstructs the same projection deterministically and a future
+# projection rule is an explicit new version, not a silent reinterpretation.
 FALLBACK_PROJECTION_V1 = "sep2828-fallback/1"
+_SUPPORTED_FALLBACK_PROJECTIONS = frozenset({FALLBACK_PROJECTION_V1})
 
 # The named binding block under ``_meta`` whose contents are authoritative for
-# the fallback digest. Everything else under ``_meta`` is excluded.
+# the fallback digest. The preimage is exactly the bound call params plus this
+# block (an allowlist); everything else under ``_meta`` is excluded by
+# construction, so the rule cannot drift as new _meta fields appear.
 _AUTHORIZATION_BINDING = "authorization_binding"
 
 
 class MalformedFallbackBindingError(ValueError):
-    """A no-SEP-2787 request envelope has no reconstructable fallback
-    projection: the named ``_meta.authorization_binding`` block is absent,
-    not an object, missing its ``nonce``, or carries an unsupported
-    ``projectionVersion``, or the ``tools/call`` ``name``/``arguments`` are
-    missing.
+    """A no-SEP-2787 fallback projection cannot be reconstructed: an
+    unsupported projection version, or a request envelope whose named
+    ``_meta.authorization_binding`` block is absent, not an object, or missing
+    its ``nonce``, or whose ``tools/call`` ``name``/``arguments`` are missing.
 
     Per SEP-2828 the fallback case is then not conformant. Verifiers fail
     closed on this rather than widening the preimage to the whole ``_meta``,
@@ -90,23 +93,35 @@ class MalformedFallbackBindingError(ValueError):
     """
 
 
-def fallback_projection(request_envelope: Mapping[str, Any]) -> dict[str, Any]:
+def fallback_projection(
+    request_envelope: Mapping[str, Any],
+    *,
+    version: str = FALLBACK_PROJECTION_V1,
+) -> dict[str, Any]:
     """The named, versioned projection a no-SEP-2787 fallback digest commits to.
 
-    Reconstructs a fixed object from only the fields that bind a decision to
-    its originating ``tools/call``:
+    The preimage is an allowlist: it contains exactly the fields that bind a
+    decision to its originating ``tools/call`` and nothing else.
 
     - ``name`` and ``arguments`` (the canonical call params);
     - the named ``_meta.authorization_binding`` block (the server's per-call
-      binding ``nonce`` and ``projectionVersion``).
+      binding ``nonce``).
 
-    Everything else under ``_meta`` is observation-local or transport-local
-    (progress tokens, trace context, UI hints, unrelated SEP blocks, fields a
-    gateway can legitimately add or strip) and is excluded, so a gateway view
-    and a provider view of the same call project to the same bytes. Raises
-    ``MalformedFallbackBindingError`` if the binding block is absent or
-    malformed: the fallback never silently widens to the whole ``_meta``.
+    Every other ``_meta`` field is excluded by construction (it is never read
+    into the projection), so a gateway view and a provider view of the same
+    call, differing only in observation-local ``_meta`` such as progress
+    tokens, trace context, UI hints, or unrelated SEP blocks, project to the
+    same bytes. The ``version`` is supplied by the caller, not inferred from the
+    observed envelope: a verifier passes the version named on the signed record
+    (``backLink.fallbackProjection``); an emitter passes the version it binds
+    under. Raises ``MalformedFallbackBindingError`` on an unsupported version or
+    an absent or malformed binding block, so the fallback never silently widens
+    to the whole ``_meta``.
     """
+    if version not in _SUPPORTED_FALLBACK_PROJECTIONS:
+        raise MalformedFallbackBindingError(
+            f"unsupported fallback projection version: {version!r}"
+        )
     meta = request_envelope.get("_meta")
     if not isinstance(meta, Mapping):
         raise MalformedFallbackBindingError(
@@ -116,11 +131,6 @@ def fallback_projection(request_envelope: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(binding, Mapping):
         raise MalformedFallbackBindingError(
             f"_meta.{_AUTHORIZATION_BINDING} is absent or not an object"
-        )
-    if binding.get("projectionVersion") != FALLBACK_PROJECTION_V1:
-        raise MalformedFallbackBindingError(
-            "unsupported fallback projectionVersion: "
-            f"{binding.get('projectionVersion')!r}"
         )
     nonce = binding.get("nonce")
     if not isinstance(nonce, str) or not nonce:
@@ -132,16 +142,20 @@ def fallback_projection(request_envelope: Mapping[str, Any]) -> dict[str, Any]:
             "request envelope is missing tools/call name or arguments"
         )
     return {
-        "projection": FALLBACK_PROJECTION_V1,
+        "projection": version,
         "name": request_envelope["name"],
         "arguments": request_envelope["arguments"],
         "authorizationBinding": dict(binding),
     }
 
 
-def request_envelope_digest(request_envelope: Mapping[str, Any]) -> str:
+def request_envelope_digest(
+    request_envelope: Mapping[str, Any],
+    *,
+    version: str = FALLBACK_PROJECTION_V1,
+) -> str:
     """``sha256:<hex>`` over the JCS canonicalization of the named fallback
-    projection of a request envelope (see ``fallback_projection``).
+    projection of a request envelope at ``version`` (see ``fallback_projection``).
 
     This is the no-SEP-2787 fallback preimage: when a deployment does not run
     2787, the decision back-link binds the request instance by this digest
@@ -150,10 +164,9 @@ def request_envelope_digest(request_envelope: Mapping[str, Any]) -> str:
     so a re-presented envelope whose arguments or binding block differ
     recomputes to a different digest and does not bind, while transport-local
     ``_meta`` a gateway adds or strips does not change it. Raises
-    ``MalformedFallbackBindingError`` if the binding block cannot be
-    reconstructed.
+    ``MalformedFallbackBindingError`` if the projection cannot be reconstructed.
     """
-    wire = canonical_json(fallback_projection(request_envelope))
+    wire = canonical_json(fallback_projection(request_envelope, version=version))
     return f"sha256:{hashlib.sha256(wire).hexdigest()}"
 
 
@@ -165,17 +178,26 @@ def verify_decision_fallback_binding(
     """Confirm a decision record's back-link pins ``request_envelope`` under
     the no-SEP-2787 fallback projection.
 
-    The no-SEP-2787 counterpart to ``verify_decision_back_link``: recomputes
-    the digest over the named projection (bound call params plus the
-    ``_meta.authorization_binding`` block) and compares it, constant-time, to
-    the record's ``backLink.attestationDigest``; then confirms the back-link's
+    The no-SEP-2787 counterpart to ``verify_decision_back_link``. The
+    projection version is taken from the signed record's
+    ``backLink.fallbackProjection``, so reconstruction is deterministic from
+    trusted data rather than inferred from the observed envelope. Recomputes the
+    digest over the named projection at that version (bound call params plus the
+    ``_meta.authorization_binding`` block), compares it constant-time to the
+    record's ``backLink.attestationDigest``, then confirms the back-link's
     ``attestationNonce`` echoes the binding block's ``nonce``, mirroring the
-    attestation path's nonce echo. A malformed or absent binding block fails
+    attestation path's nonce echo. A record naming no fallback projection or an
+    unsupported one, or an envelope with no reconstructable binding block, fails
     closed (``ok=False``, ``fallback_binding_malformed``), never widening the
     preimage to the whole ``_meta``.
     """
+    version = record.back_link.fallback_projection
+    if version is None:
+        return BackLinkResult(ok=False, reason=FALLBACK_BINDING_MALFORMED)
     try:
-        expected_digest = request_envelope_digest(request_envelope)
+        expected_digest = request_envelope_digest(
+            request_envelope, version=version
+        )
     except MalformedFallbackBindingError:
         return BackLinkResult(ok=False, reason=FALLBACK_BINDING_MALFORMED)
     if not hmac.compare_digest(

--- a/src/vaara/attestation/_receipt_types.py
+++ b/src/vaara/attestation/_receipt_types.py
@@ -67,10 +67,19 @@ class BackLink:
     is ``sha256:<hex>`` over the JCS-canonical encoding of the full
     attestation wire envelope (signature included), pinning the exact
     attestation instance.
+
+    ``fallback_projection`` is set only in the no-SEP-2787 fallback case
+    (``fallbackProjection`` on the wire): it names the projection version
+    the ``attestation_digest`` was computed under, so a verifier
+    reconstructs the same named projection deterministically from the
+    signed record rather than inferring it from the observed envelope, and
+    a later projection revision is an explicit version rather than a silent
+    reinterpretation. It is absent on the attestation path.
     """
 
     attestation_digest: str
     attestation_nonce: str
+    fallback_projection: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -144,10 +153,13 @@ class ExecutionReceipt:
 
 
 def back_link_to_dict(bl: BackLink) -> dict[str, Any]:
-    return {
+    out: dict[str, Any] = {
         "attestationDigest": bl.attestation_digest,
         "attestationNonce": bl.attestation_nonce,
     }
+    if bl.fallback_projection is not None:
+        out["fallbackProjection"] = bl.fallback_projection
+    return out
 
 
 def receipt_asserted_to_dict(ra: ReceiptAsserted) -> dict[str, Any]:
@@ -180,6 +192,7 @@ def back_link_from_dict(d: dict[str, Any]) -> BackLink:
     return BackLink(
         attestation_digest=d["attestationDigest"],
         attestation_nonce=d["attestationNonce"],
+        fallback_projection=d.get("fallbackProjection"),
     )
 
 

--- a/tests/test_decision_pairing_vectors.py
+++ b/tests/test_decision_pairing_vectors.py
@@ -96,6 +96,26 @@ def test_vaara_verifier_reproduces_fallback_binding():
     assert malformed.ok is False
     assert malformed.reason == FALLBACK_BINDING_MALFORMED
 
+    # The signed record names the projection version it used, so reconstruction
+    # keys off trusted data; a record naming an unsupported or absent projection
+    # fails closed rather than guessing the rule.
+    import dataclasses
+
+    assert decision.back_link.fallback_projection == "sep2828-fallback/1"
+    bad_version = dataclasses.replace(
+        decision,
+        back_link=dataclasses.replace(
+            decision.back_link, fallback_projection="sep2828-fallback/99"))
+    assert verify_decision_fallback_binding(
+        bad_version, request_envelope=provider).ok is False
+    no_version = dataclasses.replace(
+        decision,
+        back_link=dataclasses.replace(
+            decision.back_link, fallback_projection=None))
+    res = verify_decision_fallback_binding(no_version, request_envelope=provider)
+    assert res.ok is False
+    assert res.reason == FALLBACK_BINDING_MALFORMED
+
 
 def test_fallback_projection_excludes_transport_local_meta():
     """The projection digest is invariant to non-binding _meta a gateway can
@@ -109,37 +129,23 @@ def test_fallback_projection_excludes_transport_local_meta():
         "name": "query_table",
         "arguments": {"table": "employees", "limit": 10},
         "_meta": {
-            "authorization_binding": {
-                "nonce": "n-1",
-                "projectionVersion": "sep2828-fallback/1",
-            },
+            "authorization_binding": {"nonce": "n-1"},
         },
     }
     with_noise = {
         "name": "query_table",
         "arguments": {"table": "employees", "limit": 10},
         "_meta": {
-            "authorization_binding": {
-                "nonce": "n-1",
-                "projectionVersion": "sep2828-fallback/1",
-            },
+            "authorization_binding": {"nonce": "n-1"},
             "io.modelcontextprotocol/progressToken": "p-9",
             "trace": {"spanId": "abc"},
         },
     }
     assert request_envelope_digest(base) == request_envelope_digest(with_noise)
 
-    # Unsupported projection version and a missing block both fail closed.
-    bad_version = json_copy(base)
-    bad_version["_meta"]["authorization_binding"]["projectionVersion"] = "x/9"
+    # An unsupported version and a missing block both fail closed.
     with pytest.raises(MalformedFallbackBindingError):
-        request_envelope_digest(bad_version)
+        request_envelope_digest(base, version="sep2828-fallback/99")
     no_block = {"name": "query_table", "arguments": {}, "_meta": {}}
     with pytest.raises(MalformedFallbackBindingError):
         request_envelope_digest(no_block)
-
-
-def json_copy(obj):
-    import json
-
-    return json.loads(json.dumps(obj))

--- a/tests/vectors/decision_pairing_v0/README.md
+++ b/tests/vectors/decision_pairing_v0/README.md
@@ -45,11 +45,14 @@ published; the ES256 fixture is verified against the stored public key.
   substituted under the same attestation. Check A passes, Check B fails.
 - `fallback_envelope_binding`: the no-attestation fallback path. The
   back-link digest is recomputed over a named, versioned projection of the
-  committed `request_envelope.json` (the `tools/call` `name`+`arguments`
-  plus the `_meta.authorization_binding` block), not the whole `_meta`, so
-  an independent reader reproduces the binding rather than trusting a stored
-  digest. `request_envelope_gateway_view.json` carries different
-  transport-local `_meta` yet projects to the same digest
+  committed `request_envelope.json` (an allowlist: the `tools/call`
+  `name`+`arguments` plus the `_meta.authorization_binding` block), not the
+  whole `_meta`, so an independent reader reproduces the binding rather than
+  trusting a stored digest. The signed record names the projection version it
+  used (`backLink.fallbackProjection`, `record_names_fallback_projection`), so
+  the reader reconstructs deterministically from trusted data.
+  `request_envelope_gateway_view.json` carries different transport-local
+  `_meta` yet projects to the same digest
   (`gateway_view_matches_provider_digest`). `request_envelope_replayed.json`
   changes the bound arguments and `request_envelope_tampered_binding.json`
   changes the binding block: each recomputes to a different digest and does

--- a/tests/vectors/decision_pairing_v0/_check_independent.py
+++ b/tests/vectors/decision_pairing_v0/_check_independent.py
@@ -80,23 +80,26 @@ def verify_back_link(record: dict, attestation: dict) -> bool:
     return bl["attestationNonce"] == attestation["issuerAsserted"]["nonce"]
 
 
-FALLBACK_PROJECTION_V1 = "sep2828-fallback/1"
+_SUPPORTED_FALLBACK_PROJECTIONS = frozenset({"sep2828-fallback/1"})
 
 
-def fallback_projection(envelope: dict):
-    """Reconstruct the named, versioned no-SEP-2787 projection from a request
-    envelope, or None if it cannot be reconstructed. The preimage is only the
-    tools/call name+arguments plus the named _meta.authorization_binding block;
-    every other _meta field (trace context, progress tokens, UI hints, fields a
-    gateway adds or strips) is excluded, so a gateway and a provider view of the
-    same call project to identical bytes."""
+def fallback_projection(envelope: dict, version):
+    """Reconstruct the named projection from a request envelope at the given
+    version, or None if it cannot be reconstructed. The preimage is an
+    allowlist: only the tools/call name+arguments plus the named
+    _meta.authorization_binding block; every other _meta field (trace context,
+    progress tokens, UI hints, fields a gateway adds or strips) is excluded by
+    construction, so a gateway and a provider view of the same call project to
+    identical bytes. The version is supplied by the caller (a verifier reads it
+    from the signed record's backLink.fallbackProjection), not inferred from the
+    observed envelope."""
+    if version not in _SUPPORTED_FALLBACK_PROJECTIONS:
+        return None
     meta = envelope.get("_meta")
     if not isinstance(meta, dict):
         return None
     binding = meta.get("authorization_binding")
     if not isinstance(binding, dict):
-        return None
-    if binding.get("projectionVersion") != FALLBACK_PROJECTION_V1:
         return None
     nonce = binding.get("nonce")
     if not isinstance(nonce, str) or not nonce:
@@ -104,30 +107,36 @@ def fallback_projection(envelope: dict):
     if "name" not in envelope or "arguments" not in envelope:
         return None
     return {
-        "projection": FALLBACK_PROJECTION_V1,
+        "projection": version,
         "name": envelope["name"],
         "arguments": envelope["arguments"],
         "authorizationBinding": dict(binding),
     }
 
 
-def fallback_digest(envelope: dict):
-    """The no-2787 fallback digest over the named projection, or None if the
-    binding block cannot be reconstructed."""
-    proj = fallback_projection(envelope)
+def fallback_digest(envelope: dict, version):
+    """The no-2787 fallback digest over the named projection at version, or
+    None if the projection cannot be reconstructed."""
+    proj = fallback_projection(envelope, version)
     return None if proj is None else _sha256_hex(_jcs(proj))
 
 
 def verify_fallback_binding(record: dict, envelope: dict) -> bool:
     """No-SEP-2787 path: the back-link digest is over the named, versioned
-    projection of the request envelope, not the whole _meta. Recompute it from
-    the committed envelope rather than trusting the stored digest, confirm the
+    projection of the request envelope, not the whole _meta. The projection
+    version is read from the signed record's backLink.fallbackProjection, so
+    reconstruction is deterministic from trusted data. Recompute the digest from
+    the committed envelope rather than trusting the stored value, confirm the
     back-link nonce echoes the binding block nonce, and fail closed when the
-    binding block is absent or malformed."""
-    proj = fallback_projection(envelope)
+    record names no or an unsupported version or the binding block is
+    malformed."""
+    bl = record["backLink"]
+    version = bl.get("fallbackProjection")
+    if version is None:
+        return False
+    proj = fallback_projection(envelope, version)
     if proj is None:
         return False
-    bl = record["backLink"]
     if not hmac.compare_digest(bl["attestationDigest"], _sha256_hex(_jcs(proj))):
         return False
     return bl["attestationNonce"] == envelope["_meta"][
@@ -221,10 +230,16 @@ def _verdicts(case: Path, expected: dict) -> dict:
         elif key == "gateway_view_binding_ok":
             got[key] = verify_fallback_binding(
                 dec, _load(case, "request_envelope_gateway_view.json"))
+        elif key == "record_names_fallback_projection":
+            version = dec["backLink"].get("fallbackProjection")
+            got[key] = version in _SUPPORTED_FALLBACK_PROJECTIONS
         elif key == "gateway_view_matches_provider_digest":
+            version = dec["backLink"].get("fallbackProjection")
             got[key] = (
-                fallback_digest(_load(case, "request_envelope_gateway_view.json"))
-                == fallback_digest(_load(case, "request_envelope.json")))
+                fallback_digest(
+                    _load(case, "request_envelope_gateway_view.json"), version)
+                == fallback_digest(
+                    _load(case, "request_envelope.json"), version))
         elif key == "tampered_binding_ok":
             got[key] = verify_fallback_binding(
                 dec, _load(case, "request_envelope_tampered_binding.json"))

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/decision.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/decision.json
@@ -1,8 +1,9 @@
 {
   "alg": "HS256",
   "backLink": {
-    "attestationDigest": "sha256:80eb071ee11a6430ecced0055f09f9570e30cd328fa757871c5a9f29ffa42247",
-    "attestationNonce": "server-chosen-nonce-001"
+    "attestationDigest": "sha256:ad365b402e0bd577841ba1a4e2f2f8dae53654e8c21695f5be9632e1d36bc32a",
+    "attestationNonce": "server-chosen-nonce-001",
+    "fallbackProjection": "sep2828-fallback/1"
   },
   "decisionDerived": {
     "decidedAt": "2026-06-01T10:00:00Z",
@@ -20,6 +21,6 @@
     "secretVersion": "v1",
     "sub": "agent:reader"
   },
-  "signature": "4a3cfa73a705ffa9e6eba12441c401bba901aa69b912df6f969a5392cfe3bbc3",
+  "signature": "21af774b871225aa7d2c4388c61b3aa6460e9da4a4732e368cc229eea5e4f3c5",
   "version": 1
 }

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/expected.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/expected.json
@@ -4,8 +4,9 @@
   "gateway_view_binding_ok": true,
   "gateway_view_matches_provider_digest": true,
   "malformed_binding_fails_closed": true,
-  "note": "no SEP-2787 attestation: the backLink digest is over a named, versioned projection (the tools/call name and arguments plus the _meta.authorization_binding block), not the whole _meta. A gateway and a provider view of the same call carry different transport-local _meta yet project to the same digest; changing the bound params or the binding block breaks the back-link; an absent binding block fails closed instead of digesting the whole _meta.",
+  "note": "no SEP-2787 attestation: the backLink digest is over a named, versioned projection (the tools/call name and arguments plus the _meta.authorization_binding block), not the whole _meta. The signed record names the projection version it used (backLink.fallbackProjection), so a verifier reconstructs the same projection deterministically rather than inferring it from the observed envelope. The preimage is an allowlist: a gateway and a provider view carrying different transport-local _meta project to the same digest; changing the bound params or the binding block breaks the back-link; an absent binding block fails closed instead of digesting the whole _meta.",
   "receipt_signature_ok": true,
+  "record_names_fallback_projection": true,
   "records_paired": true,
   "replayed_binding_ok": false,
   "tampered_binding_ok": false

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt.json
@@ -1,12 +1,13 @@
 {
   "alg": "HS256",
   "backLink": {
-    "attestationDigest": "sha256:80eb071ee11a6430ecced0055f09f9570e30cd328fa757871c5a9f29ffa42247",
-    "attestationNonce": "server-chosen-nonce-001"
+    "attestationDigest": "sha256:ad365b402e0bd577841ba1a4e2f2f8dae53654e8c21695f5be9632e1d36bc32a",
+    "attestationNonce": "server-chosen-nonce-001",
+    "fallbackProjection": "sep2828-fallback/1"
   },
   "outcomeDerived": {
     "completedAt": "2026-06-01T10:00:00Z",
-    "decisionDigest": "sha256:02013b96b66b06a8db32fd188616f9b20d1991c650d3e431239370602896702c",
+    "decisionDigest": "sha256:419f6be096517e0f09b94a254a75669a8b57179e1aa13623c580cbe42c18d118",
     "resultCommitment": {
       "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
       "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
@@ -21,6 +22,6 @@
     "secretVersion": "v1",
     "sub": "agent:reader"
   },
-  "signature": "1b9965420896d5185a817e075cdd19b35db157fedd671ea3036bdabd6db63561",
+  "signature": "0d5e4c513eaa30e379b5b937ebc5ee06e65a846b111a472d7c4dc594b4d637be",
   "version": 1
 }

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope.json
@@ -1,8 +1,7 @@
 {
   "_meta": {
     "authorization_binding": {
-      "nonce": "server-chosen-nonce-001",
-      "projectionVersion": "sep2828-fallback/1"
+      "nonce": "server-chosen-nonce-001"
     },
     "io.modelcontextprotocol/serverTraceId": "trace-provider-7f3a"
   },

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_gateway_view.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_gateway_view.json
@@ -1,8 +1,7 @@
 {
   "_meta": {
     "authorization_binding": {
-      "nonce": "server-chosen-nonce-001",
-      "projectionVersion": "sep2828-fallback/1"
+      "nonce": "server-chosen-nonce-001"
     },
     "io.modelcontextprotocol/progressToken": "p-7",
     "io.modelcontextprotocol/uiHint": "table-preview"

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_replayed.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_replayed.json
@@ -1,8 +1,7 @@
 {
   "_meta": {
     "authorization_binding": {
-      "nonce": "server-chosen-nonce-001",
-      "projectionVersion": "sep2828-fallback/1"
+      "nonce": "server-chosen-nonce-001"
     },
     "io.modelcontextprotocol/serverTraceId": "trace-provider-7f3a"
   },

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_tampered_binding.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/request_envelope_tampered_binding.json
@@ -1,8 +1,7 @@
 {
   "_meta": {
     "authorization_binding": {
-      "nonce": "attacker-swapped-nonce-999",
-      "projectionVersion": "sep2828-fallback/1"
+      "nonce": "attacker-swapped-nonce-999"
     },
     "io.modelcontextprotocol/serverTraceId": "trace-provider-7f3a"
   },


### PR DESCRIPTION
## What

Follow-up to the named-projection fallback (#234). Two refinements that converged on modelcontextprotocol#2867 after the first cut landed:

1. **Projection version rides on the signed record, not the envelope.** New optional `backLink.fallbackProjection` names the version the digest was computed under. A verifier reconstructs the projection under the version the *record* declares, so reconstruction is deterministic from trusted data and a later projection revision is an explicit new version rather than a silent reinterpretation. `request_envelope_digest` / `fallback_projection` take the version as a keyword; the binding block now carries only the per-call `nonce`. A record naming no version or an unsupported one fails closed.

2. **The exclusion rule is an allowlist, not a denylist.** The preimage is exactly the bound call params plus the named binding block; every other `_meta` field is excluded by construction, so the rule cannot drift as new `_meta` fields appear. The enumerated transport-local fields are illustration only.

## Why

Rul1an (building a second consumer, "Assay") raised both on #2867: make the projection version self-describing in the record so a verifier picks the reconstruction deterministically, and state the binding as inclusion since a denylist can never be complete. rpelevin's principles (deterministic reconstruction, explicit versioning) point the same way. This puts the reference implementation ahead of the note rather than chasing it.

## Surface

- Shared `BackLink` gains optional `fallback_projection`, serialized as `fallbackProjection` only when present, so attestation-path records stay byte-identical.
- Fixtures regenerated: decision + receipt back-links carry the version, envelopes drop `projectionVersion` from the binding block, Vaara-free checker reads the version from the record.
- SEP clause, vectors README, CHANGELOG updated.

## Tests

`1622 passed, 13 skipped`; ruff + mypy clean. Covers: provider/gateway digest parity, changed params break, changed binding breaks, missing block fails closed, record names version, unsupported/absent version fails closed.
