### PR TITLE
feat: adopt the landed fallback projection id from the #2867 note

### DIFF
--- a/docs/sep/sep-server-execution-record.md
+++ b/docs/sep/sep-server-execution-record.md
@@ -176,7 +176,7 @@ following top-level fields.
 | ------------------ | ------ | -------- | ------------------------------------------------------------------------------------ |
 | `attestationDigest`| string | yes      | `sha256:<hex>` over the JCS-canonical full SEP-2787 attestation wire bytes, signature included. Pins the exact attestation instance. In the no-2787 fallback (below) it is over the named request-envelope projection instead. |
 | `attestationNonce` | string | yes      | Echoes the attestation's `issuerAsserted.nonce` for fast correlation. In the fallback it echoes `_meta.authorization_binding.nonce`. |
-| `fallbackProjection`| string | no       | Present only in the no-2787 fallback: names the projection version `attestationDigest` was computed under (this release: `sep2828-fallback/1`). Absent on the attestation path. |
+| `fallbackProjection`| string | no       | Present only in the no-2787 fallback: names the projection version `attestationDigest` was computed under (this release: `tools_call_params_plus_meta_authorization_binding_v1`). Absent on the attestation path. |
 
 If no SEP-2787 attestation exists for the call (the deployment does not run
 2787), the server MUST instead bind the request by setting `attestationDigest` to

--- a/src/vaara/attestation/_decision_verifier.py
+++ b/src/vaara/attestation/_decision_verifier.py
@@ -67,11 +67,13 @@ def verify_decision_back_link(
     return BackLinkResult(ok=True)
 
 
-# The named projection version a no-SEP-2787 fallback digest commits to. The
-# signed record names which version it used (backLink.fallbackProjection), so a
-# verifier reconstructs the same projection deterministically and a future
-# projection rule is an explicit new version, not a silent reinterpretation.
-FALLBACK_PROJECTION_V1 = "sep2828-fallback/1"
+# The named projection version a no-SEP-2787 fallback digest commits to. The id
+# is descriptive (it names what the preimage includes) and the signed record
+# names which version it used (backLink.fallbackProjection), so a verifier
+# reconstructs the same projection deterministically and a future projection rule
+# is an explicit new version, not a silent reinterpretation. This is the id the
+# non-normative SEP-2828 example note on modelcontextprotocol#2867 settled on.
+FALLBACK_PROJECTION_V1 = "tools_call_params_plus_meta_authorization_binding_v1"
 _SUPPORTED_FALLBACK_PROJECTIONS = frozenset({FALLBACK_PROJECTION_V1})
 
 # The named binding block under ``_meta`` whose contents are authoritative for

--- a/tests/test_decision_pairing_vectors.py
+++ b/tests/test_decision_pairing_vectors.py
@@ -101,11 +101,12 @@ def test_vaara_verifier_reproduces_fallback_binding():
     # fails closed rather than guessing the rule.
     import dataclasses
 
-    assert decision.back_link.fallback_projection == "sep2828-fallback/1"
+    assert (decision.back_link.fallback_projection
+            == "tools_call_params_plus_meta_authorization_binding_v1")
     bad_version = dataclasses.replace(
         decision,
         back_link=dataclasses.replace(
-            decision.back_link, fallback_projection="sep2828-fallback/99"))
+            decision.back_link, fallback_projection="unknown_projection_v9"))
     assert verify_decision_fallback_binding(
         bad_version, request_envelope=provider).ok is False
     no_version = dataclasses.replace(
@@ -145,7 +146,7 @@ def test_fallback_projection_excludes_transport_local_meta():
 
     # An unsupported version and a missing block both fail closed.
     with pytest.raises(MalformedFallbackBindingError):
-        request_envelope_digest(base, version="sep2828-fallback/99")
+        request_envelope_digest(base, version="unknown_projection_v9")
     no_block = {"name": "query_table", "arguments": {}, "_meta": {}}
     with pytest.raises(MalformedFallbackBindingError):
         request_envelope_digest(no_block)

--- a/tests/vectors/decision_pairing_v0/_check_independent.py
+++ b/tests/vectors/decision_pairing_v0/_check_independent.py
@@ -80,7 +80,8 @@ def verify_back_link(record: dict, attestation: dict) -> bool:
     return bl["attestationNonce"] == attestation["issuerAsserted"]["nonce"]
 
 
-_SUPPORTED_FALLBACK_PROJECTIONS = frozenset({"sep2828-fallback/1"})
+_SUPPORTED_FALLBACK_PROJECTIONS = frozenset(
+    {"tools_call_params_plus_meta_authorization_binding_v1"})
 
 
 def fallback_projection(envelope: dict, version):

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/decision.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/decision.json
@@ -1,9 +1,9 @@
 {
   "alg": "HS256",
   "backLink": {
-    "attestationDigest": "sha256:ad365b402e0bd577841ba1a4e2f2f8dae53654e8c21695f5be9632e1d36bc32a",
+    "attestationDigest": "sha256:aeac6a08f83dafe8569a1a195e2874b863a7e3c7d751b6c368dbc3850fd549bb",
     "attestationNonce": "server-chosen-nonce-001",
-    "fallbackProjection": "sep2828-fallback/1"
+    "fallbackProjection": "tools_call_params_plus_meta_authorization_binding_v1"
   },
   "decisionDerived": {
     "decidedAt": "2026-06-01T10:00:00Z",
@@ -21,6 +21,6 @@
     "secretVersion": "v1",
     "sub": "agent:reader"
   },
-  "signature": "21af774b871225aa7d2c4388c61b3aa6460e9da4a4732e368cc229eea5e4f3c5",
+  "signature": "2c5e9acf04971b8e21979ac9905266af810528e3c3462a4d34322ed3de4e6c3d",
   "version": 1
 }

--- a/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt.json
+++ b/tests/vectors/decision_pairing_v0/normative/fallback_envelope_binding/receipt.json
@@ -1,13 +1,13 @@
 {
   "alg": "HS256",
   "backLink": {
-    "attestationDigest": "sha256:ad365b402e0bd577841ba1a4e2f2f8dae53654e8c21695f5be9632e1d36bc32a",
+    "attestationDigest": "sha256:aeac6a08f83dafe8569a1a195e2874b863a7e3c7d751b6c368dbc3850fd549bb",
     "attestationNonce": "server-chosen-nonce-001",
-    "fallbackProjection": "sep2828-fallback/1"
+    "fallbackProjection": "tools_call_params_plus_meta_authorization_binding_v1"
   },
   "outcomeDerived": {
     "completedAt": "2026-06-01T10:00:00Z",
-    "decisionDigest": "sha256:419f6be096517e0f09b94a254a75669a8b57179e1aa13623c580cbe42c18d118",
+    "decisionDigest": "sha256:784e88f46a0c7aa47cf32ab596e8c5d983e9d39436e2cf33183997489f3d3599",
     "resultCommitment": {
       "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
       "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
@@ -22,6 +22,6 @@
     "secretVersion": "v1",
     "sub": "agent:reader"
   },
-  "signature": "0d5e4c513eaa30e379b5b937ebc5ee06e65a846b111a472d7c4dc594b4d637be",
+  "signature": "e49c336ad1a14b48ff37a529ae87b301811f1a0b2245a58c15a30806e3f0c315",
   "version": 1
 }


### PR DESCRIPTION
## What

Aligns the no-2787 fallback projection id to the value the non-normative SEP-2828 example note settled on in modelcontextprotocol#2867: `tools_call_params_plus_meta_authorization_binding_v1`. We used `sep2828-fallback/1`; the note (pushed by dinpd, confirmed by rpelevin) uses the descriptive id that names what the preimage includes.

## Why

The reference implementation already has the converged shape: named inclusion projection, version on the back-link (`fallbackProjection`), fail-closed. The only divergence was the id string. Matching it makes our committed fixtures byte-identical to what the note describes and what a second implementation (Rul1an's "Assay") will reproduce. The thread has landed, so this is locking onto consensus, not chasing a moving target.

## Scope

Value-only change: `FALLBACK_PROJECTION_V1`, the Vaara-free checker's supported set, the SEP clause example, and the regenerated decision/receipt back-link digests. Structure, allowlist rule, and fail-closed contract unchanged.

## Tests

`1622 passed, 13 skipped`; ruff + mypy clean; independent checker 7/7. Our corpus already covers rpelevin's reproducibility triad (non-binding `_meta` parity, changed params/binding fail, missing/unknown projection id fails closed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SEP documentation to reflect revised internal identifier naming.

* **Chores**
  * Updated internal identifiers to use more descriptive naming conventions.
  * Updated corresponding test fixtures and validation logic to match new identifier values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->