### PR TITLE
feat: vaara-governed-tool-call skill + fix review-resolve chain fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+- `vaara review resolve --audit-db` no longer forks the audit hash chain. It
+  was writing the `ESCALATION_RESOLVED` record (Article 14(4)(d)) through a
+  fresh `AuditTrail` whose `previous_hash` started empty, so resolving an
+  escalation into an audit DB that already held the action's lifecycle broke
+  chain continuity and `verify_chain()` flagged the trail. The resolution now
+  appends to the loaded trail and continues the chain. Surfaced by the
+  `vaara-governed-tool-call` example skill.
+
+### Added
+- `examples/skills/vaara-governed-tool-call/`: an agent skill (the portable
+  `SKILL.md` + script format) that puts an EU AI Act Article 14 human-oversight
+  checkpoint and an Article 12 record in front of a high-risk tool call. The
+  agent gates a proposed call to allow / escalate / deny, escalations route to
+  the `vaara review` queue for a human, and the decision, escalation,
+  resolution, and outcome append to a hash-chained trail that exports to a
+  signed Article 12 package and verifies offline. Drops in next to capability
+  skills (for example clinical or genomic database skills) that ship the action
+  but not the oversight.
+
 ### Changed
 - `vaara.attestation.decision.superseding_decision` now reports an
   equal-`decidedAt` tie between distinct decision records as ambiguous, raising

--- a/examples/skills/vaara-governed-tool-call/SKILL.md
+++ b/examples/skills/vaara-governed-tool-call/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: vaara-governed-tool-call
+description: >
+  Put an EU AI Act Article 14 human-oversight checkpoint and an Article 12
+  auditable record in front of a high-risk tool call. Use before an agent runs a
+  consequential or irreversible action (writing to a clinical/genomic database,
+  submitting a record to a regulator, moving money, deleting data, anything a
+  human should be able to stop and a regulator should be able to verify later).
+  Gates the call to allow / escalate / deny, routes escalations to a human review
+  queue, and writes a hash-chained record you can export and verify offline.
+---
+
+# Governed tool call (EU AI Act Article 12 + 14)
+
+## Overview
+
+Capability skills let an agent *do* things. This skill records *what it was
+allowed to do, on what basis, and what it actually did*, and inserts a human
+where the law requires one. It wraps the `vaara` package (no server needed):
+
+- **Article 14 (human oversight):** a call can be escalated to a person who must
+  resolve it before the agent proceeds. The deployer can designate specific
+  calls as always-escalate.
+- **Article 12 (record-keeping):** every decision, escalation, resolution, and
+  outcome is appended to a tamper-evident, hash-chained audit trail that exports
+  to a signed regulator package and verifies offline.
+
+The decision is Vaara's, governed by thresholds the operator sets; this skill
+does not invent verdicts. Authenticity of the final package rests on the signing
+key and the optional RFC 3161 time anchor, not on this skill.
+
+## When to use
+
+Use it before any tool call that is consequential, irreversible, or touches
+regulated data, especially alongside capability skills (for example clinical or
+genomic database skills). Do not use it for read-only, low-stakes calls; gate
+the actions a human would want to be able to stop.
+
+## Prerequisites
+
+1. `pip install vaara` (the base install covers gate, escalate, record;
+   `pip install 'vaara[attestation]'` is only needed for some export options).
+2. Pick two SQLite paths and reuse them across calls: one for the audit trail
+   (`--audit-db`), one for the review queue (`--queue-db`).
+
+## Protocol
+
+Run `scripts/governed_call.py` for each governed action.
+
+### 1. Gate the call, before executing it
+
+```
+python scripts/governed_call.py gate \
+  --agent-id <agent> --tool <tool_name> \
+  --params-json '{"...": "..."}' \
+  --audit-db audit.db --queue-db queue.db \
+  [--mode strict|balanced|eco|performance] [--require-review]
+```
+
+Read the JSON verdict and the exit code:
+
+- **`allow` (exit 0):** execute the call, then go to step 3.
+- **`escalate` (exit 10):** **STOP. Do not execute.** The call is queued for a
+  human. Surface the `action_id` to the user and wait. Proceed only after step 2
+  resolves it `allow`.
+- **`deny` (exit 20):** **do not execute.** Tell the user it was blocked by
+  policy and why.
+
+`--require-review` designates this call for mandatory human oversight: it always
+escalates regardless of score. Use it for the operations the deployer has
+decided a human must always sign off (this is the Article 14 designation). The
+risk is still scored and recorded.
+
+### 2. Human resolves an escalation (done by a person, not the agent)
+
+A reviewer lists, then resolves:
+
+```
+vaara review list --db queue.db --status pending
+vaara review resolve --db queue.db --queue-id <id> \
+  --reviewer <who> --resolution allow|deny \
+  --justification "..." --audit-db audit.db
+```
+
+`--audit-db` writes the `ESCALATION_RESOLVED` record (Article 14(4)(d) evidence)
+into the same chain. On `allow`, the agent may now execute the call; on `deny`,
+it must not.
+
+### 3. Record the outcome, after an allowed call ran
+
+```
+python scripts/governed_call.py outcome \
+  --action-id <from step 1> --agent-id <agent> --tool <tool_name> \
+  --result-json '{"...": "..."}' [--severity 0.0] --audit-db audit.db
+```
+
+### 4. Export the Article 12 package, when a regulator asks
+
+```
+python scripts/governed_call.py export-jsonl --audit-db audit.db --out trail.jsonl
+vaara trail export-article12 --trail trail.jsonl --key <ed25519.pem> --out pack.zip
+vaara trail verify --zip pack.zip
+```
+
+The package carries the full lifecycle (request, decision, escalation,
+resolution, execution, outcome), a human-readable report, and a verified hash
+chain. Add `--anchor-tsa <url>` to fold in an RFC 3161 time anchor (Article 19
+existence-in-time evidence).
+
+## Trust model (read this)
+
+- The verdict reflects Vaara's risk thresholds (`--mode`) and the deployer's
+  `--require-review` designations. It is governance, not ground truth.
+- The audit trail is tamper-evident by hash chain; tamper-*proof* comes from
+  signing the export with a real key and anchoring it. The dev key from
+  `vaara keygen --dev` is for evaluation only.
+- This skill records and gates. It does not execute your tool or vouch for the
+  tool's own correctness.

--- a/examples/skills/vaara-governed-tool-call/scripts/governed_call.py
+++ b/examples/skills/vaara-governed-tool-call/scripts/governed_call.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Governed tool call: gate a proposed action through Vaara before it runs,
+record what happened after, to a persistent Article 12 audit trail.
+
+This is the script half of the ``vaara-governed-tool-call`` skill. It wraps the
+installed ``vaara`` package (``pip install vaara``) so an agent can put an EU AI
+Act Article 14 human-oversight checkpoint and an Article 12 record in front of a
+high-risk tool call without standing up the HTTP proxy.
+
+Two subcommands:
+
+  gate     Classify, score, and decide allow / escalate / deny for a proposed
+           call. Writes the decision to the audit trail. On ``escalate`` the
+           call is enqueued to the review queue and the agent MUST stop and wait
+           for a human (see ``vaara review``). Exit code carries the verdict:
+           0 allow, 10 escalate (needs a human), 20 deny (blocked), 1 error.
+
+  outcome  After an allowed call ran, record what it did to the same trail.
+
+Both reopen the trail from SQLite, so the hash chain continues across calls and
+``vaara trail export-article12`` can package the whole lifecycle for a regulator.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+
+def _load_trail(audit_db: str):
+    from vaara.audit.sqlite_backend import SQLiteAuditBackend
+
+    backend = SQLiteAuditBackend(audit_db)
+    # load_trail() returns a trail wired to persist new records AND seeded with
+    # the last hash, so appends continue the existing chain rather than fork it.
+    return backend, backend.load_trail()
+
+
+def _parse_json_arg(raw: str, flag: str) -> dict:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"{flag}: not valid JSON: {exc}")
+    if not isinstance(value, dict):
+        sys.exit(f"{flag}: must be a JSON object, got {type(value).__name__}")
+    return value
+
+
+_EXIT = {"allow": 0, "escalate": 10, "deny": 20}
+
+# (escalate-boundary, deny-boundary). A risk below the escalate boundary
+# allows; above the deny boundary denies; in between escalates for human
+# review. These mirror `vaara mode list`.
+_MODES = {
+    "eco": (0.40, 0.60),
+    "balanced": (0.55, 0.85),
+    "performance": (0.70, 0.92),
+    "strict": (0.30, 0.55),
+}
+
+
+def cmd_gate(args: argparse.Namespace) -> int:
+    from vaara import Pipeline
+    from vaara.audit.review_queue import ReviewQueue
+    from vaara.scorer.adaptive import AdaptiveScorer
+
+    params = _parse_json_arg(args.params_json, "--params-json")
+    context = _parse_json_arg(args.context_json, "--context-json")
+
+    if args.require_review:
+        # The deployer designates this call for mandatory human oversight
+        # (EU AI Act Article 14): never auto-allow, never auto-deny, always
+        # route to a human. The risk is still scored and recorded as evidence.
+        scorer = AdaptiveScorer(threshold_allow=0.0, threshold_deny=1.01)
+    else:
+        allow_below, deny_above = _MODES[args.mode]
+        scorer = AdaptiveScorer(
+            threshold_allow=allow_below, threshold_deny=deny_above
+        )
+
+    backend, trail = _load_trail(args.audit_db)
+    queue = ReviewQueue(args.queue_db)
+    try:
+        pipe = Pipeline(
+            trail=trail, scorer=scorer, review_queue=queue,
+            enforce=not args.shadow,
+        )
+        result = pipe.intercept(
+            agent_id=args.agent_id,
+            tool_name=args.tool,
+            parameters=params,
+            context=context or None,
+            session_id=args.session_id,
+        )
+    finally:
+        queue.close()
+        backend.close()
+
+    verdict = {
+        "decision": result.decision,
+        "allowed": result.allowed,
+        "action_id": result.action_id,
+        "risk_score": round(result.risk_score, 4),
+        "risk_interval": [round(x, 4) for x in result.risk_interval],
+        "reason": result.reason,
+    }
+    if result.decision == "escalate":
+        verdict["next"] = (
+            "STOP. This call needs human sign-off. Do not execute it. It is "
+            "queued for review; a human resolves it with `vaara review resolve "
+            f"--db {args.queue_db} --queue-id <id> --resolution allow|deny "
+            f"--reviewer <who> --audit-db {args.audit_db}`. Re-check the queue "
+            "before proceeding."
+        )
+    elif result.decision == "deny":
+        verdict["next"] = "BLOCKED by policy. Do not execute. Tell the user why."
+    else:
+        verdict["next"] = (
+            "Allowed. Execute the call, then record what it did with "
+            "`governed_call.py outcome`."
+        )
+    print(json.dumps(verdict, indent=2))
+    return _EXIT.get(result.decision, 1)
+
+
+def cmd_outcome(args: argparse.Namespace) -> int:
+    result = _parse_json_arg(args.result_json, "--result-json")
+
+    backend, trail = _load_trail(args.audit_db)
+    try:
+        trail.record_execution(
+            action_id=args.action_id,
+            agent_id=args.agent_id,
+            tool_name=args.tool,
+            result=result,
+        )
+        if args.severity is not None:
+            trail.record_outcome(
+                action_id=args.action_id,
+                agent_id=args.agent_id,
+                tool_name=args.tool,
+                outcome_severity=args.severity,
+                description=args.description,
+            )
+    finally:
+        backend.close()
+    print(json.dumps({
+        "action_id": args.action_id,
+        "recorded": "execution" + ("+outcome" if args.severity is not None
+                                    else ""),
+        "audit_db": args.audit_db,
+    }, indent=2))
+    return 0
+
+
+def cmd_export_jsonl(args: argparse.Namespace) -> int:
+    from vaara.audit.sqlite_backend import SQLiteAuditBackend
+
+    backend = SQLiteAuditBackend(args.audit_db)
+    try:
+        n = backend.export_jsonl(args.out)
+    finally:
+        backend.close()
+    print(json.dumps({"trail_jsonl": args.out, "records": n}, indent=2))
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    g = sub.add_parser("gate", help="gate a proposed tool call before it runs")
+    g.add_argument("--agent-id", required=True)
+    g.add_argument("--tool", required=True, help="tool/function name")
+    g.add_argument("--params-json", default="",
+                   help="JSON object of the call arguments")
+    g.add_argument("--context-json", default="",
+                   help="JSON object of extra context (optional)")
+    g.add_argument("--session-id", default="")
+    g.add_argument("--audit-db", required=True,
+                   help="SQLite path for the Article 12 audit trail")
+    g.add_argument("--queue-db", required=True,
+                   help="SQLite path for the Article 14 review queue")
+    g.add_argument("--mode", choices=sorted(_MODES), default="strict",
+                   help="risk thresholds (default: strict, escalate-on-doubt)")
+    g.add_argument("--require-review", action="store_true",
+                   help="designate this call for mandatory human oversight: "
+                        "always escalate regardless of score (Article 14)")
+    g.add_argument("--shadow", action="store_true",
+                   help="record the decision but always allow (evidence-only)")
+    g.set_defaults(func=cmd_gate)
+
+    o = sub.add_parser("outcome", help="record what an allowed call did")
+    o.add_argument("--action-id", required=True,
+                   help="action_id returned by `gate`")
+    o.add_argument("--agent-id", required=True)
+    o.add_argument("--tool", required=True)
+    o.add_argument("--result-json", default="",
+                   help="JSON object summarizing the result")
+    o.add_argument("--severity", type=float, default=None,
+                   help="observed harm 0.0 safe .. 1.0 catastrophic (optional)")
+    o.add_argument("--description", default="")
+    o.add_argument("--audit-db", required=True)
+    o.set_defaults(func=cmd_outcome)
+
+    e = sub.add_parser("export-jsonl",
+                       help="dump the audit trail to JSONL for export-article12")
+    e.add_argument("--audit-db", required=True)
+    e.add_argument("--out", required=True, help="path to write trail.jsonl")
+    e.set_defaults(func=cmd_export_jsonl)
+
+    args = p.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -939,9 +939,12 @@ def _cmd_review_resolve(args: argparse.Namespace) -> int:
     backend = None
     if args.audit_db:
         from vaara.audit.sqlite_backend import SQLiteAuditBackend
-        from vaara.audit.trail import AuditTrail
         backend = SQLiteAuditBackend(Path(args.audit_db).expanduser())
-        trail = AuditTrail(on_record=backend.write_record)
+        # Continue the existing hash chain. A fresh AuditTrail starts at
+        # previous_hash='' and would fork the chain when the audit DB already
+        # holds the action's lifecycle, so the ESCALATION_RESOLVED record
+        # (Article 14(4)(d)) must append to the loaded trail, not a new one.
+        trail = backend.load_trail()
     try:
         with _open_review_queue(args.db) as q:
             try:


### PR DESCRIPTION
## What

Adds `examples/skills/vaara-governed-tool-call/`: an agent skill in the portable `SKILL.md` + script format (the same shape DeepMind's `science-skills` and the wider Claude/agent skills ecosystem ship). It puts an **EU AI Act Article 14 human-oversight checkpoint** and an **Article 12 record** in front of a high-risk tool call.

The agent runs `governed_call.py gate` before a consequential action: Vaara classifies, scores, and decides **allow / escalate / deny**. Escalations route to the `vaara review` queue for a human; the decision, escalation, resolution, and outcome append to a hash-chained trail that exports to a signed Article 12 package and verifies offline. It drops in next to capability skills (clinical/genomic database skills, etc.) that ship the action but not the oversight.

The verdict is Vaara's, governed by operator thresholds (`--mode`, default strict) and the deployer's `--require-review` designation (mandatory oversight for designated calls, the Article 14 designation). The skill records and gates; it does not invent verdicts or execute the tool.

## Bug fix (found by dogfooding the skill)

Building the end-to-end loop surfaced a real chain bug: `vaara review resolve --audit-db` wrote the `ESCALATION_RESOLVED` record (Article 14(4)(d)) through a fresh `AuditTrail` whose `previous_hash` started empty, **forking the Article 12 hash chain** when the audit DB already held the action's lifecycle (`verify_chain()` then flagged it). The resolution now appends to the loaded trail and continues the chain.

## Verification

- Full loop verified: `gate` (designated → escalate, exit 10) → `vaara review resolve` (allow, chain intact) → `outcome` → `export-jsonl` → `vaara trail export-article12` ("chain intact: True") → `vaara trail verify` ("Verification: OK").
- `206 cli/review tests pass`; ruff clean; no em-dashes in the docs. (cli.py mypy errors are all pre-existing and outside the edit; cli.py is not CI-gated by mypy.)

Lives in `examples/` and is not published anywhere external. Going public (marketplace / awesome-list) is a separate step.
