### PR TITLE
v0.68.0: no-2787 fallback named projection, supersession ambiguity, governed-tool-call skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.68.0] - 2026-06-09
 
 ### Fixed
 - `vaara review resolve --audit-db` no longer forks the audit hash chain. It

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.67.0"
+version = "0.68.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.67.0",
+  "version": "0.68.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.67.0",
+  "version": "0.68.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.67.0"
+__version__ = "0.68.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Roll the Unreleased changes to 0.68.0; bump the version across pyproject, `__init__`, clients/ts, and the two MCP server manifests.

Lands in this release:
- **no-SEP-2787 fallback** as a named, versioned **inclusion projection**, version on the signed back-link (`fallbackProjection`), fail-closed, id `tools_call_params_plus_meta_authorization_binding_v1` (the shape that converged on modelcontextprotocol#2867).
- **supersession** equal-`decidedAt` ties reported **ambiguous**, not broken by nonce (answers modelcontextprotocol#2852); request envelope carried as a first-class fallback fixture.
- **`vaara-governed-tool-call` example skill**: Article 12 record + Article 14 oversight in front of a high-risk tool call.
- **Fix**: `vaara review resolve --audit-db` no longer forks the audit hash chain (surfaced by the skill).

Full notes in CHANGELOG `[0.68.0]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.68.0 released across all packages and configurations.
  * Changelog updated with release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->