### PR TITLE
chore: harden the MCP-registry release gate and tidy the v0.68.0 changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,7 @@ jobs:
           EXPECTED="${RELEASE_TAG#v}"
           echo "Expected version (from tag ${RELEASE_TAG}): ${EXPECTED}"
           python3 - "$EXPECTED" <<'PY'
-          import json, sys, time, urllib.request
+          import json, sys, time, urllib.error, urllib.request
 
           expected = sys.argv[1]
           names = ["io.github.vaaraio/vaara", "io.github.vaaraio/vaara-server"]
@@ -239,8 +239,14 @@ jobs:
               # paginated and does not reliably carry every server's active entry,
               # so a multi-listing repo needs one request per name.
               url = f"{BASE}?search={name}&version=latest"
-              with urllib.request.urlopen(url, timeout=30) as fh:
-                  data = json.load(fh)
+              try:
+                  with urllib.request.urlopen(url, timeout=30) as fh:
+                      data = json.load(fh)
+              except (urllib.error.URLError, TimeoutError) as exc:
+                  # A transient read timeout or 5xx must not abort the publish gate.
+                  # Treat it as a miss so the surrounding poll retries.
+                  print(f"WARN {name}: registry read failed ({exc!r}); will retry")
+                  return None
               for entry in data.get("servers", data.get("data", [])):
                   server = entry.get("server", entry)
                   if server.get("name") != name:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [0.68.0] - 2026-06-09
 
-### Fixed
-- `vaara review resolve --audit-db` no longer forks the audit hash chain. It
-  was writing the `ESCALATION_RESOLVED` record (Article 14(4)(d)) through a
-  fresh `AuditTrail` whose `previous_hash` started empty, so resolving an
-  escalation into an audit DB that already held the action's lifecycle broke
-  chain continuity and `verify_chain()` flagged the trail. The resolution now
-  appends to the loaded trail and continues the chain. Surfaced by the
-  `vaara-governed-tool-call` example skill.
-
 ### Added
 - `examples/skills/vaara-governed-tool-call/`: an agent skill (the portable
   `SKILL.md` + script format) that puts an EU AI Act Article 14 human-oversight
@@ -38,8 +29,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   clause and the `supersession_equal_decidedat_tie` vector verdict (`winner:
   d5a` becomes `supersession: ambiguous`) are updated to match. Raised by
   rpelevin on modelcontextprotocol#2852.
-
-### Added
 - The no-SEP-2787 fallback back-link now binds a **named, versioned projection**
   of the request envelope, not the whole observed `_meta`. The preimage is an
   allowlist: exactly the `tools/call` `name`+`arguments` plus the
@@ -60,6 +49,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   no-binding envelopes as first-class fixture inputs, and the Vaara-free checker
   reproduces every verdict. Refines the no-2787 fallback shape as it converged on
   modelcontextprotocol#2867.
+
+### Fixed
+- `vaara review resolve --audit-db` no longer forks the audit hash chain. It
+  was writing the `ESCALATION_RESOLVED` record (Article 14(4)(d)) through a
+  fresh `AuditTrail` whose `previous_hash` started empty, so resolving an
+  escalation into an audit DB that already held the action's lifecycle broke
+  chain continuity and `verify_chain()` flagged the trail. The resolution now
+  appends to the loaded trail and continues the chain. Surfaced by the
+  `vaara-governed-tool-call` example skill.
 
 ## [0.67.0] - 2026-06-09
 


### PR DESCRIPTION
v0.68.0 is live on all four surfaces (PyPI, npm, the GitHub Release, and the MCP registry on both listings). The release run still went red, on the post-publish step that reads the registry back to confirm the version matches the tag. That read timed out and crashed the assertion after the publish had already succeeded.

The step polls ten times, but latest_active() let a transient read timeout or 5xx escape and abort the whole script on the first bad read. This catches those inside the poll, so a single flaky read counts as a retry. Only a sustained failure to confirm fails the gate.

Also reorders the [0.68.0] changelog section to one Added / Changed / Fixed grouping, instead of the two separate "Added" blocks it shipped with.