### PR TITLE
test: add neg_unknown_alg negative vector to the SEP-2787 attestation set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- A negative conformance vector for an unsupported `alg` identifier in the
+  SEP-2787 attestation set (`neg_unknown_alg`): a well-formed HS256 envelope
+  re-labelled `alg: "none"`, the classic algorithm-confusion shape. A conformant
+  verifier must refuse it rather than treat the envelope as unsigned. The
+  Vaara-free walker reaches `signature_ok` false (no `alg` branch); the Vaara
+  reference refuses earlier, at the parse boundary (`alg` not in `VALID_ALGS`).
+  This completes the negative coverage promised for this surface alongside the
+  receipt replay-substitution case already shipped.
+
 ## [0.69.0] - 2026-06-11
 
 ### Added

--- a/docs/sep2787-conformance.md
+++ b/docs/sep2787-conformance.md
@@ -89,7 +89,7 @@ null`.
   `_check_independent.py` walker that uses only the standard library plus
   `cryptography` and `rfc8785` to verify them without importing Vaara).
 - SEP-2787 attestation vectors live in-repo at
-  `tests/vectors/sep2787_attestation_v0/` (six cases across HS256/ES256/RS256,
+  `tests/vectors/sep2787_attestation_v0/` (seven cases across HS256/ES256/RS256,
   pinned keys, a `_check_independent.py` walker that uses only the standard
   library plus `cryptography` and `rfc8785` to verify signature, TTL, and the
   step-5 argument commitment without importing Vaara).

--- a/scripts/generate_sep2787_attestation_vectors.py
+++ b/scripts/generate_sep2787_attestation_vectors.py
@@ -166,6 +166,21 @@ def main() -> None:
           expected={"signature_ok": True, "ttl_ok": True,
                     "args_commitment_ok": False, "projection_match": None})
 
+    # Negative: unsupported `alg` identifier. A well-formed HS256 envelope
+    # re-labelled alg "none" -- the classic algorithm-confusion shape. The
+    # TTL and the argument commitment still hold, but a conformant verifier
+    # MUST refuse to verify under an algorithm it does not support, rather
+    # than treat the envelope as unsigned. The independent walker reaches
+    # signature_ok false (the alg dispatch finds no branch); Vaara refuses
+    # one layer earlier, at the parse boundary (alg not in VALID_ALGS).
+    att = _attest(alg="HS256", signing_material=HS_SECRET,
+                  args=make_args_digest(ARGS), nonce="att-nonce-hs-0007")
+    unknown = att.to_dict()
+    unknown["alg"] = "none"
+    _case("neg_unknown_alg", attestation_dict=unknown, runtime_args=ARGS,
+          expected={"signature_ok": False, "ttl_ok": True,
+                    "args_commitment_ok": True, "projection_match": True})
+
     print(f"wrote vectors under {OUT}")
     print(f"TTL evaluated at {EVAL_NOW_ISO}")
 

--- a/tests/test_attestation_vectors.py
+++ b/tests/test_attestation_vectors.py
@@ -29,10 +29,13 @@ for _mod in ("rfc8785", "cryptography"):
 from cryptography.hazmat.primitives import serialization  # noqa: E402
 
 from vaara.attestation.sep2787 import (  # noqa: E402
+    AttestationError,
     parse_attestation,
     verify_args_commitment,
     verify_attestation,
 )
+
+SUPPORTED_ALGS = frozenset({"HS256", "ES256", "RS256"})
 
 VECTORS = Path(__file__).parent / "vectors" / "sep2787_attestation_v0"
 KEYS = VECTORS / "keys"
@@ -70,14 +73,25 @@ def test_independent_walker_passes_all_cases():
     assert _load_checker().main() == 0
 
 
-def test_at_least_six_cases_present():
-    assert len(_cases()) >= 6
+def test_at_least_seven_cases_present():
+    assert len(_cases()) >= 7
 
 
 @pytest.mark.parametrize("case", _cases(), ids=lambda p: p.name)
 def test_library_verdicts_match_expected(case):
     raw = json.loads((case / "attestation.json").read_text())
     expected = json.loads((case / "expected.json").read_text())
+
+    # An unsupported `alg` is refused fail-closed at the parse boundary,
+    # before any signature work -- the independent walker reaches the same
+    # refusal one layer later, as signature_ok false. Both refuse; neither
+    # treats the envelope as unsigned.
+    if raw["alg"] not in SUPPORTED_ALGS:
+        with pytest.raises(AttestationError):
+            parse_attestation(raw)
+        assert expected["signature_ok"] is False
+        return
+
     att = parse_attestation(raw)
     material = _verifying_material(att.alg)
 

--- a/tests/vectors/sep2787_attestation_v0/README.md
+++ b/tests/vectors/sep2787_attestation_v0/README.md
@@ -55,6 +55,13 @@ three:
   deadline at the pinned instant.
 - `neg_args_mismatch`: signature and TTL valid, but the commitment binds
   arguments other than the supplied runtime arguments.
+- `neg_unknown_alg`: a well-formed HS256 envelope re-labelled `alg:
+  "none"` (the classic algorithm-confusion shape). TTL and the argument
+  commitment still hold, but the signature must be refused: a verifier
+  MUST NOT treat an unsupported `alg` as unsigned. The independent walker
+  reaches `signature_ok` false (the `alg` dispatch finds no branch); the
+  Vaara reference refuses one layer earlier, at the parse boundary
+  (`alg` not in `VALID_ALGS`, raising `AttestationError`). Both refuse.
 
 A redacted (non-identity) projection verifies with `args_commitment_ok`
 true and `projection_match` false: the verifier confirms the projection

--- a/tests/vectors/sep2787_attestation_v0/normative/neg_unknown_alg/attestation.json
+++ b/tests/vectors/sep2787_attestation_v0/normative/neg_unknown_alg/attestation.json
@@ -1,0 +1,29 @@
+{
+  "alg": "none",
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-05-29T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "att-nonce-hs-0007",
+    "secretVersion": "v1",
+    "sub": "agent:archiver"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "args": {
+          "projection": "{\"digest\":\"sha256:16fcac2dbb8f5d911362b041bbd7e2bb68393b45858d1414983be44a18df3dd4\"}",
+          "projectionDigest": "sha256:7f77dfef90fdde7e68aa1f92c8a09a9cbb10751387051978e67c1198f6206c52"
+        },
+        "name": "delete_file",
+        "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+      }
+    ]
+  },
+  "plannerDeclared": {
+    "intent": "archive obsolete report"
+  },
+  "signature": "65b66808e4ab5413a021b4f7dda3dba58ea55a84bd53cd5ed50cf4166f4be8d7",
+  "version": 1
+}

--- a/tests/vectors/sep2787_attestation_v0/normative/neg_unknown_alg/expected.json
+++ b/tests/vectors/sep2787_attestation_v0/normative/neg_unknown_alg/expected.json
@@ -1,0 +1,6 @@
+{
+  "args_commitment_ok": true,
+  "projection_match": true,
+  "signature_ok": false,
+  "ttl_ok": true
+}

--- a/tests/vectors/sep2787_attestation_v0/normative/neg_unknown_alg/runtime_args.json
+++ b/tests/vectors/sep2787_attestation_v0/normative/neg_unknown_alg/runtime_args.json
@@ -1,0 +1,4 @@
+{
+  "path": "/archive/2024-Q3.md",
+  "recursive": false
+}


### PR DESCRIPTION
Adds `neg_unknown_alg` to the SEP-2787 attestation conformance vectors: a well-formed HS256 envelope re-labelled `alg: "none"`, the classic algorithm-confusion shape. A conformant verifier must refuse it rather than treat the envelope as unsigned. The Vaara-free walker reaches `signature_ok` false (the alg dispatch finds no branch); the Vaara reference refuses one layer earlier at the parse boundary (`alg` not in `VALID_ALGS`).

This completes the negative coverage promised for this surface alongside the receipt replay-substitution case already shipped.

Generator, consuming test (parse-boundary refusal branch), vector README, conformance doc, and CHANGELOG updated. Independent walker 7/7; 249 attestation tests pass; ruff and mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SEP-2787 conformance vectors documentation from six to seven test cases.
  * Added guidance for handling unsupported algorithm identifiers in attestations.

* **Tests**
  * Added new test case validating that attestations with unsupported algorithms are properly rejected at the parse boundary.
  * Enhanced test validation to ensure signature verification fails while TTL and argument commitment checks remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->