### PR TITLE
chore(repo): commit the hard-rule .gitignore guard for watermarked SFS draft standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,12 @@ docs/blog/
 docs/grant/
 dist_verify/
 research/
+# HARD RULE — copyrighted, personally-watermarked draft standards (SFS/CEN/ISO,
+# "Downloaded by hello@vaara.io", do-not-distribute). NEVER commit, even if the
+# broad research/ line above is ever loosened. Folder also carries its own
+# .gitignore ('*') as a second guard. Do not remove either.
+research/sfs_sr315/
+**/sfs_sr315/
 .claude/
 
 # Private / internal, never publish


### PR DESCRIPTION
Commits a `.gitignore` edit that had been sitting uncommitted and resurfacing as a dirty working tree every session.

It adds a belt-and-suspenders ignore for `research/sfs_sr315/`, the personally watermarked ("Downloaded by hello@vaara.io"), do-not-distribute SFS/CEN draft standards. The broad `research/` line and the folder's own `.gitignore ('*')` already cover it. This makes the intent explicit with a hard-rule comment so the guard survives if `research/` is ever loosened.

No code change, ignore rules only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to improve commit management and enforce repository guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->