### PR TITLE
fix(attestation): TPM binding nonce is SHA-256, not SHA-512 (fTPM portability)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   to a record at a point in time, this binds an ordered sequence of quotes over a
   window (the Keylime-style loop): each tick re-quotes the TPM and folds the grown
   IMA log into a hash-linked chain. Each link's `extraData` is
-  `SHA-512(jcs(record) || prev_digest || seq)`, so dropping, reordering, or
+  `SHA-256(jcs(record) || prev_digest || seq)`, so dropping, reordering, or
   splicing a link fails its successor's binding. A `continuous` verdict requires,
   on top of every link passing the Phase-0 check: the TPM clock strictly
   increasing, `resetCount`/`restartCount` constant (no reboot, no unmeasured gap),
@@ -36,7 +36,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   record. One `vaara.tpm-evidence-bundle/v0` document carries the record, the
   quote, its AK signature, the quoted PCR values, and the IMA log; the offline
   verifier checks four links a regulator can reproduce without trusting the
-  operator: the AK signature over the quote, `extraData == sha512(jcs(record))`,
+  operator: the AK signature over the quote, `extraData == sha256(jcs(record))`,
   the supplied PCR values recomputing the signed `pcrDigest`, and the IMA log
   replaying to the quoted PCR 10. The verdict tiers `unverified` / `bound` /
   `pcr_pinned` mirror the enforcement model, with the same honesty fields: the AK

--- a/scripts/tpm/README.md
+++ b/scripts/tpm/README.md
@@ -19,7 +19,7 @@ For one bundle, four links checked by someone who trusts neither Vaara nor the
 operator:
 
 1. the AK signature verifies over the exact quote bytes;
-2. the quote's `extraData` equals `SHA-512(jcs(record))`, so the quote was taken
+2. the quote's `extraData` equals `SHA-256(jcs(record))`, so the quote was taken
    for *this* record;
 3. the supplied PCR values recompute the `pcrDigest` the AK signed;
 4. the supplied IMA log replays to the quoted PCR 10.
@@ -71,7 +71,7 @@ reference state to reach the `pcr_pinned` tier.
 `vaara verify-tpm-chain` extends Phase 0 from one quote to an ordered sequence,
 the Keylime-style loop. The capture script takes a quote on a fixed interval,
 reusing one AK, and each tick's `extraData` is the chain-extended nonce
-`SHA-512(jcs(record) || prev_digest || seq)` (`prev_digest` is the SHA-256 of the
+`SHA-256(jcs(record) || prev_digest || seq)` (`prev_digest` is the SHA-256 of the
 previous tick's quote; genesis is 32 zero bytes). The links are hash-chained, so a
 dropped, reordered, or spliced tick fails its successor's binding.
 

--- a/scripts/tpm/_assemble_bundle.py
+++ b/scripts/tpm/_assemble_bundle.py
@@ -1,7 +1,7 @@
 """Assemble a vaara.tpm-evidence-bundle/v0 from tpm2-tools capture outputs.
 
 Called by ``capture-tpm-binding.sh`` after it has driven the TPM. Kept separate
-so the canonicalisation of the record (``SHA-512(jcs(record))`` for the quote
+so the canonicalisation of the record (``SHA-256(jcs(record))`` for the quote
 nonce) and the bundle assembly run through the *same* vaara code the verifier
 uses, with no re-implementation in shell. Run under an interpreter that has
 ``vaara[attestation]`` installed.
@@ -59,7 +59,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    p_extra = sub.add_parser("extra-data", help="print SHA-512(jcs(record)) hex")
+    p_extra = sub.add_parser("extra-data", help="print SHA-256(jcs(record)) hex")
     p_extra.add_argument("record")
 
     p_asm = sub.add_parser("assemble", help="build the bundle JSON")

--- a/scripts/tpm/_assemble_chain.py
+++ b/scripts/tpm/_assemble_chain.py
@@ -6,7 +6,7 @@ assembly run through the *same* vaara code the verifier uses, with no
 re-implementation in shell.
 
 The chain nonce for tick ``seq`` is
-``SHA-512(jcs(record) || prev_digest || seq_be64)`` where ``prev_digest`` is the
+``SHA-256(jcs(record) || prev_digest || seq_be64)`` where ``prev_digest`` is the
 SHA-256 of the previous tick's ``TPMS_ATTEST`` bytes (the genesis tick uses 32 zero
 bytes). The shell computes it per tick with the ``extra-data`` subcommand before
 asking for that tick's quote, then assembles every tick at the end.

--- a/scripts/tpm/capture-tpm-binding.sh
+++ b/scripts/tpm/capture-tpm-binding.sh
@@ -2,7 +2,7 @@
 # capture-tpm-binding.sh: produce a vaara.tpm-evidence-bundle/v0 from a real TPM.
 #
 # Phase 0 of the hardware-governance binding: take a signed SEP-2828 record, ask
-# the local TPM 2.0 for a quote whose extraData carries SHA-512(jcs(record)) over
+# the local TPM 2.0 for a quote whose extraData carries SHA-256(jcs(record)) over
 # PCR 10, grab the kernel IMA measurement log, and stitch all of it into one
 # bundle that `vaara verify-tpm-binding` checks offline, trusting no operator.
 #
@@ -69,7 +69,7 @@ fi
 WORK="$(mktemp -d)"
 trap 'rm -rf "${WORK}"' EXIT
 
-echo "==> computing quote nonce = SHA-512(jcs(record))"
+echo "==> computing quote nonce = SHA-256(jcs(record))"
 EXTRA_DATA_HEX="$("${PY}" "${ASSEMBLE}" extra-data "${RECORD}")"
 
 echo "==> creating ephemeral ECC endorsement + attestation keys"

--- a/scripts/tpm/capture-tpm-chain.sh
+++ b/scripts/tpm/capture-tpm-chain.sh
@@ -4,7 +4,7 @@
 # Phase 1 of the hardware-governance binding, the continuous-attestation loop. It
 # takes one signed SEP-2828 record and, on a fixed interval, asks the local TPM 2.0
 # for a sequence of quotes over PCR 10. Each tick's extraData carries the
-# chain-extended nonce SHA-512(jcs(record) || prev_digest || seq), so the ticks are
+# chain-extended nonce SHA-256(jcs(record) || prev_digest || seq), so the ticks are
 # hash-linked: a regulator running `vaara verify-tpm-chain` offline learns the
 # measured platform held continuously across the window, with no reboot and an
 # append-only IMA log, trusting no operator.

--- a/src/vaara/attestation/_tpm.py
+++ b/src/vaara/attestation/_tpm.py
@@ -5,7 +5,7 @@ Where ``tee.py`` reads an AMD SEV-SNP report, this module reads a TPM 2.0
 ``TPM2_Quote`` and the kernel's IMA runtime-measurement log. The pairing is the
 Phase-0 piece of the hardware-governance binding: a TPM quote proves a measured,
 un-tampered platform state at a point in time, and its ``extraData`` slot carries
-``SHA-512(jcs(record))`` so the quote binds to one specific SEP-2828 record. The
+``SHA-256(jcs(record))`` so the quote binds to one specific SEP-2828 record. The
 verdict lives in :mod:`vaara.attestation._tpm_binding`; this module is the wire
 layer it stands on.
 
@@ -67,10 +67,12 @@ TPM_ALG_SHA384 = 0x000C
 TPM_ALG_SHA512 = 0x000D
 TPM_ALG_ECDSA = 0x0018
 
-# extraData is a TPM2B_DATA; its buffer maxes at sizeof(TPMU_HA) = 64 (SHA-512).
-# SHA-512(record) is 64 bytes, so it fills the slot exactly, the same reasoning
-# that puts SHA-512 in SEV-SNP's 64-byte REPORT_DATA.
-EXTRA_DATA_SIZE = 64
+# extraData/qualifyingData is a TPM2B_DATA; its buffer maxes at sizeof(TPMU_HA),
+# the TPM's largest IMPLEMENTED hash. That is only 64 on a TPM that implements
+# SHA-512; most fTPMs cap at SHA-384 (48) and reject a 64-byte nonce TPM_RC_SIZE
+# (confirmed on an AMD fTPM 2026-06-12). The binding nonce is therefore SHA-256
+# (32 bytes), which fits every TPM 2.0 since SHA-256 is mandatory.
+EXTRA_DATA_SIZE = 32
 
 # IMA extends PCR 10 by convention (CONFIG_IMA_MEASURE_PCR_IDX default).
 IMA_PCR = 10

--- a/src/vaara/attestation/_tpm_binding.py
+++ b/src/vaara/attestation/_tpm_binding.py
@@ -16,7 +16,7 @@ who trusts neither Vaara nor the operator:
 
 1. The AK signature verifies over the exact quote bytes, so the quote was
    produced by whoever holds that attestation key.
-2. ``extraData`` in the quote equals ``SHA-512(jcs(record))``, so the quote was
+2. ``extraData`` in the quote equals ``SHA-256(jcs(record))``, so the quote was
    taken *for this record* and not lifted from elsewhere.
 3. The supplied PCR values recompute the ``pcrDigest`` the AK signed, so those
    values are the ones the TPM quoted, not a convenient substitute.
@@ -77,16 +77,23 @@ TPM_BINDING_SCHEMA = "vaara.tpm-binding-attestation/v0"
 
 
 def bind_record_to_extra_data(record: dict[str, Any]) -> bytes:
-    """The 64-byte TPM quote ``extraData`` that binds a quote to a record.
+    """The 32-byte TPM quote ``extraData`` that binds a quote to a record.
 
-    ``extraData = SHA-512(canonical_json(record))`` over the FULL on-disk record
-    dict, *including* its top-level ``signature`` field. Identical preimage
-    discipline to :func:`~vaara.attestation._enforcement.bind_record_to_report_data`:
-    SHA-512 is 64 bytes, exactly the ``TPM2B_DATA`` ceiling, and hashing the whole
-    record (not the signed-block subset) closes the signature-malleability gap
-    where a stripped or swapped signature would canonicalise the same.
+    ``extraData = SHA-256(canonical_json(record))`` over the FULL on-disk record
+    dict, *including* its top-level ``signature`` field. Same preimage discipline as
+    :func:`~vaara.attestation._enforcement.bind_record_to_report_data` (hash the
+    whole record, not the signed-block subset, to close the signature-malleability
+    gap where a stripped or swapped signature would canonicalise the same).
+
+    SHA-256, not SHA-512: a quote's ``qualifyingData`` is a ``TPM2B_DATA`` whose
+    ceiling is ``sizeof(TPMU_HA)`` (the TPM's largest *implemented* hash), so a
+    64-byte nonce is rejected ``TPM_RC_SIZE`` on any TPM without SHA-512 (most fTPMs
+    cap at SHA-384 = 48 bytes; confirmed against an AMD fTPM 2026-06-12). 32 bytes
+    fits every TPM 2.0, where SHA-256 is mandatory. SEV-SNP ``REPORT_DATA`` is a
+    flat 64-byte field with no such constraint, so the enforcement side still uses
+    SHA-512; only the TPM nonce changes.
     """
-    return hashlib.sha512(canonical_json(record)).digest()
+    return hashlib.sha256(canonical_json(record)).digest()
 
 
 def bind_record_to_chain_extra_data(
@@ -94,19 +101,20 @@ def bind_record_to_chain_extra_data(
 ) -> bytes:
     """The ``extraData`` for one link of a continuous-attestation chain.
 
-    ``extraData = SHA-512(canonical_json(record) || prev_digest || seq_be64)``.
+    ``extraData = SHA-256(canonical_json(record) || prev_digest || seq_be64)``.
     Where :func:`bind_record_to_extra_data` binds a lone quote to a record, this
     additionally folds in the position in the chain (``seq``, a big-endian u64) and
     the predecessor link (``prev_digest``, the SHA-256 of the previous link's signed
     quote bytes; the genesis link uses 32 zero bytes). Because the AK signs the
     quote and the quote covers this ``extraData``, the linkage is tamper-evident:
     dropping, reordering, or splicing a link changes the ``prev_digest`` a later
-    link committed to, so its binding no longer holds. Still 64 bytes, the
-    ``TPM2B_DATA`` ceiling, for the same reason as the Phase-0 binding.
+    link committed to, so its binding no longer holds. 32 bytes, for the same
+    ``TPM2B_DATA`` portability reason as the Phase-0 binding (a 64-byte nonce is
+    rejected ``TPM_RC_SIZE`` on a TPM without SHA-512).
     """
     if seq < 0:
         raise ValueError("seq must be non-negative")
-    return hashlib.sha512(
+    return hashlib.sha256(
         canonical_json(record) + prev_digest + seq.to_bytes(8, "big")
     ).digest()
 
@@ -302,7 +310,7 @@ def _reason(
         parts.append("the quote signature did not verify against the supplied AK")
     elif not bound:
         parts.append(
-            "extraData does not equal sha512(jcs(record)): the quote does not "
+            "extraData does not equal sha256(jcs(record)): the quote does not "
             "bind to this record"
         )
     elif not pcr_digest_recomputed:
@@ -373,7 +381,7 @@ def verify_tpm_binding(
     were quoted; ``ima_log`` is the ascii IMA runtime-measurement log.
     ``expected_ima_pcr`` optionally pins the quoted PCR 10 (hex) against a vetted
     reference. ``expected_extra_data`` overrides the expected ``extraData``: by
-    default the quote is expected to bind to ``SHA-512(jcs(record))``; the
+    default the quote is expected to bind to ``SHA-256(jcs(record))``; the
     continuous-attestation chain passes the chain-extended binding from
     :func:`bind_record_to_chain_extra_data` so each link is checked against its own
     position and predecessor. ``strict`` requires the EK-rooted ``attested`` tier

--- a/src/vaara/attestation/_tpm_chain.py
+++ b/src/vaara/attestation/_tpm_chain.py
@@ -13,7 +13,7 @@ What a ``continuous`` chain proves that one quote does not
 ---------------------------------------------------------
 
 1. **Ordering, tamper-evident.** Each link's ``extraData`` is
-   ``SHA-512(jcs(record) || prev_digest || seq)`` where ``prev_digest`` is the
+   ``SHA-256(jcs(record) || prev_digest || seq)`` where ``prev_digest`` is the
    SHA-256 of the previous link's signed quote (genesis: 32 zero bytes). The AK
    signs the quote and the quote covers ``extraData``, so dropping, reordering, or
    splicing a link changes the ``prev_digest`` a later link committed to and its

--- a/tests/test_tpm_binding.py
+++ b/tests/test_tpm_binding.py
@@ -111,10 +111,10 @@ def _verify(ak_key, ak_pem, record=None, ima=None, **kw):
 # ── bind_record_to_extra_data ────────────────────────────────────────────────
 
 
-def test_binding_is_64_bytes_and_deterministic():
+def test_binding_is_32_bytes_and_deterministic():
     rec = _record()
     a = bind_record_to_extra_data(rec)
-    assert len(a) == 64
+    assert len(a) == 32
     assert a == bind_record_to_extra_data(rec)
 
 

--- a/tests/test_tpm_chain.py
+++ b/tests/test_tpm_chain.py
@@ -119,10 +119,10 @@ def _build_links(
 # --- binding primitives ---------------------------------------------------
 
 
-def test_chain_extra_data_is_64_bytes_and_deterministic():
+def test_chain_extra_data_is_32_bytes_and_deterministic():
     rec = _record()
     a = bind_record_to_chain_extra_data(rec, GENESIS_PREV_DIGEST, 0)
-    assert len(a) == 64
+    assert len(a) == 32
     assert a == bind_record_to_chain_extra_data(rec, GENESIS_PREV_DIGEST, 0)
 
 


### PR DESCRIPTION
## What

A TPM quote's `qualifyingData` is a `TPM2B_DATA` whose buffer ceiling is `sizeof(TPMU_HA)`, the TPM's largest *implemented* hash. Only a TPM that implements SHA-512 accepts a 64-byte nonce; most fTPMs cap at SHA-384 (48 bytes) and reject a 64-byte `qualifyingData` with `TPM_RC_SIZE`.

Confirmed against an AMD fTPM on 2026-06-12: `Esys_Quote` returned `0x1D5` (`TPM_RC_SIZE`) on param 1 (`qualifyingData`) with the old SHA-512 nonce.

This switches the Phase-0 record binding and the Phase-1 chain binding to SHA-256 (32 bytes), which every TPM 2.0 implements by mandate, so the quote succeeds on any conformant TPM.

## Scope

- `EXTRA_DATA_SIZE` 64 -> 32; `bind_record_to_extra_data` and `bind_record_to_chain_extra_data` now hash with `sha256`.
- Docstrings, capture/assemble scripts, README, and CHANGELOG updated to match.
- Binding and chain tests assert 32-byte digests.

SEV-SNP `REPORT_DATA` is a flat 64-byte field with no such constraint and stays on SHA-512; only the TPM nonce changes.

## Test

`1682 passed, 13 skipped`; `ruff check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * TPM attestation now uses SHA-256 instead of SHA-512 for cryptographic binding and chain nonce computation
  * Extra data size reduced from 64 to 32 bytes

* **Documentation**
  * Updated documentation and help text across build scripts and modules

* **Tests**
  * Updated test expectations for 32-byte extra data output instead of 64 bytes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->