### PR TITLE
fix(tpm): flush stale transient contexts before key creation (fTPM 0x902)

### DIFF
--- a/scripts/tpm/capture-tpm-binding.sh
+++ b/scripts/tpm/capture-tpm-binding.sh
@@ -48,7 +48,7 @@ else
   PY="python3"
 fi
 
-for tool in tpm2_createek tpm2_createak tpm2_quote tpm2_pcrread; do
+for tool in tpm2_createek tpm2_createak tpm2_quote tpm2_pcrread tpm2_flushcontext; do
   if ! command -v "${tool}" >/dev/null 2>&1; then
     echo "error: ${tool} not found; install tpm2-tools" >&2
     exit 3
@@ -71,6 +71,16 @@ trap 'rm -rf "${WORK}"' EXIT
 
 echo "==> computing quote nonce = SHA-256(jcs(record))"
 EXTRA_DATA_HEX="$("${PY}" "${ASSEMBLE}" extra-data "${RECORD}")"
+
+# fTPMs implement only a handful of transient object slots. A previous run that
+# died mid-way (or any other TPM user) can leave the EK/AK or a session resident,
+# and tpm2_createak then fails 0x902 (TPM_RC_OBJECT_MEMORY, "out of memory for
+# object contexts"). Flush stale transient objects and sessions first; harmless
+# when nothing is loaded.
+echo "==> flushing any stale transient objects + sessions"
+tpm2_flushcontext -t >/dev/null 2>&1 || true
+tpm2_flushcontext -l >/dev/null 2>&1 || true
+tpm2_flushcontext -s >/dev/null 2>&1 || true
 
 echo "==> creating ephemeral ECC endorsement + attestation keys"
 tpm2_createek -c "${WORK}/ek.ctx" -G ecc >/dev/null

--- a/scripts/tpm/capture-tpm-chain.sh
+++ b/scripts/tpm/capture-tpm-chain.sh
@@ -47,7 +47,7 @@ else
   PY="python3"
 fi
 
-for tool in tpm2_createek tpm2_createak tpm2_quote tpm2_pcrread; do
+for tool in tpm2_createek tpm2_createak tpm2_quote tpm2_pcrread tpm2_flushcontext; do
   if ! command -v "${tool}" >/dev/null 2>&1; then
     echo "error: ${tool} not found; install tpm2-tools" >&2
     exit 3
@@ -68,6 +68,16 @@ WORK="$(mktemp -d)"
 LINKS="${WORK}/links"
 mkdir -p "${LINKS}"
 trap 'rm -rf "${WORK}"' EXIT
+
+# fTPMs implement only a handful of transient object slots. A previous run that
+# died mid-way (or any other TPM user) can leave the EK/AK or a session resident,
+# and tpm2_createak then fails 0x902 (TPM_RC_OBJECT_MEMORY, "out of memory for
+# object contexts"). Flush stale transient objects and sessions first; harmless
+# when nothing is loaded.
+echo "==> flushing any stale transient objects + sessions"
+tpm2_flushcontext -t >/dev/null 2>&1 || true
+tpm2_flushcontext -l >/dev/null 2>&1 || true
+tpm2_flushcontext -s >/dev/null 2>&1 || true
 
 echo "==> creating one ephemeral ECC EK + AK, reused for every tick"
 tpm2_createek -c "${WORK}/ek.ctx" -G ecc >/dev/null


### PR DESCRIPTION
## What

Live capture on an AMD fTPM failed `tpm2_createak` with `0x902` (`TPM_RC_OBJECT_MEMORY`, "out of memory for object contexts"). fTPMs implement only a handful of transient object slots, and a prior run that died mid-way (the SHA-512 quote-size failure, fixed in #246) left the EK/AK or a session resident, so the next `createak` had no free slot.

## Fix

Both capture scripts now flush transient objects and sessions (`tpm2_flushcontext -t` / `-l` / `-s`) before creating the EK/AK. The flush is idempotent and harmless when nothing is loaded. `tpm2_flushcontext` is added to the required-tools check.

This is the cross-run-residue guard; the SHA-256 nonce fix in #246 was the actual quote blocker, now confirmed past on real hardware (the nonce computed and the quote-size error is gone).

## Test

`bash -n` clean on both scripts. Scripts are hardware-driven, not covered by the pytest suite.
