### PR TITLE
v0.70.0: hardware-rooted continuous governance (TPM 2.0 + IMA, Phases 0+1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [0.70.0] - 2026-06-12
+
+The hardware-rooted continuous-governance layer. A signed SEP-2828 execution
+record is bound to a TPM 2.0 quote and the kernel's IMA measurement log, and then
+to an ordered chain of quotes that shows the measured platform held continuously
+across a window. A regulator recomputes every link offline, without trusting the
+operator and without a vendor-specific confidential VM. This is the
+commodity-hardware floor beneath the existing SEV-SNP enforcement path: the same
+governance record, now anchored to whatever silicon a box actually has. The
+verifiers and document formats are pure and fully tested with no hardware
+present; the capture scripts feed them real evidence on a box with a TPM.
+
 ### Added
 - `vaara verify-tpm-chain`: Phase 1 of the hardware-governance binding, the
   continuous-attestation loop. Where `verify-tpm-binding` binds one TPM 2.0 quote
@@ -58,6 +70,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   reference refuses earlier, at the parse boundary (`alg` not in `VALID_ALGS`).
   This completes the negative coverage promised for this surface alongside the
   receipt replay-substitution case already shipped.
+
+### Fixed
+- The TPM quote binding nonce is SHA-256 (32 bytes), not SHA-512. A quote's
+  `qualifyingData` is a `TPM2B_DATA` whose buffer ceiling is the TPM's largest
+  *implemented* hash, so a 64-byte SHA-512 nonce is rejected `TPM_RC_SIZE` on the
+  many fTPMs that cap at SHA-384 (confirmed against an AMD fTPM). SHA-256 is
+  mandatory on every TPM 2.0 and fits the slot. SEV-SNP `REPORT_DATA` is a flat
+  64-byte field with no such constraint and is unchanged.
+- The capture scripts flush stale transient objects and sessions before creating
+  the EK/AK. fTPMs implement only a few object slots, so a prior interrupted run
+  could leave keys resident and make the next `tpm2_createak` fail
+  `TPM_RC_OBJECT_MEMORY`.
 
 ## [0.69.0] - 2026-06-11
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "0.69.0"
+version = "0.70.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.69.0",
+  "version": "0.70.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.69.0",
+      "version": "0.70.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "0.69.0",
+  "version": "0.70.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "0.69.0",
+      "version": "0.70.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "0.69.0"
+__version__ = "0.70.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## v0.70.0 — hardware-rooted continuous governance

Bundles the hardware-governance binding into one release.

- **Phase 0 (`vaara verify-tpm-binding`)**: a signed SEP-2828 execution record bound to a TPM 2.0 quote and the kernel's IMA runtime-measurement log. The offline verifier checks four links a regulator reproduces without trusting the operator: the AK signature over the quote, `extraData == sha256(jcs(record))`, the supplied PCR values recomputing the signed `pcrDigest`, and the IMA log replaying to the quoted PCR 10.
- **Phase 1 (`vaara verify-tpm-chain`)**: an ordered chain of quotes over a window, hash-linked through `SHA-256(jcs(record) || prev_digest || seq)`, with a `continuous` verdict requiring a strictly increasing TPM clock, constant reset/restart counts (no reboot), and an append-only IMA log.

This is the commodity-hardware floor beneath the existing SEV-SNP enforcement path: the same governance record, anchored to whatever silicon a box actually has. Verifiers and document formats are pure and fully tested with no hardware present.

### Fixed (live-capture on a commodity fTPM)
- TPM quote binding nonce is SHA-256 (32 B), not SHA-512: a 64-byte nonce is rejected `TPM_RC_SIZE` on fTPMs that cap at SHA-384 (confirmed on an AMD fTPM). SEV-SNP `REPORT_DATA` unchanged.
- Capture scripts flush stale transient objects/sessions before key creation, so a prior interrupted run no longer exhausts the fTPM's object slots (`TPM_RC_OBJECT_MEMORY`).

### Release mechanics
Version bumped to 0.70.0 across `pyproject.toml`, `src/vaara/__init__.py`, `clients/ts/package.json`, and both MCP-registry manifests. CHANGELOG `Unreleased` rolled into `## [0.70.0]`, which the release workflow extracts as the GitHub Release notes.

`1682 passed, 13 skipped`; `ruff` clean.
