### PR TITLE
fix(tpm): flush transient objects between chain ticks (fTPM 0x902)

### DIFF
--- a/scripts/tpm/capture-tpm-chain.sh
+++ b/scripts/tpm/capture-tpm-chain.sh
@@ -105,6 +105,12 @@ for (( seq=0; seq<TICKS; seq++ )); do
     exit 4
   fi
 
+  # Each tpm2_quote ContextLoads the AK into a transient object slot. fTPMs have
+  # only a few and the loaded objects accumulate across ticks until ContextLoad
+  # fails 0x902 (TPM_RC_OBJECT_MEMORY). Flush transient objects before each quote:
+  # the AK is reloaded from ak.ctx on disk, so every tick runs on a clean slate.
+  tpm2_flushcontext -t >/dev/null 2>&1 || true
+
   tpm2_quote \
     -c "${WORK}/ak.ctx" \
     -l "sha256:10" \


### PR DESCRIPTION
## What

A live 4-tick chain capture on an AMD fTPM failed at tick 3 with `Esys_ContextLoad` `0x902` (`TPM_RC_OBJECT_MEMORY`). The chain reuses one AK across ticks, and each `tpm2_quote` ContextLoads it into a transient object slot. fTPMs implement only a few slots and the loaded objects accumulate across ticks, so the run runs out partway through.

The start-of-run flush added in #247 only clears cross-run residue, not this in-loop accumulation.

## Fix

Flush transient objects before each tick's quote. The AK is reloaded from `ak.ctx` on disk every tick, so clearing transient objects between quotes is safe and keeps each tick on a clean slate.

Phase 0 (single-quote `verify-tpm-binding`) was unaffected and already verifies `OK tier=bound` on the same fTPM; only the multi-tick chain hit the ceiling.

## Test

`bash -n` clean. Hardware-driven script, not covered by the pytest suite. Will re-run the live chain capture once merged.
