### PR TITLE
docs: compact README + docs split, current PRIOR_ART (v1.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-06-17
+
+Patch release: documentation only. No functional change to the published package.
+
+- Rewrote the README from a 321-line reference dump into a 161-line read that leads with
+  the problem, shows the install and first call early, and pushes the detailed reference
+  into focused docs. The deep material moved verbatim into new `docs/architecture.md`
+  (how it works, scoring, the external time anchor), `docs/standards.md` (OVERT 1.0, the
+  sovereign inference harness, the SEP-2787 pair), and `docs/adapters.md` (framework
+  adapters, cloud and OSS guardrail adapters, the MCP proxy, the HTTP API, the TypeScript
+  client). Nothing was dropped; the benchmark numbers stay inline behind a disclosure.
+- Brought `docs/PRIOR_ART.md` current: chronology rows for v0.71.0 (RATS EAR neutral
+  verify), v1.0.0 (sovereign inference harness, AGPL relicense), and v1.0.2 (evidenceRef
+  recomputes end to end); a license-era note; and same-lane related work it had missed
+  (Notarized Agents / Sello, the Five-Plane architecture, Attested Tool-Server Admission,
+  the autogen/A2A/MCP signing cluster, Determs, and Interlock as the first independent
+  party recomputing the published SEP-2828 vectors).
+
 ## [1.0.2] - 2026-06-17
 
 Patch release: the evidenceRef worked example recomputes end to end, and the CI and

--- a/README.md
+++ b/README.md
@@ -14,53 +14,19 @@
   <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
 </p>
 
-Vaara is an open-source evidence layer for AI governance: it gates each agent tool call against your policy, writes an offline-verifiable execution record, and binds that record to the machine's own TPM 2.0 + IMA attestation. When a regulator, an auditor, or a public-sector buyer needs proof of what your agent actually did and why, that record is the answer. Runs entirely in your own environment. No SaaS, no telemetry.
+Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why. A regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
 
-EU AI Act Article 12 record-keeping is the driver. The same trail answers any "show me exactly what the agent did" demand: procurement validation, incident reconstruction, SOC 2 evidence.
+Vaara is an open-source evidence layer for AI governance. It checks every agent tool call against your policy, writes the call and its outcome into a hash-chained, signed record, and binds that record to your machine's own TPM 2.0 hardware root. An outside party can verify the whole trail offline, with no access to your system and none of your software. EU AI Act Article 12 record-keeping is what it was built for; it answers any "show me what the agent actually did" just as well.
 
-- Article-level EU AI Act evidence report, honest about the gaps instead of rubber-stamping them.
-- Hash-chained, tamper-evident audit trail an outside party can verify without trusting your stack, with the chain head anchorable to an external trusted timestamp (RFC 3161 / eIDAS).
-- Gate every agent tool call against your own policy: allow, block, or escalate.
-- Govern the model call itself, not only the tools around it: a signed, hardware-rooted inference receipt that a second local model cross-checks. This is the sovereign inference harness, new in v1.0.
+It runs entirely in your own environment. No SaaS, no telemetry. Python 3.10+, zero runtime dependencies.
 
-## How it works
-
-Every tool call an agent makes passes through Vaara before it runs:
-
-1. **Intercept.** Vaara catches the call (`fs.write_file`, `tx.transfer`, an MCP `tools/call`, and so on) through your framework's own hook, or transparently as an MCP proxy in front of an upstream server.
-2. **Score and decide.** Each call gets a risk score and an allow / block / escalate decision against your policy.
-3. **Record.** The call, the score, the decision, and the real-world outcome are written to a hash-chained audit trail. An outside auditor can verify the chain is intact without trusting your stack or your word.
-
-The scoring blends five expert signals and keeps adapting as outcomes come back, and each risk score carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. Those are the properties an auditor can check independently; the math is in [Benchmarks](#benchmarks) and [docs/formal_specification.md](docs/formal_specification.md).
-
-### External time anchor
-
-The hash chain proves order and integrity but not *when* it existed: every timestamp comes from your own clock, so a compromised signing key could in principle be used to forge a backdated chain. Vaara can anchor the current chain head to an external RFC 3161 Time-Stamp Authority, the standard behind eIDAS qualified electronic timestamps. The authority signs the chain head and the time, so the chain's existence is provable against a clock you do not control. Verification is offline.
-
-```bash
-pip install 'vaara[timeanchor]'
-```
-
-```python
-from vaara.audit.timeanchor import RFC3161TimeAnchorClient
-
-# Periodically, or after a batch of high-risk actions:
-trail.anchor_head(RFC3161TimeAnchorClient("https://freetsa.org/tsr"))
-```
-
-The anchor also folds into the one-command regulator package: `vaara trail export-article12 --anchor-tsa https://freetsa.org/tsr` writes the timestamp beside the signed trail as Article 19 existence-in-time evidence, and `vaara trail verify-anchor --zip <package>.zip` checks it offline.
-
-The same command folds cross-org handoffs and confidential-VM enforcement evidence into the package as verified sidecars (`--handoffs ./handoffs --enforcements ./enforced`); an attachment that does not verify fails the export, so the package never ships evidence it cannot back. It is a more complete pack, not a certificate. See [docs/verifying-evidence.md](docs/verifying-evidence.md).
-
-## Install
+## Install and first call
 
 ```bash
 pip install vaara
 ```
 
-Python 3.10+. Zero runtime deps. Optional XGBoost classifier: `pip install vaara[ml]`. Releases ship with SLSA Build Level 3 provenance, verifiable via `slsa-verifier verify-artifact`.
-
-## Quick start
+Releases ship SLSA Build Level 3 provenance, verifiable with `slsa-verifier verify-artifact`. Optional ML classifier: `pip install 'vaara[ml]'`.
 
 ```python
 from vaara.pipeline import InterceptionPipeline
@@ -78,11 +44,23 @@ else:
     print(result.reason)
 ```
 
-`report_outcome` closes the loop: the signal weights reweight based on which ones predicted the outcome.
+Every call gets a risk score and an allow / block / escalate decision against your policy, then the call, the decision, and the real outcome are written to the audit trail. `report_outcome` closes the loop: the scorer reweights based on which signals actually predicted the outcome.
 
-## What evidence looks like
+That is the whole loop. The rest of this page is what makes the record worth keeping.
 
-`vaara compliance report --format json` against a real audit trail produces an article-level evidence record an auditor can read directly. Articles without recorded events return `evidence_insufficient`, not a rubber-stamp.
+## Verify it without trusting the producer
+
+Writing a trail is the easy half. The half that matters is letting someone who does not trust you check it, with no key, no access, and none of your code. Every Vaara record is content-addressed and fail-closed on authenticity, and ships with public conformance vectors plus a standalone checker that imports no Vaara code, so an independent party reproduces every verdict offline.
+
+```bash
+vaara verify-bundle evidence-bundle.json
+```
+
+`ok` only when a signature is actually established, not merely present in a log. The same property drives the standards work behind [SEP-2828](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828): evidence that holds up for someone who runs none of your software. The full verifier set, the trust model for each verb, and where trust comes from in each case are in [docs/verifying-evidence.md](docs/verifying-evidence.md).
+
+## What the evidence looks like
+
+`vaara compliance report --format json` against a real trail produces an article-level evidence record an auditor reads directly. Articles with no recorded events return `evidence_insufficient`, not a rubber stamp.
 
 ```json
 {
@@ -98,112 +76,27 @@ else:
 }
 ```
 
-Each verdict carries the threshold-vs-observed snapshot, the rationale, and the underlying audit records, so a reviewer can trace `status` back to a concrete event without re-running the engine. The same data renders as a styled PDF for Notified Bodies (`--format pdf`, needs `vaara[pdf]`), a static HTML dashboard (`vaara compliance dashboard`), or a Sigstore-signed handoff envelope (`vaara trail export`, optional ML-DSA-65 / FIPS 204 post-quantum signer via `vaara[pq]`).
+Each verdict carries the threshold-versus-observed snapshot, the rationale, and the underlying records, so a reviewer traces `status` back to a concrete event. The same data renders as a Notified-Body PDF, a static HTML dashboard, or a Sigstore-signed handoff envelope. See [docs/COMPLIANCE.md](docs/COMPLIANCE.md).
 
-## Verify the evidence
+## What you get
 
-Producing the trail is half the job. The other half is letting someone who does not trust you check it, with no key, no access to your system, and none of your software. Every verifier below reads the wire format, is fail-closed on authenticity, and ships with public conformance vectors plus a standalone checker that imports no Vaara code, so an independent party reproduces every verdict offline. That property is the point of the standards work behind [SEP-2828](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828): the evidence is verifiable by someone who runs none of your software.
+- **Gate every tool call** against your own policy: allow, block, or escalate.
+- **A tamper-evident trail** an outside party verifies without trusting your stack, with the chain head anchorable to an external RFC 3161 / eIDAS timestamp so its existence is provable against a clock you do not control.
+- **Article-level EU AI Act evidence**, honest about the gaps instead of papering over them.
+- **Governance of the model call itself**, not only the tools around it: a hardware-rooted inference receipt that a second, different local model cross-checks. This is the sovereign inference harness, new in v1.0.
 
-```bash
-vaara verify-bundle evidence-bundle.json
-```
+## Where it plugs in
 
-| Command | What it checks |
+Native adapters route the major Python agent frameworks through the same pipeline, each via the framework's own hook, emitting identical audit events:
+
+| Framework | Entry point |
 |---|---|
-| `verify-bundle` | One evidence bundle through six lenses (identity, signature, back-link, inclusion, consistency, revocation). `ok` only when the signature is actually established, not merely present in a log. |
-| `build-bundle` | The issuer side: assembles the exact document `verify-bundle` reads, so producing and checking is one closed loop over one file. |
-| `verify-record` | The SEP-2828 wire format of any record, including one Vaara never produced. Keyless: the result commitment is the SHA-256 of the bytes beside it. |
-| `conformance-statement` | A producer proves its records conform against the published corpus, naming the exact corpus version and digest. |
-| `verify-retained` | A record under a key that has since rotated out, over the Article 12 retention window. |
-| hybrid PQC signing (`pq_verdict`) | A receipt's parallel ML-DSA-65 / FIPS 204 signature over the same preimage, for records that must outlive classical crypto. The suite is committed in the signed bytes, so stripping the post-quantum signature is a detectable downgrade, not a silent loss. |
-| `build-handoff` / `verify-handoff` | A self-contained package one org hands another org's regulator, offline, years later, under a rotated-out key. |
-| `verify-enforcement` | Binds a record to an AMD SEV-SNP confidential-VM attestation report. |
-| `export-attestation-result` | Re-expresses any attestation verdict (TPM binding, TPM chain, SEV-SNP) as an IETF RATS EAR with an AR4SI trustworthiness vector, so a Relying Party reads every root through one standards-aligned shape. While the hardware root is trusted as supplied the result tops out at the `warning` tier, never `affirming`. |
-| `verify-records`, `verify-bundles`, `verify-handoffs`, `verify-enforcements` | The set-level forms: each single-file check run over a whole directory, with a roll-up. |
-| `audit-summary` | Renders the conformance verdict for a directory as a Markdown page an auditor reads directly. |
+| LangChain | `VaaraCallbackHandler`, `vaara_wrap_tool` |
+| CrewAI | `VaaraCrewGovernance` |
+| OpenAI Agents SDK | `VaaraToolGuardrail`, `vaara_wrap_function` |
+| MCP server | `vaara.integrations.mcp_server` |
 
-Each verifier is honest about where trust comes from: content-addressing proves only that a package is internally consistent, producer identity is pinned out of band, an enforcement binding is never called `attested` in this release, and the eIDAS time anchor is the one component a holder cannot forge. Every command ships a Vaara-free checker under `tests/vectors/` that reproduces its verdicts offline. The full trust model for each verb is in [docs/verifying-evidence.md](docs/verifying-evidence.md).
-
-## Benchmarks
-
-Held-out test recall **84.7%** (95% Wilson [82.4, 86.7]) at a **4.1%** false-positive rate, and **1.2%** FPR on benign tool calls under live injection pressure. The hot-path rule scorer adds 140 µs mean / 210 µs p99 per call on commodity CPU. Every figure is reproducible end-to-end via `make bench`.
-
-<details>
-<summary>Full numbers, corpus, calibration, and chain of custody</summary>
-
-- 12,155-entry adversarial corpus (250 hand-curated + 11,905 LLM-generated), 70/15/15 split stratified by (category, source)
-- Classifier v9 (236 hand-features + 384-dim MiniLM embeddings) at calibrated threshold 0.9150 on held-out TEST n=1,827: recall 84.7% [82.4, 86.7] at FPR 4.1% [2.9, 5.7]. Phase 1 PAIR scale-up to n=300 per attacker family lands at 88.1% [85.8, 90.1]
-- Cross-model held-out recall 66.8% [64.9, 68.7] over n=2,277 with no eval-set attacker model in TRAIN; the weakest sub-cell is data_exfil against a closed-weight model at 38.9% [35.3, 42.5]. This is the honest worst case; the in-distribution number above is the easier denominator
-- BIPIA-pressure FPR on benign tool calls 1.2% [0.4, 3.6] across four agent backends (Claude Haiku 4.5, Llama-3.1-8B, Mistral-7B, Qwen-2.5-7B), n=244. Collapses from 35.2% on v8 to 1.2% on v9
-- Multi-attacker PAIR robustness: 0/25 successes per attacker across Qwen2.5-32B, Qwen2.5-72B, Llama-3.3-70B on identical seeds, Wilson upper 13.3%
-- 140 µs mean / 210 µs p99 for the hot-path rule scorer on commodity CPU; the MiniLM classifier is opt-in (`vaara[ml]`) and not in that path
-- Distribution-free conformal coverage on the score; MWU regret bound O(sqrt(T log N))
-- Chain of custody: corpus, split, training commit, and bundle SHAs locked and printed by every script
-- Current methodology and ship-gate record in [vaara-bench-v0.39](bench/vaara-bench-v0.39.md); per-cell breakdown in [vaara-bench-v0.37](bench/vaara-bench-v0.37.md). Historical bench docs live under `bench/`
-
-Each figure is reproducible from the public corpus or the bench pipeline in `bench/`.
-</details>
-
-## Framework adapters
-
-Native adapters in `src/vaara/integrations/` route the major Python agent frameworks through Vaara's pipeline. Each intercepts via the framework's own callback or hook surface, scores, gates, and emits the same audit events as a direct `pipeline.intercept()`. Frameworks are not hard dependencies (lazy import, duck typing), so audit records hash-chain together regardless of which one the action came through.
-
-| Framework | Entry point | Use |
-|---|---|---|
-| LangChain | `VaaraCallbackHandler`, `vaara_wrap_tool` | Slots into `config={"callbacks": [...]}` or wraps per-tool |
-| CrewAI | `VaaraCrewGovernance` | Wraps a crew so every agent action passes through scoring + audit |
-| OpenAI Agents SDK | `VaaraToolGuardrail`, `vaara_wrap_function` | Function-tool wrap, compatible with Responses API and Agents-SDK tracing |
-| MCP server | `vaara.integrations.mcp_server` | Exposes scoring, audit, policy reload as MCP tools |
-
-For Vaara *in front of* an upstream MCP server, see [MCP proxy](#mcp-proxy) below.
-
-## Upstream-signal adapters (cloud + OSS guardrails)
-
-Adapters route findings from cloud and OSS guardrails into Vaara's audit trail and OVERT envelope. The filter runs in the deployer's environment; Vaara records the verdict, normalises 68 provider categories onto a shared vocabulary, and tags each finding against the relevant AI Act articles. Each adapter returns a `ContentSafetyFinding` the deployer routes into `pipeline.intercept(context=finding.to_audit_context())`. Article-by-article mapping in [COMPLIANCE.md](docs/COMPLIANCE.md).
-
-<details>
-<summary>Seven cloud and OSS guardrails: Bedrock, Azure, GCP, NeMo, Guardrails AI, LLM Guard, Rebuff</summary>
-
-| Provider | Adapter | Extra | Wraps |
-|---|---|---|---|
-| AWS Bedrock Guardrails | `BedrockGuardrailsAdapter` | `vaara[bedrock]` | `ApplyGuardrail` across five Bedrock policy buckets |
-| Azure AI Content Safety | `AzureContentSafetyAdapter` | `vaara[azure-content-safety]` | `analyze_text`, Prompt Shields, Protected Material, Groundedness |
-| GCP Model Armor | `GcpModelArmorAdapter` | `vaara[gcp-model-armor]` | `sanitize_user_prompt`, `sanitize_model_response` |
-| NVIDIA NeMo Guardrails | `NemoGuardrailsAdapter` | `vaara[nemo-guardrails]` | `GenerationResponse.log.activated_rails` (input / dialog / output / retrieval) |
-| Guardrails AI | `GuardrailsAIAdapter` | `vaara[guardrails-ai]` | `ValidationOutcome.validation_summaries` from `Guard.parse` / `Guard.validate` |
-| LLM Guard | `LLMGuardAdapter` | `vaara[llm-guard]` | `scan_prompt` / `scan_output` |
-| Rebuff | `RebuffAdapter` | `vaara[rebuff]` | `DetectResponse` across heuristic, model, vector layers + canary-word leak check |
-
-Mapping table at `src/vaara/integrations/_content_safety_articles.py`. Rationale in [COMPLIANCE.md](docs/COMPLIANCE.md#cloud-guardrail-adapter-pattern).
-</details>
-
-## HTTP API
-
-The same scorer and audit trail are available over HTTP for non-Python agents and control planes that prefer a network boundary.
-
-```bash
-pip install 'vaara[server]'
-vaara serve --host 0.0.0.0 --port 8000
-
-curl -sX POST http://localhost:8000/v1/score \
-  -H 'content-type: application/json' \
-  -d '{"tool_name":"tx.transfer","agent_id":"agent-007","base_risk_score":0.5}'
-```
-
-Wire contract in [docs/openapi.yaml](docs/openapi.yaml). Operator endpoints include `POST /v1/policy/reload` (atomic hot policy swap) and named detectors `POST /v1/detect/injection` and `POST /v1/detect/pii`, with matching CLI subcommands that exit non-zero on detection for CI gating.
-
-The first-party TypeScript client ships on npm as [`@vaara/client`](clients/ts): typed wrappers over every v1 endpoint, Node 18+, ESM. JS/TS agents call Vaara without a Python sidecar.
-
-```ts
-import { VaaraClient } from "@vaara/client";
-const vaara = new VaaraClient({ baseUrl: "http://localhost:8000" });
-const r = await vaara.score({ tool_name: "tx.transfer", agent_id: "agent-007", base_risk_score: 0.6 });
-if (r.decision === "deny") throw new Error("blocked");
-```
-
-## MCP proxy
-
-`VaaraMCPProxy` sits between an MCP client (Claude Code, Cursor, any MCP host) and an upstream MCP server. Every `tools/call` routes through Vaara's pipeline before reaching the upstream: allowed calls forward transparently and report the outcome back to the scorer, blocked calls return an MCP `isError: true` with the reason. The handshake and `notifications/*` forward unchanged.
+To put Vaara **in front of** an MCP server, run it as a proxy. Every `tools/call` routes through the pipeline before reaching the upstream; allowed calls forward transparently, blocked calls return an MCP error.
 
 ```bash
 vaara-mcp-proxy \
@@ -211,105 +104,52 @@ vaara-mcp-proxy \
   --db ./mcp_audit.db
 ```
 
-Point your MCP client at the proxy instead of the upstream; the audit chain captures every call without changing client or upstream behavior. Upstreams can be local (`--upstream` launches a local stdio server) or remote (`--upstream-url NAME=URL` over Streamable HTTP). This is distinct from `mcp_server`, which exposes Vaara itself as a tool.
+Point your MCP client (Claude Code, Cursor, any host) at the proxy instead of the upstream. There is also an HTTP API (`pip install 'vaara[server]'`, `vaara serve`) and a first-party TypeScript client on npm ([`@vaara/client`](clients/ts)) for non-Python agents. Framework details, the cloud and OSS guardrail adapters (Bedrock, Azure, GCP, NeMo, Guardrails AI, LLM Guard, Rebuff), and the multi-tenant proxy are in [docs/adapters.md](docs/adapters.md).
+
+## How it scores
+
+Each risk score blends five expert signals and keeps adapting as outcomes come back, and it carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. On a held-out adversarial corpus the classifier reaches **84.7%** recall (95% Wilson [82.4, 86.7]) at a **4.1%** false-positive rate, and **1.2%** FPR on benign calls under live injection pressure. The hot-path rule scorer adds 140 µs mean per call on commodity CPU; the ML classifier is opt-in (`vaara[ml]`) and off that path. Every figure is reproducible via `make bench`.
 
 <details>
-<summary>Fleet shape: one proxy, many upstreams, multi-tenant policy</summary>
+<summary>Full numbers, corpus, calibration, and chain of custody</summary>
 
-`vaara-mcp-proxy` also runs over Streamable HTTP with fan-out, so one process can serve a fleet:
+- 12,155-entry adversarial corpus (250 hand-curated + 11,905 LLM-generated), 70/15/15 split stratified by (category, source).
+- Classifier v9 (236 hand-features + 384-dim MiniLM embeddings) at calibrated threshold 0.9150 on held-out TEST n=1,827: recall 84.7% [82.4, 86.7] at FPR 4.1% [2.9, 5.7].
+- Cross-model held-out recall 66.8% [64.9, 68.7] over n=2,277 with no eval-set attacker model in TRAIN; the weakest sub-cell is data_exfil against a closed-weight model at 38.9%. This is the honest worst case; the in-distribution number above is the easier denominator.
+- BIPIA-pressure FPR on benign tool calls 1.2% [0.4, 3.6] across four agent backends (Claude Haiku 4.5, Llama-3.1-8B, Mistral-7B, Qwen-2.5-7B). Down from 35.2% on v8.
+- Multi-attacker PAIR robustness: 0/25 successes per attacker across Qwen2.5-32B, Qwen2.5-72B, Llama-3.3-70B on identical seeds, Wilson upper 13.3%.
+- Distribution-free conformal coverage on the score; MWU regret bound O(sqrt(T log N)).
+- Chain of custody: corpus, split, training commit, and bundle SHAs locked and printed by every script.
 
-```bash
-vaara-mcp-proxy \
-  --transport http --http-host 127.0.0.1 --http-port 8765 \
-  --upstream 'github=npx -y @github/mcp-server' \
-  --upstream 'sap=npx -y @sap/mdk-mcp-server'
-```
-
-Each `POST /mcp` reads two headers: `X-Vaara-Upstream` picks the upstream slot, `X-Vaara-Tenant` scopes the policy, audit chain, and OVERT envelope. Single-upstream deployments keep the silent-default contract; multi-upstream deployments require `X-Vaara-Upstream` per call and return 400 with the slot list when it is missing. `vaara serve --policy-dir DIR` loads one policy per file (filename stem becomes `tenant_id`, `default.yaml` is the fallback) and hot-reloads per tenant.
+Method and per-cell breakdown: [docs/architecture.md](docs/architecture.md) and [bench/](bench/).
 </details>
 
-<details>
-<summary>Operator perimeter and request attestation</summary>
+## Standards and attestation
 
-Repeatable `--allow-tool` / `--deny-tool` flags (and the same for resources and prompts) filter the MCP surface. Filtered tools are dropped from `tools/list` before the client sees them and any matching call is rejected at the perimeter without contacting the upstream. Denylist wins on overlap; no flags means passthrough. Every allowed `resources/read` and `prompts/get` writes a request+decision audit pair so a regulator can reconstruct exactly what the agent read.
+- **[SEP-2828](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828)** signed execution records and **SEP-2787** request-attestation test vectors, in the MCP standards process. A second independent implementation has reproduced the SEP-2828 conformance vectors from a clean checkout with no shared code.
+- **OVERT 1.0** ([overt.is](https://overt.is/)): Vaara is the Arbiter and emits Protocol Profile 1.0 Base Envelopes (canonical CBOR, Ed25519) alongside every record when attestation is on.
+- **Post-quantum**: an optional parallel ML-DSA-65 / FIPS 204 signature over the same preimage, so a stripped post-quantum signature is a detectable downgrade rather than a silent loss.
+- **Sovereign inference harness** (v1.0): a local model behind a signing proxy that emits a hardware-rooted inference receipt a second local model cross-checks. Developed privately, published here under AGPL-3.0.
 
-OVERT envelopes per interaction turn on with `--overt-signing-key`, `--overt-operator-key`, `--overt-receipts-dir`. SEP-2787 request attestation paired with an execution receipt turns on with `--attest-signing-key PATH` and `--attest-receipts-dir DIR`: each allowed call writes a pre-execution attestation and a post-execution receipt linked by a `backLink` digest. Key type auto-detects from the file (EC P-256 = ES256, RSA = RS256, raw bytes = HS256). Generate and verify offline:
+Details and the offline checkers for each: [docs/standards.md](docs/standards.md).
 
-```
-vaara keygen --attest --out attest_key.pem
-vaara attest verify  0000000001-ab12cd34-attest.json  --pubkey-file attest_key.pem.pub
-vaara receipt verify 0000000001-ab12cd34-receipt.json --attestation 0000000001-ab12cd34-attest.json --pubkey-file attest_key.pem.pub
-```
-
-Both verifiers exit non-zero on any failed check, so they drop straight into CI. Format in [docs/execution-receipts.md](docs/execution-receipts.md), conformance surface in [docs/sep2787-conformance.md](docs/sep2787-conformance.md).
-</details>
-
-Worked examples: [`examples/github-mcp-proxy-demo/`](examples/github-mcp-proxy-demo/) (Vaara in front of `github/github-mcp-server`, 42 tools) and [`examples/sap-mcp-proxy-demo/`](examples/sap-mcp-proxy-demo/) (community SAP MCP servers).
-
-## OVERT 1.0 attestation
-
-OVERT 1.0 is an open standard for runtime trust in AI systems ([overt.is](https://overt.is/), authored by Glacis Technologies, published 25 March 2026): a signed, schema-closed envelope a relying party can verify offline without trusting the emitter. Vaara is the **Arbiter** in OVERT terms and ships Protocol Profile 1.0 Base Envelopes (canonical CBOR per RFC 8949, Ed25519 signatures, HMAC-SHA256 commitments, closed 9-field schema) alongside every audit record when attestation is enabled.
-
-```
-pip install 'vaara[attestation]'
-```
-
-```python
-from vaara.attestation.overt import emit_base_envelope, make_request_commitment, encoder_binary_identity
-
-envelope = emit_base_envelope(
-    signing_key=key,
-    request_commitment=make_request_commitment(payload, operator_key=op_key),
-    encoder_binary_identity=encoder_binary_identity(arbiter_version=f"vaara/{vaara.__version__}", policy_hash=ph),
-    non_content_metadata={"action_class": "tx.transfer", "decision": "escalate"},
-    monotonic_counter=42,
-    arbiter_instance_identifier=uuid_bytes,
-)
-```
-
-`vaara overt verify RECEIPT.cbor --pubkey-file PUB.bin` validates any canonical-CBOR Base Envelope. The verifier reads only the wire format and takes no dependency on Vaara's emitter, so any conformant implementation can route through it. Adjacent surfaces (`vaara.attestation.iap` notary + transparency log, `vaara.attestation.s3p` aggregate intervals, an experimental AMD SEV-SNP TEE hook) and the OVERT 1.0 Part 3 control walk are in [COMPLIANCE.md](docs/COMPLIANCE.md).
-
-## Sovereign inference harness
-
-The governance proxy binds a `tools/call`. The sovereign inference harness, published in v1.0, binds the model call underneath it: which model answered, on which silicon-resident weights, given what input, and what it returned. It runs a local model behind a signing proxy (OpenAI- and ollama-compatible) and emits a hardware-rooted inference receipt that a second, different local model independently cross-checks. The point is signed evidence that the inference itself is accounted for, not only the tooling around it.
-
-Two envelopes mirror the SEP-2787 attestation and receipt pair and reuse its canonicalization (RFC 8785 JCS) and signing stack (HS256 / ES256 / RS256), so a verifier that already reads Vaara records needs no new crypto:
-
-- `InferenceAttestation` is the pre-call commitment: declared intent, a request commitment, an issuer block with a TTL, and the model facts the proxy derived at call time.
-- `InferenceReceipt` is the post-call outcome, back-linked to the exact attestation, carrying status, an output commitment, eval-stat counters, and an honest `tier` self-label.
-
-Tier A (`integrity`) binds model, input, and output with no determinism claim and ships standalone. Tier B (`replay`), the byte-reproducibility claim, is deferred and labeled as such instead of overclaimed.
-
-```python
-from vaara.attestation.inference import emit_inference_attestation, emit_inference_receipt
-```
-
-The session, chain, cross-check, and determinism verifiers each ship a Vaara-free checker that reproduces its verdict offline, and the governance console renders a live inference chain an outside party can replay. Install with `pip install 'vaara[attestation]'`. Developed privately, published here under AGPL-3.0-or-later.
-
-## Where things live
+## Docs
 
 | Path | Contents |
 |---|---|
-| [docs/formal_specification.md](docs/formal_specification.md) | MWU regret bound, conformal coverage, security properties |
-| [docs/conformal-prediction.md](docs/conformal-prediction.md) | Plain-language explainer for compliance reviewers and legal counsel |
-| [docs/execution-receipts.md](docs/execution-receipts.md) | Execution receipts paired with SEP-2787 request attestation |
-| [docs/sep2787-conformance.md](docs/sep2787-conformance.md) | What `vaara attest verify` / `vaara receipt verify` check |
-| [docs/COMPLIANCE.md](docs/COMPLIANCE.md) | EU AI Act (Art. 9, 11 to 15, 61) and DORA (Art. 10, 12, 13) mapping, eval numbers |
-| [docs/VERDICTS.md](docs/VERDICTS.md) | Per-article evidence sufficiency thresholds and decision tree |
-| [CHANGELOG.md](CHANGELOG.md) | Version-by-version feature evolution |
-| [docs/PRIOR_ART.md](docs/PRIOR_ART.md) | When each Vaara concept first shipped, plus adjacent published work |
-| [docs/OWASP_AGENTIC.md](docs/OWASP_AGENTIC.md) | Mapping to OWASP Top 10 for Agentic Applications 2026 |
-| [docs/OVERT_CONTROLS.md](docs/OVERT_CONTROLS.md) | Mapping to OVERT 1.0 Part 3 Agentic AI Controls |
-| [docs/mit_ai_risk_repository_mapping.md](docs/mit_ai_risk_repository_mapping.md) | Coverage map against the MIT AI Risk Repository v4 |
-| [docs/signing-keys.md](docs/signing-keys.md) | Release signing and verification |
-| [.github/SECURITY.md](.github/SECURITY.md) | Security policy and reporting |
-| [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md) | Contribution guidelines |
+| [docs/verifying-evidence.md](docs/verifying-evidence.md) | Every verifier and its trust model |
+| [docs/architecture.md](docs/architecture.md) | Scoring, conformal coverage, time anchor, formal properties |
+| [docs/standards.md](docs/standards.md) | SEP-2828, SEP-2787, OVERT, the sovereign inference harness |
+| [docs/adapters.md](docs/adapters.md) | Framework and cloud/OSS guardrail adapters, multi-tenant proxy |
+| [docs/COMPLIANCE.md](docs/COMPLIANCE.md) | EU AI Act and DORA article mapping, eval numbers |
+| [CHANGELOG.md](CHANGELOG.md) | Version-by-version evolution |
+| [docs/PRIOR_ART.md](docs/PRIOR_ART.md) | When each concept first shipped, plus adjacent work |
 
-Acknowledgements:
+## Acknowledgements
 
-- Vaara is listed in the industry acknowledgements of the [IMDA Model AI Governance Framework for Agentic AI v1.5](https://www.imda.gov.sg/-/media/imda/files/about/emerging-tech-and-research/artificial-intelligence/mgf-for-agentic-ai.pdf) (Singapore, 20 May 2026).
-- The [AMD AI Developer Program](https://www.linkedin.com/posts/amd-developer_meet-henri-sirkkavaara-henri-created-vaara-activity-7459667676555132928-QFSd) ran a coordinated multi-channel developer testimonial of Vaara in May 2026.
-- [Article 14 runtime: why oversight of agentic AI has to be evidenced as action, not model](https://futurium.ec.europa.eu/ga/apply-ai-alliance/community-content/article-14-runtime-why-oversight-agentic-ai-has-be-evidenced-action-not-model) is the position post on the EU Apply AI Alliance Futurium.
+- Listed in the industry acknowledgements of the [IMDA Model AI Governance Framework for Agentic AI v1.5](https://www.imda.gov.sg/-/media/imda/files/about/emerging-tech-and-research/artificial-intelligence/mgf-for-agentic-ai.pdf) (Singapore, 20 May 2026).
+- The [AMD AI Developer Program](https://www.linkedin.com/posts/amd-developer_meet-henri-sirkkavaara-henri-created-vaara-activity-7459667676555132928-QFSd) ran a developer testimonial of Vaara in May 2026.
+- [Article 14 runtime: why oversight of agentic AI has to be evidenced as action, not model](https://futurium.ec.europa.eu/ga/apply-ai-alliance/community-content/article-14-runtime-why-oversight-agentic-ai-has-be-evidenced-action-not-model), the position post on the EU Apply AI Alliance Futurium.
 
 > Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/PRIOR_ART.md
+++ b/docs/PRIOR_ART.md
@@ -13,6 +13,10 @@ Version numbers and dates can be verified against
 and the `vX.Y.Z` tags on
 [https://github.com/vaaraio/vaara/tags](https://github.com/vaaraio/vaara/tags).
 
+From v1.0.0 (2026-06-17) the project is licensed AGPL-3.0-or-later; releases
+through v0.71.0 were published under Apache 2.0. Tag dates and version numbers
+verify against the PyPI history and the `vX.Y.Z` git tags regardless of license era.
+
 ## When each Vaara concept first shipped
 
 | Concept | First shipped | Where to read it |
@@ -65,6 +69,9 @@ and the `vX.Y.Z` tags on
 | Post-quantum hybrid-signed execution receipts with the signature suite committed in the signed preimage (a stripped PQC signature is a detectable downgrade) | v0.69.0, 2026-06-11 | `src/vaara/attestation/`, `docs/design/pq-hybrid-signing-spec.md` |
 | TPM 2.0 plus IMA binding of a signed SEP-2828 record, offline-verifiable on commodity hardware (`verify-tpm-binding`) | v0.70.0, 2026-06-12 | `src/vaara/attestation/`, `scripts/tpm/` |
 | Continuous TPM 2.0 plus IMA attestation chain bound to the per-action record (`verify-tpm-chain`) | v0.70.0, 2026-06-12 | `src/vaara/attestation/`, `tests/test_tpm_chain.py` |
+| RATS EAR neutral verify: a Vaara attestation verdict re-expressed as an IETF RATS EAR (draft-ietf-rats-ear) carrying an AR4SI trustworthiness vector (draft-ietf-rats-ar4si), root-agnostic across TPM binding, TPM chain, and SEV-SNP (`export-attestation-result`) | v0.71.0, 2026-06-16 | `src/vaara/attestation/`, `docs/design/attestation-result-spec.md` |
+| Sovereign inference harness: a local model emits a signed, hardware-rooted inference receipt that a second local model independently cross-checks, with session, chain, cross-check, and determinism verifiers (first public release, AGPL-3.0-or-later) | v1.0.0, 2026-06-17 | `src/vaara/`, `CHANGELOG.md` v1.0.0 |
+| evidenceRef worked example recomputes end to end from real tool-surface bytes (surface bytes to surface hash to drift record to content-addressed `evidenceRef`), so a second implementation can reproduce the whole chain | v1.0.2, 2026-06-17 | `tests/vectors/evidence_ref_v0/`, `CHANGELOG.md` v1.0.2 |
 
 The `CHANGELOG.md` entry for each version carries the substantive
 description and, where relevant, the failure mode that motivated the
@@ -98,6 +105,30 @@ than a judgment of the work.
   intervening monitors that act at runtime to preempt predicted
   violations. Adjacent to Vaara's policy-driven runtime decisions and
   external-scorer composition (shipped v0.14.0, 2026-05-17).
+- **Notarized Agents: Receiver-Attested Confidential Receipts for AI
+  Agent Actions.** arXiv:2606.04193v1, published 2026-06-02. Inverts
+  the trust boundary so the service receiving an agent's call signs a
+  receipt of what it observed, encrypts it to the owner, and publishes
+  it to a witness-cosigned Merkle log (the Sello protocol). Same problem
+  statement as Vaara (the entity producing the log is the entity being
+  logged), with a different placement: the signature is on the receiving
+  service rather than at a governance proxy in front of the agent, and
+  the root of trust is a transparency log rather than a hardware
+  attestation. Situates a wider field (Signet, AgentROA, Agent Passport
+  System, draft-farley-acta, SCITT). Vaara's signed execution-receipt
+  envelope shipped at v0.42.0 (2026-05-29); its transparency-log
+  consistency proofs at v0.54.0 (2026-06-05).
+- **A Five-Plane Reference Architecture for Runtime Governance of
+  Production AI Agents.** arXiv:2606.12320v1, published 2026-06-10. A
+  reasoning plane that adjudicates intent over four enforcement planes
+  (network, identity, endpoint, data), with stop-anywhere mediation,
+  composite principals whose authority attenuates through delegation
+  chains, and audit treated as a structured evidence substrate. Direct
+  conceptual neighbour to Vaara's interception pipeline (v0.1.0,
+  2026-04-10) and per-article `verdict_inputs` / `contributing_events`
+  (v0.26.0, 2026-05-21); it specifies a policy-engine core and
+  architecture, where Vaara ships a proxy whose audit substrate is
+  cryptographically signed and hardware-bound.
 
 ### Safety cases with runtime confidence updates
 
@@ -154,6 +185,54 @@ than a judgment of the work.
   use-case-specific benchmarks. Adjacent in motivation to Vaara's
   policy-driven decisions over agent tool calls, in a deployment
   context Vaara does not currently target.
+
+### Agent-action signing and attestation protocols
+
+- **Attested Tool-Server Admission: A Security Extension to the Model
+  Context Protocol.** arXiv:2605.24248v2, published 2026-06-01. Three
+  additive mechanisms for MCP: an offline-signed clearance assertion a
+  tool server publishes at a well-known URI and a host verifies against
+  a pinned trust root; a deny-by-default per-server tool allowlist; and
+  a flavor-gated enforcement mode writing every decision to a
+  tamper-evident audit log, stated in RFC-2119 form as an MCP addendum.
+  Adjacent to Vaara's MCP proxy and signed records: admission-time trust
+  of a tool server, where Vaara attests the per-call action at runtime.
+- **Signed agent-action receipt and identity proposals in the framework
+  repos (2026-06).** A cluster of proposals converging on the primitive
+  Vaara shipped earlier: AutoGen Cryptographic Action Receipts
+  (microsoft/autogen#7360, Ed25519-signed, SHA-256 input/output hashes,
+  offline-verifiable); a minimal Ed25519 + RFC-9421 per-message signing
+  extension for A2A (a2aproject/A2A#1829); A2A agent-identity
+  verification with AgentCard revocation (a2aproject/A2A#1497); signed
+  MCP tool manifests for tool-poisoning / rug-pull defense
+  (modelcontextprotocol#2913); and runtime tool-drift detection
+  (modelcontextprotocol#2826). Vaara shipped the signed per-action
+  execution-receipt envelope at v0.42.0 (2026-05-29) and the DID-bound
+  receipt identity with revocation at v0.52.0 to v0.55.0 (2026-06-02 to
+  2026-06-05), ahead of these proposals; listing them records the
+  convergence, not a competitive claim.
+
+### Same-lane open projects
+
+- **Determs (Verifiable Decision Record).** determs.com,
+  github.com/determs-com, PyPI `determs`; surfaced 2026-06-07. An open
+  spec plus reference implementation for per-action machine-generated
+  records (Article 12) whose digests are anchored to public
+  infrastructure (Article 19). Anchor-centric: no signing key in the
+  trust path, with verification from the record JSON, RFC 8785,
+  SHA-256, and public-blockchain anchor data (OpenTimestamps to
+  Bitcoin). Vaara's comparable evidence story combines a signature, an
+  independent eIDAS-qualified RFC-3161 time anchor (v0.48.0, 2026-05-31),
+  transparency-log consistency proofs (v0.54.0, 2026-06-05), and a
+  revocation registry (v0.55.0, 2026-06-05).
+- **Interlock (getinterlock.dev).** Runtime tool-drift detection at the
+  MCP layer (modelcontextprotocol discussion #2826). Notable to this
+  document because Interlock has begun recomputing Vaara's published
+  SEP-2828 evidenceRef drift vectors, the first independent exercise of
+  the keyless conformance verifier shipped at v0.60.0 (2026-06-07).
+  Interlock detects drift; Vaara emits the signed, content-addressed
+  record the drift check resolves against. Listed as adjacent and
+  interoperating.
 
 ### Classical foundations
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,97 @@
+# Adapters and interfaces
+
+How to put Vaara into an existing agent stack: native framework adapters, cloud and OSS guardrail signal adapters, the MCP proxy, the HTTP API, and the TypeScript client.
+
+## Framework adapters
+
+Native adapters in `src/vaara/integrations/` route the major Python agent frameworks through Vaara's pipeline. Each intercepts via the framework's own callback or hook surface, scores, gates, and emits the same audit events as a direct `pipeline.intercept()`. Frameworks are not hard dependencies (lazy import, duck typing), so audit records hash-chain together regardless of which one the action came through.
+
+| Framework | Entry point | Use |
+|---|---|---|
+| LangChain | `VaaraCallbackHandler`, `vaara_wrap_tool` | Slots into `config={"callbacks": [...]}` or wraps per-tool |
+| CrewAI | `VaaraCrewGovernance` | Wraps a crew so every agent action passes through scoring + audit |
+| OpenAI Agents SDK | `VaaraToolGuardrail`, `vaara_wrap_function` | Function-tool wrap, compatible with Responses API and Agents-SDK tracing |
+| MCP server | `vaara.integrations.mcp_server` | Exposes scoring, audit, policy reload as MCP tools |
+
+## Upstream-signal adapters (cloud + OSS guardrails)
+
+Adapters route findings from cloud and OSS guardrails into Vaara's audit trail and OVERT envelope. The filter runs in the deployer's environment; Vaara records the verdict, normalises 68 provider categories onto a shared vocabulary, and tags each finding against the relevant AI Act articles. Each adapter returns a `ContentSafetyFinding` the deployer routes into `pipeline.intercept(context=finding.to_audit_context())`. Article-by-article mapping in [COMPLIANCE.md](COMPLIANCE.md).
+
+| Provider | Adapter | Extra | Wraps |
+|---|---|---|---|
+| AWS Bedrock Guardrails | `BedrockGuardrailsAdapter` | `vaara[bedrock]` | `ApplyGuardrail` across five Bedrock policy buckets |
+| Azure AI Content Safety | `AzureContentSafetyAdapter` | `vaara[azure-content-safety]` | `analyze_text`, Prompt Shields, Protected Material, Groundedness |
+| GCP Model Armor | `GcpModelArmorAdapter` | `vaara[gcp-model-armor]` | `sanitize_user_prompt`, `sanitize_model_response` |
+| NVIDIA NeMo Guardrails | `NemoGuardrailsAdapter` | `vaara[nemo-guardrails]` | `GenerationResponse.log.activated_rails` (input / dialog / output / retrieval) |
+| Guardrails AI | `GuardrailsAIAdapter` | `vaara[guardrails-ai]` | `ValidationOutcome.validation_summaries` from `Guard.parse` / `Guard.validate` |
+| LLM Guard | `LLMGuardAdapter` | `vaara[llm-guard]` | `scan_prompt` / `scan_output` |
+| Rebuff | `RebuffAdapter` | `vaara[rebuff]` | `DetectResponse` across heuristic, model, vector layers + canary-word leak check |
+
+Mapping table at `src/vaara/integrations/_content_safety_articles.py`. Rationale in [COMPLIANCE.md](COMPLIANCE.md#cloud-guardrail-adapter-pattern).
+
+## MCP proxy
+
+`VaaraMCPProxy` sits between an MCP client (Claude Code, Cursor, any MCP host) and an upstream MCP server. Every `tools/call` routes through Vaara's pipeline before reaching the upstream: allowed calls forward transparently and report the outcome back to the scorer, blocked calls return an MCP `isError: true` with the reason. The handshake and `notifications/*` forward unchanged.
+
+```bash
+vaara-mcp-proxy \
+  --upstream npx --upstream-arg -y --upstream-arg @sap/mdk-mcp-server \
+  --db ./mcp_audit.db
+```
+
+Point your MCP client at the proxy instead of the upstream; the audit chain captures every call without changing client or upstream behavior. Upstreams can be local (`--upstream` launches a local stdio server) or remote (`--upstream-url NAME=URL` over Streamable HTTP). This is distinct from `mcp_server`, which exposes Vaara itself as a tool.
+
+Worked examples: [`examples/github-mcp-proxy-demo/`](../examples/github-mcp-proxy-demo/) (Vaara in front of `github/github-mcp-server`, 42 tools) and [`examples/sap-mcp-proxy-demo/`](../examples/sap-mcp-proxy-demo/) (community SAP MCP servers).
+
+### Fleet shape: one proxy, many upstreams, multi-tenant policy
+
+`vaara-mcp-proxy` also runs over Streamable HTTP with fan-out, so one process can serve a fleet:
+
+```bash
+vaara-mcp-proxy \
+  --transport http --http-host 127.0.0.1 --http-port 8765 \
+  --upstream 'github=npx -y @github/mcp-server' \
+  --upstream 'sap=npx -y @sap/mdk-mcp-server'
+```
+
+Each `POST /mcp` reads two headers: `X-Vaara-Upstream` picks the upstream slot, `X-Vaara-Tenant` scopes the policy, audit chain, and OVERT envelope. Single-upstream deployments keep the silent-default contract; multi-upstream deployments require `X-Vaara-Upstream` per call and return 400 with the slot list when it is missing. `vaara serve --policy-dir DIR` loads one policy per file (filename stem becomes `tenant_id`, `default.yaml` is the fallback) and hot-reloads per tenant.
+
+### Operator perimeter and request attestation
+
+Repeatable `--allow-tool` / `--deny-tool` flags (and the same for resources and prompts) filter the MCP surface. Filtered tools are dropped from `tools/list` before the client sees them and any matching call is rejected at the perimeter without contacting the upstream. Denylist wins on overlap; no flags means passthrough. Every allowed `resources/read` and `prompts/get` writes a request+decision audit pair so a regulator can reconstruct exactly what the agent read.
+
+OVERT envelopes per interaction turn on with `--overt-signing-key`, `--overt-operator-key`, `--overt-receipts-dir`. SEP-2787 request attestation paired with an execution receipt turns on with `--attest-signing-key PATH` and `--attest-receipts-dir DIR`: each allowed call writes a pre-execution attestation and a post-execution receipt linked by a `backLink` digest. Key type auto-detects from the file (EC P-256 = ES256, RSA = RS256, raw bytes = HS256). Generate and verify offline:
+
+```bash
+vaara keygen --attest --out attest_key.pem
+vaara attest verify  0000000001-ab12cd34-attest.json  --pubkey-file attest_key.pem.pub
+vaara receipt verify 0000000001-ab12cd34-receipt.json --attestation 0000000001-ab12cd34-attest.json --pubkey-file attest_key.pem.pub
+```
+
+Both verifiers exit non-zero on any failed check, so they drop straight into CI. Format in [execution-receipts.md](execution-receipts.md), conformance surface in [sep2787-conformance.md](sep2787-conformance.md).
+
+## HTTP API
+
+The same scorer and audit trail are available over HTTP for non-Python agents and control planes that prefer a network boundary.
+
+```bash
+pip install 'vaara[server]'
+vaara serve --host 0.0.0.0 --port 8000
+
+curl -sX POST http://localhost:8000/v1/score \
+  -H 'content-type: application/json' \
+  -d '{"tool_name":"tx.transfer","agent_id":"agent-007","base_risk_score":0.5}'
+```
+
+Wire contract in [openapi.yaml](openapi.yaml). Operator endpoints include `POST /v1/policy/reload` (atomic hot policy swap) and named detectors `POST /v1/detect/injection` and `POST /v1/detect/pii`, with matching CLI subcommands that exit non-zero on detection for CI gating.
+
+### TypeScript client
+
+The first-party TypeScript client ships on npm as [`@vaara/client`](../clients/ts): typed wrappers over every v1 endpoint, Node 18+, ESM. JS/TS agents call Vaara without a Python sidecar.
+
+```ts
+import { VaaraClient } from "@vaara/client";
+const vaara = new VaaraClient({ baseUrl: "http://localhost:8000" });
+const r = await vaara.score({ tool_name: "tx.transfer", agent_id: "agent-007", base_risk_score: 0.6 });
+if (r.decision === "deny") throw new Error("blocked");
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,32 @@
+# Architecture
+
+How Vaara processes a tool call, how it scores, and how the audit trail is anchored in time. The formal guarantees (MWU regret bound, conformal coverage, security properties) are in [formal_specification.md](formal_specification.md); the benchmark numbers are in the project [README](../README.md#how-it-scores) and under [bench/](../bench/).
+
+## How it works
+
+Every tool call an agent makes passes through Vaara before it runs:
+
+1. **Intercept.** Vaara catches the call (`fs.write_file`, `tx.transfer`, an MCP `tools/call`, and so on) through your framework's own hook, or transparently as an MCP proxy in front of an upstream server.
+2. **Score and decide.** Each call gets a risk score and an allow / block / escalate decision against your policy.
+3. **Record.** The call, the score, the decision, and the real-world outcome are written to a hash-chained audit trail. An outside auditor can verify the chain is intact without trusting your stack or your word.
+
+The scoring blends five expert signals and keeps adapting as outcomes come back, and each risk score carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. Those are the properties an auditor can check independently; the math is in [formal_specification.md](formal_specification.md) and a plain-language version for compliance reviewers and legal counsel is in [conformal-prediction.md](conformal-prediction.md).
+
+## External time anchor
+
+The hash chain proves order and integrity but not *when* it existed: every timestamp comes from your own clock, so a compromised signing key could in principle be used to forge a backdated chain. Vaara can anchor the current chain head to an external RFC 3161 Time-Stamp Authority, the standard behind eIDAS qualified electronic timestamps. The authority signs the chain head and the time, so the chain's existence is provable against a clock you do not control. Verification is offline.
+
+```bash
+pip install 'vaara[timeanchor]'
+```
+
+```python
+from vaara.audit.timeanchor import RFC3161TimeAnchorClient
+
+# Periodically, or after a batch of high-risk actions:
+trail.anchor_head(RFC3161TimeAnchorClient("https://freetsa.org/tsr"))
+```
+
+The anchor also folds into the one-command regulator package: `vaara trail export-article12 --anchor-tsa https://freetsa.org/tsr` writes the timestamp beside the signed trail as Article 19 existence-in-time evidence, and `vaara trail verify-anchor --zip <package>.zip` checks it offline.
+
+The same command folds cross-org handoffs and confidential-VM enforcement evidence into the package as verified sidecars (`--handoffs ./handoffs --enforcements ./enforced`); an attachment that does not verify fails the export, so the package never ships evidence it cannot back. It is a more complete pack, not a certificate. See [verifying-evidence.md](verifying-evidence.md).

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,0 +1,43 @@
+# Standards and attestation
+
+Vaara's standards-aligned outputs: OVERT 1.0 envelopes, the SEP-2787 execution-receipt pair, and the sovereign inference harness. For the verifier trust model behind each, see [verifying-evidence.md](verifying-evidence.md). For the SEP-2787 request-attestation format and conformance surface, see [execution-receipts.md](execution-receipts.md) and [sep2787-conformance.md](sep2787-conformance.md).
+
+## OVERT 1.0 attestation
+
+OVERT 1.0 is an open standard for runtime trust in AI systems ([overt.is](https://overt.is/), authored by Glacis Technologies, published 25 March 2026): a signed, schema-closed envelope a relying party can verify offline without trusting the emitter. Vaara is the **Arbiter** in OVERT terms and ships Protocol Profile 1.0 Base Envelopes (canonical CBOR per RFC 8949, Ed25519 signatures, HMAC-SHA256 commitments, closed 9-field schema) alongside every audit record when attestation is enabled.
+
+```bash
+pip install 'vaara[attestation]'
+```
+
+```python
+from vaara.attestation.overt import emit_base_envelope, make_request_commitment, encoder_binary_identity
+
+envelope = emit_base_envelope(
+    signing_key=key,
+    request_commitment=make_request_commitment(payload, operator_key=op_key),
+    encoder_binary_identity=encoder_binary_identity(arbiter_version=f"vaara/{vaara.__version__}", policy_hash=ph),
+    non_content_metadata={"action_class": "tx.transfer", "decision": "escalate"},
+    monotonic_counter=42,
+    arbiter_instance_identifier=uuid_bytes,
+)
+```
+
+`vaara overt verify RECEIPT.cbor --pubkey-file PUB.bin` validates any canonical-CBOR Base Envelope. The verifier reads only the wire format and takes no dependency on Vaara's emitter, so any conformant implementation can route through it. Adjacent surfaces (`vaara.attestation.iap` notary + transparency log, `vaara.attestation.s3p` aggregate intervals, an experimental AMD SEV-SNP TEE hook) and the OVERT 1.0 Part 3 control walk are in [COMPLIANCE.md](COMPLIANCE.md). The OVERT control mapping is in [OVERT_CONTROLS.md](OVERT_CONTROLS.md).
+
+## Sovereign inference harness
+
+The governance proxy binds a `tools/call`. The sovereign inference harness, published in v1.0, binds the model call underneath it: which model answered, on which silicon-resident weights, given what input, and what it returned. It runs a local model behind a signing proxy (OpenAI- and ollama-compatible) and emits a hardware-rooted inference receipt that a second, different local model independently cross-checks. The point is signed evidence that the inference itself is accounted for, not only the tooling around it.
+
+Two envelopes mirror the SEP-2787 attestation and receipt pair and reuse its canonicalization (RFC 8785 JCS) and signing stack (HS256 / ES256 / RS256), so a verifier that already reads Vaara records needs no new crypto:
+
+- `InferenceAttestation` is the pre-call commitment: declared intent, a request commitment, an issuer block with a TTL, and the model facts the proxy derived at call time.
+- `InferenceReceipt` is the post-call outcome, back-linked to the exact attestation, carrying status, an output commitment, eval-stat counters, and an honest `tier` self-label.
+
+Tier A (`integrity`) binds model, input, and output with no determinism claim and ships standalone. Tier B (`replay`), the byte-reproducibility claim, is deferred and labeled as such instead of overclaimed.
+
+```python
+from vaara.attestation.inference import emit_inference_attestation, emit_inference_receipt
+```
+
+The session, chain, cross-check, and determinism verifiers each ship a Vaara-free checker that reproduces its verdict offline, and the governance console renders a live inference chain an outside party can replay. Install with `pip install 'vaara[attestation]'`. Developed privately, published here under AGPL-3.0-or-later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.0.2"
+version = "1.0.3"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Documentation-only release (v1.0.3). No functional change to the package.

## README
Rewrites the README from a 321-line reference dump into a 161-line read with a clear arc: hook the problem, show install and first call early, keep a technical reader with the verify-without-trusting-us property, and push the reference mass into focused docs. No knowledge dropped; the deep material moved verbatim into:
- `docs/architecture.md` (how it works, scoring, external time anchor)
- `docs/standards.md` (OVERT 1.0, sovereign inference harness, SEP-2787 pair)
- `docs/adapters.md` (framework + cloud/OSS guardrail adapters, MCP proxy, HTTP API, TS client)

Benchmark numbers stay inline behind a disclosure block. IMDA and AMD acknowledgements kept.

## PRIOR_ART
Brings `docs/PRIOR_ART.md` current: chronology rows for v0.71.0 (RATS EAR neutral verify), v1.0.0 (sovereign inference harness, AGPL relicense), and v1.0.2 (evidenceRef recomputes end to end); a license-era note; and same-lane related work it had missed (Notarized Agents/Sello, the Five-Plane architecture, Attested Tool-Server Admission, the autogen/A2A/MCP signing cluster, Determs, and Interlock as the first independent party recomputing the published SEP-2828 vectors).

Version bumped to 1.0.3 across pyproject, __init__, package.json, server.json, server-vaara-server.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined README with clearer installation guidance and verification workflow.
  * New architecture documentation covering end-to-end tool-call flow and audit trail anchoring.
  * New standards documentation for OVERT attestation format and inference harness.
  * New adapters documentation detailing framework integrations (LangChain, CrewAI, OpenAI Agents SDK, MCP) and API options.
  * Updated reference materials with expanded chronology and citations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->