### PR TITLE
test(x402): recomputable settlement-to-receipt mapping vectors

### DIFF
--- a/tests/test_x402_settlement_vectors.py
+++ b/tests/test_x402_settlement_vectors.py
@@ -1,0 +1,100 @@
+"""Guard: the committed x402<->Vaara accountability vectors verify independently.
+
+Runs ``_check_independent.py`` (stdlib + cryptography + rfc8785, no Vaara
+imports) over the committed fixtures, then confirms the Vaara reference
+implementation reproduces the same binding and signature. If the format or a
+fixture drifts, the second-implementation checker fails here in CI rather than
+silently shipping a broken worked example.
+
+The vectors bind an x402 settlement to a SEP-2828 decision record across an
+action lifecycle (an in-progress step0 and a terminal step1) on two rails: a
+generic ``paymentHash`` and a Sui exact-scheme settlement result.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+for _mod in ("rfc8785", "cryptography"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            "attestation extra not installed (pip install 'vaara[attestation]')",
+            allow_module_level=True,
+        )
+
+VECTORS = Path(__file__).parent / "vectors" / "x402_settlement_v0"
+CHECKER = VECTORS / "_check_independent.py"
+_RAILS = ("generic", "sui")
+_STEPS = ("step0", "step1")
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "_x402_settlement_vector_checker", CHECKER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load(rail: str, step: str, name: str) -> dict:
+    return json.loads((VECTORS / rail / step / name).read_text())
+
+
+def test_independent_checker_passes_all_cases():
+    assert _load_checker().main() == 0
+
+
+def test_both_rails_present_with_lifecycle_steps():
+    for rail in _RAILS:
+        for step in _STEPS:
+            assert (VECTORS / rail / step / "settlement.json").is_file()
+            assert (VECTORS / rail / step / "receipt.json").is_file()
+
+
+def test_vaara_reproduces_binding_and_signature():
+    """The Vaara reference verifier reproduces, on its own implementation, the
+    two properties the independent checker asserts: the receipt signature
+    verifies under the committed public key, and the receipt's evidenceRef
+    digest is the JCS-canonical SHA-256 of the settlement it binds."""
+    import rfc8785
+    from cryptography.hazmat.primitives import serialization
+
+    from vaara.attestation.decision import (
+        parse_decision_record,
+        verify_decision_signature,
+    )
+
+    pub = serialization.load_pem_public_key(
+        (VECTORS / "keys" / "es256_public.pem").read_bytes())
+
+    for rail in _RAILS:
+        for step in _STEPS:
+            settlement = _load(rail, step, "settlement.json")
+            receipt_dict = _load(rail, step, "receipt.json")
+
+            record = parse_decision_record(receipt_dict)
+            assert verify_decision_signature(
+                record, verifying_material=pub) is True, f"{rail}/{step} sig"
+
+            ref = record.decision_derived.evidence_ref
+            assert ref is not None and ref.canonicalization == "JCS"
+            digest = "sha256:" + hashlib.sha256(
+                rfc8785.dumps(settlement)).hexdigest()
+            assert ref.digest == digest, f"{rail}/{step} binding"
+
+
+def test_lifecycle_steps_have_distinct_action_refs():
+    """A mid-task (terminal=false) receipt cannot be passed off as the final
+    (terminal=true) one: the two lifecycle points carry distinct action_refs
+    and opposite terminal flags on every rail."""
+    for rail in _RAILS:
+        s0 = _load(rail, "step0", "settlement.json")
+        s1 = _load(rail, "step1", "settlement.json")
+        assert s0["terminal"] is False
+        assert s1["terminal"] is True
+        assert s0["actionRef"] != s1["actionRef"]

--- a/tests/vectors/x402_settlement_v0/_check_independent.py
+++ b/tests/vectors/x402_settlement_v0/_check_independent.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Independent checker for the x402 <-> Vaara accountability mapping, across an
+action lifecycle, on two rails (generic and Sui exact-scheme).
+
+Imports only the standard library plus ``cryptography`` and ``rfc8785``. It does
+not import Vaara. For each rail it reads the committed step0 (in-progress) and
+step1 (terminal) fixtures and reproduces, per step, three verdicts a third party
+can confirm with only the settlement and the receipt in hand:
+
+  action_ref_recomputes        sha256 over the JCS-canonical action tuple
+                               (agentId, actionType, scope, timestampMs, seq,
+                               terminal) equals settlement.actionRef, the join
+                               key. Nothing rail-specific enters the tuple.
+  settlement_binding_resolves  sha256 over the JCS-canonical settlement record
+                               equals the receipt's evidenceRef.digest.
+  receipt_signature_ok         the ES256 signature verifies over the canonical
+                               (version, alg, backLink, decisionDerived,
+                               issuerAsserted) blocks against the public key.
+
+And one cross-step verdict per rail:
+
+  lifecycle_distinguishes_terminal
+                               the in-progress and terminal steps have distinct
+                               action_refs, carry terminal=false / terminal=true,
+                               and the in-progress receipt does not resolve
+                               against the terminal settlement. A mid-task
+                               receipt cannot be passed off as the final one.
+
+The Sui rail binds the facilitator's verified settlement result (the Sui tx
+digest plus value/recipient asserted from the net balance change to payTo), not
+a re-derivation from the transaction, so the same recompute holds without the
+join key reaching into the PTB.
+
+Run: python tests/vectors/x402_settlement_v0/_check_independent.py
+Exit 0 means every verdict matched expected.json.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+HERE = Path(__file__).resolve().parent
+KEYS = HERE / "keys"
+_DECISION_BLOCKS = ("version", "alg", "backLink", "decisionDerived",
+                    "issuerAsserted")
+_ACTION_KEYS = ("agentId", "actionType", "scope", "timestampMs", "seq",
+                "terminal")
+_RAILS = ("generic", "sui")
+
+
+def _jcs(obj) -> bytes:
+    return rfc8785.dumps(obj)
+
+
+def _sha256_hex(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def action_ref_recomputes(settlement: dict) -> bool:
+    action = {k: settlement[k] for k in _ACTION_KEYS}
+    return _sha256_hex(_jcs(action)) == settlement["actionRef"]
+
+
+def settlement_binding_resolves(receipt: dict, settlement: dict) -> bool:
+    ref = receipt.get("decisionDerived", {}).get("evidenceRef")
+    if not isinstance(ref, dict) or ref.get("canonicalization") != "JCS":
+        return False
+    return _sha256_hex(_jcs(settlement)) == ref.get("digest")
+
+
+def receipt_signature_ok(receipt: dict) -> bool:
+    if receipt.get("alg") != "ES256":
+        return False
+    sig = receipt.get("signature", "")
+    if len(sig) != 128:
+        return False
+    payload = _jcs({k: receipt[k] for k in _DECISION_BLOCKS})
+    pub = serialization.load_pem_public_key(
+        (KEYS / "es256_public.pem").read_bytes())
+    raw = bytes.fromhex(sig)
+    der = encode_dss_signature(
+        int.from_bytes(raw[:32], "big"), int.from_bytes(raw[32:], "big"))
+    try:
+        pub.verify(der, payload, ec.ECDSA(hashes.SHA256()))
+        return True
+    except InvalidSignature:
+        return False
+
+
+def _step_verdicts(settlement: dict, receipt: dict) -> dict:
+    return {
+        "action_ref_recomputes": action_ref_recomputes(settlement),
+        "settlement_binding_resolves": settlement_binding_resolves(
+            receipt, settlement),
+        "receipt_signature_ok": receipt_signature_ok(receipt),
+    }
+
+
+def lifecycle_distinguishes_terminal(s0: dict, r0: dict, s1: dict) -> bool:
+    # distinct join keys for the two lifecycle points
+    if s0["actionRef"] == s1["actionRef"]:
+        return False
+    # the tuple carries an explicit, opposite terminal flag
+    if s0.get("terminal") is not False or s1.get("terminal") is not True:
+        return False
+    # the in-progress receipt does not resolve against the terminal settlement:
+    # a mid-task receipt cannot be presented where the final one is required
+    ref0 = r0.get("decisionDerived", {}).get("evidenceRef", {})
+    return _sha256_hex(_jcs(s1)) != ref0.get("digest")
+
+
+def _load(rail: str, step: str, name: str) -> dict:
+    return json.loads((HERE / rail / step / name).read_text())
+
+
+def _rail_verdicts(rail: str) -> dict:
+    s0 = _load(rail, "step0", "settlement.json")
+    r0 = _load(rail, "step0", "receipt.json")
+    s1 = _load(rail, "step1", "settlement.json")
+    r1 = _load(rail, "step1", "receipt.json")
+    return {
+        "step0": _step_verdicts(s0, r0),
+        "step1": _step_verdicts(s1, r1),
+        "lifecycle_distinguishes_terminal": lifecycle_distinguishes_terminal(
+            s0, r0, s1),
+    }
+
+
+def main() -> int:
+    expected = json.loads((HERE / "expected.json").read_text())
+    got = {rail: _rail_verdicts(rail) for rail in _RAILS}
+    ok = got == expected
+    for rail in _RAILS:
+        for step in ("step0", "step1"):
+            for k, v in got[rail][step].items():
+                print(f"[{'OK' if v else 'FAIL'}] {rail}.{step}.{k}: {v}")
+        lv = got[rail]["lifecycle_distinguishes_terminal"]
+        print(f"[{'OK' if lv else 'FAIL'}] {rail}.lifecycle_distinguishes_terminal: {lv}")
+    print(f"\n{'all verdicts matched expected' if ok else 'MISMATCH vs expected'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/x402_settlement_v0/expected.json
+++ b/tests/vectors/x402_settlement_v0/expected.json
@@ -1,0 +1,28 @@
+{
+  "generic": {
+    "lifecycle_distinguishes_terminal": true,
+    "step0": {
+      "action_ref_recomputes": true,
+      "receipt_signature_ok": true,
+      "settlement_binding_resolves": true
+    },
+    "step1": {
+      "action_ref_recomputes": true,
+      "receipt_signature_ok": true,
+      "settlement_binding_resolves": true
+    }
+  },
+  "sui": {
+    "lifecycle_distinguishes_terminal": true,
+    "step0": {
+      "action_ref_recomputes": true,
+      "receipt_signature_ok": true,
+      "settlement_binding_resolves": true
+    },
+    "step1": {
+      "action_ref_recomputes": true,
+      "receipt_signature_ok": true,
+      "settlement_binding_resolves": true
+    }
+  }
+}

--- a/tests/vectors/x402_settlement_v0/generic/step0/receipt.json
+++ b/tests/vectors/x402_settlement_v0/generic/step0/receipt.json
@@ -1,0 +1,32 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:b965e9cb1f9910bc827beced4910064ad1c80b0cfde78476d0da5910b2b52e30",
+    "attestationNonce": "x402-generic-0"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-17T10:00:00Z",
+    "decision": "allow",
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:8e3e2226bb5954e8696aa189369f18249749d4f91b3c4402f48c4debcb147547",
+      "ref": "x402:action_ref/sha256:638c16ea5d1d79e75878d860c90e2a84417c9496404ccb867fdecd9f2aa76709",
+      "schema": "x402.settlement/v0"
+    },
+    "policyId": "policy:x402-fulfillment/1",
+    "reason": "agent acted within the authorized scope of the settled order",
+    "riskScore": "0.10",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "ES256",
+    "iat": "2026-06-17T10:00:00Z",
+    "iss": "issuer://merchant-gateway",
+    "nonce": "d-generic-0",
+    "secretVersion": "v1",
+    "sub": "agent:checkout-bot"
+  },
+  "signature": "044761eb8a502518ab20e6bbe475a8a94315cabe9460f6a91f4e0240b91f149ad882f55835fc1052d5ec1fe02ff399bd3eb7f4dd20c6035586cae42a5f38668a",
+  "version": 1
+}

--- a/tests/vectors/x402_settlement_v0/generic/step0/settlement.json
+++ b/tests/vectors/x402_settlement_v0/generic/step0/settlement.json
@@ -1,0 +1,11 @@
+{
+  "actionRef": "sha256:638c16ea5d1d79e75878d860c90e2a84417c9496404ccb867fdecd9f2aa76709",
+  "actionType": "purchase.fulfill",
+  "agentId": "agent:checkout-bot",
+  "paymentHash": "0x9c1f4ad2b7e84410a0f7c2d6e1b3f59a7c0d2e4f6a8b1c3d5e7f9a0b1c2d3e4f6",
+  "schema": "x402.settlement/v0",
+  "scope": "merchant:acme/order:INV-1/amount:42.00USDC",
+  "seq": 0,
+  "terminal": false,
+  "timestampMs": 1779200000000
+}

--- a/tests/vectors/x402_settlement_v0/generic/step1/receipt.json
+++ b/tests/vectors/x402_settlement_v0/generic/step1/receipt.json
@@ -1,0 +1,32 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:306d1327acfa3b2a00b72c81154bcb666c5b1e3e211f70151773b9769dc9145f",
+    "attestationNonce": "x402-generic-1"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-17T10:00:00Z",
+    "decision": "allow",
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:cf7477e2f356b0d885b8878e2143de119b0df8af7226b061668571d76dda2723",
+      "ref": "x402:action_ref/sha256:42f279db7f430127d682f1ccf6acdf90e679086b3c78b38fa30085cd6addc2f3",
+      "schema": "x402.settlement/v0"
+    },
+    "policyId": "policy:x402-fulfillment/1",
+    "reason": "agent acted within the authorized scope of the settled order",
+    "riskScore": "0.10",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "ES256",
+    "iat": "2026-06-17T10:00:00Z",
+    "iss": "issuer://merchant-gateway",
+    "nonce": "d-generic-1",
+    "secretVersion": "v1",
+    "sub": "agent:checkout-bot"
+  },
+  "signature": "f12064c4295085b8b8470d42c3918dc414fdf2b658a3246186de81a934726d5aaff21e11a551e7f18854473abe9e480c58f35f92c535271776c8fd1ad415fd3a",
+  "version": 1
+}

--- a/tests/vectors/x402_settlement_v0/generic/step1/settlement.json
+++ b/tests/vectors/x402_settlement_v0/generic/step1/settlement.json
@@ -1,0 +1,11 @@
+{
+  "actionRef": "sha256:42f279db7f430127d682f1ccf6acdf90e679086b3c78b38fa30085cd6addc2f3",
+  "actionType": "purchase.fulfill",
+  "agentId": "agent:checkout-bot",
+  "paymentHash": "0x9c1f4ad2b7e84410a0f7c2d6e1b3f59a7c0d2e4f6a8b1c3d5e7f9a0b1c2d3e4f6",
+  "schema": "x402.settlement/v0",
+  "scope": "merchant:acme/order:INV-1/amount:42.00USDC",
+  "seq": 1,
+  "terminal": true,
+  "timestampMs": 1779200000000
+}

--- a/tests/vectors/x402_settlement_v0/keys/es256_public.pem
+++ b/tests/vectors/x402_settlement_v0/keys/es256_public.pem
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6/uudvA125I0rvwjyfS+pMCJ++Mk
+qQAudgle3Ya+pfZauxkrmvzq1deDtSz26f7scOdO0YuQyaN3TMIlzD0zPA==
+-----END PUBLIC KEY-----

--- a/tests/vectors/x402_settlement_v0/sui/step0/receipt.json
+++ b/tests/vectors/x402_settlement_v0/sui/step0/receipt.json
@@ -1,0 +1,32 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:96dc7a26c0dc0dbe51d836a9ad84a2fc02a25eaff5dc40a6c56ae72615f22be7",
+    "attestationNonce": "x402-sui-0"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-17T10:00:00Z",
+    "decision": "allow",
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:ee621c44017fe87a59bff93658000b3b787c4175927c97b21795eb6347e86c28",
+      "ref": "x402:action_ref/sha256:638c16ea5d1d79e75878d860c90e2a84417c9496404ccb867fdecd9f2aa76709",
+      "schema": "x402.settlement.sui/v0"
+    },
+    "policyId": "policy:x402-fulfillment/1",
+    "reason": "agent acted within the authorized scope of the settled order",
+    "riskScore": "0.10",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "ES256",
+    "iat": "2026-06-17T10:00:00Z",
+    "iss": "issuer://merchant-gateway",
+    "nonce": "d-sui-0",
+    "secretVersion": "v1",
+    "sub": "agent:checkout-bot"
+  },
+  "signature": "07004c69436c820797bb008ed6d1d867ecd15b68b453221d56474ab865935bce1b8ae9b22627f97df6d5d1dac4db65ae78d822743e675cb2f69c35f9c34272de",
+  "version": 1
+}

--- a/tests/vectors/x402_settlement_v0/sui/step0/settlement.json
+++ b/tests/vectors/x402_settlement_v0/sui/step0/settlement.json
@@ -1,0 +1,21 @@
+{
+  "actionRef": "sha256:638c16ea5d1d79e75878d860c90e2a84417c9496404ccb867fdecd9f2aa76709",
+  "actionType": "purchase.fulfill",
+  "agentId": "agent:checkout-bot",
+  "schema": "x402.settlement.sui/v0",
+  "scope": "merchant:acme/order:INV-1/amount:42.00USDC",
+  "seq": 0,
+  "settlement": {
+    "amount": "42.00",
+    "assertedFrom": "net-balance-change-to-payTo",
+    "asset": "0x2::sui::SUI",
+    "network": "testnet",
+    "payTo": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "rail": "sui",
+    "scheme": "exact",
+    "txDigest": "11111111111111111111111111111111",
+    "verifiedBy": "facilitator://sui-exact"
+  },
+  "terminal": false,
+  "timestampMs": 1779200000000
+}

--- a/tests/vectors/x402_settlement_v0/sui/step1/receipt.json
+++ b/tests/vectors/x402_settlement_v0/sui/step1/receipt.json
@@ -1,0 +1,32 @@
+{
+  "alg": "ES256",
+  "backLink": {
+    "attestationDigest": "sha256:c89d63157717a264aad120ef743de5cf9e785e75e260afd99524a6b89ce4fec3",
+    "attestationNonce": "x402-sui-1"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-17T10:00:00Z",
+    "decision": "allow",
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:15f24edbd3dcf86027819cc362bd8822462fe53e773d1f3bb1743a865d9b1b1e",
+      "ref": "x402:action_ref/sha256:42f279db7f430127d682f1ccf6acdf90e679086b3c78b38fa30085cd6addc2f3",
+      "schema": "x402.settlement.sui/v0"
+    },
+    "policyId": "policy:x402-fulfillment/1",
+    "reason": "agent acted within the authorized scope of the settled order",
+    "riskScore": "0.10",
+    "thresholdAllow": "0.30",
+    "thresholdBlock": "0.80"
+  },
+  "issuerAsserted": {
+    "alg": "ES256",
+    "iat": "2026-06-17T10:00:00Z",
+    "iss": "issuer://merchant-gateway",
+    "nonce": "d-sui-1",
+    "secretVersion": "v1",
+    "sub": "agent:checkout-bot"
+  },
+  "signature": "8446671c585649d1b5b747361ce00bb2fb999830d6889415d7d9aa9b0d9ad7c73ce8cc0f4ba4da4ad30522dc3cd791533a393772cad658380e9463199925817e",
+  "version": 1
+}

--- a/tests/vectors/x402_settlement_v0/sui/step1/settlement.json
+++ b/tests/vectors/x402_settlement_v0/sui/step1/settlement.json
@@ -1,0 +1,21 @@
+{
+  "actionRef": "sha256:42f279db7f430127d682f1ccf6acdf90e679086b3c78b38fa30085cd6addc2f3",
+  "actionType": "purchase.fulfill",
+  "agentId": "agent:checkout-bot",
+  "schema": "x402.settlement.sui/v0",
+  "scope": "merchant:acme/order:INV-1/amount:42.00USDC",
+  "seq": 1,
+  "settlement": {
+    "amount": "42.00",
+    "assertedFrom": "net-balance-change-to-payTo",
+    "asset": "0x2::sui::SUI",
+    "network": "testnet",
+    "payTo": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "rail": "sui",
+    "scheme": "exact",
+    "txDigest": "11111111111111111111111111111111",
+    "verifiedBy": "facilitator://sui-exact"
+  },
+  "terminal": true,
+  "timestampMs": 1779200000000
+}


### PR DESCRIPTION
## What

Cross-producer test vectors that bind an x402 settlement to a signed execution receipt, plus a CI guard (`tests/test_x402_settlement_vectors.py`, 4 tests).

This is the durable, CI-guarded home for the recomputable mapping discussed in x402-foundation/x402#2648.

## Shape

Two rails (`generic`, `sui`) x two lifecycle steps (`step0` non-terminal, `step1` terminal):

- The action tuple `(agentId, actionType, scope, timestampMs, seq, terminal)` is canonicalized with RFC 8785 (JCS).
- The tuple is **rail-independent**: the same `action_ref` appears on both rails; only the settlement bytes and `evidenceRef.digest` differ.
- `terminal`/`seq` distinguish a mid-task receipt from the final one, so a non-terminal receipt cannot pose as the settled action.
- The Sui rail binds the facilitator's *verified* result (txDigest + payTo/asset/amount asserted from net-balance-change), not a tx re-derivation. Sui values are testnet placeholders.

## How it is checked

`tests/vectors/x402_settlement_v0/_check_independent.py` reproduces the binding and ES256 verification with **no Vaara import** (stdlib + `cryptography` + `rfc8785`). The test runs that independent checker, then confirms the Vaara reference implementation (`parse_decision_record` + `verify_decision_signature`) reproduces the same binding and signature.

## Verification

- Independent checker: 14/14 OK across both rails.
- New test: 4 passed.
- Full suite: 1815 passed, 13 skipped (pre-existing FastAPI deprecation warnings only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for settlement accountability validation with end-to-end verification of settlement binding, cryptographic signatures, and lifecycle state transitions
  * Added test vector fixtures supporting validation across multiple settlement scenarios and configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->