### PR TITLE
feat(credential): receipt-bound credential broker, the authority layer (v1.1.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ tests/adversarial/traces/
 .profile
 .gitconfig
 .ripgreprc
+.idea
 .idea/
 .vscode/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-06-18
+
+Minor release: the credential broker, Vaara's authority layer. Observability gains an
+enforcement edge. The proxy can mint a signed, short-lived credential bound to a specific
+attestation digest (transitively the mediation receipt) and scoped to one tool plus an
+args commitment plus tenant. A gateway in front of a protected tool refuses any call that
+lacks a valid, unexpired, non-revoked, attestation-bound grant. Bypass stops being silent
+and successful; it becomes "defeat the broker first." This is detection, not a
+mathematical completeness claim.
+
+- New `vaara.credential` package: grant types, parse, emit, verify, and the
+  `CredentialGateway`. The grant reuses the SEP-2787 signing stack (HS256 / ES256 / RS256
+  over RFC 8785 JCS), so the grant key matches the attestation and receipt key.
+- Proxy minting is gated behind `_mint_credentials`, default off. No runtime behavior
+  changes for existing deployments until an operator turns it on with an attestation key
+  configured.
+- Conformance vectors under `conformance/sep2828/credential_grant_v0/` with a checker that
+  verifies grants without importing Vaara, so an independent implementer can recompute the
+  format. Five verdict vectors covering valid, expired, wrong-scope, revoked, and tampered
+  grants.
+- Design spec at `docs/design/credential-broker-spec.md` covering the grant schema, the
+  binding chain to the receipt, the threat model, and the honest limits of the approach.
+
 ## [1.0.3] - 2026-06-17
 
 Patch release: documentation only. No functional change to the published package.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/conformance/sep2828/credential_grant_v0/README.md
+++ b/conformance/sep2828/credential_grant_v0/README.md
@@ -1,0 +1,46 @@
+# Credential-grant conformance vectors, v0
+
+Fixtures for the receipt-bound credential broker: the authority half of
+Vaara's "separate intelligence from authority" move. A grant is a standalone
+signed envelope the proxy mints between the allow decision and the upstream
+forward, scoped to one tool + args commitment + tenant, bound to a specific
+attestation digest, and short-lived. A gateway in front of a protected tool
+refuses any call lacking a valid, unexpired, scope-matching, attestation-bound
+grant.
+
+Each set under `sets/<name>/` holds the bytes a neutral verifier needs:
+
+- `grant.json`: the brokered-credential wire envelope.
+- `attestation.json`: the SEP-2787 attestation the grant is bound to (its
+  digest is the `binding.attestationDigest`).
+- `inputs.json`: the runtime call a gateway sees: `toolName`, `args`,
+  `tenantId`, the `now` epoch, and the HS256 `keyHex`.
+
+`expected.json` maps each set to its verdict `{ok, reason}`. The verdict
+precedence is `bad_signature` -> `expired` -> `scope_mismatch` ->
+`binding_unknown`, so an expired-but-authentic grant is never mislabeled.
+
+## Reproduce it without Vaara
+
+`_check_independent.py` re-derives every verdict from the committed bytes with
+no `import vaara`: the HS256 signature over the JCS-canonical preimage
+`{version, alg, scope, binding, asserted}`, the bound attestation digest
+(sha256 over the JCS of `attestation.json`), and the args commitment (the
+two-step hash-only projection). The one shared primitive is RFC 8785 (JCS);
+the rest is the standard library.
+
+```
+python conformance/sep2828/credential_grant_v0/_check_independent.py
+```
+
+Exit 0 means a second implementation reproduced the format. All vectors are
+HS256; ES256 / RS256 verify the identical preimage with a public key. Regenerate
+with `python scripts/build_credential_grant_vectors.py`.
+
+## Honest scope
+
+This is detection of a defeated broker, not a mathematical-completeness claim.
+Completeness holds only for tools placed behind a gateway that runs the check;
+a tool reachable by another path (operator root, an alternate credential
+source, a purely-local action) is caught after the fact by reconciliation, not
+prevented here. See `docs/design/credential-broker-spec.md`.

--- a/conformance/sep2828/credential_grant_v0/_check_independent.py
+++ b/conformance/sep2828/credential_grant_v0/_check_independent.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Independent verifier for the v0 credential-grant vectors.
+
+A second implementation of the brokered-credential rules, written from the
+wire spec alone with no ``import vaara``. For each committed set it
+re-derives, from the bytes on disk:
+
+* the HS256 signature over the JCS-canonical grant preimage
+  ``{version, alg, scope, binding, asserted}``;
+* the bound attestation digest (sha256 over the JCS of ``attestation.json``);
+* the args commitment (the two-step hash-only projection Vaara uses);
+
+then reproduces the gateway verdict in the same precedence
+(bad_signature -> expired -> scope_mismatch -> binding_unknown) and compares
+it to ``expected.json``. ``rfc8785`` provides the one shared primitive (JCS);
+everything else is the standard library. All vectors are HS256; ES256 / RS256
+verify the identical preimage with a public key, so the format claim carries.
+
+Run: ``python conformance/sep2828/credential_grant_v0/_check_independent.py``.
+Exit 0 means every set reproduced its expected verdict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+from pathlib import Path
+
+import rfc8785
+
+HERE = Path(__file__).resolve().parent
+CLOCK_SKEW_SECONDS = 30
+
+
+def _jcs(value) -> bytes:
+    return rfc8785.dumps(value)
+
+
+def _sha256_digest(payload: bytes) -> str:
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def _args_commitment(args) -> str:
+    inner = _sha256_digest(_jcs(args))
+    return _sha256_digest(_jcs({"digest": inner}))
+
+
+def _preimage(grant) -> bytes:
+    return _jcs(
+        {
+            "version": grant["version"],
+            "alg": grant["alg"],
+            "scope": grant["scope"],
+            "binding": grant["binding"],
+            "asserted": grant["asserted"],
+        }
+    )
+
+
+def _iso_to_epoch(iso: str):
+    from datetime import datetime
+
+    try:
+        if iso.endswith("Z"):
+            iso = iso[:-1] + "+00:00"
+        return datetime.fromisoformat(iso).timestamp()
+    except (ValueError, TypeError):
+        return None
+
+
+def verdict(grant, attestation, inputs) -> dict:
+    """Reproduce the gateway verdict for one set (HS256 only)."""
+    key = bytes.fromhex(inputs["keyHex"])
+    expected_sig = hmac.new(key, _preimage(grant), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected_sig, grant.get("signature", "")):
+        return {"ok": False, "reason": "bad_signature"}
+
+    asserted = grant["asserted"]
+    iat_epoch = _iso_to_epoch(asserted["iat"])
+    now = inputs["now"]
+    if iat_epoch is None:
+        return {"ok": False, "reason": "expired"}
+    deadline = iat_epoch + asserted["expSeconds"] + CLOCK_SKEW_SECONDS
+    if iat_epoch > now + CLOCK_SKEW_SECONDS or now > deadline:
+        return {"ok": False, "reason": "expired"}
+
+    scope = grant["scope"]
+    if scope["toolName"] != inputs["toolName"]:
+        return {"ok": False, "reason": "scope_mismatch"}
+    if scope["tenantId"] != inputs["tenantId"]:
+        return {"ok": False, "reason": "scope_mismatch"}
+    if scope["argsCommitment"] != _args_commitment(inputs["args"]):
+        return {"ok": False, "reason": "scope_mismatch"}
+
+    known = {_sha256_digest(_jcs(attestation))}
+    if grant["binding"]["attestationDigest"] not in known:
+        return {"ok": False, "reason": "binding_unknown"}
+
+    return {"ok": True, "reason": "ok"}
+
+
+def main() -> int:
+    expected = json.loads((HERE / "expected.json").read_text())
+    failures = 0
+    for name in sorted(expected):
+        d = HERE / "sets" / name
+        grant = json.loads((d / "grant.json").read_text())
+        attestation = json.loads((d / "attestation.json").read_text())
+        inputs = json.loads((d / "inputs.json").read_text())
+        got = verdict(grant, attestation, inputs)
+        ok = got == expected[name]
+        failures += 0 if ok else 1
+        print(f"[{'OK' if ok else 'FAIL'}] {name}: {got['reason']}")
+        if not ok:
+            print("  want:", expected[name])
+            print("  got :", got)
+    print(f"\n{len(expected) - failures}/{len(expected)} sets matched expected.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/sep2828/credential_grant_v0/expected.json
+++ b/conformance/sep2828/credential_grant_v0/expected.json
@@ -1,0 +1,22 @@
+{
+  "bad_signature": {
+    "ok": false,
+    "reason": "bad_signature"
+  },
+  "binding_unknown": {
+    "ok": false,
+    "reason": "binding_unknown"
+  },
+  "expired": {
+    "ok": false,
+    "reason": "expired"
+  },
+  "ok": {
+    "ok": true,
+    "reason": "ok"
+  },
+  "scope_mismatch": {
+    "ok": false,
+    "reason": "scope_mismatch"
+  }
+}

--- a/conformance/sep2828/credential_grant_v0/sets/bad_signature/attestation.json
+++ b/conformance/sep2828/credential_grant_v0/sets/bad_signature/attestation.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "plannerDeclared": {
+    "intent": "tools/call/files.read"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-18T11:59:06Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "4A1sMS-rRPEjUEOnWd_c1hrI",
+    "secretVersion": "9a08d205",
+    "sub": "tenant-alpha/default"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "name": "files.read",
+        "serverFingerprint": "cmd:sha256:092c79e8f80e559e404bcf660c48f3522b67aba9ff1484b0367e1a4ddef7431d",
+        "args": {
+          "projection": "{\"digest\":\"sha256:81cfc61c8cb71718b34a4ae23d591fb5c189c8f6856e52e366d490be910b6b39\"}",
+          "projectionDigest": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2"
+        }
+      }
+    ]
+  },
+  "signature": "aec8e87ef443deec053bf9ed1a219171466684c037ce93092d72406819a84b61"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/bad_signature/grant.json
+++ b/conformance/sep2828/credential_grant_v0/sets/bad_signature/grant.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "scope": {
+    "argsCommitment": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2",
+    "tenantId": "tenant-alpha",
+    "toolName": "files.read"
+  },
+  "binding": {
+    "attestationDigest": "sha256:78fb051dbed07e84f706d41fb4c28064e2e57e2c54ccf97e0d0d468674654827",
+    "attestationNonce": "4A1sMS-rRPEjUEOnWd_c1hrI"
+  },
+  "asserted": {
+    "expSeconds": 60,
+    "iat": "2026-06-18T12:00:00Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "grant-nonce-fixed",
+    "secretVersion": "key-v1",
+    "sub": "tenant-alpha/default"
+  },
+  "signature": "00cc95c72c49f2670fd15c9e5427518a1b0004e976726a08435d539b8c8ca3fb"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/bad_signature/inputs.json
+++ b/conformance/sep2828/credential_grant_v0/sets/bad_signature/inputs.json
@@ -1,0 +1,9 @@
+{
+  "toolName": "files.read",
+  "args": {
+    "path": "/data/report.txt"
+  },
+  "tenantId": "tenant-alpha",
+  "now": 1781784005.0,
+  "keyHex": "636f6e666f726d616e63652d63726564656e7469616c2d6772616e742d76302d7368617265642d7365637265742121"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/binding_unknown/attestation.json
+++ b/conformance/sep2828/credential_grant_v0/sets/binding_unknown/attestation.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "plannerDeclared": {
+    "intent": "tools/call/files.read"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-18T11:59:06Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "DdhmkIgsSgEwdnSFM8HZVmoK",
+    "secretVersion": "9a08d205",
+    "sub": "tenant-alpha/default"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "name": "files.read",
+        "serverFingerprint": "cmd:sha256:092c79e8f80e559e404bcf660c48f3522b67aba9ff1484b0367e1a4ddef7431d",
+        "args": {
+          "projection": "{\"digest\":\"sha256:81cfc61c8cb71718b34a4ae23d591fb5c189c8f6856e52e366d490be910b6b39\"}",
+          "projectionDigest": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2"
+        }
+      }
+    ]
+  },
+  "signature": "1282f201e6bfa3728cb75a4b6374e52aac53c86ea27d0ab618cb4d8c57e0c324"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/binding_unknown/grant.json
+++ b/conformance/sep2828/credential_grant_v0/sets/binding_unknown/grant.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "scope": {
+    "argsCommitment": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2",
+    "tenantId": "tenant-alpha",
+    "toolName": "files.read"
+  },
+  "binding": {
+    "attestationDigest": "sha256:78fb051dbed07e84f706d41fb4c28064e2e57e2c54ccf97e0d0d468674654827",
+    "attestationNonce": "4A1sMS-rRPEjUEOnWd_c1hrI"
+  },
+  "asserted": {
+    "expSeconds": 60,
+    "iat": "2026-06-18T12:00:00Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "grant-nonce-fixed",
+    "secretVersion": "key-v1",
+    "sub": "tenant-alpha/default"
+  },
+  "signature": "17cc95c72c49f2670fd15c9e5427518a1b0004e976726a08435d539b8c8ca3fb"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/binding_unknown/inputs.json
+++ b/conformance/sep2828/credential_grant_v0/sets/binding_unknown/inputs.json
@@ -1,0 +1,9 @@
+{
+  "toolName": "files.read",
+  "args": {
+    "path": "/data/report.txt"
+  },
+  "tenantId": "tenant-alpha",
+  "now": 1781784005.0,
+  "keyHex": "636f6e666f726d616e63652d63726564656e7469616c2d6772616e742d76302d7368617265642d7365637265742121"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/expired/attestation.json
+++ b/conformance/sep2828/credential_grant_v0/sets/expired/attestation.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "plannerDeclared": {
+    "intent": "tools/call/files.read"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-18T11:59:06Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "4A1sMS-rRPEjUEOnWd_c1hrI",
+    "secretVersion": "9a08d205",
+    "sub": "tenant-alpha/default"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "name": "files.read",
+        "serverFingerprint": "cmd:sha256:092c79e8f80e559e404bcf660c48f3522b67aba9ff1484b0367e1a4ddef7431d",
+        "args": {
+          "projection": "{\"digest\":\"sha256:81cfc61c8cb71718b34a4ae23d591fb5c189c8f6856e52e366d490be910b6b39\"}",
+          "projectionDigest": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2"
+        }
+      }
+    ]
+  },
+  "signature": "aec8e87ef443deec053bf9ed1a219171466684c037ce93092d72406819a84b61"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/expired/grant.json
+++ b/conformance/sep2828/credential_grant_v0/sets/expired/grant.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "scope": {
+    "argsCommitment": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2",
+    "tenantId": "tenant-alpha",
+    "toolName": "files.read"
+  },
+  "binding": {
+    "attestationDigest": "sha256:78fb051dbed07e84f706d41fb4c28064e2e57e2c54ccf97e0d0d468674654827",
+    "attestationNonce": "4A1sMS-rRPEjUEOnWd_c1hrI"
+  },
+  "asserted": {
+    "expSeconds": 60,
+    "iat": "2026-06-18T12:00:00Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "grant-nonce-fixed",
+    "secretVersion": "key-v1",
+    "sub": "tenant-alpha/default"
+  },
+  "signature": "17cc95c72c49f2670fd15c9e5427518a1b0004e976726a08435d539b8c8ca3fb"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/expired/inputs.json
+++ b/conformance/sep2828/credential_grant_v0/sets/expired/inputs.json
@@ -1,0 +1,9 @@
+{
+  "toolName": "files.read",
+  "args": {
+    "path": "/data/report.txt"
+  },
+  "tenantId": "tenant-alpha",
+  "now": 1781789000.0,
+  "keyHex": "636f6e666f726d616e63652d63726564656e7469616c2d6772616e742d76302d7368617265642d7365637265742121"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/ok/attestation.json
+++ b/conformance/sep2828/credential_grant_v0/sets/ok/attestation.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "plannerDeclared": {
+    "intent": "tools/call/files.read"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-18T11:59:06Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "4A1sMS-rRPEjUEOnWd_c1hrI",
+    "secretVersion": "9a08d205",
+    "sub": "tenant-alpha/default"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "name": "files.read",
+        "serverFingerprint": "cmd:sha256:092c79e8f80e559e404bcf660c48f3522b67aba9ff1484b0367e1a4ddef7431d",
+        "args": {
+          "projection": "{\"digest\":\"sha256:81cfc61c8cb71718b34a4ae23d591fb5c189c8f6856e52e366d490be910b6b39\"}",
+          "projectionDigest": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2"
+        }
+      }
+    ]
+  },
+  "signature": "aec8e87ef443deec053bf9ed1a219171466684c037ce93092d72406819a84b61"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/ok/grant.json
+++ b/conformance/sep2828/credential_grant_v0/sets/ok/grant.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "scope": {
+    "argsCommitment": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2",
+    "tenantId": "tenant-alpha",
+    "toolName": "files.read"
+  },
+  "binding": {
+    "attestationDigest": "sha256:78fb051dbed07e84f706d41fb4c28064e2e57e2c54ccf97e0d0d468674654827",
+    "attestationNonce": "4A1sMS-rRPEjUEOnWd_c1hrI"
+  },
+  "asserted": {
+    "expSeconds": 60,
+    "iat": "2026-06-18T12:00:00Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "grant-nonce-fixed",
+    "secretVersion": "key-v1",
+    "sub": "tenant-alpha/default"
+  },
+  "signature": "17cc95c72c49f2670fd15c9e5427518a1b0004e976726a08435d539b8c8ca3fb"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/ok/inputs.json
+++ b/conformance/sep2828/credential_grant_v0/sets/ok/inputs.json
@@ -1,0 +1,9 @@
+{
+  "toolName": "files.read",
+  "args": {
+    "path": "/data/report.txt"
+  },
+  "tenantId": "tenant-alpha",
+  "now": 1781784005.0,
+  "keyHex": "636f6e666f726d616e63652d63726564656e7469616c2d6772616e742d76302d7368617265642d7365637265742121"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/scope_mismatch/attestation.json
+++ b/conformance/sep2828/credential_grant_v0/sets/scope_mismatch/attestation.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "plannerDeclared": {
+    "intent": "tools/call/files.read"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "expSeconds": 300,
+    "iat": "2026-06-18T11:59:06Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "4A1sMS-rRPEjUEOnWd_c1hrI",
+    "secretVersion": "9a08d205",
+    "sub": "tenant-alpha/default"
+  },
+  "payloadDerived": {
+    "toolCalls": [
+      {
+        "name": "files.read",
+        "serverFingerprint": "cmd:sha256:092c79e8f80e559e404bcf660c48f3522b67aba9ff1484b0367e1a4ddef7431d",
+        "args": {
+          "projection": "{\"digest\":\"sha256:81cfc61c8cb71718b34a4ae23d591fb5c189c8f6856e52e366d490be910b6b39\"}",
+          "projectionDigest": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2"
+        }
+      }
+    ]
+  },
+  "signature": "aec8e87ef443deec053bf9ed1a219171466684c037ce93092d72406819a84b61"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/scope_mismatch/grant.json
+++ b/conformance/sep2828/credential_grant_v0/sets/scope_mismatch/grant.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "alg": "HS256",
+  "scope": {
+    "argsCommitment": "sha256:22a7553ad5a0608e2553f02f441c1c2453f4f91381f61b5de9b9c9f34a5cf5d2",
+    "tenantId": "tenant-alpha",
+    "toolName": "files.read"
+  },
+  "binding": {
+    "attestationDigest": "sha256:78fb051dbed07e84f706d41fb4c28064e2e57e2c54ccf97e0d0d468674654827",
+    "attestationNonce": "4A1sMS-rRPEjUEOnWd_c1hrI"
+  },
+  "asserted": {
+    "expSeconds": 60,
+    "iat": "2026-06-18T12:00:00Z",
+    "iss": "vaara-mcp-proxy",
+    "nonce": "grant-nonce-fixed",
+    "secretVersion": "key-v1",
+    "sub": "tenant-alpha/default"
+  },
+  "signature": "17cc95c72c49f2670fd15c9e5427518a1b0004e976726a08435d539b8c8ca3fb"
+}

--- a/conformance/sep2828/credential_grant_v0/sets/scope_mismatch/inputs.json
+++ b/conformance/sep2828/credential_grant_v0/sets/scope_mismatch/inputs.json
@@ -1,0 +1,9 @@
+{
+  "toolName": "files.read",
+  "args": {
+    "path": "/etc/shadow"
+  },
+  "tenantId": "tenant-alpha",
+  "now": 1781784005.0,
+  "keyHex": "636f6e666f726d616e63652d63726564656e7469616c2d6772616e742d76302d7368617265642d7365637265742121"
+}

--- a/docs/design/credential-broker-spec.md
+++ b/docs/design/credential-broker-spec.md
@@ -1,0 +1,113 @@
+# Receipt-bound credential broker (v0)
+
+Status: Phase A, off by default. This is Vaara's authority layer: the move from
+observability ("if it went through me I can prove what it was") to control
+enforcement ("a tool cannot act unless it routed through me"). It separates
+*intelligence* from *authority* the way OAuth separated identity from
+authority. The model proposes a tool call; only Vaara grants the temporary,
+scoped, receipt-bound capability to execute it.
+
+```
+LLM proposes -> Vaara mediates -> short-lived, scoped, bound credential -> tool
+```
+
+## A. Token shape
+
+A brokered credential is a standalone signed envelope (`vaara.credential`),
+not a field of the SEP-2787 attestation or the execution receipt. The
+attestation is emitted before the upstream forward and the receipt after the
+outcome, so a credential that must travel *with* the request cannot live in a
+receipt that does not exist yet.
+
+The signature covers the JCS (RFC 8785) encoding of
+`{version, alg, scope, binding, asserted}` and does not cover itself:
+
+- `scope`: `{toolName, argsCommitment, tenantId}`. `argsCommitment` is the
+  attested arguments' `ArgsProjection.projectionDigest`.
+- `binding`: `{attestationDigest, attestationNonce}`. The digest is
+  `attestation_digest(att)`, the same value the receipt back-links, so an
+  auditor can join grant to attestation to receipt offline.
+- `asserted`: `{iss, sub, iat, expSeconds, nonce, secretVersion}`. `iss` is
+  `vaara-mcp-proxy`; `sub` is `"{tenant}/{upstream}"`; `expSeconds` defaults
+  to 60.
+
+The signing stack is the SEP-2787 one (HS256 / ES256 / RS256) reused
+unchanged, so the grant key equals the attestation/receipt key and a verifier
+that already handles SEP-2787 signatures needs no new crypto. Each signed
+block is a closed schema: an unrecognized wire key is a hard reject, keeping
+the modeled preimage byte-exact to the wire.
+
+## B. Where it is minted
+
+`AttestPairEmitter.emit_grant` mints and persists the credential
+(`{counter}-{nonce}-grant.json`) right after the attestation, inside
+`mcp_proxy._handle_tools_call`, between the allow decision and the upstream
+forward. The proxy injects it at `params._meta["vaara/credential"]`. The
+upstream client serializes the whole payload, so `_meta` reaches the upstream
+verbatim. Minting is gated on `proxy._mint_credentials` (default `False`):
+observability is unchanged until an operator opts into enforcement.
+
+If minting fails it is logged and swallowed and no credential is injected; a
+gateway then fails closed on the missing credential rather than blocking
+traffic on a broker error.
+
+## C. Verification
+
+`verify_grant` is the standalone check a gateway runs before letting a tool
+execute. It gates on five facts and reports the first failing reason, in this
+precedence, so an expired-but-authentic grant is never mislabeled:
+
+1. `bad_signature` - signature does not match the grant blocks.
+2. `expired` - now is past `iat + expSeconds` (or the grant is future-dated),
+   using the same clock-skew window the SEP-2787 and inference verifiers use
+   (30 s).
+3. `scope_mismatch` - the runtime tool, tenant, or args do not match the
+   committed scope. The args commitment is re-derived with `make_args_digest`,
+   so a mutated argument after minting fails here.
+4. `revoked` - the issuer or its bound key was revoked at or before issuance
+   (`RevocationRegistry`).
+5. `binding_unknown` - the bound attestation digest is not in the set of known
+   mediation digests the verifier was given. Fail-closed when no set is
+   supplied.
+
+`CredentialGateway` is the reference shim. It reads the credential from
+`params._meta`, parses it under the closed schema (`malformed` on failure),
+loads the known digests by recomputing `attestation_digest` over every
+`*-attest.json` in the proxy's receipts directory, and runs `verify_grant`. A
+missing `_meta` returns `missing_credential`.
+
+## D. Auditor reconciliation
+
+For tools not behind the gateway, completeness is recovered after the fact, not
+at call time. The gateway can fingerprint each used credential as
+`sha256(JCS(credential))`. Vaara receipts each yield an
+`(attestationDigest, attestationNonce)` via their back-link. The join: for each
+used credential, the `binding.attestationDigest` must match a receipt's
+`backLink.attestationDigest`. A used credential with no matching receipt, or a
+provider action with no credential at all, is the signal of a defeated or
+bypassed broker.
+
+## E. Honest limits
+
+This is detection of a defeated broker, not a mathematical-completeness claim.
+What it does NOT cover:
+
+- Operator root. Someone who controls the proxy host can mint or forge.
+- Alternate credential sources. A tool that accepts some other auth is not
+  constrained by this.
+- Tool-side alternate auth and purely-local actions (filesystem, exec) with no
+  mediation chokepoint to put a gateway in front of.
+- `_meta` stripping by an intermediary. This degrades to a
+  `missing_credential` refusal, which is fail-closed and acceptable.
+
+The mint-before-receipt ordering means a true grant-to-receipt binding is
+fully checkable only at reconciliation; the live shim checks
+attestation-digest membership. This is honest and matches the
+attestation/receipt split already in the stack.
+
+## F. Conformance
+
+`conformance/sep2828/credential_grant_v0/` ships vectors plus an independent
+checker that re-derives every verdict with no `import vaara` (RFC 8785 +
+standard library). Regenerate with
+`scripts/build_credential_grant_vectors.py`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.0.3"
+version = "1.1.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/scripts/build_credential_grant_vectors.py
+++ b/scripts/build_credential_grant_vectors.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Generate the credential_grant_v0 conformance vectors.
+
+Run once with Vaara installed; emits, under
+``conformance/sep2828/credential_grant_v0/sets/<name>/``, a real bound grant
+plus the attestation it pins, the HS256 key, and the runtime call a gateway
+would see. The committed ``_check_independent.py`` then re-derives every
+verdict from those bytes with NO ``import vaara`` (rfc8785 + hashlib + hmac),
+which is the whole point: a neutral party reproduces the format.
+
+Usage: ``python scripts/build_credential_grant_vectors.py``
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from vaara.attestation._sep2787_canonical import iso8601_to_epoch
+from vaara.attestation.receipt import attestation_digest
+from vaara.credential import GrantBinding, GrantScope, emit_grant
+from vaara.integrations._mcp_attest import build_attest_emitter
+
+ROOT = Path(__file__).resolve().parent.parent
+OUT = ROOT / "conformance" / "sep2828" / "credential_grant_v0"
+KEY = b"conformance-credential-grant-v0-shared-secret!!"
+IAT = "2026-06-18T12:00:00Z"
+IAT_EPOCH = iso8601_to_epoch(IAT)
+TOOL = "files.read"
+ARGS = {"path": "/data/report.txt"}
+TENANT = "tenant-alpha"
+
+
+def _attestation(emitter):
+    att, _counter = emitter.emit_attestation(
+        tool_name=TOOL, arguments=ARGS, upstream_name="default", tenant_id=TENANT
+    )
+    return att
+
+
+def _grant(att, *, nonce="grant-nonce-fixed", exp=60):
+    scope = GrantScope(
+        tool_name=TOOL,
+        args_commitment=att.payload_derived.tool_calls[0].args.projection_digest,
+        tenant_id=TENANT,
+    )
+    binding = GrantBinding(
+        attestation_digest=attestation_digest(att),
+        attestation_nonce=att.issuer_asserted.nonce,
+    )
+    return emit_grant(
+        scope=scope, binding=binding, iss="vaara-mcp-proxy",
+        sub=f"{TENANT}/default", secret_version="key-v1", alg="HS256",
+        signing_material=KEY, exp_seconds=exp, nonce=nonce, iat=IAT,
+    )
+
+
+def _write(name, *, grant, attestation, runtime):
+    d = OUT / "sets" / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "grant.json").write_text(json.dumps(grant.to_dict(), indent=2) + "\n")
+    (d / "attestation.json").write_text(
+        json.dumps(attestation.to_dict(), indent=2) + "\n"
+    )
+    (d / "inputs.json").write_text(json.dumps(runtime, indent=2) + "\n")
+
+
+def main() -> int:
+    with TemporaryDirectory() as tmp:
+        key_file = Path(tmp) / "k"
+        key_file.write_bytes(KEY)
+        emitter = build_attest_emitter(
+            signing_key_path=key_file, receipts_dir=Path(tmp) / "r",
+            upstream_commands={"default": ["echo"]},
+        )
+        att = _attestation(emitter)
+        other = _attestation(emitter)  # a different attestation, for binding_unknown
+        grant = _grant(att)
+
+        base_runtime = {
+            "toolName": TOOL, "args": ARGS, "tenantId": TENANT,
+            "now": IAT_EPOCH + 5, "keyHex": KEY.hex(),
+        }
+        expected = {}
+
+        _write("ok", grant=grant, attestation=att, runtime=base_runtime)
+        expected["ok"] = {"ok": True, "reason": "ok"}
+
+        forged = grant.to_dict()
+        forged["signature"] = ("00" if forged["signature"][:2] != "00" else "11") + forged["signature"][2:]
+        d = OUT / "sets" / "bad_signature"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "grant.json").write_text(json.dumps(forged, indent=2) + "\n")
+        (d / "attestation.json").write_text(json.dumps(att.to_dict(), indent=2) + "\n")
+        (d / "inputs.json").write_text(json.dumps(base_runtime, indent=2) + "\n")
+        expected["bad_signature"] = {"ok": False, "reason": "bad_signature"}
+
+        _write("scope_mismatch", grant=grant, attestation=att,
+               runtime={**base_runtime, "args": {"path": "/etc/shadow"}})
+        expected["scope_mismatch"] = {"ok": False, "reason": "scope_mismatch"}
+
+        _write("expired", grant=grant, attestation=att,
+               runtime={**base_runtime, "now": IAT_EPOCH + 5000})
+        expected["expired"] = {"ok": False, "reason": "expired"}
+
+        _write("binding_unknown", grant=grant, attestation=other, runtime=base_runtime)
+        expected["binding_unknown"] = {"ok": False, "reason": "binding_unknown"}
+
+        (OUT / "expected.json").write_text(json.dumps(expected, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {len(expected)} sets to {OUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.0.3",
+  "version": "1.1.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.0.3",
+  "version": "1.1.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.0.3"
+__version__ = "1.1.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/credential/__init__.py
+++ b/src/vaara/credential/__init__.py
@@ -1,0 +1,49 @@
+"""Receipt-bound, scoped, short-lived credential broker (OAuth-for-agents).
+
+Vaara's authority layer: the proxy mints a signed, short-lived credential
+bound to a specific attestation digest (transitively the mediation receipt)
+and scoped to one tool + args-commitment + tenant. A gateway in front of a
+protected tool refuses any call lacking a valid, unexpired, non-revoked,
+attestation-bound grant. This turns bypass from "silent and succeeds" into
+"requires defeating the broker"; it is detection, not a mathematical
+completeness claim (see ``docs/design/credential-broker-spec.md``).
+
+The grant reuses the SEP-2787 signing stack (HS256 / ES256 / RS256 over RFC
+8785 JCS) so the grant key matches the attestation/receipt key.
+"""
+
+from __future__ import annotations
+
+from vaara.credential._grant_emit import emit_grant, verify_grant_signature
+from vaara.credential._grant_parse import (
+    asserted_from_dict,
+    binding_from_dict,
+    grant_from_dict,
+    scope_from_dict,
+)
+from vaara.credential._grant_types import (
+    BrokeredCredential,
+    GrantAlgorithm,
+    GrantAsserted,
+    GrantBinding,
+    GrantScope,
+)
+from vaara.credential._grant_verify import GrantVerdict, verify_grant
+from vaara.credential.gateway import CredentialGateway
+
+__all__ = [
+    "BrokeredCredential",
+    "CredentialGateway",
+    "GrantAlgorithm",
+    "GrantAsserted",
+    "GrantBinding",
+    "GrantScope",
+    "GrantVerdict",
+    "asserted_from_dict",
+    "binding_from_dict",
+    "emit_grant",
+    "grant_from_dict",
+    "scope_from_dict",
+    "verify_grant",
+    "verify_grant_signature",
+]

--- a/src/vaara/credential/_grant_emit.py
+++ b/src/vaara/credential/_grant_emit.py
@@ -1,0 +1,163 @@
+"""Emit and verify-signature for brokered-credential (grant) envelopes.
+
+Internal module. Public surface is in ``vaara.credential``.
+
+Reuses the SEP-2787 canonicalization (RFC 8785 JCS) and signing stack
+(HS256 / ES256 / RS256) unchanged, so the grant key matches the
+attestation/receipt key and a verifier that already handles SEP-2787
+signatures handles grants with no new crypto. The only new wire shape is the
+envelope layout (``_grant_types``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from vaara.attestation._sep2787_canonical import (
+    canonical_json,
+    new_nonce,
+    now_iso8601,
+)
+from vaara.attestation._sep2787_signing import (
+    sign_es256,
+    sign_hs256,
+    sign_rs256,
+    verify_es256,
+    verify_hs256,
+    verify_rs256,
+)
+from vaara.attestation._sep2787_types import (
+    VALID_ALGS,
+    Algorithm,
+    AttestationError,
+)
+from vaara.credential._grant_types import (
+    BrokeredCredential,
+    GrantAsserted,
+    GrantBinding,
+    GrantScope,
+    asserted_to_dict,
+    binding_to_dict,
+    scope_to_dict,
+)
+
+
+def _signing_payload(
+    *,
+    version: int,
+    alg: Algorithm,
+    scope: GrantScope,
+    binding: GrantBinding,
+    asserted: GrantAsserted,
+) -> bytes:
+    """JCS-canonical encoding of the grant blocks, signature excluded."""
+    body = {
+        "version": version,
+        "alg": alg,
+        "scope": scope_to_dict(scope),
+        "binding": binding_to_dict(binding),
+        "asserted": asserted_to_dict(asserted),
+    }
+    return canonical_json(body)
+
+
+def emit_grant(
+    *,
+    scope: GrantScope,
+    binding: GrantBinding,
+    iss: str,
+    sub: str,
+    secret_version: str,
+    alg: Algorithm,
+    signing_material: Any,
+    exp_seconds: int = 60,
+    nonce: Optional[str] = None,
+    iat: Optional[str] = None,
+    version: int = 1,
+) -> BrokeredCredential:
+    """Build, JCS-canonicalize, and sign a BrokeredCredential envelope.
+
+    ``binding`` pins the attestation instance the grant authorizes against
+    (build it from ``attestation_digest`` + the attestation nonce).
+    ``signing_material`` is either a bytes shared secret (HS256) or a
+    private-key object from ``cryptography.hazmat`` (ES256 / RS256).
+    """
+    if alg not in VALID_ALGS:
+        raise AttestationError(f"unsupported alg: {alg!r}")
+    if exp_seconds <= 0:
+        raise AttestationError("exp_seconds must be a positive integer")
+    if not binding.attestation_digest.startswith("sha256:"):
+        raise AttestationError("binding.attestationDigest MUST be a 'sha256:' digest")
+    if not binding.attestation_nonce:
+        raise AttestationError("binding.attestationNonce MUST be non-empty")
+
+    asserted = GrantAsserted(
+        iss=iss,
+        sub=sub,
+        iat=iat or now_iso8601(),
+        exp_seconds=exp_seconds,
+        nonce=nonce or new_nonce(),
+        secret_version=secret_version,
+    )
+
+    payload = _signing_payload(
+        version=version, alg=alg, scope=scope, binding=binding, asserted=asserted
+    )
+
+    if alg == "HS256":
+        if not isinstance(signing_material, (bytes, bytearray)):
+            raise AttestationError("HS256 requires bytes shared_secret")
+        signature_hex = sign_hs256(payload, shared_secret=bytes(signing_material))
+    elif alg == "ES256":
+        signature_hex = sign_es256(payload, private_key=signing_material)
+    elif alg == "RS256":
+        signature_hex = sign_rs256(payload, private_key=signing_material)
+    else:
+        raise AttestationError(f"unreachable alg: {alg!r}")
+
+    return BrokeredCredential(
+        version=version,
+        alg=alg,
+        scope=scope,
+        binding=binding,
+        asserted=asserted,
+        signature=signature_hex,
+    )
+
+
+def verify_grant_signature(
+    credential: BrokeredCredential,
+    *,
+    verifying_material: Any,
+) -> bool:
+    """Verify the grant signature only (scope/expiry/revocation are separate).
+
+    Returns True iff the signature matches the JCS-canonical encoding of the
+    grant blocks under ``verifying_material`` (bytes shared secret for HS256,
+    public-key object for ES256 / RS256).
+    """
+    payload = _signing_payload(
+        version=credential.version,
+        alg=credential.alg,
+        scope=credential.scope,
+        binding=credential.binding,
+        asserted=credential.asserted,
+    )
+
+    if credential.alg == "HS256":
+        if not isinstance(verifying_material, (bytes, bytearray)):
+            return False
+        return verify_hs256(
+            payload,
+            signature_hex=credential.signature,
+            shared_secret=bytes(verifying_material),
+        )
+    if credential.alg == "ES256":
+        return verify_es256(
+            payload, signature_hex=credential.signature, public_key=verifying_material
+        )
+    if credential.alg == "RS256":
+        return verify_rs256(
+            payload, signature_hex=credential.signature, public_key=verifying_material
+        )
+    return False

--- a/src/vaara/credential/_grant_parse.py
+++ b/src/vaara/credential/_grant_parse.py
@@ -1,0 +1,115 @@
+"""Closed-schema parsers for brokered-credential wire objects.
+
+Internal module. Public surface is in ``vaara.credential``.
+
+Each ``*_from_dict`` validates one signed block against a closed key set and
+fails closed on any unrecognized field, mirroring
+``vaara.attestation._receipt_types``. Signature verification is separate
+(``_grant_emit.verify_grant_signature``); these only model-validate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from vaara.attestation._sep2787_types import VALID_ALGS, AttestationError
+from vaara.credential._grant_types import (
+    ASSERTED_KEYS,
+    BINDING_KEYS,
+    GRANT_KEYS,
+    SCOPE_KEYS,
+    BrokeredCredential,
+    GrantAsserted,
+    GrantBinding,
+    GrantScope,
+)
+
+
+def _reject_unknown_keys(
+    d: dict[str, Any], allowed: frozenset[str], where: str
+) -> None:
+    """Fail closed on any key not in the closed schema for a signed block.
+
+    A silently dropped key would let a model-deriving verifier and a
+    byte-exact verifier disagree over the signed preimage. Extending the
+    schema is an explicit version bump, not a tolerated field.
+    """
+    extra = set(d) - allowed
+    if extra:
+        raise AttestationError(
+            f"{where} carries unrecognized field(s) {sorted(extra)!r}; "
+            "the signed schema is closed"
+        )
+
+
+def _require_str(d: dict[str, Any], key: str, where: str) -> str:
+    value = d.get(key)
+    if not isinstance(value, str) or not value:
+        raise AttestationError(f"{where}.{key} must be a non-empty string")
+    return value
+
+
+def scope_from_dict(d: dict[str, Any]) -> GrantScope:
+    if not isinstance(d, dict):
+        raise AttestationError("scope must be an object")
+    _reject_unknown_keys(d, SCOPE_KEYS, "scope")
+    tenant = d.get("tenantId")
+    if not isinstance(tenant, str):
+        raise AttestationError("scope.tenantId must be a string")
+    return GrantScope(
+        tool_name=_require_str(d, "toolName", "scope"),
+        args_commitment=_require_str(d, "argsCommitment", "scope"),
+        tenant_id=tenant,
+    )
+
+
+def binding_from_dict(d: dict[str, Any]) -> GrantBinding:
+    if not isinstance(d, dict):
+        raise AttestationError("binding must be an object")
+    _reject_unknown_keys(d, BINDING_KEYS, "binding")
+    digest = _require_str(d, "attestationDigest", "binding")
+    if not digest.startswith("sha256:"):
+        raise AttestationError("binding.attestationDigest MUST be 'sha256:'")
+    return GrantBinding(
+        attestation_digest=digest,
+        attestation_nonce=_require_str(d, "attestationNonce", "binding"),
+    )
+
+
+def asserted_from_dict(d: dict[str, Any]) -> GrantAsserted:
+    if not isinstance(d, dict):
+        raise AttestationError("asserted must be an object")
+    _reject_unknown_keys(d, ASSERTED_KEYS, "asserted")
+    exp = d.get("expSeconds")
+    if not isinstance(exp, int) or isinstance(exp, bool) or exp <= 0:
+        raise AttestationError("asserted.expSeconds must be a positive integer")
+    return GrantAsserted(
+        iss=_require_str(d, "iss", "asserted"),
+        sub=_require_str(d, "sub", "asserted"),
+        iat=_require_str(d, "iat", "asserted"),
+        exp_seconds=exp,
+        nonce=_require_str(d, "nonce", "asserted"),
+        secret_version=_require_str(d, "secretVersion", "asserted"),
+    )
+
+
+def grant_from_dict(d: dict[str, Any]) -> BrokeredCredential:
+    """Parse and validate a credential wire object (signature unchecked here)."""
+    if not isinstance(d, dict):
+        raise AttestationError("credential must be an object")
+    _reject_unknown_keys(d, GRANT_KEYS, "credential")
+    for req in ("version", "alg", "scope", "binding", "asserted", "signature"):
+        if req not in d:
+            raise AttestationError(f"credential missing required field {req!r}")
+    if not isinstance(d["version"], int) or isinstance(d["version"], bool):
+        raise AttestationError("credential.version must be an integer")
+    if d["alg"] not in VALID_ALGS:
+        raise AttestationError(f"unsupported alg {d['alg']!r}")
+    return BrokeredCredential(
+        version=d["version"],
+        alg=d["alg"],
+        scope=scope_from_dict(d["scope"]),
+        binding=binding_from_dict(d["binding"]),
+        asserted=asserted_from_dict(d["asserted"]),
+        signature=_require_str(d, "signature", "credential"),
+    )

--- a/src/vaara/credential/_grant_types.py
+++ b/src/vaara/credential/_grant_types.py
@@ -1,0 +1,132 @@
+"""Dataclasses and serialization for brokered-credential (grant) envelopes.
+
+Internal module. Public surface is in ``vaara.credential``.
+
+A brokered credential is a standalone signed envelope the proxy mints between
+the *allow* decision and the upstream *forward*. It is the authority half of
+Vaara's "separate intelligence from authority" move: the model proposes a tool
+call, but only a valid, unexpired, non-revoked, attestation-bound grant lets a
+gateway-protected tool actually run.
+
+The credential is NOT embedded in the attestation or the receipt. The
+attestation is emitted *before* the forward and the receipt *after* the
+outcome, so a credential that must travel *with* the request cannot live in a
+receipt that does not exist yet. The grant instead pins the attestation digest
+(``binding.attestationDigest``), which the receipt also back-links, so an
+auditor can join grant -> attestation -> receipt offline.
+
+The signing stack is the SEP-2787 one (HS256 / ES256 / RS256 over RFC 8785
+JCS) reused unchanged, so the grant key matches the attestation/receipt key.
+Each signed block is a closed schema (parsers in ``_grant_parse``): an
+unrecognized wire key is a hard reject, keeping the modeled preimage
+byte-exact to the wire.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from vaara.attestation._sep2787_types import Algorithm
+
+GrantAlgorithm = Algorithm
+
+
+@dataclass(frozen=True)
+class GrantScope:
+    """What the credential authorizes: one tool, one args commitment, one tenant.
+
+    ``args_commitment`` is the ``ArgsProjection.projection_digest`` of the
+    attested arguments. The gateway re-derives it from the runtime arguments
+    and rejects on mismatch, so a mutated argument after minting fails scope.
+    """
+
+    tool_name: str
+    args_commitment: str
+    tenant_id: str
+
+
+@dataclass(frozen=True)
+class GrantBinding:
+    """The attestation instance this grant is bound to.
+
+    ``attestation_digest`` is ``attestation_digest(att)``; ``attestation_nonce``
+    is the attestation's ``issuerAsserted.nonce``.
+    """
+
+    attestation_digest: str
+    attestation_nonce: str
+
+
+@dataclass(frozen=True)
+class GrantAsserted:
+    """Issuer-asserted grant facts: who, for whom, when, how long, which key."""
+
+    iss: str
+    sub: str
+    iat: str
+    exp_seconds: int
+    nonce: str
+    secret_version: str
+
+
+@dataclass(frozen=True)
+class BrokeredCredential:
+    """A signed, short-lived, scoped, attestation-bound credential envelope.
+
+    The signature is over the JCS encoding of
+    ``{version, alg, scope, binding, asserted}`` and does not cover itself.
+    """
+
+    version: int
+    alg: GrantAlgorithm
+    scope: GrantScope
+    binding: GrantBinding
+    asserted: GrantAsserted
+    signature: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "alg": self.alg,
+            "scope": scope_to_dict(self.scope),
+            "binding": binding_to_dict(self.binding),
+            "asserted": asserted_to_dict(self.asserted),
+            "signature": self.signature,
+        }
+
+
+def scope_to_dict(s: GrantScope) -> dict[str, Any]:
+    return {
+        "argsCommitment": s.args_commitment,
+        "tenantId": s.tenant_id,
+        "toolName": s.tool_name,
+    }
+
+
+def binding_to_dict(b: GrantBinding) -> dict[str, Any]:
+    return {
+        "attestationDigest": b.attestation_digest,
+        "attestationNonce": b.attestation_nonce,
+    }
+
+
+def asserted_to_dict(a: GrantAsserted) -> dict[str, Any]:
+    return {
+        "expSeconds": a.exp_seconds,
+        "iat": a.iat,
+        "iss": a.iss,
+        "nonce": a.nonce,
+        "secretVersion": a.secret_version,
+        "sub": a.sub,
+    }
+
+
+SCOPE_KEYS = frozenset({"argsCommitment", "tenantId", "toolName"})
+BINDING_KEYS = frozenset({"attestationDigest", "attestationNonce"})
+ASSERTED_KEYS = frozenset(
+    {"expSeconds", "iat", "iss", "nonce", "secretVersion", "sub"}
+)
+GRANT_KEYS = frozenset(
+    {"version", "alg", "scope", "binding", "asserted", "signature"}
+)

--- a/src/vaara/credential/_grant_verify.py
+++ b/src/vaara/credential/_grant_verify.py
@@ -1,0 +1,94 @@
+"""Verify a brokered credential against the runtime call it claims to authorize.
+
+Internal module. Public surface is in ``vaara.credential``.
+
+``verify_grant`` is the standalone, composable check a gateway runs before
+letting a tool execute. It gates on five facts, reported as the first failing
+reason so an expired-but-authentic grant is never mislabeled as a bad
+signature:
+
+1. ``bad_signature``  - signature does not match the grant blocks.
+2. ``expired``        - now is past ``iat + expSeconds`` (or the grant is
+   future-dated), with the same clock-skew window the SEP-2787/inference
+   verifiers use.
+3. ``scope_mismatch`` - the runtime tool / tenant / args do not match the
+   committed scope (args re-derived with ``make_args_digest``).
+4. ``revoked``        - the issuer or its bound key was revoked at or before
+   issuance (``RevocationRegistry``).
+5. ``binding_unknown``- the bound attestation digest is not in the set of
+   known mediation digests the verifier was given (fail-closed when no set is
+   supplied).
+
+This is detection of a defeated broker, not a mathematical-completeness claim.
+Completeness holds only for tools placed behind a gateway that runs this; see
+``gateway.py`` and the reconciliation fallback in the design doc.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from vaara.attestation._sep2787_canonical import iso8601_to_epoch, make_args_digest
+from vaara.credential._grant_emit import verify_grant_signature
+from vaara.credential._grant_types import BrokeredCredential
+
+GrantReason = str  # one of the literals documented above; "ok" on success
+
+
+@dataclass(frozen=True)
+class GrantVerdict:
+    """Result of ``verify_grant``: ``ok`` plus the first failing ``reason``."""
+
+    ok: bool
+    reason: GrantReason
+
+
+def verify_grant(
+    credential: BrokeredCredential,
+    *,
+    verifying_material: Any,
+    runtime_tool_name: str,
+    runtime_args: Any,
+    runtime_tenant_id: str,
+    revocation: Any = None,
+    known_attestation_digests: Optional[frozenset[str]] = None,
+    now: Optional[float] = None,
+    clock_skew_seconds: int = 30,
+) -> GrantVerdict:
+    """Check a credential against the runtime call. See module docstring."""
+    if not verify_grant_signature(credential, verifying_material=verifying_material):
+        return GrantVerdict(False, "bad_signature")
+
+    asserted = credential.asserted
+    iat_epoch = iso8601_to_epoch(asserted.iat)
+    current = now if now is not None else time.time()
+    if iat_epoch is None:
+        return GrantVerdict(False, "expired")
+    future_dated = iat_epoch > current + clock_skew_seconds
+    deadline = iat_epoch + asserted.exp_seconds + clock_skew_seconds
+    if future_dated or current > deadline:
+        return GrantVerdict(False, "expired")
+
+    scope = credential.scope
+    if scope.tool_name != runtime_tool_name:
+        return GrantVerdict(False, "scope_mismatch")
+    if scope.tenant_id != runtime_tenant_id:
+        return GrantVerdict(False, "scope_mismatch")
+    runtime_commitment = make_args_digest(runtime_args).projection_digest
+    if scope.args_commitment != runtime_commitment:
+        return GrantVerdict(False, "scope_mismatch")
+
+    if revocation is not None:
+        status = revocation.status(
+            asserted.iss, asserted.iat, keyid=asserted.secret_version
+        )
+        if status.revoked:
+            return GrantVerdict(False, "revoked")
+
+    known = known_attestation_digests or frozenset()
+    if credential.binding.attestation_digest not in known:
+        return GrantVerdict(False, "binding_unknown")
+
+    return GrantVerdict(True, "ok")

--- a/src/vaara/credential/gateway.py
+++ b/src/vaara/credential/gateway.py
@@ -1,0 +1,98 @@
+"""Reference gateway shim: refuse a tool call lacking a valid grant.
+
+Public surface for ``vaara.credential``.
+
+A ``CredentialGateway`` sits in front of a protected tool and answers one
+question: may this ``tools/call`` execute? It reads the brokered credential
+from ``params._meta["vaara/credential"]``, parses it under the closed schema,
+and runs ``verify_grant`` against the runtime tool name, arguments, and tenant,
+plus the set of attestation digests Vaara actually minted (read from the
+proxy's receipts directory).
+
+Honest scope: completeness holds only for tools placed behind this gateway. A
+tool reachable by some other path (operator root, an alternate credential
+source, a purely-local action with no chokepoint) is not covered here; that
+residual is caught after the fact by reconciliation (credential fingerprint
+joined to receipt digest), described in ``docs/design/credential-broker-spec.md``.
+A stripped ``_meta`` degrades to a ``missing_credential`` refusal, which is
+fail-closed and acceptable.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+from vaara.attestation._sep2787_types import AttestationError
+from vaara.attestation.receipt import attestation_digest
+from vaara.attestation.sep2787 import parse_attestation
+from vaara.credential._grant_parse import grant_from_dict
+from vaara.credential._grant_verify import GrantVerdict, verify_grant
+
+
+class CredentialGateway:
+    """Authorize gateway-protected tool calls against brokered credentials."""
+
+    def __init__(
+        self,
+        *,
+        verifying_material: Any,
+        receipts_dir: Path,
+        expected_tenant: Optional[str] = None,
+        revocation: Any = None,
+        clock_skew_seconds: int = 30,
+    ) -> None:
+        self._vm = verifying_material
+        self._receipts_dir = Path(receipts_dir)
+        self._expected_tenant = expected_tenant
+        self._rev = revocation
+        self._clock_skew_seconds = clock_skew_seconds
+
+    def _load_known_digests(self) -> frozenset[str]:
+        """Recompute the attestation digest of every ``*-attest.json`` on disk.
+
+        The attestation is written before the upstream forward, so by the time
+        a credential reaches a protected tool its digest is present. Each
+        digest equals the grant's ``binding.attestationDigest`` and the
+        receipt's ``backLink.attestationDigest``. A file that fails to parse is
+        skipped: it cannot match a digest, so skipping it only ever refuses,
+        never wrongly admits.
+        """
+        digests: set[str] = set()
+        if not self._receipts_dir.is_dir():
+            return frozenset()
+        for path in self._receipts_dir.glob("*-attest.json"):
+            try:
+                att = parse_attestation(json.loads(path.read_text(encoding="utf-8")))
+                digests.add(attestation_digest(att))
+            except (OSError, ValueError, AttestationError):
+                continue
+        return frozenset(digests)
+
+    def authorize(
+        self,
+        params: Optional[dict[str, Any]],
+        *,
+        tool_name: str,
+        arguments: Any,
+    ) -> GrantVerdict:
+        """Return the verdict for a ``tools/call``; fail closed on any defect."""
+        meta = (params or {}).get("_meta") or {}
+        cred_dict = meta.get("vaara/credential")
+        if cred_dict is None:
+            return GrantVerdict(False, "missing_credential")
+        try:
+            cred = grant_from_dict(cred_dict)
+        except AttestationError:
+            return GrantVerdict(False, "malformed")
+        return verify_grant(
+            cred,
+            verifying_material=self._vm,
+            runtime_tool_name=tool_name,
+            runtime_args=arguments,
+            runtime_tenant_id=self._expected_tenant or "",
+            revocation=self._rev,
+            known_attestation_digests=self._load_known_digests(),
+            clock_skew_seconds=self._clock_skew_seconds,
+        )

--- a/src/vaara/integrations/_mcp_attest.py
+++ b/src/vaara/integrations/_mcp_attest.py
@@ -186,6 +186,70 @@ class AttestPairEmitter:
             logger.exception("SEP-2787 attestation emission failed for tool=%r", tool_name)
             return None
 
+    def emit_grant(
+        self,
+        *,
+        attestation: Any,
+        counter: int,
+        tool_name: str,
+        upstream_name: str,
+        tenant_id: str,
+        grant_exp_seconds: int = 60,
+    ) -> "Optional[Any]":
+        """Mint and persist a short-lived credential bound to ``attestation``.
+
+        Returns the ``BrokeredCredential`` on success, ``None`` on failure
+        (logged and swallowed: authority minting must not block traffic, and a
+        gateway fails closed on a missing credential). The args commitment is
+        read straight off the attestation so the grant scope cannot drift from
+        what was attested. Paired filename ``{counter}-{nonce}-grant.json``.
+        """
+        try:
+            from vaara.attestation.receipt import attestation_digest
+            from vaara.credential import (
+                GrantBinding,
+                GrantScope,
+                emit_grant as _emit_grant,
+            )
+
+            args_commitment = (
+                attestation.payload_derived.tool_calls[0].args.projection_digest
+            )
+            scope = GrantScope(
+                tool_name=tool_name,
+                args_commitment=args_commitment,
+                tenant_id=tenant_id,
+            )
+            binding = GrantBinding(
+                attestation_digest=attestation_digest(attestation),
+                attestation_nonce=attestation.issuer_asserted.nonce,
+            )
+            sub = f"{tenant_id}/{upstream_name}" if tenant_id else upstream_name
+
+            credential = _emit_grant(
+                scope=scope,
+                binding=binding,
+                iss=_ISS,
+                sub=sub,
+                secret_version=self._secret_version,
+                alg=self._alg,
+                signing_material=self._signing_key,
+                exp_seconds=grant_exp_seconds,
+            )
+
+            nonce_tag = attestation.issuer_asserted.nonce[:8]
+            path = self._receipts_dir / f"{counter:010d}-{nonce_tag}-grant.json"
+            path.write_text(
+                json.dumps(credential.to_dict(), indent=2), encoding="utf-8"
+            )
+            logger.debug(
+                "Grant %s tool=%r upstream=%r", path.name, tool_name, upstream_name
+            )
+            return credential
+        except Exception:
+            logger.exception("Credential grant emission failed for tool=%r", tool_name)
+            return None
+
     def emit_receipt(
         self,
         *,

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -225,6 +225,12 @@ class VaaraMCPProxy:
         self._stdout_lock = threading.Lock()
         self._overt = overt_emitter
         self._attest = attest_emitter
+        # Authority layer (Phase A): when True and an attestation emitter is
+        # configured, mint a short-lived, scoped, attestation-bound credential
+        # per allowed tools/call and inject it at params._meta["vaara/credential"]
+        # for a CredentialGateway downstream. Default OFF: observability is
+        # unchanged until an operator opts into enforcement.
+        self._mint_credentials = False
         # Notification router. stdio default writes through the shared stdout
         # lock; HTTP transport swaps in HttpRouter in run_http(). The router is
         # the only surface allowed to deliver upstream-initiated notifications
@@ -1037,6 +1043,19 @@ class VaaraMCPProxy:
                 tenant_id=_REQUEST_TENANT.get(),
                 intent_override=_REQUEST_INTENT.get(),
             )
+        if self._mint_credentials and self._attest is not None and attest_pair is not None:
+            _att, _counter = attest_pair
+            grant = self._attest.emit_grant(
+                attestation=_att,
+                counter=_counter,
+                tool_name=tool_name,
+                upstream_name=upstream_name,
+                tenant_id=_REQUEST_TENANT.get(),
+            )
+            if grant is not None:
+                params = request.setdefault("params", {})
+                meta = params.setdefault("_meta", {})
+                meta["vaara/credential"] = grant.to_dict()
         with self._inflight_lock:
             if progress_token is not None:
                 self._inflight_progress[progress_token] = (

--- a/tests/credential/test_gateway_refuses.py
+++ b/tests/credential/test_gateway_refuses.py
@@ -1,0 +1,105 @@
+"""The gateway shim refuses calls that lack a valid, bound credential."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
+from vaara.credential import CredentialGateway  # noqa: E402
+
+KEY = b"x" * 32
+TOOL = "read_file"
+ARGS = {"path": "/tmp/x"}
+
+
+def _emitter(receipts_dir: Path) -> Any:
+    from vaara.integrations._mcp_attest import build_attest_emitter
+
+    return build_attest_emitter(
+        signing_key_path=_keyfile(receipts_dir),
+        receipts_dir=receipts_dir,
+        upstream_commands={"default": ["echo"]},
+    )
+
+
+def _keyfile(d: Path) -> Path:
+    p = d.parent / "attest.key"
+    p.write_bytes(KEY)
+    return p
+
+
+def _mint_through_emitter(receipts_dir: Path, *, tenant: str = "t1") -> dict:
+    """Emit a real attestation + bound grant; return the credential wire dict."""
+    em = _emitter(receipts_dir)
+    att, counter = em.emit_attestation(
+        tool_name=TOOL, arguments=ARGS, upstream_name="default", tenant_id=tenant
+    )
+    cred = em.emit_grant(
+        attestation=att, counter=counter, tool_name=TOOL,
+        upstream_name="default", tenant_id=tenant,
+    )
+    return cred.to_dict()
+
+
+def _gateway(receipts_dir: Path, tenant: str = "t1") -> CredentialGateway:
+    return CredentialGateway(
+        verifying_material=KEY, receipts_dir=receipts_dir, expected_tenant=tenant
+    )
+
+
+def test_no_meta_is_missing_credential(tmp_path: Path):
+    d = tmp_path / "r"
+    d.mkdir()
+    gw = _gateway(d)
+    v = gw.authorize({"name": TOOL}, tool_name=TOOL, arguments=ARGS)
+    assert not v.ok and v.reason == "missing_credential"
+
+
+def test_valid_minted_grant_is_ok(tmp_path: Path):
+    d = tmp_path / "r"
+    d.mkdir()
+    cred = _mint_through_emitter(d)
+    gw = _gateway(d)
+    params = {"_meta": {"vaara/credential": cred}}
+    v = gw.authorize(params, tool_name=TOOL, arguments=ARGS)
+    assert v.ok and v.reason == "ok"
+
+
+def test_mutated_args_is_scope_mismatch(tmp_path: Path):
+    d = tmp_path / "r"
+    d.mkdir()
+    cred = _mint_through_emitter(d)
+    gw = _gateway(d)
+    params = {"_meta": {"vaara/credential": cred}}
+    v = gw.authorize(params, tool_name=TOOL, arguments={"path": "/etc/shadow"})
+    assert not v.ok and v.reason == "scope_mismatch"
+
+
+def test_malformed_credential_refused(tmp_path: Path):
+    d = tmp_path / "r"
+    d.mkdir()
+    cred = _mint_through_emitter(d)
+    cred["rogue"] = 1
+    gw = _gateway(d)
+    params = {"_meta": {"vaara/credential": cred}}
+    v = gw.authorize(params, tool_name=TOOL, arguments=ARGS)
+    assert not v.ok and v.reason == "malformed"
+
+
+def test_unknown_binding_when_attest_file_absent(tmp_path: Path):
+    # Mint in one dir, point the gateway at an empty dir: the attestation
+    # digest is not known there, so the bound grant is refused (fail-closed).
+    mint_dir = tmp_path / "r"
+    mint_dir.mkdir()
+    empty_dir = tmp_path / "e"
+    empty_dir.mkdir()
+    cred = _mint_through_emitter(mint_dir)
+    gw = _gateway(empty_dir)
+    params = {"_meta": {"vaara/credential": cred}}
+    v = gw.authorize(params, tool_name=TOOL, arguments=ARGS)
+    assert not v.ok and v.reason == "binding_unknown"

--- a/tests/credential/test_grant_conformance.py
+++ b/tests/credential/test_grant_conformance.py
@@ -1,0 +1,57 @@
+"""The credential_grant_v0 vectors: Vaara and the independent checker agree."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
+ROOT = Path(__file__).resolve().parents[2]
+VECTORS = ROOT / "conformance" / "sep2828" / "credential_grant_v0"
+
+
+def _cases():
+    return sorted(json.loads((VECTORS / "expected.json").read_text()))
+
+
+def test_at_least_four_cases_present():
+    assert len(_cases()) >= 4
+
+
+def test_independent_checker_passes():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+@pytest.mark.parametrize("name", _cases())
+def test_in_tree_verifier_agrees_with_vectors(name):
+    from vaara.attestation.receipt import attestation_digest
+    from vaara.attestation.sep2787 import parse_attestation
+    from vaara.credential import grant_from_dict, verify_grant
+
+    d = VECTORS / "sets" / name
+    expected = json.loads((VECTORS / "expected.json").read_text())[name]
+    grant = grant_from_dict(json.loads((d / "grant.json").read_text()))
+    att = parse_attestation(json.loads((d / "attestation.json").read_text()))
+    inputs = json.loads((d / "inputs.json").read_text())
+
+    verdict = verify_grant(
+        grant,
+        verifying_material=bytes.fromhex(inputs["keyHex"]),
+        runtime_tool_name=inputs["toolName"],
+        runtime_args=inputs["args"],
+        runtime_tenant_id=inputs["tenantId"],
+        known_attestation_digests=frozenset({attestation_digest(att)}),
+        now=inputs["now"],
+    )
+    assert verdict.ok == expected["ok"]
+    assert verdict.reason == expected["reason"]

--- a/tests/credential/test_grant_emit_verify.py
+++ b/tests/credential/test_grant_emit_verify.py
@@ -1,0 +1,173 @@
+"""Unit tests for the brokered-credential mint/verify path."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
+from cryptography.hazmat.primitives.asymmetric import ec  # noqa: E402
+
+from vaara.attestation import RevocationEntry, RevocationRegistry  # noqa: E402
+from vaara.attestation._sep2787_canonical import (  # noqa: E402
+    iso8601_to_epoch,
+    make_args_digest,
+)
+from vaara.attestation._sep2787_types import AttestationError  # noqa: E402
+from vaara.credential import (  # noqa: E402
+    GrantBinding,
+    GrantScope,
+    emit_grant,
+    grant_from_dict,
+    verify_grant,
+    verify_grant_signature,
+)
+
+SECRET = b"s" * 32
+DIGEST = "sha256:" + "ab" * 32
+NONCE = "att-nonce-xyz"
+IAT = "2026-06-18T12:00:00Z"
+IAT_EPOCH = iso8601_to_epoch(IAT)
+ARGS = {"path": "/tmp/report.txt"}
+COMMIT = make_args_digest(ARGS).projection_digest
+
+
+def _scope(tool="fs.read", tenant="tenant-a", commitment=COMMIT):
+    return GrantScope(tool_name=tool, args_commitment=commitment, tenant_id=tenant)
+
+
+def _mint(*, alg="HS256", material=SECRET, scope=None, exp_seconds=60, iat=IAT):
+    return emit_grant(
+        scope=scope or _scope(),
+        binding=GrantBinding(attestation_digest=DIGEST, attestation_nonce=NONCE),
+        iss="vaara-mcp-proxy",
+        sub="tenant-a/upstream",
+        secret_version="key-v1",
+        alg=alg,
+        signing_material=material,
+        exp_seconds=exp_seconds,
+        iat=iat,
+    )
+
+
+def _ok(cred, material=SECRET, **over):
+    kw = dict(
+        verifying_material=material,
+        runtime_tool_name="fs.read",
+        runtime_args=ARGS,
+        runtime_tenant_id="tenant-a",
+        known_attestation_digests=frozenset({DIGEST}),
+        now=IAT_EPOCH + 5,
+    )
+    kw.update(over)
+    return verify_grant(cred, **kw)
+
+
+def test_round_trip_to_from_dict():
+    cred = _mint()
+    again = grant_from_dict(cred.to_dict())
+    assert again == cred
+
+
+def test_happy_path_hs256():
+    v = _ok(_mint())
+    assert v.ok and v.reason == "ok"
+
+
+def test_happy_path_es256():
+    priv = ec.generate_private_key(ec.SECP256R1())
+    cred = _mint(alg="ES256", material=priv)
+    v = _ok(cred, material=priv.public_key())
+    assert v.ok and v.reason == "ok"
+
+
+def test_signature_verifies_standalone():
+    assert verify_grant_signature(_mint(), verifying_material=SECRET) is True
+    assert verify_grant_signature(_mint(), verifying_material=b"wrong" * 8) is False
+
+
+def test_tamper_signature_bad_signature():
+    cred = _mint()
+    forged = grant_from_dict({**cred.to_dict(), "signature": "00" * 32})
+    assert _ok(forged).reason == "bad_signature"
+
+
+def test_tamper_tool_name_scope_mismatch():
+    assert _ok(_mint(), runtime_tool_name="fs.write").reason == "scope_mismatch"
+
+
+def test_tamper_tenant_scope_mismatch():
+    assert _ok(_mint(), runtime_tenant_id="tenant-b").reason == "scope_mismatch"
+
+
+def test_mutated_args_scope_mismatch():
+    assert _ok(_mint(), runtime_args={"path": "/etc/shadow"}).reason == "scope_mismatch"
+
+
+def test_expired_past_deadline():
+    # iat + exp(60) + skew(30) = +90s; now at +200s is expired.
+    assert _ok(_mint(exp_seconds=60), now=IAT_EPOCH + 200).reason == "expired"
+
+
+def test_future_dated_expired():
+    # now well before iat (beyond skew) is future-dated -> expired.
+    assert _ok(_mint(), now=IAT_EPOCH - 200).reason == "expired"
+
+
+def test_unparseable_iat_expired():
+    cred = _mint(iat="not-a-timestamp")
+    assert _ok(cred).reason == "expired"
+
+
+def test_revocation_before_iat_revoked():
+    reg = RevocationRegistry(
+        (RevocationEntry(scope="key", subject="key-v1", revoked_at="2026-06-18T11:00:00Z"),)
+    )
+    assert _ok(_mint(), revocation=reg).reason == "revoked"
+
+
+def test_revocation_after_iat_not_revoked():
+    reg = RevocationRegistry(
+        (RevocationEntry(scope="key", subject="key-v1", revoked_at="2026-06-18T13:00:00Z"),)
+    )
+    assert _ok(_mint(), revocation=reg).ok
+
+
+def test_revocation_identity_scope_revoked():
+    reg = RevocationRegistry(
+        (
+            RevocationEntry(
+                scope="identity",
+                subject="vaara-mcp-proxy",
+                revoked_at="2026-06-18T11:00:00Z",
+            ),
+        )
+    )
+    assert _ok(_mint(), revocation=reg).reason == "revoked"
+
+
+def test_binding_absent_unknown():
+    assert _ok(_mint(), known_attestation_digests=frozenset()).reason == "binding_unknown"
+
+
+def test_binding_none_fails_closed():
+    assert _ok(_mint(), known_attestation_digests=None).reason == "binding_unknown"
+
+
+def test_extra_wire_key_malformed():
+    bad = {**_mint().to_dict(), "rogue": 1}
+    with pytest.raises(AttestationError):
+        grant_from_dict(bad)
+
+
+def test_extra_scope_key_malformed():
+    d = _mint().to_dict()
+    d["scope"]["rogue"] = "x"
+    with pytest.raises(AttestationError):
+        grant_from_dict(d)
+
+
+def test_non_positive_exp_rejected_at_mint():
+    with pytest.raises(AttestationError):
+        _mint(exp_seconds=0)

--- a/tests/credential/test_grant_proxy_integration.py
+++ b/tests/credential/test_grant_proxy_integration.py
@@ -1,0 +1,112 @@
+"""The proxy mints + injects a bound credential on an allowed tools/call."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
+KEY = b"x" * 32
+
+
+@pytest.fixture
+def receipts_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "receipts"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def emitter(tmp_path: Path, receipts_dir: Path) -> Any:
+    from vaara.integrations._mcp_attest import build_attest_emitter
+
+    key = tmp_path / "attest.key"
+    key.write_bytes(KEY)
+    return build_attest_emitter(
+        signing_key_path=key,
+        receipts_dir=receipts_dir,
+        upstream_commands={"default": ["echo"]},
+    )
+
+
+def _make_proxy(monkeypatch, *, emitter, mint: bool, **kwargs):
+    from vaara.audit.trail import AuditTrail
+    from vaara.integrations import mcp_proxy
+    from vaara.pipeline import InterceptionPipeline
+
+    trail = AuditTrail(on_record=lambda _r: None)
+    pipeline = InterceptionPipeline(trail=trail)
+    monkeypatch.setattr(
+        "vaara.integrations._mcp_upstream.UpstreamMCPClient.__init__",
+        lambda self, command, **kw: None,
+    )
+    p = mcp_proxy.VaaraMCPProxy(
+        upstream_command=["echo"], pipeline=pipeline, attest_emitter=emitter, **kwargs
+    )
+    p._mint_credentials = mint
+    mock_upstream = MagicMock()
+    mock_upstream.request.return_value = {
+        "jsonrpc": "2.0", "id": 1,
+        "result": {"content": [{"type": "text", "text": "ok"}]},
+    }
+    p._upstream = mock_upstream
+    return p
+
+
+def _grants(receipts_dir: Path) -> list[dict]:
+    return [json.loads(f.read_text()) for f in sorted(receipts_dir.glob("*-grant.json"))]
+
+
+def _attests(receipts_dir: Path) -> list[dict]:
+    return [json.loads(f.read_text()) for f in sorted(receipts_dir.glob("*-attest.json"))]
+
+
+def test_allowed_call_mints_and_injects_grant(monkeypatch, emitter, receipts_dir):
+    from vaara.attestation.receipt import attestation_digest
+    from vaara.attestation.sep2787 import parse_attestation
+
+    p = _make_proxy(monkeypatch, emitter=emitter, mint=True)
+    request = {
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": "/tmp/x"}},
+    }
+    p._handle_tools_call(request)
+
+    grants = _grants(receipts_dir)
+    assert len(grants) == 1
+    grant = grants[0]
+
+    # The grant binds the digest of the paired attestation.
+    att = parse_attestation(_attests(receipts_dir)[0])
+    assert grant["binding"]["attestationDigest"] == attestation_digest(att)
+
+    # The credential is injected on the forwarded request payload.
+    forwarded = p._upstream.request.call_args.args[0]
+    assert forwarded["params"]["_meta"]["vaara/credential"] == grant
+
+
+def test_mint_disabled_injects_nothing(monkeypatch, emitter, receipts_dir):
+    p = _make_proxy(monkeypatch, emitter=emitter, mint=False)
+    request = {
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": "/tmp/x"}},
+    }
+    p._handle_tools_call(request)
+    assert _grants(receipts_dir) == []
+    forwarded = p._upstream.request.call_args.args[0]
+    assert "_meta" not in forwarded.get("params", {})
+
+
+def test_blocked_call_mints_no_grant(monkeypatch, emitter, receipts_dir):
+    p = _make_proxy(monkeypatch, emitter=emitter, mint=True, denylist={"delete_db"})
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "delete_db", "arguments": {}},
+    })
+    assert _grants(receipts_dir) == []


### PR DESCRIPTION
## What

Adds the credential broker, Vaara's authority layer. The proxy can mint a signed, short-lived credential bound to an attestation digest (transitively the mediation receipt) and scoped to one tool plus an args commitment plus tenant. A `CredentialGateway` in front of a protected tool refuses any call that lacks a valid, unexpired, non-revoked, attestation-bound grant. Bypass stops being silent and successful; it becomes "defeat the broker first." This is detection, not a mathematical completeness claim.

## Scope and safety

Minting is gated behind `proxy._mint_credentials`, default off. Existing deployments see no runtime change until an operator turns it on with an attestation key configured. The grant reuses the SEP-2787 signing stack (HS256 / ES256 / RS256 over RFC 8785 JCS), so the grant key matches the attestation and receipt key.

## Proof surface

Conformance vectors under `conformance/sep2828/credential_grant_v0/` recompute without importing Vaara, so an independent implementer can verify the format. Five verdicts: valid, expired, scope-mismatch, unknown-binding, bad-signature. Design and threat model in `docs/design/credential-broker-spec.md`.

## Release

Minor bump to v1.1.0 (pyproject, `__init__`, TS client, both MCP server manifests). CHANGELOG updated. Full suite: 1849 passed, 13 skipped; ruff clean.
