### PR TITLE
fix(ci): v1.1.1 — scope CodeQL off conformance-vector builders

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+name: vaara-codeql
+
+# Dev-time conformance-vector generators are excluded from analysis.
+# They exist to emit intentionally-public recompute fixtures: the shared
+# HS256 test key and the HMAC signatures derived from it ARE the published
+# artifact, so py/clear-text-storage-sensitive-data does not apply. The
+# fixtures let a neutral party recompute every verdict with no `import vaara`.
+paths-ignore:
+  - scripts/build_credential_grant_vectors.py
+  - tests/vectors/handoff_set_v0/_generate.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-06-18
+
+Patch release: clear the CodeQL `py/clear-text-storage-sensitive-data` false positives on
+main. The flagged writes are the conformance-vector builders emitting intentionally-public
+recompute fixtures (the shared HS256 test key and the HMAC signatures derived from it are
+the published artifact, not a leaked secret). The genuinely key-bearing write was never
+flagged; CodeQL tainted the library-derived grant and attestation objects instead.
+
+- Added `.github/codeql/codeql-config.yml` with `paths-ignore` for the two dev-time vector
+  generators (`scripts/build_credential_grant_vectors.py`,
+  `tests/vectors/handoff_set_v0/_generate.py`), wired in via the CodeQL workflow
+  `config-file`. No application code or runtime behavior changes.
+
 ## [1.1.0] - 2026-06-18
 
 Minor release: the credential broker, Vaara's authority layer. Observability gains an

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.1.0"
+version = "1.1.1"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Clears the four new `py/clear-text-storage-sensitive-data` CodeQL alerts (179-182) on main plus the pre-existing #155, all on dev-time conformance-vector generators.

The flagged writes emit intentionally-public recompute fixtures: the shared HS256 test key and the HMAC signatures derived from it are the published artifact, not a leaked secret. The genuinely key-bearing write (`keyHex` into inputs.json) was never flagged; CodeQL tainted the library-derived grant and attestation objects instead.

Fix: `.github/codeql/codeql-config.yml` with `paths-ignore` for the two generators, wired via the workflow `config-file`. No application code or runtime behavior changes. Version bumped to 1.1.1 across pyproject, __init__, clients/ts, server.json, server-vaara-server.json; CHANGELOG 1.1.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.1.1 (patch release) across all packages (Python, TypeScript, and server).
  * Added CodeQL configuration to optimize code analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->