### PR TITLE
feat(audit): self-hosted rfc3161 timestamp anchors for receipts

### DIFF
--- a/scripts/anchor_receipt_demo.py
+++ b/scripts/anchor_receipt_demo.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Mint and verify a self-hosted rfc3161 timestamp anchor over a Vaara receipt.
+
+Fully offline: stands up a local Time-Stamping Authority, anchors the receipt's
+signed-payload digest (SPEC.md Section 4), prints the timestampAnchors entry,
+then verifies it back. No third party, no network.
+
+    python scripts/anchor_receipt_demo.py [path/to/receipt.json]
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from vaara.audit.receipt_anchor import SelfHostedTSA, verify_receipt_anchor
+
+DEFAULT = (Path(__file__).resolve().parents[1]
+           / "tests/vectors/x402_settlement_v0/generic/step1/receipt.json")
+
+
+def main() -> int:
+    path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT
+    receipt = json.loads(path.read_text())
+
+    tsa = SelfHostedTSA.create()
+    anchor = tsa.anchor_receipt(receipt)
+    attested = verify_receipt_anchor(receipt, anchor)
+
+    print(f"receipt        : {path}")
+    print(f"authority      : {anchor['authority']} (self-hosted, not qualified)")
+    print(f"method         : {anchor['method']}")
+    print(f"anchoredDigest : {anchor['anchoredDigest']}")
+    print(f"attested time  : {attested.isoformat()}")
+    print(f"token (b64, {len(anchor['token'])} chars): {anchor['token'][:64]}...")
+    print("\ntimestampAnchors entry:")
+    print(json.dumps(anchor, indent=2))
+    print(f"\nverified: token attests this receipt at {attested.isoformat()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vaara/audit/receipt_anchor.py
+++ b/src/vaara/audit/receipt_anchor.py
@@ -1,0 +1,200 @@
+"""Self-hosted RFC 3161 timestamp anchors for Vaara receipts (SPEC.md Section 4).
+
+A receipt's signature proves who decided and what it bound to, not *when*. A
+``timestampAnchors`` entry adds a time attestation over the receipt from an
+authority separate from the signing key. This is the ``rfc3161`` method's
+*producer*: it stands up a local Time-Stamping Authority (EC keypair +
+self-signed cert with the timeStamping EKU) and issues RFC 3161 tokens over a
+receipt's signed-payload digest, fully offline, no third party. The
+``rfc3161-eidas-qualified`` method is the same token from a qualified TSA and
+adds only legal weight; it is swappable.
+
+Tokens verify offline via ``vaara.audit.timeanchor.verify_timestamp_token`` so
+producer and verifier share one trust check. ``verify_receipt_anchor`` also pins
+anchoredDigest == sha256 of the JCS signed payload (SPEC.md Section 6 rule 3).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import rfc8785
+from asn1crypto import algos, cms, core, tsp
+from asn1crypto import x509 as asn1_x509
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+from vaara.audit.timeanchor import TimeAnchorError, verify_timestamp_token
+
+# Signed payload (SPEC.md 2.1): signature + timestampAnchors excluded, so a
+# receipt can gain anchors after signing without invalidating it.
+_SIGNED_BLOCKS = ("version", "alg", "backLink", "decisionDerived",
+                  "issuerAsserted")
+# Unregistered policy OID: marks "self-hosted, not qualified" by construction.
+_TSA_POLICY_OID = "1.3.6.1.4.1.58530.3161.1"
+
+
+def _signed_payload_digest(receipt: dict) -> bytes:
+    try:
+        payload = {k: receipt[k] for k in _SIGNED_BLOCKS}
+    except KeyError as exc:
+        raise TimeAnchorError(f"receipt missing signed-payload block: {exc}") from exc
+    return hashlib.sha256(rfc8785.dumps(payload)).digest()
+
+
+def anchored_digest(receipt: dict) -> str:
+    """The ``anchoredDigest`` a conforming anchor must carry for this receipt."""
+    return "sha256:" + _signed_payload_digest(receipt).hex()
+
+
+class SelfHostedTSA:
+    """A local RFC 3161 TSA: EC P-256 key + self-signed timeStamping cert."""
+
+    def __init__(self, key: ec.EllipticCurvePrivateKey, cert: x509.Certificate) -> None:
+        self._key = key
+        self._cert = cert
+        self._cert_asn1 = asn1_x509.Certificate.load(
+            cert.public_bytes(serialization.Encoding.DER))
+
+    @property
+    def authority(self) -> str:
+        cn = self._cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+        return cn[0].value if cn else "vaara-self-hosted-tsa"
+
+    @classmethod
+    def create(cls, common_name: str = "vaara-self-hosted-tsa",
+               *, serial: int = 1) -> "SelfHostedTSA":
+        key = ec.generate_private_key(ec.SECP256R1())
+        name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+        # ponytail: the token's gen_time carries the attested instant; the wide
+        # cert window just keeps the authority from expiring under old receipts.
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name).issuer_name(name)
+            .public_key(key.public_key()).serial_number(serial)
+            .not_valid_before(datetime(2020, 1, 1, tzinfo=timezone.utc))
+            .not_valid_after(datetime(2100, 1, 1, tzinfo=timezone.utc))
+            .add_extension(
+                x509.ExtendedKeyUsage([ExtendedKeyUsageOID.TIME_STAMPING]),
+                critical=True)
+            .sign(key, hashes.SHA256())
+        )
+        return cls(key, cert)
+
+    def save(self, directory: Path) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "tsa_key.pem").write_bytes(self._key.private_bytes(
+            serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption()))
+        (directory / "tsa_cert.pem").write_bytes(
+            self._cert.public_bytes(serialization.Encoding.PEM))
+
+    @classmethod
+    def load(cls, directory: Path) -> "SelfHostedTSA":
+        key = serialization.load_pem_private_key(
+            (directory / "tsa_key.pem").read_bytes(), password=None)
+        cert = x509.load_pem_x509_certificate(
+            (directory / "tsa_cert.pem").read_bytes())
+        if not isinstance(key, ec.EllipticCurvePrivateKey):
+            raise TimeAnchorError("TSA key is not an EC private key")
+        return cls(key, cert)
+
+    @classmethod
+    def load_or_create(cls, directory: Path,
+                       common_name: str = "vaara-self-hosted-tsa") -> "SelfHostedTSA":
+        if (directory / "tsa_key.pem").exists():
+            return cls.load(directory)
+        tsa = cls.create(common_name)
+        tsa.save(directory)
+        return tsa
+
+    def issue_token(self, digest: bytes, *, serial: int = 1,
+                    gen_time: Optional[datetime] = None) -> bytes:
+        """Issue a DER ``TimeStampToken`` over a 32-byte sha256 ``digest``."""
+        if len(digest) != 32:
+            raise TimeAnchorError(
+                f"expected a 32-byte sha256 digest, got {len(digest)} bytes")
+        tst_info = tsp.TSTInfo({
+            "version": "v1",
+            "policy": _TSA_POLICY_OID,
+            "message_imprint": tsp.MessageImprint({
+                "hash_algorithm": algos.DigestAlgorithm({"algorithm": "sha256"}),
+                "hashed_message": digest,
+            }),
+            "serial_number": serial,
+            "gen_time": gen_time or datetime.now(timezone.utc),
+        })
+        tst_der = tst_info.dump()
+        signed_attrs = cms.CMSAttributes([
+            cms.CMSAttribute({"type": "content_type", "values": ["tst_info"]}),
+            cms.CMSAttribute({"type": "message_digest",
+                              "values": [hashlib.sha256(tst_der).digest()]}),
+        ])
+        # Signature covers the attrs as a SET OF; the verifier rebuilds the same
+        # bytes via signed_attrs.untag().dump().
+        signature = self._key.sign(signed_attrs.dump(), ec.ECDSA(hashes.SHA256()))
+        tbs = self._cert_asn1["tbs_certificate"]
+        signer_info = cms.SignerInfo({
+            "version": "v1",
+            "sid": cms.SignerIdentifier({
+                "issuer_and_serial_number": cms.IssuerAndSerialNumber({
+                    "issuer": tbs["issuer"], "serial_number": tbs["serial_number"],
+                })}),
+            "digest_algorithm": algos.DigestAlgorithm({"algorithm": "sha256"}),
+            "signed_attrs": signed_attrs,
+            "signature_algorithm": algos.SignedDigestAlgorithm(
+                {"algorithm": "sha256_ecdsa"}),
+            "signature": signature,
+        })
+        signed_data = cms.SignedData({
+            "version": "v3",
+            "digest_algorithms": cms.DigestAlgorithms(
+                [algos.DigestAlgorithm({"algorithm": "sha256"})]),
+            "encap_content_info": cms.EncapsulatedContentInfo({
+                "content_type": "tst_info",
+                "content": core.ParsableOctetString(tst_der)}),
+            "certificates": cms.CertificateSet(
+                [cms.CertificateChoices({"certificate": self._cert_asn1})]),
+            "signer_infos": cms.SignerInfos([signer_info]),
+        })
+        return cms.ContentInfo(
+            {"content_type": "signed_data", "content": signed_data}).dump()
+
+    def anchor_receipt(self, receipt: dict) -> dict[str, Any]:
+        """Produce a SPEC.md Section 4 ``timestampAnchors`` entry for ``receipt``."""
+        raw = _signed_payload_digest(receipt)
+        return {
+            "method": "rfc3161",
+            "anchoredDigest": "sha256:" + raw.hex(),
+            "token": base64.b64encode(self.issue_token(raw)).decode("ascii"),
+            "authority": self.authority,
+        }
+
+
+def verify_receipt_anchor(receipt: dict, anchor: dict) -> datetime:
+    """Verify a ``timestampAnchors`` entry against its receipt. Returns UTC time.
+
+    Pins anchoredDigest == sha256 of the JCS signed payload (rule 3), then
+    verifies the token attests that digest via the shared offline verifier.
+    """
+    if anchor.get("method") not in ("rfc3161", "rfc3161-eidas-qualified"):
+        raise TimeAnchorError(f"not an rfc3161 anchor: method={anchor.get('method')!r}")
+    expected = "sha256:" + _signed_payload_digest(receipt).hex()
+    if anchor.get("anchoredDigest") != expected:
+        raise TimeAnchorError(
+            "anchoredDigest does not match the receipt's signed payload")
+    try:
+        token_der = base64.b64decode(anchor["token"])
+    except Exception as exc:
+        raise TimeAnchorError(f"anchor token is not valid base64: {exc}") from exc
+    return verify_timestamp_token(
+        token_der, bytes.fromhex(expected.split(":", 1)[1]), hash_algorithm="sha256")
+
+
+__all__ = ["SelfHostedTSA", "anchored_digest", "verify_receipt_anchor"]

--- a/tests/test_receipt_anchor.py
+++ b/tests/test_receipt_anchor.py
@@ -7,12 +7,14 @@ from pathlib import Path
 
 import pytest
 
-from vaara.audit.receipt_anchor import (
+pytest.importorskip("asn1crypto")  # the 'timeanchor' extra; skip when absent
+
+from vaara.audit.receipt_anchor import (  # noqa: E402
     SelfHostedTSA,
     anchored_digest,
     verify_receipt_anchor,
 )
-from vaara.audit.timeanchor import TimeAnchorError
+from vaara.audit.timeanchor import TimeAnchorError  # noqa: E402
 
 VECTOR = (Path(__file__).resolve().parents[1]
           / "tests/vectors/x402_settlement_v0/generic/step1/receipt.json")

--- a/tests/test_receipt_anchor.py
+++ b/tests/test_receipt_anchor.py
@@ -1,0 +1,61 @@
+"""Self-hosted rfc3161 receipt anchors round-trip and pin to the receipt."""
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from vaara.audit.receipt_anchor import (
+    SelfHostedTSA,
+    anchored_digest,
+    verify_receipt_anchor,
+)
+from vaara.audit.timeanchor import TimeAnchorError
+
+VECTOR = (Path(__file__).resolve().parents[1]
+          / "tests/vectors/x402_settlement_v0/generic/step1/receipt.json")
+
+
+@pytest.fixture
+def receipt() -> dict:
+    return json.loads(VECTOR.read_text())
+
+
+def test_anchor_has_spec_shape_and_verifies(receipt: dict) -> None:
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt)
+    assert set(anchor) == {"method", "anchoredDigest", "token", "authority"}
+    assert anchor["method"] == "rfc3161"
+    # anchoredDigest == sha256 of the JCS signed payload (SPEC.md rule 3),
+    # recomputed independently of the producer.
+    assert anchor["anchoredDigest"] == anchored_digest(receipt)
+    attested = verify_receipt_anchor(receipt, anchor)
+    assert attested.tzinfo is not None
+
+
+def test_anchor_rejects_tampered_receipt(receipt: dict) -> None:
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt)
+    tampered = dict(receipt, version=receipt["version"] + 1)
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(tampered, anchor)
+
+
+def test_anchor_rejects_forged_token(receipt: dict) -> None:
+    # A token from a different TSA over a different digest must not pass even if
+    # the anchoredDigest field is set correctly: the token's imprint won't match.
+    good = SelfHostedTSA.create().anchor_receipt(receipt)
+    other = SelfHostedTSA.create()
+    forged_token = other.issue_token(bytes(32))
+    swapped = dict(good, token=base64.b64encode(forged_token).decode())
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(receipt, swapped)
+
+
+def test_tsa_persists_authority_identity(tmp_path) -> None:
+    first = SelfHostedTSA.load_or_create(tmp_path, "vaara-test-tsa")
+    second = SelfHostedTSA.load_or_create(tmp_path, "ignored-on-load")
+    assert first.authority == second.authority == "vaara-test-tsa"
+    # Same persisted key signs verifiable tokens after a reload.
+    digest = bytes(range(32))
+    assert second.issue_token(digest)


### PR DESCRIPTION
Producer half of SPEC.md Section 4 timestampAnchors: we now mint our own rfc3161 time anchors over a receipt, fully offline, no third party.

## What

- `src/vaara/audit/receipt_anchor.py` — `SelfHostedTSA` stands up a local Time-Stamping Authority (EC P-256 key + self-signed timeStamping-EKU cert) and issues real RFC 3161 TimeStampTokens over a receipt's signed-payload digest. `anchor_receipt(receipt)` returns the conforming `{method, anchoredDigest, token, authority}` entry where `anchoredDigest` is the sha256 of the JCS signed payload (Section 6 rule 3). `verify_receipt_anchor()` pins the anchor to the receipt, then verifies the token through the pre-existing offline verifier in `timeanchor.py`, so producer and verifier share one trust check.
- `tests/test_receipt_anchor.py` — round-trip, tampered-receipt rejection, forged-token rejection, persisted-authority reload (4 tests).
- `scripts/anchor_receipt_demo.py` — offline demo: prints the timestampAnchors JSON and the verified attested time for a vector receipt.

## Why

The receipt signature proves who decided and what it bound to, not when. A self-hosted anchor gives technical time evidence with no external dependency. The `rfc3161-eidas-qualified` method is the same token shape from a qualified TSA and adds only legal weight, swappable.

Pure-Python issuer (asn1crypto), no openssl subprocess: the verifier already existed, this completes the pair.

Conformance suite still 14/14, ruff clean.