### PR TITLE
Phase C: capability scopes for grants (typed, enforceable arg limits)

### DIFF
--- a/src/vaara/credential/__init__.py
+++ b/src/vaara/credential/__init__.py
@@ -14,6 +14,7 @@ The grant reuses the SEP-2787 signing stack (HS256 / ES256 / RS256 over RFC
 
 from __future__ import annotations
 
+from vaara.credential._grant_capability import Capability
 from vaara.credential._grant_emit import emit_grant, verify_grant_signature
 from vaara.credential._grant_parse import (
     asserted_from_dict,
@@ -33,6 +34,7 @@ from vaara.credential.gateway import CredentialGateway
 
 __all__ = [
     "BrokeredCredential",
+    "Capability",
     "CredentialGateway",
     "GrantAlgorithm",
     "GrantAsserted",

--- a/src/vaara/credential/_grant_capability.py
+++ b/src/vaara/credential/_grant_capability.py
@@ -1,0 +1,157 @@
+"""Typed capability constraints for capability-mode grants (Phase C).
+
+Internal module. Public surface is in ``vaara.credential``.
+
+A Phase A grant pins exact arguments via ``scope.argsCommitment`` and the
+gateway enforces byte-equality. A capability grant instead carries a list of
+typed constraints over named arguments, and the gateway enforces each at call
+time, so one credential authorizes a *bounded class* of calls (the
+authority-layer move: control what is allowed, not just prove what happened).
+
+Coverage is CLOSED: in capability mode the set of runtime argument keys must
+equal the set of constrained argument names. An unnamed runtime arg fails
+``capability_uncovered``; pin an argument that must not vary with an ``eq``
+constraint.
+
+Each capability is a signed, closed-schema block (camelCase-free: the wire
+keys are ``arg``/``op``/``value``). Numeric bounds are decimal-as-string;
+floats and bools in the signed value are rejected, consistent with the JCS
+reject-floats guard in ``_sep2787_canonical``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from vaara.attestation._sep2787_types import AttestationError
+
+CAPABILITY_KEYS = frozenset({"arg", "op", "value"})
+NUMERIC_OPS = frozenset({"le", "ge"})
+VALID_OPS = NUMERIC_OPS | frozenset({"eq", "in"})
+
+
+@dataclass(frozen=True)
+class Capability:
+    """One typed constraint over a named tool argument.
+
+    ``op`` is ``le``/``ge`` (numeric, Decimal compare), ``eq`` (pin to a fixed
+    value), or ``in`` (membership). ``value`` is a decimal string for
+    ``le``/``ge``, an arbitrary string for ``eq``, or a tuple of strings for
+    ``in``.
+    """
+
+    arg: str
+    op: str
+    value: Any
+
+
+def capability_to_dict(c: Capability) -> dict[str, Any]:
+    value: Any = list(c.value) if c.op == "in" else c.value
+    return {"arg": c.arg, "op": c.op, "value": value}
+
+
+def capability_from_dict(d: dict[str, Any]) -> Capability:
+    """Parse one capability wire object under its closed schema."""
+    if not isinstance(d, dict):
+        raise AttestationError("capability must be an object")
+    extra = set(d) - CAPABILITY_KEYS
+    if extra:
+        raise AttestationError(
+            f"capability carries unrecognized field(s) {sorted(extra)!r}; "
+            "the signed schema is closed"
+        )
+    arg = d.get("arg")
+    op = d.get("op")
+    if not isinstance(arg, str) or not arg:
+        raise AttestationError("capability.arg must be a non-empty string")
+    if op not in VALID_OPS:
+        raise AttestationError(f"capability.op must be one of {sorted(VALID_OPS)!r}")
+    value = d.get("value")
+    if op == "in":
+        if not isinstance(value, list) or not value:
+            raise AttestationError("capability.value for 'in' must be a non-empty list")
+        if not all(isinstance(item, str) for item in value):
+            raise AttestationError("capability.value 'in' items must be strings")
+        return Capability(arg=arg, op=op, value=tuple(value))
+    if op in NUMERIC_OPS:
+        if not isinstance(value, str) or not value:
+            raise AttestationError(f"capability.value for {op!r} must be a decimal string")
+        try:
+            Decimal(value)
+        except InvalidOperation as e:
+            raise AttestationError(f"capability.value {value!r} is not a decimal") from e
+        return Capability(arg=arg, op=op, value=value)
+    # eq
+    if not isinstance(value, str):
+        raise AttestationError("capability.value for 'eq' must be a string")
+    return Capability(arg=arg, op=op, value=value)
+
+
+def _as_decimal(v: Any) -> Decimal | None:
+    """Coerce a runtime arg value to Decimal, or None if not a real number."""
+    if isinstance(v, bool) or not isinstance(v, (int, float, str)):
+        return None
+    try:
+        return Decimal(str(v))
+    except InvalidOperation:
+        return None
+
+
+def _check(cap: Capability, actual: Any) -> bool:
+    if cap.op == "eq":
+        return not isinstance(actual, bool) and str(actual) == cap.value
+    if cap.op == "in":
+        return not isinstance(actual, bool) and str(actual) in cap.value
+    a = _as_decimal(actual)
+    bound = _as_decimal(cap.value)
+    if a is None or bound is None:
+        return False  # fail closed on a malformed value or bound
+    return a <= bound if cap.op == "le" else a >= bound
+
+
+def evaluate(capabilities: tuple[Capability, ...], runtime_args: Any) -> tuple[bool, str]:
+    """Enforce capability constraints against runtime args (closed coverage).
+
+    Returns ``(ok, reason)``: ``(True, "ok")`` when every runtime arg is named
+    by a capability and every constraint holds; otherwise ``(False, reason)``
+    with ``capability_uncovered`` (a runtime arg no capability names) or
+    ``capability_exceeded`` (a constraint failed or a named arg is missing).
+    """
+    if not isinstance(runtime_args, dict):
+        return (False, "capability_exceeded")
+    named = {c.arg for c in capabilities}
+    for key in runtime_args:
+        if key not in named:
+            return (False, "capability_uncovered")
+    for cap in capabilities:
+        if cap.arg not in runtime_args or not _check(cap, runtime_args[cap.arg]):
+            return (False, "capability_exceeded")
+    return (True, "ok")
+
+
+def _demo() -> None:
+    """Self-check: bound holds, over-bound / unnamed / pinned-mismatch fail."""
+    caps = (
+        Capability("amount", "le", "500"),
+        Capability("vendor", "in", ("acme", "globex")),
+        Capability("destination", "eq", "0xABC"),
+    )
+    ok = {"amount": 400, "vendor": "acme", "destination": "0xABC"}
+    assert evaluate(caps, ok) == (True, "ok")
+    assert evaluate(caps, {**ok, "amount": 600}) == (False, "capability_exceeded")
+    assert evaluate(caps, {**ok, "vendor": "evilcorp"}) == (False, "capability_exceeded")
+    assert evaluate(caps, {**ok, "destination": "0xDEAD"}) == (False, "capability_exceeded")
+    assert evaluate(caps, {**ok, "memo": "hi"}) == (False, "capability_uncovered")
+    assert evaluate(caps, {"amount": 400, "vendor": "acme"}) == (False, "capability_exceeded")
+    # round-trip + bool rejected as a numeric
+    assert capability_from_dict(capability_to_dict(caps[0])) == caps[0]
+    assert evaluate((Capability("n", "le", "5"),), {"n": True}) == (False, "capability_exceeded")
+    # malformed bound fails closed rather than raising
+    assert evaluate((Capability("n", "le", "abc"),), {"n": 1}) == (False, "capability_exceeded")
+    print("ok")
+
+
+if __name__ == "__main__":
+    _demo()

--- a/src/vaara/credential/_grant_emit.py
+++ b/src/vaara/credential/_grant_emit.py
@@ -11,7 +11,7 @@ envelope layout (``_grant_types``).
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from vaara.attestation._sep2787_canonical import (
     canonical_json,
@@ -31,6 +31,7 @@ from vaara.attestation._sep2787_types import (
     Algorithm,
     AttestationError,
 )
+from vaara.credential._grant_capability import Capability, capability_to_dict
 from vaara.credential._grant_types import (
     BrokeredCredential,
     GrantAsserted,
@@ -49,15 +50,18 @@ def _signing_payload(
     scope: GrantScope,
     binding: GrantBinding,
     asserted: GrantAsserted,
+    capabilities: Sequence[Capability] = (),
 ) -> bytes:
     """JCS-canonical encoding of the grant blocks, signature excluded."""
-    body = {
+    body: dict[str, Any] = {
         "version": version,
         "alg": alg,
         "scope": scope_to_dict(scope),
         "binding": binding_to_dict(binding),
         "asserted": asserted_to_dict(asserted),
     }
+    if capabilities:
+        body["capabilities"] = [capability_to_dict(c) for c in capabilities]
     return canonical_json(body)
 
 
@@ -74,6 +78,7 @@ def emit_grant(
     nonce: Optional[str] = None,
     iat: Optional[str] = None,
     version: int = 1,
+    capabilities: Sequence[Capability] = (),
 ) -> BrokeredCredential:
     """Build, JCS-canonicalize, and sign a BrokeredCredential envelope.
 
@@ -81,6 +86,10 @@ def emit_grant(
     (build it from ``attestation_digest`` + the attestation nonce).
     ``signing_material`` is either a bytes shared secret (HS256) or a
     private-key object from ``cryptography.hazmat`` (ES256 / RS256).
+
+    Passing ``capabilities`` mints a capability-mode grant: the gateway
+    enforces the typed constraints against runtime args (closed coverage)
+    instead of the exact ``scope.argsCommitment``.
     """
     if alg not in VALID_ALGS:
         raise AttestationError(f"unsupported alg: {alg!r}")
@@ -101,7 +110,12 @@ def emit_grant(
     )
 
     payload = _signing_payload(
-        version=version, alg=alg, scope=scope, binding=binding, asserted=asserted
+        version=version,
+        alg=alg,
+        scope=scope,
+        binding=binding,
+        asserted=asserted,
+        capabilities=capabilities,
     )
 
     if alg == "HS256":
@@ -122,6 +136,7 @@ def emit_grant(
         binding=binding,
         asserted=asserted,
         signature=signature_hex,
+        capabilities=tuple(capabilities),
     )
 
 
@@ -142,6 +157,7 @@ def verify_grant_signature(
         scope=credential.scope,
         binding=credential.binding,
         asserted=credential.asserted,
+        capabilities=credential.capabilities,
     )
 
     if credential.alg == "HS256":

--- a/src/vaara/credential/_grant_parse.py
+++ b/src/vaara/credential/_grant_parse.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Any
 
 from vaara.attestation._sep2787_types import VALID_ALGS, AttestationError
+from vaara.credential._grant_capability import Capability, capability_from_dict
 from vaara.credential._grant_types import (
     ASSERTED_KEYS,
     BINDING_KEYS,
@@ -105,6 +106,12 @@ def grant_from_dict(d: dict[str, Any]) -> BrokeredCredential:
         raise AttestationError("credential.version must be an integer")
     if d["alg"] not in VALID_ALGS:
         raise AttestationError(f"unsupported alg {d['alg']!r}")
+    caps_raw = d.get("capabilities")
+    capabilities: tuple[Capability, ...] = ()
+    if caps_raw is not None:
+        if not isinstance(caps_raw, list) or not caps_raw:
+            raise AttestationError("credential.capabilities must be a non-empty list")
+        capabilities = tuple(capability_from_dict(c) for c in caps_raw)
     return BrokeredCredential(
         version=d["version"],
         alg=d["alg"],
@@ -112,4 +119,5 @@ def grant_from_dict(d: dict[str, Any]) -> BrokeredCredential:
         binding=binding_from_dict(d["binding"]),
         asserted=asserted_from_dict(d["asserted"]),
         signature=_require_str(d, "signature", "credential"),
+        capabilities=capabilities,
     )

--- a/src/vaara/credential/_grant_types.py
+++ b/src/vaara/credential/_grant_types.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from vaara.attestation._sep2787_types import Algorithm
+from vaara.credential._grant_capability import Capability, capability_to_dict
 
 GrantAlgorithm = Algorithm
 
@@ -84,9 +85,10 @@ class BrokeredCredential:
     binding: GrantBinding
     asserted: GrantAsserted
     signature: str
+    capabilities: tuple[Capability, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "version": self.version,
             "alg": self.alg,
             "scope": scope_to_dict(self.scope),
@@ -94,6 +96,9 @@ class BrokeredCredential:
             "asserted": asserted_to_dict(self.asserted),
             "signature": self.signature,
         }
+        if self.capabilities:
+            d["capabilities"] = [capability_to_dict(c) for c in self.capabilities]
+        return d
 
 
 def scope_to_dict(s: GrantScope) -> dict[str, Any]:
@@ -128,5 +133,5 @@ ASSERTED_KEYS = frozenset(
     {"expSeconds", "iat", "iss", "nonce", "secretVersion", "sub"}
 )
 GRANT_KEYS = frozenset(
-    {"version", "alg", "scope", "binding", "asserted", "signature"}
+    {"version", "alg", "scope", "binding", "asserted", "signature", "capabilities"}
 )

--- a/src/vaara/credential/_grant_verify.py
+++ b/src/vaara/credential/_grant_verify.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 from vaara.attestation._sep2787_canonical import iso8601_to_epoch, make_args_digest
+from vaara.credential._grant_capability import evaluate
 from vaara.credential._grant_emit import verify_grant_signature
 from vaara.credential._grant_types import BrokeredCredential
 
@@ -76,9 +77,16 @@ def verify_grant(
         return GrantVerdict(False, "scope_mismatch")
     if scope.tenant_id != runtime_tenant_id:
         return GrantVerdict(False, "scope_mismatch")
-    runtime_commitment = make_args_digest(runtime_args).projection_digest
-    if scope.args_commitment != runtime_commitment:
-        return GrantVerdict(False, "scope_mismatch")
+    if credential.capabilities:
+        # Capability mode: enforce typed constraints (closed coverage) instead
+        # of the exact args commitment, which becomes a mint-time anchor only.
+        ok, reason = evaluate(credential.capabilities, runtime_args)
+        if not ok:
+            return GrantVerdict(False, reason)
+    else:
+        runtime_commitment = make_args_digest(runtime_args).projection_digest
+        if scope.args_commitment != runtime_commitment:
+            return GrantVerdict(False, "scope_mismatch")
 
     if revocation is not None:
         status = revocation.status(

--- a/tests/credential/test_grant_capability.py
+++ b/tests/credential/test_grant_capability.py
@@ -1,0 +1,146 @@
+"""Capability-mode grant tests (Phase C): typed, enforceable arg limits."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
+from cryptography.hazmat.primitives.asymmetric import ec  # noqa: E402
+
+from vaara.attestation._sep2787_canonical import (  # noqa: E402
+    iso8601_to_epoch,
+    make_args_digest,
+)
+from vaara.attestation._sep2787_types import AttestationError  # noqa: E402
+from vaara.credential import (  # noqa: E402
+    Capability,
+    GrantBinding,
+    GrantScope,
+    emit_grant,
+    grant_from_dict,
+    verify_grant,
+)
+
+SECRET = b"s" * 32
+DIGEST = "sha256:" + "ab" * 32
+NONCE = "att-nonce-xyz"
+IAT = "2026-06-18T12:00:00Z"
+IAT_EPOCH = iso8601_to_epoch(IAT)
+
+# Mint-time attested args; runtime args vary within the capability bounds.
+MINT_ARGS = {"amount": 100, "vendor": "acme", "destination": "0xABC"}
+COMMIT = make_args_digest(MINT_ARGS).projection_digest
+CAPS = (
+    Capability("amount", "le", "500"),
+    Capability("vendor", "in", ("acme", "globex")),
+    Capability("destination", "eq", "0xABC"),
+)
+RUNTIME_OK = {"amount": 400, "vendor": "globex", "destination": "0xABC"}
+
+
+def _mint(*, alg="HS256", material=SECRET, capabilities=CAPS):
+    return emit_grant(
+        scope=GrantScope(tool_name="pay.send", args_commitment=COMMIT, tenant_id="tenant-a"),
+        binding=GrantBinding(attestation_digest=DIGEST, attestation_nonce=NONCE),
+        iss="vaara-mcp-proxy",
+        sub="tenant-a/upstream",
+        secret_version="key-v1",
+        alg=alg,
+        signing_material=material,
+        exp_seconds=60,
+        iat=IAT,
+        capabilities=capabilities,
+    )
+
+
+def _verify(cred, *, material=SECRET, runtime_args=None, **over):
+    kw = dict(
+        verifying_material=material,
+        runtime_tool_name="pay.send",
+        runtime_args=RUNTIME_OK if runtime_args is None else runtime_args,
+        runtime_tenant_id="tenant-a",
+        known_attestation_digests=frozenset({DIGEST}),
+        now=IAT_EPOCH + 5,
+    )
+    kw.update(over)
+    return verify_grant(cred, **kw)
+
+
+def test_round_trip_preserves_capabilities():
+    cred = _mint()
+    again = grant_from_dict(cred.to_dict())
+    assert again == cred
+    assert again.capabilities == CAPS
+
+
+def test_within_bounds_hs256_ok():
+    v = _verify(_mint())
+    assert v.ok and v.reason == "ok"
+
+
+def test_within_bounds_es256_ok():
+    priv = ec.generate_private_key(ec.SECP256R1())
+    cred = _mint(alg="ES256", material=priv)
+    v = _verify(cred, material=priv.public_key())
+    assert v.ok and v.reason == "ok"
+
+
+def test_commitment_not_enforced_in_capability_mode():
+    # Runtime args differ from MINT_ARGS but stay within bounds -> still ok.
+    assert _verify(_mint(), runtime_args={"amount": 499, "vendor": "acme", "destination": "0xABC"}).ok
+
+
+def test_over_numeric_bound_exceeded():
+    args = {"amount": 600, "vendor": "acme", "destination": "0xABC"}
+    assert _verify(_mint(), runtime_args=args).reason == "capability_exceeded"
+
+
+def test_value_not_in_set_exceeded():
+    args = {"amount": 100, "vendor": "evilcorp", "destination": "0xABC"}
+    assert _verify(_mint(), runtime_args=args).reason == "capability_exceeded"
+
+
+def test_pinned_arg_mismatch_exceeded():
+    args = {"amount": 100, "vendor": "acme", "destination": "0xDEAD"}
+    assert _verify(_mint(), runtime_args=args).reason == "capability_exceeded"
+
+
+def test_unnamed_runtime_arg_uncovered():
+    args = {**RUNTIME_OK, "memo": "drain"}
+    assert _verify(_mint(), runtime_args=args).reason == "capability_uncovered"
+
+
+def test_missing_named_arg_exceeded():
+    args = {"amount": 100, "vendor": "acme"}  # destination dropped
+    assert _verify(_mint(), runtime_args=args).reason == "capability_exceeded"
+
+
+def test_capabilities_are_signed():
+    cred = _mint()
+    d = cred.to_dict()
+    d["capabilities"][0]["value"] = "999"  # raise the bound after signing
+    forged = grant_from_dict(d)
+    assert _verify(forged).reason == "bad_signature"
+
+
+def test_unknown_capability_key_malformed():
+    d = _mint().to_dict()
+    d["capabilities"][0]["rogue"] = 1
+    with pytest.raises(AttestationError):
+        grant_from_dict(d)
+
+
+def test_float_capability_value_rejected():
+    d = _mint().to_dict()
+    d["capabilities"][0]["value"] = 500.0  # float in a signed numeric bound
+    with pytest.raises(AttestationError):
+        grant_from_dict(d)
+
+
+def test_empty_capabilities_list_rejected():
+    d = _mint().to_dict()
+    d["capabilities"] = []
+    with pytest.raises(AttestationError):
+        grant_from_dict(d)


### PR DESCRIPTION
## What

Phase A's credential broker mints a grant that pins exact arguments: the gateway enforces byte-equality, so one grant authorizes one frozen call. That proves a call was mediated but cannot express a bounded class of calls.

This adds capability scopes. A grant can carry typed constraints over named arguments, and the gateway enforces each at call time:

- `amount le 500` (numeric upper bound)
- `vendor in [acme, globex]` (membership)
- `destination eq 0xABC` (pin)

Coverage is closed: every runtime argument must be named by a capability or the call is rejected. Pin the arguments you do not want to vary with `eq`; bound the ones you do. One credential authorizes a bounded class of calls instead of one frozen call, which is the authority-layer move from proving what happened to controlling what is allowed.

## How

- New `_grant_capability.py`: the `Capability` type, closed-schema serialize and parse (rejects floats and bools in signed values), and `evaluate()` doing closed coverage plus per-op predicate checks. Numeric bounds are decimal-as-string compared via `Decimal`; a malformed value or bound fails closed.
- The optional `capabilities` block is signed and threaded through types, emit, parse, and verify.
- Backward compatible: capabilities absent keeps Phase A exact-args mode with a byte-identical signing preimage, so existing vectors and the independent-recompute conformance check are unchanged.
- In capability mode `verify_grant` enforces the predicates and skips the exact args commitment, which becomes a mint-time audit anchor.

## Tests

13 new cases (bounds, set membership, pinning, closed coverage, signed-ness, closed-schema rejection). Full suite green (1866 passed, 13 skipped), ruff and mypy clean.

## Out of scope

A policy engine that generates capability templates, nested arg paths, and auto-minting capability grants in the proxy (opt-in via `emit_grant(capabilities=...)` until policy lands).
