### PR TITLE
fix(release): complete v1.2.0 publish — npm + MCP manifests to 1.2.0

### DIFF
--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -1,0 +1,163 @@
+name: Republish (npm + MCP Registry)
+
+# Recovery workflow for when the tagged Release run published PyPI and the
+# GitHub Release correctly but the npm and/or MCP Registry jobs failed (e.g.
+# a stale manifest version). Re-running the original run is no use: it is
+# frozen to the tag commit. This dispatches the two package-registry
+# publishes against the current default branch, and deliberately does NOT
+# touch PyPI or the GitHub Release.
+#
+# MCP Registry has no off-Actions path (it authenticates via GitHub OIDC),
+# so this workflow is the only clean way to re-publish those manifests.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (no leading v), e.g. 1.2.0. Must match main.'
+        required: true
+        type: string
+
+permissions: read-all
+
+concurrency:
+  group: republish-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  publish-npm:
+    name: Publish TypeScript client to npm
+    runs-on: ubuntu-latest
+    if: ${{ vars.NPM_PUBLISH_ENABLED == 'true' }}
+    permissions:
+      contents: read
+      id-token: write  # required for npm provenance
+    defaults:
+      run:
+        working-directory: clients/ts
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.0.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Confirm package.json matches requested version
+        run: |
+          set -euo pipefail
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$pkg" != "$VERSION" ]; then
+            echo "::error::clients/ts/package.json is ${pkg}, requested ${VERSION}. Bump main first."
+            exit 1
+          fi
+      - name: Install (npm ci)
+        run: npm ci --no-audit --no-fund
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: node --test test/*.test.mjs
+      - name: Publish to npm with provenance (skip if already published)
+        run: |
+          set -euo pipefail
+          if npm view "@vaara/client@${VERSION}" version >/dev/null 2>&1; then
+            echo "@vaara/client@${VERSION} already on npm; nothing to do."
+            exit 0
+          fi
+          npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-mcp-registry:
+    name: Publish manifests to the MCP Registry
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # checkout server.json manifests
+      id-token: write  # OIDC login to MCP Registry, no stored secret
+    env:
+      MCP_PUBLISHER_VERSION: v1.7.9
+      EXPECTED_VERSION: ${{ inputs.version }}
+    steps:
+      - name: Checkout (for server.json manifests)
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - name: Install mcp-publisher CLI
+        run: |
+          set -euo pipefail
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          url="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${os}_${arch}.tar.gz"
+          echo "Downloading mcp-publisher from ${url}"
+          curl -fsSL "$url" | tar xz mcp-publisher
+          ./mcp-publisher --version || true
+      - name: Authenticate to the MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+      - name: Publish both manifests
+        run: |
+          set -uo pipefail
+          publish_one() {
+            manifest="$1"
+            echo "::group::mcp-publisher publish ${manifest}"
+            out="$(./mcp-publisher publish "$manifest" 2>&1)" && rc=0 || rc=$?
+            echo "$out"
+            echo "::endgroup::"
+            if [ "$rc" -ne 0 ]; then
+              if echo "$out" | grep -qiE 'already exists|already published|duplicate'; then
+                echo "Version already present on the registry for ${manifest}; treating as success."
+                return 0
+              fi
+              echo "::error::Publishing ${manifest} failed (exit ${rc})."
+              return "$rc"
+            fi
+          }
+          publish_one server.json
+          publish_one server-vaara-server.json
+      - name: Assert registry version matches the requested version
+        run: |
+          set -euo pipefail
+          EXPECTED="${EXPECTED_VERSION#v}"
+          echo "Expected version: ${EXPECTED}"
+          python3 - "$EXPECTED" <<'PY'
+          import json, sys, time, urllib.error, urllib.request
+
+          expected = sys.argv[1]
+          names = ["io.github.vaaraio/vaara", "io.github.vaaraio/vaara-server"]
+          OFFICIAL = "io.modelcontextprotocol.registry/official"
+          BASE = "https://registry.modelcontextprotocol.io/v0/servers"
+
+          def latest_active(name):
+              url = f"{BASE}?search={name}&version=latest"
+              try:
+                  with urllib.request.urlopen(url, timeout=30) as fh:
+                      data = json.load(fh)
+              except (urllib.error.URLError, TimeoutError) as exc:
+                  print(f"WARN {name}: registry read failed ({exc!r}); will retry")
+                  return None
+              for entry in data.get("servers", data.get("data", [])):
+                  server = entry.get("server", entry)
+                  if server.get("name") != name:
+                      continue
+                  meta = (entry.get("_meta") or {}).get(OFFICIAL, {})
+                  if meta.get("isLatest") and meta.get("status") == "active":
+                      return server.get("version")
+              return None
+
+          failed = []
+          for name in names:
+              latest = None
+              for _ in range(10):
+                  latest = latest_active(name)
+                  if latest == expected:
+                      print(f"OK   {name}: latest active version {latest} matches {expected}")
+                      break
+                  time.sleep(6)
+              else:
+                  print(f"FAIL {name}: expected {expected}, registry latest active is {latest!r}")
+                  failed.append(name)
+
+          if failed:
+              print("::error::MCP Registry latest version does not match the requested version.")
+              sys.exit(1)
+          print("MCP Registry is in sync with", expected)
+          PY

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/scripts/release_prepare.sh
+++ b/scripts/release_prepare.sh
@@ -15,7 +15,7 @@
 #   1. Pre-flight: required files exist, CHANGELOG entry present,
 #      working tree clean except for the staged release changes.
 #   2. Bumps version in pyproject.toml + clients/ts/package.json +
-#      src/vaara/__init__.py.
+#      src/vaara/__init__.py + server.json + server-vaara-server.json.
 #   3. ruff check on changed Python paths.
 #   4. pytest --no-header on the full suite (skips adversarial dir;
 #      deselects pre-existing known-failing test).
@@ -70,10 +70,17 @@ fi
 sed -i -E "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"$/version = \"${VERSION}\"/" pyproject.toml
 sed -i -E "s/^  \"version\": \"[0-9]+\.[0-9]+\.[0-9]+\",$/  \"version\": \"${VERSION}\",/" clients/ts/package.json
 sed -i -E "s/^__version__ = \"[0-9]+\.[0-9]+\.[0-9]+\"$/__version__ = \"${VERSION}\"/" src/vaara/__init__.py
+# MCP Registry manifests: bump every semver "version" value (root listing
+# + the pypi package entry). The release workflow asserts the live registry
+# version equals the tag, so a stale manifest fails the publish gate.
+sed -i -E "s/(\"version\": \")[0-9]+\.[0-9]+\.[0-9]+(\")/\1${VERSION}\2/g" \
+  server.json server-vaara-server.json
 
 grep -E "^version = \"${VERSION}\"$" pyproject.toml >/dev/null
 grep -E "\"version\": \"${VERSION}\"" clients/ts/package.json >/dev/null
 grep -E "^__version__ = \"${VERSION}\"$" src/vaara/__init__.py >/dev/null
+grep -E "\"version\": \"${VERSION}\"" server.json >/dev/null
+grep -E "\"version\": \"${VERSION}\"" server-vaara-server.json >/dev/null
 
 # 3. Lint changed paths (best-effort; lint all of src + tests if no
 # precise change list)
@@ -90,7 +97,8 @@ fi
   --deselect tests/test_adversarial_classifier_integration.py::test_known_bad_metadata_ssrf_scores_high
 
 # 5. Stage explicit paths only
-git add CHANGELOG.md pyproject.toml clients/ts/package.json src/vaara/__init__.py
+git add CHANGELOG.md pyproject.toml clients/ts/package.json src/vaara/__init__.py \
+  server.json server-vaara-server.json
 # Re-add any other paths the caller has already staged
 git status --short
 

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.1.1",
+  "version": "1.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.1.1",
+  "version": "1.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## What

The v1.2.0 Release run published PyPI and the signed GitHub Release correctly, then failed on two jobs because three version files were never bumped past 1.1.1:

- `clients/ts/package.json` — npm returned E403 (cannot republish existing `@vaara/client@1.1.1`)
- `server.json` + `server-vaara-server.json` — the MCP Registry post-publish assert expected 1.2.0; registry stayed at 1.1.1

## Changes

- Bump `clients/ts/package.json`, `server.json`, `server-vaara-server.json` to 1.2.0.
- `scripts/release_prepare.sh` now bumps both MCP manifests (the prior script bumped package.json but never touched the manifests — the real recurrence gap).
- Add `.github/workflows/republish.yml`: a `workflow_dispatch` recovery path that re-publishes only npm + MCP Registry against `main`. It deliberately leaves PyPI and the GitHub Release untouched. The MCP Registry authenticates via GitHub OIDC and has no off-Actions publish path, so a dispatch workflow is the only clean way to re-publish those manifests.

## Why not just rerun the failed jobs

`gh run rerun` is frozen to the tag commit (still 1.1.1), so it would fail identically. Re-tagging would re-fire the PyPI job (no `skip-existing`, would fail and block the chain) and re-sign/overwrite the published GitHub Release. This PR + the dispatch workflow avoid touching either.

## Publish step (manual, after merge)

`gh workflow run republish.yml --ref main -f version=1.2.0`