### PR TITLE
chore(release): v1.2.1 docs refresh across PyPI, npm, MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-06-19
+
+Patch release: documentation only. No functional change to the published package.
+
+- Brought the README current with the two pillars it never mentioned. The standards
+  section now leads with the canonical `vaara.receipt/v1` spec (`SPEC.md`), with the x402
+  settlement binding and the eIDAS qualified-timestamp profile pinning to it and the
+  self-hosted RFC 3161 anchor; "What you get" now lists the v1.1.0 credential broker, the
+  authority layer that turns a record into enforcement; and a `SPEC.md` row was added to
+  the docs table.
+- Brought `docs/PRIOR_ART.md` current: chronology rows for the credential broker (v1.1.0),
+  the canonical `vaara.receipt/v1` spec, the self-hosted RFC 3161 anchors, and typed
+  capability scopes on credential grants (v1.2.0).
+
+This release exists to refresh the README on PyPI and the package metadata on npm and the
+MCP Registry, which serve the version's README rather than main. Code is unchanged.
+
 ## [1.2.0] - 2026-06-19
 
 Minor release: the receipt format gets a canonical spec, self-hosted time anchoring, and

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.2.0"
+version = "1.2.1"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Docs-only patch release. Bumps version to 1.2.1 across pyproject.toml, src/vaara/__init__.py, server.json, server-vaara-server.json, and clients/ts/package.json so the PyPI project page, the npm client, and the MCP Registry serve the current README instead of the v1.2.0 README. Adds the [1.2.1] CHANGELOG entry. No functional change.

Follows #273, which landed the README (credential broker, vaara.receipt/v1 as canonical parent) and PRIOR_ART rows on main.