### PR TITLE
docs(prior-art): cite Agent Authorization Envelope (AAE) as adjacent grant-layer spec

### DIFF
--- a/docs/PRIOR_ART.md
+++ b/docs/PRIOR_ART.md
@@ -215,6 +215,17 @@ than a judgment of the work.
   receipt identity with revocation at v0.52.0 to v0.55.0 (2026-06-02 to
   2026-06-05), ahead of these proposals; listing them records the
   convergence, not a competitive claim.
+- **Agent Authorization Envelope (AAE).** Kroehl,
+  draft-kroehl-agentic-trust-aae-00 (IETF Internet-Draft, 21 May
+  2026). A structured authorization container for autonomous agents,
+  built from MANDATE, CONSTRAINTS, and VALIDITY blocks bound to W3C
+  DIDs and Verifiable Credentials, with SHA-256 delegation-chain
+  linking computed over the parent envelope's raw JWS serialization
+  (canonicalization explicitly excluded). AAE specifies the
+  authorization a gate evaluates against; a Vaara receipt records the
+  decision the gate reached and binds it to a recomputable evidence
+  record. Adjacent at the grant layer and interoperable: a Vaara
+  authorization-decision receipt can name the AAE it evaluated.
 
 ### Same-lane open projects
 


### PR DESCRIPTION
Records the Agent Authorization Envelope (AAE) — `draft-kroehl-agentic-trust-aae-00` (IETF Internet-Draft, 21 May 2026) — in PRIOR_ART as the adjacent grant-layer spec.

AAE is an authorization container (MANDATE / CONSTRAINTS / VALIDITY over W3C DIDs and Verifiable Credentials), not a receipt format. Verified against the live draft: no `receipt_id`, no JCS/RFC 8785, delegation hash computed over raw JWS octets with canonicalization explicitly excluded, temporal bounds via RFC 3339 (no RFC 3161). It specifies the authorization a gate evaluates against; a Vaara receipt records the decision the gate reached. Adjacent and interoperable: a Vaara authorization-decision receipt can name the AAE it evaluated.

Docs-only, single file, +11 lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated prior art documentation to include Agent Authorization Envelope (AAE) as a reference for authorization and attestation protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->