### PR TITLE
chore(release): v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-06-20
+
+Patch release: documentation only. Records the Agent Authorization Envelope (AAE) in prior art.
+
+- `docs/PRIOR_ART.md` cites AAE (`draft-kroehl-agentic-trust-aae-00`, IETF, 21 May 2026) as the adjacent grant-layer spec: an authorization container (MANDATE, CONSTRAINTS, VALIDITY over W3C DIDs and Verifiable Credentials), not a receipt format. Verified against the live draft: no `receipt_id`, no JCS, delegation hash over raw JWS octets with canonicalization excluded. A Vaara authorization-decision receipt can name the AAE it evaluated. No code or conformance-vector changes.
+
 ## [1.3.0] - 2026-06-20
 
 Minor release: proof-carrying enforcement reaches the proxy, and every authorization receipt carries a signed coverage boundary.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.3.0"
+version = "1.3.1"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Patch release shipping the AAE prior-art citation to every plane. Bumps pyproject.toml, server.json (x2), clients/ts/package.json to 1.3.1; adds CHANGELOG 1.3.1 section. Docs-only, no code/conformance-vector changes.