### PR TITLE
feat(integrations): CrewAI completeness adapter (gap-evident tool-call receipts)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ nemo-guardrails = ["nemoguardrails>=0.10"]
 guardrails-ai = ["guardrails-ai>=0.5"]
 llm-guard = ["llm-guard>=0.3"]
 rebuff = ["rebuff>=0.1"]
+crewai = ["crewai>=1.0"]
 
 [project.scripts]
 vaara = "vaara.cli:main"

--- a/src/vaara/integrations/crewai.py
+++ b/src/vaara/integrations/crewai.py
@@ -11,6 +11,14 @@ tools.  Vaara integrates at two levels:
    starts working.  This catches dangerous task assignments before
    any tool calls happen.
 
+3. **Completeness-level** — ``VaaraGovernance`` registers CrewAI's
+   ``before_tool_call`` / ``after_tool_call`` hooks and turns every tool
+   call into a gap-evident authorization record. A per-run monotonic
+   ``seq`` plus ``running_count`` ride inside a key-free, hash-chained
+   Vaara receipt, so a dropped tool-call record is a provable gap from the
+   held records alone. See ``VaaraGovernance`` below for the contract and
+   wiring.
+
 Integration:
 
     from crewai import Crew, Agent, Task
@@ -30,9 +38,18 @@ Requires: crewai >= 0.30 (not a hard dependency — imported at runtime)
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
-from typing import Any
+import threading
+import time
+from collections import deque
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional, TypedDict
+from uuid import uuid4
 
+from vaara.audit.receipts import CommitPayload, OutcomePayload, Receipt
+from vaara.credential._contiguity import ContiguityReport, verify_contiguity
 from vaara.integrations.langchain import (
     ToolExecutionBlocked,
 )
@@ -201,3 +218,322 @@ class VaaraCrewGovernance:
                     agent.tools = self.wrap_tools(agent.tools, agent_id=agent_id)
 
         return crew.kickoff()
+
+
+# ---------------------------------------------------------------------------
+# Completeness-level integration: gap-evident tool-call receipts via hooks.
+# ---------------------------------------------------------------------------
+
+_ALLOW = "allow"
+_DEFAULT_BOUNDARY = "crew-run"
+_V0_REASON = "recorded (v0 always-allow completeness mode)"
+_RECEIPT_VERSION = "1.0"
+
+
+class GovernanceDecision(TypedDict, total=False):
+    """Pre-execution authorization record, mirroring crewAI PR #6030.
+
+    Defined structurally so the adapter ships without importing
+    ``crewai.governance`` (not in a released CrewAI yet). All keys are optional,
+    matching the upstream ``total=False`` contract. ``seq`` / ``running_count``
+    are surfaced at the top level on purpose: omission-detection only works if
+    the completeness envelope is framework-neutral and uniform across providers,
+    while the cryptographic evidence stays per-vendor under ``extensions``.
+    """
+
+    decision_id: str
+    agent_id: str
+    agent_role: str
+    tool: str
+    request_id: str
+    params_hash: str
+    decision: str
+    reason: str
+    issued_at: str
+    seq: int
+    running_count: int
+    extensions: dict[str, Any]
+
+
+class GovernanceOutcome(TypedDict, total=False):
+    """Post-execution result record linked to a ``GovernanceDecision``."""
+
+    decision_id: str
+    outcome: str
+    seq: int
+    extensions: dict[str, Any]
+
+
+class VaaraGovernance:
+    """Records a contiguous, receipt-backed decision stream for a crew run.
+
+    One instance per crew run (or per process, if you scope boundaries with
+    ``boundary_id_for``). Thread-safe: CrewAI may execute tools concurrently, so
+    the sequence counter and the ledgers are guarded by a single lock.
+
+        from vaara.integrations.crewai import VaaraGovernance, register
+
+        gov = VaaraGovernance()
+        register(gov)                  # registers both tool-call hooks
+        crew.kickoff(...)
+        assert gov.verify_run().ok     # no tool-call record was dropped
+
+    The boundary a sequence is scoped to is the crew run: by default the crew's
+    id, overridable via ``boundary_id_for``. v0 runs in recording mode (every
+    call allowed and recorded) and the before hook fails open, because a
+    recorder must never halt the crew it observes.
+    """
+
+    def __init__(
+        self,
+        *,
+        boundary_id_for: Optional[Callable[[Any], Optional[str]]] = None,
+        threshold_allow: float = 0.4,
+        threshold_deny: float = 0.7,
+    ) -> None:
+        self._boundary_id_for = boundary_id_for
+        self._threshold_allow = threshold_allow
+        self._threshold_deny = threshold_deny
+        self._lock = threading.Lock()
+        # Per-boundary monotonic sequence, gap-free by construction.
+        self._counters: dict[str, int] = {}
+        # Ledgers, keyed by boundary id.
+        self._decisions: dict[str, list[GovernanceDecision]] = {}
+        self._outcomes: dict[str, list[GovernanceOutcome]] = {}
+        # Per-decision lookups for the after hook and receipt assembly.
+        self._commits: dict[str, CommitPayload] = {}
+        self._completeness_by_id: dict[str, dict[str, Any]] = {}
+        self._receipts_by_id: dict[str, Receipt] = {}
+        # FIFO pairing of before -> after by (boundary, tool, params_hash). The
+        # decision sequence is the completeness proof and never depends on this;
+        # pairing only attaches outcomes. A context-carried request id (or the
+        # PR #6030 decision_id round-trip) would make it exact.
+        self._pending: dict[tuple[str, str, str], deque[str]] = {}
+
+    # -- hooks ---------------------------------------------------------------
+
+    def before_tool_call(self, context: Any) -> None:
+        """Record a pre-execution decision. Registerable as a before hook.
+
+        Returns ``None`` (allow). Failures are logged and swallowed: a recorder
+        must not block the call it observes.
+        """
+        try:
+            boundary_id = self._boundary_for(context)
+            tool_name = _opt_str(getattr(context, "tool_name", ""))
+            params_hash = _params_hash(getattr(context, "tool_input", None) or {})
+            agent = getattr(context, "agent", None)
+            agent_id = _opt_str(getattr(agent, "id", ""))
+            agent_role = _opt_str(getattr(agent, "role", ""))
+
+            with self._lock:
+                seq = self._counters.get(boundary_id, 0)
+                self._counters[boundary_id] = seq + 1
+                running_count = seq + 1
+                decided_at = time.time()
+                decision_id = f"{boundary_id}#{seq}"
+                commit = CommitPayload(
+                    action_id=decision_id,
+                    decision=_ALLOW,
+                    risk_score=0.0,
+                    threshold_allow=self._threshold_allow,
+                    threshold_deny=self._threshold_deny,
+                    decided_at=decided_at,
+                )
+                completeness = {
+                    "boundaryId": boundary_id,
+                    "seq": seq,
+                    "runningCount": running_count,
+                }
+                decision: GovernanceDecision = {
+                    "decision_id": decision_id,
+                    "agent_id": agent_id,
+                    "agent_role": agent_role,
+                    "tool": tool_name,
+                    "request_id": uuid4().hex,
+                    "params_hash": "sha256:" + params_hash,
+                    "decision": _ALLOW,
+                    "reason": _V0_REASON,
+                    "issued_at": _iso8601(decided_at),
+                    "seq": seq,
+                    "running_count": running_count,
+                    "extensions": {
+                        "vaara": {
+                            "receiptVersion": _RECEIPT_VERSION,
+                            "commitHash": commit.hash(),
+                            "completeness": completeness,
+                        }
+                    },
+                }
+                self._decisions.setdefault(boundary_id, []).append(decision)
+                self._commits[decision_id] = commit
+                self._completeness_by_id[decision_id] = completeness
+                self._pending.setdefault(
+                    (boundary_id, tool_name, params_hash), deque()
+                ).append(decision_id)
+        except Exception:
+            logger.exception("Vaara before_tool_call hook failed; allowing call")
+        return None
+
+    def after_tool_call(self, context: Any) -> None:
+        """Record a post-execution outcome paired to its decision.
+
+        Registerable as an after hook. Returns ``None`` so the tool result is
+        left untouched. Failures are logged and swallowed.
+        """
+        try:
+            boundary_id = self._boundary_for(context)
+            tool_name = _opt_str(getattr(context, "tool_name", ""))
+            params_hash = _params_hash(getattr(context, "tool_input", None) or {})
+            errored = _looks_errored(context)
+
+            with self._lock:
+                queue = self._pending.get((boundary_id, tool_name, params_hash))
+                decision_id = queue.popleft() if queue else None
+                if decision_id is None:
+                    # No matching pre-record (hook registered mid-run, or the
+                    # pairing heuristic missed). The decision sequence, which is
+                    # the completeness proof, is unaffected; skip the outcome.
+                    return None
+                commit = self._commits.get(decision_id)
+                completeness = self._completeness_by_id.get(decision_id, {})
+                outcome_payload = OutcomePayload(
+                    action_id=decision_id,
+                    commit_hash=commit.hash() if commit is not None else "",
+                    outcome_severity=1.0 if errored else 0.0,
+                    recorded_at=time.time(),
+                )
+                outcome: GovernanceOutcome = {
+                    "decision_id": decision_id,
+                    "outcome": "error" if errored else "executed",
+                    "seq": int(completeness.get("seq", -1)),
+                    "extensions": {
+                        "vaara": {
+                            "outcomeHash": outcome_payload.hash(),
+                            "completeness": completeness,
+                        }
+                    },
+                }
+                self._outcomes.setdefault(boundary_id, []).append(outcome)
+                if commit is not None:
+                    self._receipts_by_id[decision_id] = Receipt(
+                        commit=commit, outcome=outcome_payload
+                    )
+        except Exception:
+            logger.exception("Vaara after_tool_call hook failed")
+        return None
+
+    # -- reads ---------------------------------------------------------------
+
+    def decisions(self, boundary_id: Optional[str] = None) -> list[GovernanceDecision]:
+        with self._lock:
+            if boundary_id is None:
+                return [d for ds in self._decisions.values() for d in ds]
+            return list(self._decisions.get(boundary_id, []))
+
+    def outcomes(self, boundary_id: Optional[str] = None) -> list[GovernanceOutcome]:
+        with self._lock:
+            if boundary_id is None:
+                return [o for outs in self._outcomes.values() for o in outs]
+            return list(self._outcomes.get(boundary_id, []))
+
+    def receipts(self, boundary_id: Optional[str] = None) -> list[Receipt]:
+        """Key-free Vaara receipt pairs, for ``verify_receipt`` recomputation."""
+        decisions = self.decisions(boundary_id)
+        with self._lock:
+            out: list[Receipt] = []
+            for d in decisions:
+                rid = d.get("decision_id")
+                if rid is not None and rid in self._receipts_by_id:
+                    out.append(self._receipts_by_id[rid])
+            return out
+
+    def verify_run(self, boundary_id: Optional[str] = None) -> ContiguityReport:
+        """Check the held decision stream for gaps under one boundary.
+
+        Builds the ``evidence`` shape ``verify_contiguity`` expects from the
+        completeness blocks the decisions carry. With ``boundary_id`` omitted,
+        the boundary is inferred when the records name exactly one (and
+        ``verify_contiguity`` raises if they span more than one).
+        """
+        evidence_records = [
+            {"completeness": d["extensions"]["vaara"]["completeness"]}
+            for d in self.decisions(boundary_id)
+            if "vaara" in d.get("extensions", {})
+        ]
+        return verify_contiguity(evidence_records, boundary_id)
+
+    # -- internals -----------------------------------------------------------
+
+    def _boundary_for(self, context: Any) -> str:
+        if self._boundary_id_for is not None:
+            try:
+                bid = self._boundary_id_for(context)
+            except Exception:
+                logger.exception("boundary_id_for callable raised; using default")
+                bid = None
+            if bid:
+                return str(bid)
+        crew = getattr(context, "crew", None)
+        cid = getattr(crew, "id", None)
+        if cid:
+            return str(cid)
+        return _DEFAULT_BOUNDARY
+
+
+def register(
+    governance: VaaraGovernance, *, before: bool = True, after: bool = True
+) -> None:
+    """Register a ``VaaraGovernance`` instance's hooks with CrewAI.
+
+    Thin convenience over ``crewai.hooks``. Raises ``ImportError`` with an
+    install hint if CrewAI is not present.
+    """
+    try:
+        from crewai.hooks import (
+            register_after_tool_call_hook,
+            register_before_tool_call_hook,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "vaara.integrations.crewai.register requires CrewAI. "
+            'Install with: pip install "vaara[crewai]"'
+        ) from exc
+    if before:
+        register_before_tool_call_hook(governance.before_tool_call)
+    if after:
+        register_after_tool_call_hook(governance.after_tool_call)
+
+
+def _params_hash(tool_input: Any) -> str:
+    """SHA-256 over the canonical JSON of the tool input.
+
+    Uses the same canonicalization as Vaara receipts (sorted keys, compact
+    separators, no NaN). Non-serializable inputs fall back to their ``repr`` so
+    the hook never raises on an exotic argument.
+    """
+    try:
+        canonical = json.dumps(
+            tool_input, sort_keys=True, separators=(",", ":"), allow_nan=False
+        )
+    except (TypeError, ValueError):
+        canonical = json.dumps(repr(tool_input), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _looks_errored(context: Any) -> bool:
+    """Best-effort: a raw tool result that is an exception means the call failed."""
+    raw = getattr(context, "raw_tool_result", None)
+    return isinstance(raw, BaseException)
+
+
+def _opt_str(value: Any) -> str:
+    return str(value) if value else ""
+
+
+def _iso8601(epoch: float) -> str:
+    return (
+        datetime.fromtimestamp(epoch, tz=timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )

--- a/tests/test_integrations_crewai_governance.py
+++ b/tests/test_integrations_crewai_governance.py
@@ -1,0 +1,236 @@
+"""Tests for the CrewAI completeness adapter (``VaaraGovernance``).
+
+Uses ``SimpleNamespace`` fakes for CrewAI's ``ToolCallHookContext`` so the suite
+runs without CrewAI installed. The adapter only reads ``tool_name``,
+``tool_input``, ``agent``, ``crew``, and ``raw_tool_result`` off the context.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from vaara.audit.receipts import verify_receipt
+from vaara.credential._contiguity import verify_contiguity
+from vaara.integrations.crewai import VaaraGovernance, register
+
+
+def _ctx(
+    *,
+    tool_name="search",
+    tool_input=None,
+    crew_id="crew-1",
+    agent_id="a1",
+    agent_role="Researcher",
+    raw_tool_result=None,
+):
+    return SimpleNamespace(
+        tool_name=tool_name,
+        tool_input={"q": "x"} if tool_input is None else tool_input,
+        agent=SimpleNamespace(id=agent_id, role=agent_role),
+        crew=SimpleNamespace(id=crew_id),
+        task=SimpleNamespace(id="t1"),
+        tool_result=None,
+        raw_tool_result=raw_tool_result,
+    )
+
+
+def test_run_is_contiguous_and_verifies():
+    gov = VaaraGovernance()
+    for i in range(10):
+        gov.before_tool_call(_ctx(tool_input={"i": i}))
+        gov.after_tool_call(_ctx(tool_input={"i": i}))
+
+    report = gov.verify_run("crew-1")
+    assert report.ok
+    assert report.present == 10
+    assert report.expected == 10
+    assert report.missing_seqs == []
+
+    decisions = gov.decisions("crew-1")
+    assert [d["seq"] for d in decisions] == list(range(10))
+    for d in decisions:
+        assert d["running_count"] == d["seq"] + 1
+        comp = d["extensions"]["vaara"]["completeness"]
+        assert comp["seq"] == d["seq"]
+        assert comp["runningCount"] == d["running_count"]
+        assert comp["boundaryId"] == "crew-1"
+
+
+def test_dropped_record_is_a_provable_gap():
+    """The PR #6030 contract-test fixture: a dropped tool-call record is a
+    provable gap from the held records alone, no issuer and no witness."""
+    gov = VaaraGovernance()
+    for i in range(10):
+        gov.before_tool_call(_ctx(tool_input={"i": i}))
+
+    held = gov.decisions("crew-1")
+    # A verifier is handed nine of the ten records; seq 4 was silently dropped.
+    kept = [d for d in held if d["seq"] != 4]
+    evidence = [
+        {"completeness": d["extensions"]["vaara"]["completeness"]} for d in kept
+    ]
+
+    report = verify_contiguity(evidence, "crew-1")
+    assert not report.ok
+    assert report.missing_seqs == [4]
+    assert report.present == 9
+    assert report.expected == 10
+
+
+def test_leading_drop_is_a_provable_gap():
+    """A dropped first record is caught: a surviving record's running_count
+    establishes the expected length, so the absent seq 0 shows as a gap."""
+    gov = VaaraGovernance()
+    for i in range(6):
+        gov.before_tool_call(_ctx(tool_input={"i": i}))
+
+    held = gov.decisions("crew-1")
+    # Drop seq 0. The held records still carry running_count up to 6.
+    kept = [d for d in held if d["seq"] != 0]
+    evidence = [
+        {"completeness": d["extensions"]["vaara"]["completeness"]} for d in kept
+    ]
+
+    report = verify_contiguity(evidence, "crew-1")
+    assert not report.ok
+    assert report.expected == 6
+    assert report.present == 5
+    assert report.missing_seqs == [0]
+
+
+def test_tail_drop_is_the_known_limitation():
+    """running_count is per-record (seq+1), not a sealed run total, so dropping
+    the final record(s) is NOT detectable from the held set alone. This is the
+    boundary of the guarantee: a closing/sealing record would be needed to catch
+    a tail truncation. Interior and leading drops are caught (see above)."""
+    gov = VaaraGovernance()
+    for i in range(6):
+        gov.before_tool_call(_ctx(tool_input={"i": i}))
+
+    held = gov.decisions("crew-1")
+    kept = [d for d in held if d["seq"] < 4]  # drop the last two
+    evidence = [
+        {"completeness": d["extensions"]["vaara"]["completeness"]} for d in kept
+    ]
+
+    report = verify_contiguity(evidence, "crew-1")
+    assert report.ok  # documents the limitation, not an endorsement
+    assert report.present == 4
+    assert report.expected == 4
+
+
+def test_receipts_recompute():
+    gov = VaaraGovernance()
+    gov.before_tool_call(_ctx(tool_input={"a": 1}))
+    gov.after_tool_call(_ctx(tool_input={"a": 1}, raw_tool_result="ok"))
+
+    receipts = gov.receipts("crew-1")
+    assert len(receipts) == 1
+    assert receipts[0].outcome is not None
+    assert verify_receipt(receipts[0])
+
+
+def test_outcome_references_decision_seq():
+    gov = VaaraGovernance()
+    gov.before_tool_call(_ctx(tool_input={"a": 1}))
+    gov.after_tool_call(_ctx(tool_input={"a": 1}))
+
+    outcomes = gov.outcomes("crew-1")
+    decision = gov.decisions("crew-1")[0]
+    assert len(outcomes) == 1
+    assert outcomes[0]["seq"] == 0
+    assert outcomes[0]["outcome"] == "executed"
+    assert outcomes[0]["decision_id"] == decision["decision_id"]
+
+
+def test_errored_outcome_is_recorded():
+    gov = VaaraGovernance()
+    gov.before_tool_call(_ctx(tool_input={"a": 1}))
+    gov.after_tool_call(
+        _ctx(tool_input={"a": 1}, raw_tool_result=RuntimeError("boom"))
+    )
+    assert gov.outcomes("crew-1")[0]["outcome"] == "error"
+
+
+def test_boundaries_are_independent():
+    gov = VaaraGovernance()
+    for crew_id in ("crew-A", "crew-B"):
+        for i in range(3):
+            gov.before_tool_call(_ctx(tool_input={"i": i}, crew_id=crew_id))
+
+    assert [d["seq"] for d in gov.decisions("crew-A")] == [0, 1, 2]
+    assert [d["seq"] for d in gov.decisions("crew-B")] == [0, 1, 2]
+    assert gov.verify_run("crew-A").ok
+    assert gov.verify_run("crew-B").ok
+
+
+def test_verify_run_without_boundary_raises_when_records_span_many():
+    gov = VaaraGovernance()
+    gov.before_tool_call(_ctx(crew_id="crew-A"))
+    gov.before_tool_call(_ctx(crew_id="crew-B"))
+    with pytest.raises(ValueError):
+        gov.verify_run()
+
+
+def test_params_hash_is_order_independent():
+    gov = VaaraGovernance()
+    gov.before_tool_call(_ctx(tool_input={"a": 1, "b": 2}))
+    gov.before_tool_call(_ctx(tool_input={"b": 2, "a": 1}))
+    decisions = gov.decisions("crew-1")
+    assert decisions[0]["params_hash"] == decisions[1]["params_hash"]
+    assert decisions[0]["params_hash"].startswith("sha256:")
+
+
+def test_default_boundary_when_no_crew():
+    gov = VaaraGovernance()
+    ctx = SimpleNamespace(
+        tool_name="t", tool_input={"a": 1}, agent=None, crew=None, raw_tool_result=None
+    )
+    gov.before_tool_call(ctx)
+    comp = gov.decisions()[0]["extensions"]["vaara"]["completeness"]
+    assert comp["boundaryId"] == "crew-run"
+
+
+def test_custom_boundary_callable():
+    gov = VaaraGovernance(boundary_id_for=lambda _context: "run-42")
+    gov.before_tool_call(_ctx())
+    assert gov.decisions("run-42")[0]["seq"] == 0
+
+
+def test_non_serializable_tool_input_does_not_raise():
+    gov = VaaraGovernance()
+    gov.before_tool_call(_ctx(tool_input={"obj": object()}))
+    assert gov.decisions("crew-1")[0]["params_hash"].startswith("sha256:")
+
+
+def test_hooks_return_none():
+    gov = VaaraGovernance()
+    assert gov.before_tool_call(_ctx()) is None
+    assert gov.after_tool_call(_ctx()) is None
+
+
+def test_register_wires_both_hooks(monkeypatch):
+    calls: dict[str, object] = {}
+    fake_hooks = types.ModuleType("crewai.hooks")
+    fake_hooks.register_before_tool_call_hook = lambda fn: calls.__setitem__("before", fn)
+    fake_hooks.register_after_tool_call_hook = lambda fn: calls.__setitem__("after", fn)
+    fake_pkg = types.ModuleType("crewai")
+    fake_pkg.hooks = fake_hooks
+    monkeypatch.setitem(sys.modules, "crewai", fake_pkg)
+    monkeypatch.setitem(sys.modules, "crewai.hooks", fake_hooks)
+
+    gov = VaaraGovernance()
+    register(gov)
+    assert calls["before"] == gov.before_tool_call
+    assert calls["after"] == gov.after_tool_call
+
+
+def test_register_without_crewai_raises(monkeypatch):
+    monkeypatch.setitem(sys.modules, "crewai", None)
+    monkeypatch.setitem(sys.modules, "crewai.hooks", None)
+    with pytest.raises(ImportError, match=r"vaara\[crewai\]"):
+        register(VaaraGovernance())


### PR DESCRIPTION
## What

Adds `VaaraGovernance`, a CrewAI completeness adapter, under `vaara.integrations.crewai`. Register two hooks (`before_tool_call` / `after_tool_call`) and every tool call in a crew run becomes a gap-evident authorization record: a per-run monotonic `seq` and `running_count` carried inside a key-free, hash-chained Vaara receipt. A dropped tool-call record is then a provable gap from the held records alone, with no access to the issuer and no external witness.

## Why

The CrewAI governance contract converging on PR #6030 (crewAIInc/crewAI#5888) is tamper-evident: signed records, `params_hash`, a hash chain under `extensions`. It does not yet capture omission-evidence, how a verifier knows a record was never silently dropped. This adapter is the working reference for that completeness layer.

## Shape

- Records follow the vendor-neutral `GovernanceDecision` / `GovernanceOutcome` contract. Vaara evidence sits under `extensions["vaara"]`; `seq` / `running_count` are also surfaced at the top level, because omission-detection only works if the sequence is uniform across providers.
- The contract shape is defined structurally, so the adapter ships without importing `crewai.governance` (not in a released CrewAI yet).
- `verify_run()` runs `vaara.credential.verify_contiguity` over the held decisions and returns a `ContiguityReport`.
- v0 is recording mode (always-allow); the before hook fails open, so a recorder never halts the crew it observes. Capability-scope enforcement is a later opt-in layer.
- Coexists with the existing `VaaraCrewGovernance` (tool-wrapping and task screening); that path is unchanged.

## Tests

16 new tests in `tests/test_integrations_crewai_governance.py`, including the dropped-record contract-test fixture and an explicit test documenting the tail-drop limit: `running_count` is per-record (`seq + 1`), so a pure tail truncation needs a sealing record to catch. Interior and leading drops are caught. Existing integrations suite stays green. Adds the `vaara[crewai]` extra.
