### PR TITLE
feat(integrations): seal CrewAI runs to catch tail-drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- The CrewAI completeness adapter can seal a run. `VaaraGovernance.finalize_run()` emits a terminal record that pins the boundary's final decision count, so a dropped tail shows as a provable gap even though the removed records took their own sequence number with them. This lifts the per-record running count (which alone cannot see a truncation) to catch a tail drop, and it addresses the v1.4.0 honest limit for this adapter. The sealing block is additive: a run that is never finalized verifies exactly as before, and the shared `verify-contiguity` path is byte-identical for streams that carry no seal.
+- The irreducible residual is documented in the code and tests: a suffix drop that also suppresses the sealing record stays invisible from the held set alone. An external anchor, the rfc3161 timestamp minted over the run, is what closes that; the held set cannot.
+
 ## [1.5.0] - 2026-06-21
 
 Minor release: an AP2 checkout binding profile. The actions an agent takes after an AP2 checkout settles can carry the same recomputable, gap-evident record as any other authorization decision, pinned to the checkout they followed.

--- a/src/vaara/credential/_contiguity.py
+++ b/src/vaara/credential/_contiguity.py
@@ -119,37 +119,56 @@ def verify_contiguity(
     ``runningCount`` says it should. ``runningCount`` must equal ``seq + 1`` for
     every held record, or the count itself is inconsistent. The report is
     self-contained evidence of completeness or of the specific receipts absent.
+
+    An optional sealing block (``{"sealed": True, "total": N}``) finalizes a run
+    and lets a dropped tail be caught; without it, dropping the last record(s)
+    is invisible from the held set alone. See the inline note below.
     """
     boundary, blocks = _completeness_records(evidence_records, boundary_id)
-    if not blocks:
+    # A sealing block (``{"sealed": True, "total": N}``) pins the run length
+    # independently of the held decision records. It is optional and additive: a
+    # stream carrying only ``{seq, runningCount}`` blocks behaves exactly as
+    # before. When a seal is present, a dropped tail still shows as missing even
+    # though the dropped records took their own ``seq`` with them. A suffix that
+    # also suppresses the seal stays outside held-set-alone detection; an
+    # external anchor (e.g. an rfc3161 timestamp over the run) closes that.
+    seq_blocks = [b for b in blocks if not b.get("sealed")]
+    sealed_total = max(
+        (int(b["total"]) for b in blocks if b.get("sealed")), default=0
+    )
+
+    if not seq_blocks:
+        # Nothing but a possible seal. A seal asserting N over zero held records
+        # is a fully-dropped run; no seal and no records is a no-op.
         return ContiguityReport(
             boundary_id=boundary,
             present=0,
-            expected=0,
-            missing_seqs=[],
+            expected=sealed_total,
+            missing_seqs=list(range(sealed_total)),
             duplicate_seqs=[],
             count_mismatches=[],
-            ok=True,
+            ok=(sealed_total == 0),
         )
 
-    seqs = [int(b["seq"]) for b in blocks]
-    counts = [int(b["runningCount"]) for b in blocks]
+    seqs = [int(b["seq"]) for b in seq_blocks]
+    counts = [int(b["runningCount"]) for b in seq_blocks]
     max_seq = max(seqs)
     max_running = max(counts)
-    # What the stream claims exists: the furthest seq, or a runningCount that
-    # outruns it (a later receipt was dropped, taking its own seq with it).
-    expected = max(max_seq + 1, max_running)
+    # What the stream claims exists: the furthest seq, a runningCount that
+    # outruns it (a later receipt was dropped, taking its own seq with it), or
+    # the sealed total when the run was finalized.
+    expected = max(max_seq + 1, max_running, sealed_total)
 
     seq_counts = Counter(seqs)
     duplicate_seqs = sorted(s for s, n in seq_counts.items() if n > 1)
     missing_seqs = sorted(set(range(expected)) - set(seqs))
     count_mismatches = [
         {"seq": int(b["seq"]), "runningCount": int(b["runningCount"])}
-        for b in blocks
+        for b in seq_blocks
         if int(b["runningCount"]) != int(b["seq"]) + 1
     ]
 
-    present = len(blocks)
+    present = len(seq_blocks)
     ok = (
         not missing_seqs
         and not duplicate_seqs

--- a/src/vaara/integrations/crewai.py
+++ b/src/vaara/integrations/crewai.py
@@ -309,6 +309,10 @@ class VaaraGovernance:
         # pairing only attaches outcomes. A context-carried request id (or the
         # PR #6030 decision_id round-trip) would make it exact.
         self._pending: dict[tuple[str, str, str], deque[str]] = {}
+        # Per-boundary sealing record, set by ``finalize_run``. Optional: a run
+        # that is never finalized verifies exactly as before, minus tail-drop
+        # detection.
+        self._seals: dict[str, dict[str, Any]] = {}
 
     # -- hooks ---------------------------------------------------------------
 
@@ -461,7 +465,52 @@ class VaaraGovernance:
             for d in self.decisions(boundary_id)
             if "vaara" in d.get("extensions", {})
         ]
+        with self._lock:
+            if boundary_id is None:
+                seals = list(self._seals.values())
+            else:
+                seal = self._seals.get(boundary_id)
+                seals = [seal] if seal is not None else []
+        for seal in seals:
+            evidence_records.append({"completeness": dict(seal)})
         return verify_contiguity(evidence_records, boundary_id)
+
+    def finalize_run(self, boundary_id: Optional[str] = None) -> dict[str, Any]:
+        """Seal a run: emit a terminal record pinning the final decision count.
+
+        ``running_count`` is per-record (``seq + 1``), so a truncated stream
+        still looks internally consistent and a dropped tail is invisible from
+        the held set alone. A sealing record carries the boundary's final total;
+        ``verify_run`` then flags a short set even when the missing records took
+        their own ``seq`` with them.
+
+        The irreducible residual: a suffix drop that *also* removes this seal
+        stays invisible from the held set alone. An external anchor (an rfc3161
+        timestamp minted over the run) closes that, and is recorded separately.
+
+        Returns the sealing completeness block so a holder can carry it beside
+        the decision stream. Re-sealing updates the total to the current count.
+        """
+        with self._lock:
+            if boundary_id is None:
+                known = list(self._counters)
+                if len(known) == 1:
+                    boundary_id = known[0]
+                elif not known:
+                    boundary_id = _DEFAULT_BOUNDARY
+                else:
+                    raise ValueError(
+                        "finalize_run needs an explicit boundary_id when the "
+                        "recorder spans more than one boundary"
+                    )
+            total = self._counters.get(boundary_id, 0)
+            seal: dict[str, Any] = {
+                "boundaryId": boundary_id,
+                "sealed": True,
+                "total": total,
+            }
+            self._seals[boundary_id] = seal
+            return dict(seal)
 
     # -- internals -----------------------------------------------------------
 

--- a/tests/test_integrations_crewai_governance.py
+++ b/tests/test_integrations_crewai_governance.py
@@ -102,25 +102,76 @@ def test_leading_drop_is_a_provable_gap():
     assert report.missing_seqs == [0]
 
 
-def test_tail_drop_is_the_known_limitation():
-    """running_count is per-record (seq+1), not a sealed run total, so dropping
-    the final record(s) is NOT detectable from the held set alone. This is the
-    boundary of the guarantee: a closing/sealing record would be needed to catch
-    a tail truncation. Interior and leading drops are caught (see above)."""
+def test_tail_drop_is_caught_with_a_sealing_record():
+    """A finalized run pins its total, so a dropped tail shows as missing even
+    though the removed records took their own ``seq`` with them. This is the
+    upgrade over per-record ``running_count`` (which alone cannot see a
+    truncation). Interior and leading drops are caught without a seal (above)."""
     gov = VaaraGovernance()
     for i in range(6):
         gov.before_tool_call(_ctx(tool_input={"i": i}))
+    seal = gov.finalize_run("crew-1")
+    assert seal == {"boundaryId": "crew-1", "sealed": True, "total": 6}
 
     held = gov.decisions("crew-1")
     kept = [d for d in held if d["seq"] < 4]  # drop the last two
     evidence = [
         {"completeness": d["extensions"]["vaara"]["completeness"]} for d in kept
     ]
+    evidence.append({"completeness": seal})  # the seal survives
 
     report = verify_contiguity(evidence, "crew-1")
-    assert report.ok  # documents the limitation, not an endorsement
+    assert not report.ok
+    assert report.present == 4
+    assert report.expected == 6
+    assert report.missing_seqs == [4, 5]
+
+
+def test_finalized_run_verifies_whole():
+    """A complete, sealed run verifies; the seal does not perturb a full set."""
+    gov = VaaraGovernance()
+    for i in range(6):
+        gov.before_tool_call(_ctx(tool_input={"i": i}))
+    gov.finalize_run("crew-1")
+
+    report = gov.verify_run("crew-1")
+    assert report.ok
+    assert report.present == 6
+    assert report.expected == 6
+    assert report.missing_seqs == []
+
+
+def test_tail_drop_with_seal_also_removed_is_the_residual():
+    """The irreducible limit: a suffix drop that also suppresses the sealing
+    record stays invisible from the held set alone. An external anchor (an
+    rfc3161 timestamp over the run) is what closes this; the held set cannot."""
+    gov = VaaraGovernance()
+    for i in range(6):
+        gov.before_tool_call(_ctx(tool_input={"i": i}))
+    gov.finalize_run("crew-1")
+
+    held = gov.decisions("crew-1")
+    kept = [d for d in held if d["seq"] < 4]  # drop last two AND withhold seal
+    evidence = [
+        {"completeness": d["extensions"]["vaara"]["completeness"]} for d in kept
+    ]
+
+    report = verify_contiguity(evidence, "crew-1")
+    assert report.ok  # documents the residual, not an endorsement
     assert report.present == 4
     assert report.expected == 4
+
+
+def test_seal_alone_flags_a_fully_dropped_run():
+    """A seal asserting N over zero held records is a fully-dropped run."""
+    evidence = [
+        {"completeness": {"boundaryId": "crew-1", "sealed": True, "total": 3}}
+    ]
+    report = verify_contiguity(evidence, "crew-1")
+    assert not report.ok
+    assert report.present == 0
+    assert report.expected == 3
+    assert report.missing_seqs == [0, 1, 2]
 
 
 def test_receipts_recompute():


### PR DESCRIPTION
## What

`VaaraGovernance.finalize_run()` seals a CrewAI run: it emits a terminal record that pins the boundary's final decision count. A verifier handed a truncated stream now sees the dropped tail as a provable gap, even though the removed records took their own `seq` with them.

This addresses the v1.4.0 honest limit for this adapter. Per-record `running_count` is `seq + 1`, so a truncated stream still looks internally consistent and a tail drop is invisible from the held set alone. A sealing record fixes that.

## How

- `finalize_run(boundary_id=None)` records `{"boundaryId", "sealed": True, "total": N}` for the boundary and returns it so a holder can carry it beside the decision stream.
- `verify_run()` folds the seal into the evidence it builds.
- `verify_contiguity()` gains additive sealing-block support: when a seal is present, `expected = max(max_seq + 1, max_running, sealed_total)`. The seal carries no `seq`/`runningCount`, so it is split out before the per-record count check.

## Backward compatibility

The sealing block is opt-in. A run that is never finalized verifies exactly as before. The shared `verify_contiguity` path is byte-identical for streams that carry no seal, so the other callers (`vaara verify-contiguity`, the MCP attest emitter, authorization receipts) are unaffected. Confirmed: full suite 1922 passed, mypy and ruff clean.

## The residual, stated plainly

A suffix drop that *also* suppresses the sealing record stays invisible from the held set alone. No field closes that. An external anchor, the rfc3161 timestamp minted over the run, is what closes it; the held set cannot. This is documented in `_contiguity.py` and pinned by `test_tail_drop_with_seal_also_removed_is_the_residual`.

## Tests

- `test_tail_drop_is_caught_with_a_sealing_record` (the lift; replaces `test_tail_drop_is_the_known_limitation`)
- `test_finalized_run_verifies_whole`
- `test_tail_drop_with_seal_also_removed_is_the_residual`
- `test_seal_alone_flags_a_fully_dropped_run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sealing mechanism to detect truncated or incomplete audit runs and validate transaction stream completeness.
  * Enhanced verification to detect dropped tail records within expected ranges.

* **Documentation**
  * Clarified external time-anchoring requirements for ensuring complete audit evidence when irreducible residuals remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->