### PR TITLE
docs(spec): sync SPEC.md completeness section to the sealing record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- The CrewAI completeness adapter can seal a run. `VaaraGovernance.finalize_run()` emits a terminal record that pins the boundary's final decision count, so a dropped tail shows as a provable gap even though the removed records took their own sequence number with them. This lifts the per-record running count (which alone cannot see a truncation) to catch a tail drop, and it addresses the v1.4.0 honest limit for this adapter. The sealing block is additive: a run that is never finalized verifies exactly as before, and the shared `verify-contiguity` path is byte-identical for streams that carry no seal.
+- The irreducible residual is documented in the code and tests: a suffix drop that also suppresses the sealing record stays invisible from the held set alone. An external anchor, the rfc3161 timestamp minted over the run, is what closes that; the held set cannot.
+
 ## [1.5.0] - 2026-06-21
 
 Minor release: an AP2 checkout binding profile. The actions an agent takes after an AP2 checkout settles can carry the same recomputable, gap-evident record as any other authorization decision, pinned to the checkout they followed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - The CrewAI completeness adapter can seal a run. `VaaraGovernance.finalize_run()` emits a terminal record that pins the boundary's final decision count, so a dropped tail shows as a provable gap even though the removed records took their own sequence number with them. This lifts the per-record running count (which alone cannot see a truncation) to catch a tail drop, and it addresses the v1.4.0 honest limit for this adapter. The sealing block is additive: a run that is never finalized verifies exactly as before, and the shared `verify-contiguity` path is byte-identical for streams that carry no seal.
 - The irreducible residual is documented in the code and tests: a suffix drop that also suppresses the sealing record stays invisible from the held set alone. An external anchor, the rfc3161 timestamp minted over the run, is what closes that; the held set cannot.
+- Synced the canonical spec to the sealing record. `SPEC.md` Section 5.3 now describes the terminal sealing block (`{boundaryId, sealed: true, total: N}`) and the full completeness layering: `seq` for order, the hash chain for tamper-evidence, the seal for a truncated tail, and the rfc3161 anchor for the seal-suppressed residual. The earlier text described the tail truncation as an open limit, which the seal has since closed to that residual. The published I-D resyncs at its next revision.
 
 ## [1.5.0] - 2026-06-21
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -177,6 +177,11 @@ machine reason (`capability_exceeded`, `binding_unknown`, `missing_credential`,
   under the boundary up to and including this one (`runningCount` = `seq + 1`).
   The block is absent when no sequence is asserted, leaving the record
   byte-identical to a completeness-free decision.
+- An optional sealing record finalizes the boundary: a terminal completeness
+  block (`{boundaryId, sealed: true, total: N}`) that pins the boundary's final
+  count independently of the per-record sequence. It is additive and emitted once
+  the boundary is closed; a boundary that is never sealed verifies exactly as
+  before, with the seal absent and the stream byte-identical.
 
 A verdict is only as meaningful as what the issuer could see. `allow` over an
 unbounded surface and `allow` over a stated one are identical bytes with
@@ -201,12 +206,20 @@ into each record, a dropped receipt is a missing sequence number that any holder
 detects from the receipts alone: the highest running count names how many exist,
 so a short set is self-evidently incomplete and the absent `seq` is named. This
 needs no issuer access and no external witness. The `tests/vectors/contiguity_v0/`
-vectors and the `vaara verify-contiguity` surface carry that check. One honest
-limit remains: a pure tail truncation (holding `0..k` with nothing after) cannot
-be told from a complete stream by contiguity alone, since the latest held count
-is then `k + 1`. Closing it is the job of an rfc3161 anchor over the running
-count (Section 4), which attests that at time T, N receipts existed under the
-boundary.
+vectors and the `vaara verify-contiguity` surface carry that check.
+
+The per-record running count alone cannot tell a pure tail truncation (holding
+`0..k` with nothing after) from a complete stream, since the latest held count is
+then `k + 1` and reads as whole. The optional sealing record closes that gap: when
+a boundary is finalized, the holder expects `max(seq + 1, runningCount, total)`
+records, so a dropped tail shows as the missing range up to the sealed `total`. A
+boundary that is never sealed verifies exactly as before. One residual remains, and
+it is irreducible from the held set alone: a suffix drop that also suppresses the
+sealing record leaves nothing to detect. Closing that is the job of an rfc3161
+anchor over the running count (Section 4), which attests that at time T, N receipts
+existed under the boundary. The layering is `seq` for order, the hash chain for
+tamper-evidence, the sealing record for a truncated tail, and the timestamp anchor
+for the seal-suppressed residual.
 
 ### 5.4 Profile example: AP2 checkout binding
 

--- a/src/vaara/credential/_contiguity.py
+++ b/src/vaara/credential/_contiguity.py
@@ -119,37 +119,56 @@ def verify_contiguity(
     ``runningCount`` says it should. ``runningCount`` must equal ``seq + 1`` for
     every held record, or the count itself is inconsistent. The report is
     self-contained evidence of completeness or of the specific receipts absent.
+
+    An optional sealing block (``{"sealed": True, "total": N}``) finalizes a run
+    and lets a dropped tail be caught; without it, dropping the last record(s)
+    is invisible from the held set alone. See the inline note below.
     """
     boundary, blocks = _completeness_records(evidence_records, boundary_id)
-    if not blocks:
+    # A sealing block (``{"sealed": True, "total": N}``) pins the run length
+    # independently of the held decision records. It is optional and additive: a
+    # stream carrying only ``{seq, runningCount}`` blocks behaves exactly as
+    # before. When a seal is present, a dropped tail still shows as missing even
+    # though the dropped records took their own ``seq`` with them. A suffix that
+    # also suppresses the seal stays outside held-set-alone detection; an
+    # external anchor (e.g. an rfc3161 timestamp over the run) closes that.
+    seq_blocks = [b for b in blocks if not b.get("sealed")]
+    sealed_total = max(
+        (int(b["total"]) for b in blocks if b.get("sealed")), default=0
+    )
+
+    if not seq_blocks:
+        # Nothing but a possible seal. A seal asserting N over zero held records
+        # is a fully-dropped run; no seal and no records is a no-op.
         return ContiguityReport(
             boundary_id=boundary,
             present=0,
-            expected=0,
-            missing_seqs=[],
+            expected=sealed_total,
+            missing_seqs=list(range(sealed_total)),
             duplicate_seqs=[],
             count_mismatches=[],
-            ok=True,
+            ok=(sealed_total == 0),
         )
 
-    seqs = [int(b["seq"]) for b in blocks]
-    counts = [int(b["runningCount"]) for b in blocks]
+    seqs = [int(b["seq"]) for b in seq_blocks]
+    counts = [int(b["runningCount"]) for b in seq_blocks]
     max_seq = max(seqs)
     max_running = max(counts)
-    # What the stream claims exists: the furthest seq, or a runningCount that
-    # outruns it (a later receipt was dropped, taking its own seq with it).
-    expected = max(max_seq + 1, max_running)
+    # What the stream claims exists: the furthest seq, a runningCount that
+    # outruns it (a later receipt was dropped, taking its own seq with it), or
+    # the sealed total when the run was finalized.
+    expected = max(max_seq + 1, max_running, sealed_total)
 
     seq_counts = Counter(seqs)
     duplicate_seqs = sorted(s for s, n in seq_counts.items() if n > 1)
     missing_seqs = sorted(set(range(expected)) - set(seqs))
     count_mismatches = [
         {"seq": int(b["seq"]), "runningCount": int(b["runningCount"])}
-        for b in blocks
+        for b in seq_blocks
         if int(b["runningCount"]) != int(b["seq"]) + 1
     ]
 
-    present = len(blocks)
+    present = len(seq_blocks)
     ok = (
         not missing_seqs
         and not duplicate_seqs

--- a/src/vaara/integrations/crewai.py
+++ b/src/vaara/integrations/crewai.py
@@ -309,6 +309,10 @@ class VaaraGovernance:
         # pairing only attaches outcomes. A context-carried request id (or the
         # PR #6030 decision_id round-trip) would make it exact.
         self._pending: dict[tuple[str, str, str], deque[str]] = {}
+        # Per-boundary sealing record, set by ``finalize_run``. Optional: a run
+        # that is never finalized verifies exactly as before, minus tail-drop
+        # detection.
+        self._seals: dict[str, dict[str, Any]] = {}
 
     # -- hooks ---------------------------------------------------------------
 
@@ -461,7 +465,52 @@ class VaaraGovernance:
             for d in self.decisions(boundary_id)
             if "vaara" in d.get("extensions", {})
         ]
+        with self._lock:
+            if boundary_id is None:
+                seals = list(self._seals.values())
+            else:
+                seal = self._seals.get(boundary_id)
+                seals = [seal] if seal is not None else []
+        for seal in seals:
+            evidence_records.append({"completeness": dict(seal)})
         return verify_contiguity(evidence_records, boundary_id)
+
+    def finalize_run(self, boundary_id: Optional[str] = None) -> dict[str, Any]:
+        """Seal a run: emit a terminal record pinning the final decision count.
+
+        ``running_count`` is per-record (``seq + 1``), so a truncated stream
+        still looks internally consistent and a dropped tail is invisible from
+        the held set alone. A sealing record carries the boundary's final total;
+        ``verify_run`` then flags a short set even when the missing records took
+        their own ``seq`` with them.
+
+        The irreducible residual: a suffix drop that *also* removes this seal
+        stays invisible from the held set alone. An external anchor (an rfc3161
+        timestamp minted over the run) closes that, and is recorded separately.
+
+        Returns the sealing completeness block so a holder can carry it beside
+        the decision stream. Re-sealing updates the total to the current count.
+        """
+        with self._lock:
+            if boundary_id is None:
+                known = list(self._counters)
+                if len(known) == 1:
+                    boundary_id = known[0]
+                elif not known:
+                    boundary_id = _DEFAULT_BOUNDARY
+                else:
+                    raise ValueError(
+                        "finalize_run needs an explicit boundary_id when the "
+                        "recorder spans more than one boundary"
+                    )
+            total = self._counters.get(boundary_id, 0)
+            seal: dict[str, Any] = {
+                "boundaryId": boundary_id,
+                "sealed": True,
+                "total": total,
+            }
+            self._seals[boundary_id] = seal
+            return dict(seal)
 
     # -- internals -----------------------------------------------------------
 

--- a/tests/test_integrations_crewai_governance.py
+++ b/tests/test_integrations_crewai_governance.py
@@ -102,25 +102,76 @@ def test_leading_drop_is_a_provable_gap():
     assert report.missing_seqs == [0]
 
 
-def test_tail_drop_is_the_known_limitation():
-    """running_count is per-record (seq+1), not a sealed run total, so dropping
-    the final record(s) is NOT detectable from the held set alone. This is the
-    boundary of the guarantee: a closing/sealing record would be needed to catch
-    a tail truncation. Interior and leading drops are caught (see above)."""
+def test_tail_drop_is_caught_with_a_sealing_record():
+    """A finalized run pins its total, so a dropped tail shows as missing even
+    though the removed records took their own ``seq`` with them. This is the
+    upgrade over per-record ``running_count`` (which alone cannot see a
+    truncation). Interior and leading drops are caught without a seal (above)."""
     gov = VaaraGovernance()
     for i in range(6):
         gov.before_tool_call(_ctx(tool_input={"i": i}))
+    seal = gov.finalize_run("crew-1")
+    assert seal == {"boundaryId": "crew-1", "sealed": True, "total": 6}
 
     held = gov.decisions("crew-1")
     kept = [d for d in held if d["seq"] < 4]  # drop the last two
     evidence = [
         {"completeness": d["extensions"]["vaara"]["completeness"]} for d in kept
     ]
+    evidence.append({"completeness": seal})  # the seal survives
 
     report = verify_contiguity(evidence, "crew-1")
-    assert report.ok  # documents the limitation, not an endorsement
+    assert not report.ok
+    assert report.present == 4
+    assert report.expected == 6
+    assert report.missing_seqs == [4, 5]
+
+
+def test_finalized_run_verifies_whole():
+    """A complete, sealed run verifies; the seal does not perturb a full set."""
+    gov = VaaraGovernance()
+    for i in range(6):
+        gov.before_tool_call(_ctx(tool_input={"i": i}))
+    gov.finalize_run("crew-1")
+
+    report = gov.verify_run("crew-1")
+    assert report.ok
+    assert report.present == 6
+    assert report.expected == 6
+    assert report.missing_seqs == []
+
+
+def test_tail_drop_with_seal_also_removed_is_the_residual():
+    """The irreducible limit: a suffix drop that also suppresses the sealing
+    record stays invisible from the held set alone. An external anchor (an
+    rfc3161 timestamp over the run) is what closes this; the held set cannot."""
+    gov = VaaraGovernance()
+    for i in range(6):
+        gov.before_tool_call(_ctx(tool_input={"i": i}))
+    gov.finalize_run("crew-1")
+
+    held = gov.decisions("crew-1")
+    kept = [d for d in held if d["seq"] < 4]  # drop last two AND withhold seal
+    evidence = [
+        {"completeness": d["extensions"]["vaara"]["completeness"]} for d in kept
+    ]
+
+    report = verify_contiguity(evidence, "crew-1")
+    assert report.ok  # documents the residual, not an endorsement
     assert report.present == 4
     assert report.expected == 4
+
+
+def test_seal_alone_flags_a_fully_dropped_run():
+    """A seal asserting N over zero held records is a fully-dropped run."""
+    evidence = [
+        {"completeness": {"boundaryId": "crew-1", "sealed": True, "total": 3}}
+    ]
+    report = verify_contiguity(evidence, "crew-1")
+    assert not report.ok
+    assert report.present == 0
+    assert report.expected == 3
+    assert report.missing_seqs == [0, 1, 2]
 
 
 def test_receipts_recompute():


### PR DESCRIPTION
## What

`SPEC.md` Section 5.3 still described a pure tail truncation as an open completeness limit closed only by an external rfc3161 anchor. The sealing record shipped in #284 closed that limit to a narrower residual, so the canonical spec was understating what the implementation already does.

This is a docs-only sync. No code, no conformance-vector, and no published-package change.

## Why

The completeness layering we ship is now four layers, and the spec named only three:

- `seq` for order (contiguous `0..N-1`, gap-free by construction)
- the hash chain for tamper-evidence
- the sealing record for a truncated tail
- the rfc3161 timestamp anchor for the seal-suppressed residual

Before this change a reader of the normative parent would conclude a dropped tail is undetectable without an external anchor. With the seal, a finalized boundary carries a terminal block `{boundaryId, sealed: true, total: N}`, the holder expects `max(seq + 1, runningCount, total)` records, and a dropped tail shows as the missing range up to the sealed total. The only case left for the anchor is a suffix drop that also suppresses the seal.

## Changes

- `SPEC.md` 5.3: added the terminal sealing block to the completeness list, and re-layered the honest-limit paragraph so the seal sits between contiguity and the anchor. The 0-indexed base (`seq` starting at 0, `runningCount = seq + 1`) is unchanged.
- `CHANGELOG.md`: Unreleased entry for the spec sync.

The published Internet-Draft (`draft-sirkkavaara-vaara-receipt-00`) resyncs at its next revision; the `-00` source is left untouched here.
