### PR TITLE
docs(spec): sync SPEC.md completeness section to the sealing record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 - The CrewAI completeness adapter can seal a run. `VaaraGovernance.finalize_run()` emits a terminal record that pins the boundary's final decision count, so a dropped tail shows as a provable gap even though the removed records took their own sequence number with them. This lifts the per-record running count (which alone cannot see a truncation) to catch a tail drop, and it addresses the v1.4.0 honest limit for this adapter. The sealing block is additive: a run that is never finalized verifies exactly as before, and the shared `verify-contiguity` path is byte-identical for streams that carry no seal.
 - The irreducible residual is documented in the code and tests: a suffix drop that also suppresses the sealing record stays invisible from the held set alone. An external anchor, the rfc3161 timestamp minted over the run, is what closes that; the held set cannot.
+- Synced the canonical spec to the sealing record. `SPEC.md` Section 5.3 now describes the terminal sealing block (`{boundaryId, sealed: true, total: N}`) and the full completeness layering: `seq` for order, the hash chain for tamper-evidence, the seal for a truncated tail, and the rfc3161 anchor for the seal-suppressed residual. The earlier text described the tail truncation as an open limit, which the seal has since closed to that residual. The published I-D resyncs at its next revision.
 
 ## [1.5.0] - 2026-06-21
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -177,6 +177,11 @@ machine reason (`capability_exceeded`, `binding_unknown`, `missing_credential`,
   under the boundary up to and including this one (`runningCount` = `seq + 1`).
   The block is absent when no sequence is asserted, leaving the record
   byte-identical to a completeness-free decision.
+- An optional sealing record finalizes the boundary: a terminal completeness
+  block (`{boundaryId, sealed: true, total: N}`) that pins the boundary's final
+  count independently of the per-record sequence. It is additive and emitted once
+  the boundary is closed; a boundary that is never sealed verifies exactly as
+  before, with the seal absent and the stream byte-identical.
 
 A verdict is only as meaningful as what the issuer could see. `allow` over an
 unbounded surface and `allow` over a stated one are identical bytes with
@@ -201,12 +206,20 @@ into each record, a dropped receipt is a missing sequence number that any holder
 detects from the receipts alone: the highest running count names how many exist,
 so a short set is self-evidently incomplete and the absent `seq` is named. This
 needs no issuer access and no external witness. The `tests/vectors/contiguity_v0/`
-vectors and the `vaara verify-contiguity` surface carry that check. One honest
-limit remains: a pure tail truncation (holding `0..k` with nothing after) cannot
-be told from a complete stream by contiguity alone, since the latest held count
-is then `k + 1`. Closing it is the job of an rfc3161 anchor over the running
-count (Section 4), which attests that at time T, N receipts existed under the
-boundary.
+vectors and the `vaara verify-contiguity` surface carry that check.
+
+The per-record running count alone cannot tell a pure tail truncation (holding
+`0..k` with nothing after) from a complete stream, since the latest held count is
+then `k + 1` and reads as whole. The optional sealing record closes that gap: when
+a boundary is finalized, the holder expects `max(seq + 1, runningCount, total)`
+records, so a dropped tail shows as the missing range up to the sealed `total`. A
+boundary that is never sealed verifies exactly as before. One residual remains, and
+it is irreducible from the held set alone: a suffix drop that also suppresses the
+sealing record leaves nothing to detect. Closing that is the job of an rfc3161
+anchor over the running count (Section 4), which attests that at time T, N receipts
+existed under the boundary. The layering is `seq` for order, the hash chain for
+tamper-evidence, the sealing record for a truncated tail, and the timestamp anchor
+for the seal-suppressed residual.
 
 ### 5.4 Profile example: AP2 checkout binding
 


### PR DESCRIPTION
## What

`SPEC.md` Section 5.3 still described a pure tail truncation as an open completeness limit closed only by an external rfc3161 anchor. The sealing record shipped in #284 closed that limit to a narrower residual, so the canonical spec was understating what the implementation already does.

This is a docs-only sync. No code, no conformance-vector, and no published-package change.

## Why

The completeness layering we ship is now four layers, and the spec named only three:

- `seq` for order (contiguous `0..N-1`, gap-free by construction)
- the hash chain for tamper-evidence
- the sealing record for a truncated tail
- the rfc3161 timestamp anchor for the seal-suppressed residual

Before this change a reader of the normative parent would conclude a dropped tail is undetectable without an external anchor. With the seal, a finalized boundary carries a terminal block `{boundaryId, sealed: true, total: N}`, the holder expects `max(seq + 1, runningCount, total)` records, and a dropped tail shows as the missing range up to the sealed total. The only case left for the anchor is a suffix drop that also suppresses the seal.

## Changes

- `SPEC.md` 5.3: added the terminal sealing block to the completeness list, and re-layered the honest-limit paragraph so the seal sits between contiguity and the anchor. The 0-indexed base (`seq` starting at 0, `runningCount = seq + 1`) is unchanged.
- `CHANGELOG.md`: Unreleased entry for the spec sync.

The published Internet-Draft (`draft-sirkkavaara-vaara-receipt-00`) resyncs at its next revision; the `-00` source is left untouched here.
