### PR TITLE
chore(release): v1.8.0 one binding mechanism, not one per plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-22
+
+Minor release: one binding mechanism, not one per plane. The named profiles (x402, AP2, TAP) are instances of a single schema-agnostic binding. A verifier carrying an `external_execution_evidence` slot resolves it against a `vaara.receipt/v1` authorization receipt as the recomputable producer, and a new plane pins by naming its artifact through the slot with no new code. The completeness layer rides along, so a dropped record inside the boundary is still a provable gap.
+
 - Generic external-execution-evidence binding profile: the schema-agnostic binding the named profiles (x402, AP2, TAP) are instances of. There is one binding mechanism, not one per plane. A verifier carrying an `external_execution_evidence` slot (`linked_call_id` / `evidence_hash` / `evidence_type`, the shape used by agentrust trace-spec #34 and cMCP #301) resolves it against a `vaara.receipt/v1` authorization receipt as the recomputable producer: the slot's `evidence_hash` equals the receipt's `decisionDerived.evidenceRef.digest`, the `linked_call_id` is the call the receipt names (`evidenceRef.ref` equal to `mcp:call/<linked_call_id>`), and the `evidence_type` is the receipt's evidence schema. A new plane pins by naming its artifact through the slot rather than defining a profile of its own. `SPEC.md` Section 5.6, `tests/vectors/external_evidence_v0/`.
 - The trace is the coverage boundary and each receipt carries a signed completeness block, so a slot's per-record `evidence_hash` proves a record exists while the held running count proves none inside the boundary was dropped. The `dropped` vector withholds one record, slot and receipt both, and the running count still flags it. Every verdict recomputes offline from the held bytes with no live endpoint, through the independent checker that imports no Vaara.
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.7.0"
+version = "1.8.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.7.0",
+  "version": "1.8.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.7.0",
+  "version": "1.8.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.7.0"
+__version__ = "1.8.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
# v1.8.0: one binding mechanism, not one per plane

The named profiles (x402, AP2, TAP) are instances of a single schema-agnostic binding, not three separate engines. This release makes that engine explicit: a verifier carrying an `external_execution_evidence` slot resolves it against a `vaara.receipt/v1` authorization receipt as the recomputable producer. A new plane pins by naming its artifact through the slot rather than defining a profile of its own.

## Changes

- Generic external-execution-evidence binding profile in `SPEC.md` Section 5.6, with conformance vectors under `tests/vectors/external_evidence_v0/`.
- The binding, recomputed offline with no live endpoint: the slot's `evidence_hash` equals the receipt's `decisionDerived.evidenceRef.digest`; the `linked_call_id` is the call the receipt names (`evidenceRef.ref` equal to `mcp:call/<linked_call_id>`); the `evidence_type` is the receipt's evidence schema.
- The slot shape (`linked_call_id` / `evidence_hash` / `evidence_type`) is the one used by agentrust trace-spec #34 and cMCP #301, so an existing carrier resolves without a new schema.

## Properties

- One mechanism. x402, AP2, and TAP are labels on the same binding; a new plane needs no new code, only an artifact named through the slot.
- Completeness rides along. The trace is the coverage boundary and each receipt carries a signed completeness block. A per-record `evidence_hash` proves a record exists; the held running count proves none inside the boundary was dropped. The `dropped` vector withholds one record from both slot and receipt, and the running count still flags it.

## Verification

- Every verdict recomputes from held bytes through an independent checker that imports no Vaara and reaches no live endpoint.
- `tests/vectors/external_evidence_v0/` ships the `complete` and `dropped` corpora plus the standalone checker. Full suite green.
