### PR TITLE
v1.9.0: enforce the next action on a sealed worst-case class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.0] - 2026-06-22
 
 - Enforcement-time consumption of the sealed worst-case class: the v1.7.0 seal's `maxClass`, beyond bounding a gap at audit time, gates a chain recipient's own next unattended action. `enforce_on_sealed_class(...)` and the `vaara enforce-by-class` verb hold a policy set of permitted action classes and permit iff the sealed worst-case class is a member, failing closed when no class is sealed (exit 0 permit, 1 deny). It is a membership test, not an ordering over class labels (SPEC 5.3 computes no ordering). A permitted class permits even over a gap, since the seal bounds the gap at that class; the recipient consumes the committed bound and does not re-derive the chain or query a log. `SPEC.md` Section 5.3, `tests/vectors/class_gate_v0/` with an independent checker that imports no Vaara.
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.8.0"
+version = "1.9.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.8.0",
+  "version": "1.9.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.8.0",
+  "version": "1.9.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
# v1.9.0: enforce the next action on a sealed worst-case class

The v1.7.0 seal bounds a gap's worst case at audit time. This release consumes that sealed `maxClass` at enforcement time: a chain recipient deciding its own next unattended action holds a policy set of permitted action classes and proceeds only when the sealed worst-case class is a member.

## Changes

- `enforce_on_sealed_class(evidence_records, permitted_classes, boundary_id=None)` in `src/vaara/credential/_contiguity.py`, exported from the package, and the `vaara enforce-by-class` verb (exit 0 permit, 1 deny, 2 usage).
- `SPEC.md` Section 5.3 states the rule: a membership test over the sealed class, with no ordering over class labels.
- `tests/vectors/class_gate_v0/` with four corpora (permit, gap-bounded permit, class-denied, unbounded-deny), a signed terminal seal, and a standalone checker.

## Properties

- Membership, not ordering. SPEC 5.3 computes no ordering over class labels, so the gate asks only whether the sealed worst-case class is in the permitted set.
- Fail-closed. With no sealed class, a gap's worst case is unbounded, so the gate denies.
- A permitted class permits even over a gap. The seal already bounds the gap at that class, so the recipient consumes the committed bound; it does not re-derive the chain or query a log.

## Verification

- Every verdict recomputes from held bytes through an independent checker that imports no Vaara. The terminal seal is ES256-signed, so the bound is under signature.
- Full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.9.0 across all packages and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->