### PR TITLE
feat(ingest): v1.10.0 the universal evidence sink (vaara.ingest/v0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.0] - 2026-06-23
+
+Minor release: the universal evidence sink. Foreign evidence flows in; one canonical signed record flows out, so adjacent formats become source formats rather than rivals.
+
+- New `vaara.ingest/v0` signed envelope and the `vaara ingest` verb. It seals any record `normalize` understands (SEP-2643, SEP-2787, SEP-2817, or an unrecognized record) into one signed, content-addressed envelope. `evidenceRef.digest` is `sha256:` + JCS(normalized evidence); the honest gap report (`missing`), the established proof fields (`sep2828`), and the non-proof context (`advisory`) all live inside that digested object, so editing the gap report or a proof field breaks the signature. The envelope asserts nothing the source did not establish: no fabricated verdict, no fabricated back-link, which is why it is a sibling of `vaara.receipt/v1` and cannot reuse the receipt or authorization envelopes. Reuses the JCS + ES256/HS256/RS256 stack with no new crypto. `completeness` carries a per-stream `seq` and `runningCount`, so a dropped record inside a stream is a provable gap.
+- The published conformance corpus is generated from the registry, not authored by hand. `tests/vectors/ingest_v0/_generate.py` loops the normalize input corpus into deterministic `{record, evidence}` pairs; `_check_independent.py` reproduces every content address and HS256 signature with no Vaara import (pure standard library plus the JCS canonicalizer). Adding a source format is a `SourceProfile` registration plus one input fixture, and its vector materializes from the loop. A drift guard fails the suite if emit logic changes without a regenerate.
+- `vaara ingest RECORD.json` signs with a PEM `--key` (EC P-256 to ES256, RSA to RS256) or `--hs256-secret-file`, and writes the `{record, evidence}` pair to stdout or `--out`.
+- `SPEC.md` Section 6 specifies the envelope and its conformance run; Conformance and Versioning renumber to Sections 7 and 8.
+
 ## [1.9.1] - 2026-06-23
 
 - Bind the sealed `maxClass` to the signature at every consume path, closing a relabeling gap in the v1.9.0 enforce-by-class gate. `maxClass` lives in the unsigned `evidence` block; it rides under signature only through the binding `decisionDerived.evidenceRef.digest` == `sha256:` + JCS(`evidence`). v1.9.0 verified the record signature but never recomputed that digest, so relabeling a sealed `maxClass` to a permitted class left the record signature intact and the gate trusted the forgery. Now the sealed class is consumed only from a seal whose evidence binds; an unbound (relabeled) seal contributes no class and the gate fails closed. New `evidence_binding_ok(receipt)` in `vaara.credential` performs the check; the independent checker reports `all_evidence_bound` and gates `maxClass` on it; `vaara enforce-by-class` drops unbound receipts before gating and takes an optional `--key` to verify issuer signatures too.

--- a/SPEC.md
+++ b/SPEC.md
@@ -351,7 +351,42 @@ receipts, and the issuer's public key, with no live verifier endpoint to trust. 
 execution evidence pins here by naming its artifact through this slot, rather than
 defining a new primitive or a profile of its own.
 
-## 6. Conformance
+## 6. The ingest envelope (`vaara.ingest/v0`)
+
+The profiles in Section 5 bind external evidence *into* a `vaara.receipt/v1`
+decision: they carry a verdict, or a back-link, or both. Not every foreign
+record is a decision. An adjacent log line, an identity assertion, a denial, an
+invocation context establishes something narrower, and forcing it into a receipt
+or an authorization envelope would fabricate a verdict or a back-link the source
+never carried. The ingest envelope is the sink for exactly that case: it wraps
+any foreign record, content-addressed, and asserts nothing the source did not
+establish.
+
+It is a sibling envelope to `vaara.receipt/v1`, not a profile of it, and reuses
+the Section 1 canonicalization and the Section 2.1 signing construction
+unchanged. The signed payload is:
+
+- `schema` = `vaara.ingest/v0`, `version`, `alg`.
+- `sourceFormat`, the recognized format of the foreign record (or `unknown`).
+- `evidenceRef`: `digest` = `sha256(JCS(normalized_evidence))`,
+  `canonicalization` = `JCS`, `schema` = `vaara.normalized-evidence/v0`, and an
+  optional non-authoritative `ref` locator.
+- `ingestAsserted`: `iss` / `sub` / `iat` / `nonce` / `secretVersion` / `alg`.
+- `completeness`: a per-stream `seq` and `runningCount`; a lone ingest is `seq 1`
+  of a one-record stream.
+
+`signature` is appended over the JCS encoding of that payload.
+
+The normalized evidence object pinned by `evidenceRef.digest` carries the SEP-2828
+fields the source establishes (`sep2828`), the context it carries that is not on
+its own a proof (`advisory`), and the honest gap report (`missing`): what a
+complete signed record still needs that this source does not supply. Because the
+object is bound by digest under the signature, editing the gap report, a proof
+field, or the source format breaks verification. The sink never launders a weak
+source into a strong-looking receipt; the `missing` list is the record admitting
+what it is not.
+
+## 7. Conformance
 
 An implementation conforms to `vaara.receipt/v1` if, for every receipt it emits:
 
@@ -363,9 +398,12 @@ An implementation conforms to `vaara.receipt/v1` if, for every receipt it emits:
 
 The committed vectors plus `_check_independent.py` are the reference conformance
 suite; `python tests/vectors/x402_settlement_v0/_check_independent.py` exiting 0
-is a passing run for the x402 profile.
+is a passing run for the x402 profile. A `vaara.ingest/v0` envelope conforms when
+the evidence object recomputes to `evidenceRef.digest` and the signature verifies,
+both reproducible with no Vaara import;
+`python tests/vectors/ingest_v0/_check_independent.py` exiting 0 is a passing run.
 
-## 7. Versioning
+## 8. Versioning
 
 The envelope version is the integer `version` field and the `vaara.receipt/vN`
 schema id. Additive, backward-compatible changes (new optional fields, new

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.9.1"
+version = "1.10.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.9.1",
+  "version": "1.10.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.9.1",
+  "version": "1.10.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.9.1"
+__version__ = "1.10.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_ingest_emit.py
+++ b/src/vaara/attestation/_ingest_emit.py
@@ -1,0 +1,272 @@
+"""Emit and verify-signature for ``vaara.ingest/v0`` envelopes.
+
+Internal module. Public surface is in ``vaara.attestation.receipt``.
+
+This is the universal sink's wire shape. Foreign evidence (a SEP-2643
+denial, a SEP-2787 attestation, a did:web ARD, a raw log line) is first
+mapped onto the SEP-2828 evidence model by ``vaara...normalize``, then
+sealed here into one signed, content-addressed record.
+
+The two existing envelopes do not fit arbitrary foreign evidence:
+``emit_receipt`` hard-requires a SEP-2787 back-link, and
+``mint_authorization_receipt`` hard-requires a credential and a verdict.
+Forcing a heterogeneous source into either would fabricate semantics the
+source never carried (a back-link that does not exist, a decision that was
+never rendered). The whole value of the sink is honest normalization, so
+it gets its own envelope that asserts nothing the source did not establish.
+
+What the envelope binds:
+
+- ``evidenceRef`` content-addresses the normalized evidence object by
+  ``sha256:<JCS(normalized)>``. The honest gap report (``missing``), the
+  established proof fields (``sep2828``), and the non-proof context
+  (``advisory``) all live inside that digested object, so they travel under
+  the envelope signature: tamper with the gap report and the digest, and
+  therefore the signature, no longer verifies.
+- ``completeness`` carries a per-stream ``seq`` and ``runningCount``. A lone
+  ingest is ``seq 1`` of a one-record stream; a dropped record inside a
+  longer stream is then a provable gap.
+
+Reuses the SEP-2787 canonicalization (RFC 8785 JCS) and signing stack
+(HS256 / ES256 / RS256) unchanged. No new crypto. The content-address
+recompute is pure JCS + sha256: a third party reproduces it with zero
+Vaara import.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from vaara.attestation._normalize import NormalizedEvidence
+from vaara.attestation._sep2787_canonical import (
+    canonical_json,
+    new_nonce,
+    now_iso8601,
+)
+from vaara.attestation._sep2787_signing import (
+    sign_es256,
+    sign_hs256,
+    sign_rs256,
+    verify_es256,
+    verify_hs256,
+    verify_rs256,
+)
+from vaara.attestation._sep2787_types import (
+    VALID_ALGS,
+    Algorithm,
+    AttestationError,
+)
+
+# Pinned in SPEC.md alongside vaara.receipt/v1. ``v0`` because the foreign
+# normalization surface is still widening; the crypto stack is v1-stable.
+INGEST_SCHEMA = "vaara.ingest/v0"
+NORMALIZED_EVIDENCE_SCHEMA = "vaara.normalized-evidence/v0"
+
+
+def _evidence_digest(evidence: dict[str, Any]) -> str:
+    """sha256 over the JCS canonicalization of the normalized evidence.
+
+    Pure JCS + sha256, the content address an independent verifier
+    recomputes without importing Vaara.
+    """
+    return f"sha256:{hashlib.sha256(canonical_json(evidence)).hexdigest()}"
+
+
+def _single_record_completeness() -> dict[str, int]:
+    """Completeness for a lone ingest: seq 1 of a one-record stream."""
+    return {"seq": 1, "runningCount": 1}
+
+
+@dataclass(frozen=True)
+class IngestReceipt:
+    """A signed ``vaara.ingest/v0`` envelope plus its evidence object.
+
+    ``record`` is the signed envelope. ``evidence`` is the normalized
+    evidence object it content-addresses (``NormalizedEvidence.to_dict()``);
+    its ``sha256:<JCS>`` digest is pinned by ``record["evidenceRef"]["digest"]``
+    under the signature. The two travel together but bind by hash, so the
+    evidence bytes may also be carried out of band.
+    """
+
+    record: dict[str, Any]
+    evidence: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"record": self.record, "evidence": self.evidence}
+
+
+def _signing_body(
+    *,
+    version: int,
+    alg: Algorithm,
+    source_format: str,
+    evidence_ref: dict[str, Any],
+    ingest_asserted: dict[str, Any],
+    completeness: dict[str, Any],
+) -> dict[str, Any]:
+    """The envelope payload that gets canonicalized and signed.
+
+    Everything substantive about the source lives in the digested evidence
+    object; the envelope itself stays thin and carries only what binds and
+    routes. ``sourceFormat`` is echoed here purely so a verifier can assert
+    it equals the evidence object's own ``sourceFormat`` (a bound cross-check,
+    never a second source of truth).
+    """
+    return {
+        "schema": INGEST_SCHEMA,
+        "version": version,
+        "alg": alg,
+        "sourceFormat": source_format,
+        "evidenceRef": evidence_ref,
+        "ingestAsserted": ingest_asserted,
+        "completeness": completeness,
+    }
+
+
+def emit_ingest_receipt(
+    *,
+    normalized: NormalizedEvidence,
+    iss: str,
+    sub: str,
+    secret_version: str,
+    alg: Algorithm,
+    signing_material: Any,
+    nonce: Optional[str] = None,
+    iat: Optional[str] = None,
+    completeness: Optional[dict[str, Any]] = None,
+    evidence_ref: Optional[str] = None,
+    version: int = 0,
+    sig_suite: Optional[str] = None,
+) -> IngestReceipt:
+    """Seal one normalized foreign record into a signed ingest envelope.
+
+    ``normalized`` is the output of ``vaara...normalize`` for one source
+    document. It is content-addressed and pinned by the envelope's
+    ``evidenceRef.digest``; nothing about it is re-asserted in the envelope,
+    so the honest ``missing`` gap report travels under the signature without
+    being editable apart from it.
+
+    ``signing_material`` is a bytes shared secret (HS256) or a private-key
+    object from ``cryptography.hazmat`` (ES256 / RS256), the same key shapes
+    the SEP-2787 stack takes. ``completeness`` defaults to a single-record
+    stream; pass ``{"seq": n, "runningCount": m}`` to place this record in a
+    longer ingest stream. ``evidence_ref`` is an optional, non-authoritative
+    locator (URI or path) for the evidence bytes; the digest is what binds.
+    """
+    if alg not in VALID_ALGS:
+        raise AttestationError(f"unsupported alg: {alg!r}")
+
+    evidence = normalized.to_dict()
+    ref: dict[str, Any] = {
+        "digest": _evidence_digest(evidence),
+        "canonicalization": "JCS",
+        "schema": NORMALIZED_EVIDENCE_SCHEMA,
+    }
+    if evidence_ref is not None:
+        if not isinstance(evidence_ref, str) or not evidence_ref:
+            raise AttestationError(
+                "evidenceRef.ref must be a non-empty string or absent"
+            )
+        ref["ref"] = evidence_ref
+
+    ingest_asserted: dict[str, Any] = {
+        "iss": iss,
+        "sub": sub,
+        "iat": iat or now_iso8601(),
+        "nonce": nonce or new_nonce(),
+        "secretVersion": secret_version,
+        "alg": alg,
+    }
+    if sig_suite is not None:
+        ingest_asserted["sigSuite"] = sig_suite
+
+    body = _signing_body(
+        version=version,
+        alg=alg,
+        source_format=normalized.source_format,
+        evidence_ref=ref,
+        ingest_asserted=ingest_asserted,
+        completeness=completeness or _single_record_completeness(),
+    )
+
+    payload = canonical_json(body)
+    if alg == "HS256":
+        if not isinstance(signing_material, (bytes, bytearray)):
+            raise AttestationError("HS256 requires bytes shared_secret")
+        signature_hex = sign_hs256(payload, shared_secret=bytes(signing_material))
+    elif alg == "ES256":
+        signature_hex = sign_es256(payload, private_key=signing_material)
+    elif alg == "RS256":
+        signature_hex = sign_rs256(payload, private_key=signing_material)
+    else:
+        raise AttestationError(f"unreachable alg: {alg!r}")
+
+    record = {**body, "signature": signature_hex}
+    return IngestReceipt(record=record, evidence=evidence)
+
+
+def verify_ingest_signature(
+    record: dict[str, Any],
+    evidence: dict[str, Any],
+    verifying_material: Any,
+) -> bool:
+    """Verify an ingest envelope against its evidence object.
+
+    Returns True iff (1) the evidence object recomputes to the content
+    address pinned in ``record["evidenceRef"]["digest"]``, (2) the envelope's
+    ``sourceFormat`` matches the evidence object's, and (3) the signature
+    matches the JCS-canonical encoding of the envelope (signature field
+    removed) under ``verifying_material``. ``verifying_material`` is a bytes
+    shared secret (HS256) or a public-key object (ES256 / RS256).
+
+    Any structural surprise (missing field, wrong type, unknown alg) is a
+    verification failure, not an exception.
+    """
+    if not isinstance(record, dict) or not isinstance(evidence, dict):
+        return False
+    try:
+        ref = record["evidenceRef"]
+        pinned_digest = ref["digest"]
+        alg = record["alg"]
+        signature_hex = record["signature"]
+    except (KeyError, TypeError):
+        return False
+    if not isinstance(signature_hex, str):
+        return False
+
+    try:
+        recomputed = _evidence_digest(evidence)
+    except AttestationError:
+        return False
+    if recomputed != pinned_digest:
+        return False
+    if record.get("sourceFormat") != evidence.get("sourceFormat"):
+        return False
+    if alg not in VALID_ALGS:
+        return False
+
+    body = {k: v for k, v in record.items() if k != "signature"}
+    try:
+        payload = canonical_json(body)
+    except AttestationError:
+        return False
+
+    if alg == "HS256":
+        if not isinstance(verifying_material, (bytes, bytearray)):
+            return False
+        return verify_hs256(
+            payload,
+            signature_hex=signature_hex,
+            shared_secret=bytes(verifying_material),
+        )
+    if alg == "ES256":
+        return verify_es256(
+            payload, signature_hex=signature_hex, public_key=verifying_material
+        )
+    if alg == "RS256":
+        return verify_rs256(
+            payload, signature_hex=signature_hex, public_key=verifying_material
+        )
+    return False

--- a/src/vaara/attestation/_normalize.py
+++ b/src/vaara/attestation/_normalize.py
@@ -33,8 +33,12 @@ gap when the extra is absent.
 
 from __future__ import annotations
 
+import logging
+import threading
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
 
 SOURCE_SEP2643 = "sep2643"
 SOURCE_SEP2787 = "sep2787"
@@ -81,6 +85,70 @@ class NormalizedEvidence:
             "missing": list(self.missing),
             "notes": list(self.notes),
         }
+
+
+@dataclass(frozen=True)
+class SourceProfile:
+    """A pluggable foreign-evidence format the sink can ingest.
+
+    ``detector`` returns True when a document is this format; ``normalizer``
+    maps it onto the SEP-2828 evidence model. Lower ``priority`` runs first in
+    ``detect_format``, so a more specific format can pre-empt a looser one
+    regardless of registration order.
+    """
+
+    source_format: str
+    source_title: str
+    detector: Callable[[Any], bool]
+    normalizer: Callable[[Any], "NormalizedEvidence"]
+    priority: int = 100
+
+
+# A new format is a registry entry (data), not a new dispatch branch. The lock
+# mirrors taxonomy.actions.ActionRegistry: plugins may register from different
+# threads at startup while detect_format()/normalize() read on the hot path.
+_REGISTRY_LOCK = threading.RLock()
+SOURCE_PROFILE_REGISTRY: dict[str, SourceProfile] = {}
+
+
+def register(profile: SourceProfile) -> None:
+    """Register a source profile under its ``source_format`` id.
+
+    A clashing id silently replaces the prior profile but logs a warning, so
+    plugins with overlapping formats are visible at startup instead of failing
+    mysteriously later (same contract as ``ActionRegistry.register``).
+    """
+    with _REGISTRY_LOCK:
+        existing = SOURCE_PROFILE_REGISTRY.get(profile.source_format)
+        if existing is not None and existing is not profile:
+            logger.warning(
+                "SourceProfile registry: replacing profile %r "
+                "(previous %r registered; new one wins)",
+                profile.source_format, existing.source_title,
+            )
+        SOURCE_PROFILE_REGISTRY[profile.source_format] = profile
+
+
+def _ordered_profiles() -> list[SourceProfile]:
+    """Profiles in detection order: ascending priority, id breaking ties."""
+    with _REGISTRY_LOCK:
+        return sorted(
+            SOURCE_PROFILE_REGISTRY.values(),
+            key=lambda p: (p.priority, p.source_format),
+        )
+
+
+def _unknown_record() -> NormalizedEvidence:
+    """The result for a document no registered profile recognizes."""
+    return NormalizedEvidence(
+        source_format=SOURCE_UNKNOWN,
+        source_title="unrecognized record",
+        recognized=False,
+        notes=(
+            "not a SEP-2643 denial, SEP-2787 attestation, or SEP-2817 "
+            "invocation audit context; nothing to normalize",
+        ),
+    )
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -148,38 +216,38 @@ def _looks_like_attestation(doc: Any) -> bool:
 
 
 def detect_format(doc: Any) -> str:
-    """Identify which adjacent-SEP record ``doc`` is, or ``"unknown"``."""
-    if _looks_like_attestation(doc):
-        return SOURCE_SEP2787
-    if _denial_authorization(doc) is not None:
-        return SOURCE_SEP2643
-    if _ai_invocation(doc) is not None:
-        return SOURCE_SEP2817
+    """Identify which registered source format ``doc`` is, or ``"unknown"``.
+
+    Detectors run in ascending ``priority`` order; the first match wins, so a
+    new profile slots into the precedence chain by its priority alone.
+    """
+    for profile in _ordered_profiles():
+        try:
+            if profile.detector(doc):
+                return profile.source_format
+        except Exception:
+            # A misbehaving third-party detector must not block detection of
+            # the other formats; treat it as a non-match and keep going.
+            logger.warning(
+                "SourceProfile %r detector raised; treating as no-match",
+                profile.source_format, exc_info=True,
+            )
     return SOURCE_UNKNOWN
 
 
 def normalize(doc: Any, *, source_format: str = "auto") -> NormalizedEvidence:
-    """Map a foreign MCP record onto the SEP-2828 evidence model.
+    """Map a foreign record onto the SEP-2828 evidence model.
 
-    ``source_format`` is ``"auto"`` (detect) or one of ``"sep2643"``,
-    ``"sep2787"``, ``"sep2817"`` to force a reading.
+    ``source_format`` is ``"auto"`` (detect from the registry) or a registered
+    source-format id (e.g. ``"sep2643"``, ``"sep2787"``, ``"sep2817"``) to
+    force a reading. An unrecognized document, or a forced format with no
+    registered profile, yields an unrecognized result with nothing normalized.
     """
     fmt = detect_format(doc) if source_format == "auto" else source_format
-    if fmt == SOURCE_SEP2787:
-        return _normalize_attestation(doc)
-    if fmt == SOURCE_SEP2643:
-        return _normalize_denial(doc)
-    if fmt == SOURCE_SEP2817:
-        return _normalize_invocation(doc)
-    return NormalizedEvidence(
-        source_format=SOURCE_UNKNOWN,
-        source_title="unrecognized record",
-        recognized=False,
-        notes=(
-            "not a SEP-2643 denial, SEP-2787 attestation, or SEP-2817 "
-            "invocation audit context; nothing to normalize",
-        ),
-    )
+    profile = SOURCE_PROFILE_REGISTRY.get(fmt)
+    if profile is None:
+        return _unknown_record()
+    return profile.normalizer(doc)
 
 
 def _unrecognized(fmt: str, title: str, why: str) -> NormalizedEvidence:
@@ -382,3 +450,30 @@ def _back_link_from_attestation(
         },
         None,
     )
+
+
+# ── Built-in source profiles ───────────────────────────────────────────────
+# Registered at module load in the historical detection order via explicit
+# priorities, so detect_format() is independent of registration/import order.
+# Adding a format is one register() call (data), not new dispatch code.
+register(SourceProfile(
+    source_format=SOURCE_SEP2787,
+    source_title="SEP-2787 tool-call attestation",
+    detector=_looks_like_attestation,
+    normalizer=_normalize_attestation,
+    priority=10,
+))
+register(SourceProfile(
+    source_format=SOURCE_SEP2643,
+    source_title="SEP-2643 authorization denial",
+    detector=lambda doc: _denial_authorization(doc) is not None,
+    normalizer=_normalize_denial,
+    priority=20,
+))
+register(SourceProfile(
+    source_format=SOURCE_SEP2817,
+    source_title="SEP-2817 AI invocation audit context",
+    detector=lambda doc: _ai_invocation(doc) is not None,
+    normalizer=_normalize_invocation,
+    priority=30,
+))

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -137,6 +137,13 @@ from vaara.attestation._normalize import (
     detect_format,
     normalize,
 )
+from vaara.attestation._ingest_emit import (
+    INGEST_SCHEMA,
+    NORMALIZED_EVIDENCE_SCHEMA,
+    IngestReceipt,
+    emit_ingest_receipt,
+    verify_ingest_signature,
+)
 from vaara.attestation._receipt_conformance import (
     ConformanceCheck,
     ConformanceReport,
@@ -286,6 +293,11 @@ __all__ = [
     "NormalizedEvidence",
     "detect_format",
     "normalize",
+    "INGEST_SCHEMA",
+    "NORMALIZED_EVIDENCE_SCHEMA",
+    "IngestReceipt",
+    "emit_ingest_receipt",
+    "verify_ingest_signature",
     "DidDocumentCache",
     "EvidenceBundle",
     "ExecutionReceipt",

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -2846,6 +2846,94 @@ def _cmd_normalize(args: argparse.Namespace) -> int:
     return 0 if result.recognized else 1
 
 
+def _resolve_ingest_signer(args: argparse.Namespace) -> tuple[Any, Any, str]:
+    """Resolve the signing material and alg for ``vaara ingest``.
+
+    Returns ``(signing_material, alg, error)``. ``error`` is "" on success.
+    HS256 takes a raw shared-secret file; a PEM private key signs ES256 (EC)
+    or RS256 (RSA), the alg detected from the key type, mirroring the
+    ``--pubkey-file`` / ``--hs256-secret-file`` split on the verify side.
+    """
+    if args.hs256_secret_file:
+        try:
+            secret = Path(args.hs256_secret_file).expanduser().read_bytes()
+        except OSError as exc:
+            return None, None, f"--hs256-secret-file: {exc}"
+        return secret, "HS256", ""
+    if args.key:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec, rsa
+        try:
+            priv = serialization.load_pem_private_key(
+                Path(args.key).expanduser().read_bytes(), password=None
+            )
+        except (OSError, ValueError) as exc:
+            return None, None, f"--key: {exc}"
+        if isinstance(priv, ec.EllipticCurvePrivateKey):
+            return priv, "ES256", ""
+        if isinstance(priv, rsa.RSAPrivateKey):
+            return priv, "RS256", ""
+        return None, None, "--key: unsupported key type (need EC P-256 or RSA)"
+    return None, None, "one of --key (PEM) or --hs256-secret-file is required"
+
+
+def _cmd_ingest(args: argparse.Namespace) -> int:
+    """Seal one foreign evidence record into a signed vaara.ingest/v0 envelope.
+
+    The universal sink. Reads any record ``normalize`` understands, maps it
+    onto the SEP-2828 evidence model, and seals it into one signed,
+    content-addressed envelope: ``evidenceRef.digest`` pins the normalized
+    evidence, and the honest gap report rides inside that digest under the
+    signature. Nothing the source did not establish is asserted; an
+    unrecognized record still seals, honestly marked as such.
+    """
+    from vaara.attestation.receipt import emit_ingest_receipt, normalize
+    from vaara.attestation.sep2787 import AttestationError
+
+    path = Path(args.record).expanduser()
+    if not path.is_file():
+        print(f"vaara ingest: not a file: {path}", file=sys.stderr)
+        return 2
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"vaara ingest: cannot read record JSON: {exc}", file=sys.stderr)
+        return 1
+
+    signing_material, alg, error = _resolve_ingest_signer(args)
+    if error:
+        print(f"vaara ingest: {error}", file=sys.stderr)
+        return 2
+
+    normalized = normalize(doc, source_format=args.format)
+    try:
+        receipt = emit_ingest_receipt(
+            normalized=normalized,
+            iss=args.iss,
+            sub=args.sub,
+            secret_version=args.secret_version,
+            alg=alg,
+            signing_material=signing_material,
+            evidence_ref=args.evidence_ref,
+        )
+    except AttestationError as exc:
+        print(f"vaara ingest: {exc}", file=sys.stderr)
+        return 1
+
+    text = json.dumps(receipt.to_dict(), indent=2, sort_keys=True)
+    if args.out:
+        out_path = Path(args.out).expanduser()
+        try:
+            out_path.write_text(text + "\n", encoding="utf-8")
+        except OSError as exc:
+            print(f"vaara ingest: cannot write {out_path}: {exc}", file=sys.stderr)
+            return 1
+        print(f"wrote {out_path} ({normalized.source_format})", file=sys.stderr)
+    else:
+        print(text)
+    return 0
+
+
 def _path_value(doc: dict[str, Any], dotted: str) -> Any:
     """Follow a dotted path into a nested dict; None if absent."""
     cur: Any = doc
@@ -4647,6 +4735,46 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit the normalized evidence mapping as JSON",
     )
     pnz.set_defaults(func=_cmd_normalize)
+
+    ping = sub.add_parser(
+        "ingest",
+        help="Seal any foreign evidence record into one signed, "
+             "content-addressed vaara.ingest/v0 envelope: normalize it onto "
+             "the SEP-2828 model, then sign, with the honest gap report bound "
+             "under the signature. The universal sink.",
+    )
+    ping.add_argument(
+        "record",
+        help="Path to a JSON file holding a SEP-2643, SEP-2787, or SEP-2817 record",
+    )
+    ping.add_argument(
+        "--format", default="auto",
+        choices=("auto", "sep2643", "sep2787", "sep2817"),
+        help="Source format (default: auto-detect)",
+    )
+    ping.add_argument(
+        "--key",
+        help="PEM private key to sign with (EC P-256 -> ES256, RSA -> RS256)",
+    )
+    ping.add_argument(
+        "--hs256-secret-file", dest="hs256_secret_file", default=None,
+        help="Raw shared-secret file to sign with HS256 (alternative to --key)",
+    )
+    ping.add_argument("--iss", default="urn:vaara:ingest", help="Issuer identity")
+    ping.add_argument("--sub", default="ingest", help="Subject")
+    ping.add_argument(
+        "--secret-version", dest="secret_version", default="1",
+        help="Signing-key version label (default: 1)",
+    )
+    ping.add_argument(
+        "--evidence-ref", dest="evidence_ref", default=None,
+        help="Optional non-authoritative locator (URI/path) for the evidence bytes",
+    )
+    ping.add_argument(
+        "--out", default=None,
+        help="Write the {record, evidence} JSON here (default: stdout)",
+    )
+    ping.set_defaults(func=_cmd_ingest)
 
     pvrs = sub.add_parser(
         "verify-records",

--- a/tests/test_ingest_emit.py
+++ b/tests/test_ingest_emit.py
@@ -1,0 +1,263 @@
+"""vaara.ingest/v0: the universal sink envelope.
+
+Every registered foreign source normalizes, then seals into one signed,
+content-addressed ingest envelope. These tests run generatively over the
+existing normalize input corpus, so a new SourceProfile that drops an input
+fixture is covered here with no new test code: the per-source vector grind
+becomes a loop over the registry.
+
+Ingest always canonicalizes to sign, so the attestation extra (rfc8785) is
+the baseline; the whole module skips without it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+rfc8785 = pytest.importorskip("rfc8785")  # the only third-party dep recompute needs
+
+from vaara.attestation.receipt import (  # noqa: E402
+    INGEST_SCHEMA,
+    NORMALIZED_EVIDENCE_SCHEMA,
+    emit_ingest_receipt,
+    normalize,
+    verify_ingest_signature,
+)
+
+INPUTS = Path(__file__).resolve().parent / "vectors" / "normalize_v0" / "inputs"
+KEY = b"ingest-conformance-shared-secret-0001"
+
+# Fixed nonce + iat make the signed envelope reproducible: a golden vector,
+# not a fresh record each run.
+FIXED = dict(
+    iss="did:web:vaara.io",
+    sub="sink",
+    secret_version="k1",
+    alg="HS256",
+    signing_material=KEY,
+    nonce="ingest-fixed-nonce-000000",
+    iat="2026-06-23T00:00:00Z",
+)
+
+
+def _corpus():
+    return sorted(p.stem for p in INPUTS.glob("*.json"))
+
+
+def _doc(name: str) -> dict:
+    return json.loads((INPUTS / f"{name}.json").read_text())
+
+
+def _emit(name: str, **over):
+    return emit_ingest_receipt(normalized=normalize(_doc(name)), **{**FIXED, **over})
+
+
+# ── Every source seals and round-trips ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", _corpus())
+def test_every_source_seals_and_verifies(name):
+    r = _emit(name)
+    assert r.record["schema"] == INGEST_SCHEMA
+    assert r.record["sourceFormat"] == r.evidence["sourceFormat"]
+    ref = r.record["evidenceRef"]
+    assert ref["schema"] == NORMALIZED_EVIDENCE_SCHEMA
+    assert ref["canonicalization"] == "JCS"
+    assert ref["digest"].startswith("sha256:")
+    assert verify_ingest_signature(r.record, r.evidence, KEY)
+    # The evidence object is the normalized source, unaltered.
+    assert r.evidence == normalize(_doc(name)).to_dict()
+
+
+@pytest.mark.parametrize("name", _corpus())
+def test_digest_recomputes_with_zero_vaara_import(name):
+    # rfc8785 + sha256 only: a third party reproduces the content address.
+    r = _emit(name)
+    recomputed = "sha256:" + hashlib.sha256(rfc8785.dumps(r.evidence)).hexdigest()
+    assert recomputed == r.record["evidenceRef"]["digest"]
+
+
+@pytest.mark.parametrize("name", _corpus())
+def test_hs256_signature_recomputes_with_zero_vaara_import(name):
+    # HS256 is pure stdlib hmac: the full signature verifies without Vaara.
+    r = _emit(name)
+    body = {k: v for k, v in r.record.items() if k != "signature"}
+    expected = hmac.new(KEY, rfc8785.dumps(body), hashlib.sha256).hexdigest()
+    assert expected == r.record["signature"]
+
+
+def test_emit_is_deterministic_under_fixed_nonce_and_iat():
+    assert _emit("sep2817_single").record == _emit("sep2817_single").record
+
+
+# ── The honest gap report travels under the signature ─────────────────────────
+
+
+def test_tampering_the_gap_report_breaks_verification():
+    r = _emit("sep2817_single")
+    assert r.evidence["missing"]  # there is a real gap to forge away
+    forged = {**r.evidence, "missing": []}
+    assert not verify_ingest_signature(r.record, forged, KEY)
+
+
+def test_tampering_a_proof_field_breaks_verification():
+    r = _emit("sep2643_url_denial")
+    # Flip the refused outcome to allowed: must not verify.
+    forged = {**r.evidence, "sep2828": {"outcomeDerived": {"status": "allowed"}}}
+    assert not verify_ingest_signature(r.record, forged, KEY)
+
+
+def test_sourceformat_mismatch_breaks_verification():
+    r = _emit("sep2817_single")
+    forged = {**r.evidence, "sourceFormat": "sep2643"}
+    assert not verify_ingest_signature(r.record, forged, KEY)
+
+
+def test_unknown_source_still_seals_honestly():
+    r = _emit("unknown")
+    assert r.record["sourceFormat"] == "unknown"
+    assert r.evidence["recognized"] is False
+    assert verify_ingest_signature(r.record, r.evidence, KEY)
+
+
+# ── Completeness ──────────────────────────────────────────────────────────────
+
+
+def test_single_record_completeness_is_the_default():
+    assert _emit("sep2817_single").record["completeness"] == {
+        "seq": 1,
+        "runningCount": 1,
+    }
+
+
+def test_stream_completeness_is_carried_and_signed():
+    r = _emit("sep2817_single", completeness={"seq": 3, "runningCount": 7})
+    assert r.record["completeness"] == {"seq": 3, "runningCount": 7}
+    assert verify_ingest_signature(r.record, r.evidence, KEY)
+    forged = {**r.record, "completeness": {"seq": 1, "runningCount": 1}}
+    assert not verify_ingest_signature(forged, r.evidence, KEY)
+
+
+# ── Signing modes, surface, and rejects ───────────────────────────────────────
+
+
+def test_es256_round_trip():
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    sk = ec.generate_private_key(ec.SECP256R1())
+    r = emit_ingest_receipt(
+        normalized=normalize(_doc("sep2817_single")),
+        iss="i", sub="s", secret_version="k1", alg="ES256", signing_material=sk,
+    )
+    assert verify_ingest_signature(r.record, r.evidence, sk.public_key())
+    assert not verify_ingest_signature(
+        r.record, {**r.evidence, "missing": []}, sk.public_key()
+    )
+
+
+def test_optional_evidence_ref_locator_is_bound():
+    r = _emit("sep2817_single", evidence_ref="https://logs.example/abc")
+    assert r.record["evidenceRef"]["ref"] == "https://logs.example/abc"
+    assert verify_ingest_signature(r.record, r.evidence, KEY)
+
+
+def test_unsupported_alg_is_rejected():
+    from vaara.attestation.sep2787 import AttestationError
+
+    with pytest.raises(AttestationError):
+        emit_ingest_receipt(
+            normalized=normalize(_doc("unknown")),
+            iss="i", sub="s", secret_version="k1", alg="NONE", signing_material=b"x",
+        )
+
+
+def test_public_reexport_is_wired():
+    from vaara.attestation import _ingest_emit
+
+    assert emit_ingest_receipt is _ingest_emit.emit_ingest_receipt
+    assert verify_ingest_signature is _ingest_emit.verify_ingest_signature
+
+
+# ── Published conformance corpus (generated, not hand-authored) ───────────────
+
+VECTORS = Path(__file__).resolve().parent / "vectors" / "ingest_v0"
+
+
+def test_committed_vectors_match_fresh_emit():
+    # Drift guard: if emit logic changes without regenerating the corpus, the
+    # committed pairs stop matching and this fails, forcing a conscious regen.
+    meta = json.loads((VECTORS / "corpus.json").read_text())
+    secret = bytes.fromhex(meta["sharedSecretHex"])
+    f = meta["fixed"]
+    for name in meta["cases"]:
+        committed = json.loads((VECTORS / "cases" / f"{name}.json").read_text())
+        r = emit_ingest_receipt(
+            normalized=normalize(_doc(name)),
+            iss=f["iss"], sub=f["sub"], secret_version=f["secretVersion"],
+            alg="HS256", signing_material=secret, nonce=f["nonce"], iat=f["iat"],
+        )
+        assert r.record == committed["record"], f"{name}: record drift; regenerate"
+        assert r.evidence == committed["evidence"], f"{name}: evidence drift; regen"
+
+
+def test_corpus_tracks_the_full_input_registry():
+    # The corpus is a loop over the registry's input fixtures: every one is in.
+    meta = json.loads((VECTORS / "corpus.json").read_text())
+    assert sorted(meta["cases"]) == _corpus()
+
+
+def test_independent_checker_passes():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+# ── CLI: vaara ingest ─────────────────────────────────────────────────────────
+
+
+def test_cli_ingest_hs256_seals_and_verifies(tmp_path, capsys):
+    from vaara.cli import main
+
+    sec = tmp_path / "sec.bin"
+    sec.write_bytes(KEY)
+    rc = main([
+        "ingest", str(INPUTS / "sep2817_single.json"),
+        "--hs256-secret-file", str(sec),
+        "--iss", "did:web:vaara.io", "--sub", "sink", "--secret-version", "k1",
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["record"]["schema"] == INGEST_SCHEMA
+    assert verify_ingest_signature(out["record"], out["evidence"], KEY)
+
+
+def test_cli_ingest_writes_out_file(tmp_path):
+    from vaara.cli import main
+
+    sec = tmp_path / "sec.bin"
+    sec.write_bytes(KEY)
+    out = tmp_path / "receipt.json"
+    rc = main([
+        "ingest", str(INPUTS / "sep2643_url_denial.json"),
+        "--hs256-secret-file", str(sec), "--out", str(out),
+    ])
+    assert rc == 0
+    d = json.loads(out.read_text())
+    assert verify_ingest_signature(d["record"], d["evidence"], KEY)
+
+
+def test_cli_ingest_requires_a_signing_key(capsys):
+    from vaara.cli import main
+
+    rc = main(["ingest", str(INPUTS / "unknown.json")])
+    assert rc == 2
+    assert "required" in capsys.readouterr().err

--- a/tests/vectors/ingest_v0/README.md
+++ b/tests/vectors/ingest_v0/README.md
@@ -1,0 +1,53 @@
+# vaara.ingest/v0 conformance corpus
+
+The universal sink in vector form. Each case is one foreign evidence record
+(a SEP-2643 denial, a SEP-2787 attestation, a SEP-2817 invocation context, an
+unrecognized record) mapped onto the SEP-2828 evidence model and sealed into
+one signed, content-addressed `vaara.ingest/v0` envelope.
+
+## Layout
+
+- `cases/<name>.json`, a `{record, evidence}` pair. `record` is the signed
+  envelope; `evidence` is the normalized evidence object it content-addresses.
+- `corpus.json`, the manifest: the case list, the published HS256 test
+  secret, the fixed `nonce`/`iat` that make the envelopes reproducible, each
+  case's content address and signature, and a `corpusDigest` over the set.
+- `_check_independent.py`, a standalone verifier that imports no Vaara code.
+- `_generate.py`, regenerates the whole corpus from the registry.
+
+## What passing means
+
+Run the checker:
+
+    python tests/vectors/ingest_v0/_check_independent.py
+
+For every case it recomputes, from the envelope rules alone:
+
+1. the content address: `sha256` over the RFC 8785 (JCS) canonical bytes of
+   the evidence object, equal to `record.evidenceRef.digest`;
+2. the HS256 signature: `HMAC-SHA256` over the JCS bytes of the envelope with
+   the signature field removed;
+3. the bind: the envelope `sourceFormat` equals the evidence `sourceFormat`;
+4. the `corpusDigest` over the manifest.
+
+Steps 1, 2 and 4 are pure standard library. Only the JCS canonicalizer
+(`rfc8785`) is a third-party dependency. The honest gap report (`missing`),
+the established proof fields (`sep2828`), and the non-proof context
+(`advisory`) all live inside the digested evidence object, so editing any of
+them breaks the content address and therefore the signature.
+
+The conformance unit is recompute-determinism over these vectors, not the
+authenticity of this publisher. The corpus signs with a published HS256 test
+secret to keep the checker dependency-light; production identity is asymmetric
+(ES256 / did:web).
+
+## Regenerating
+
+The corpus is never hand-edited. It is a loop over the normalize input corpus
+at `../normalize_v0/inputs/`. Add a source format by registering its
+`SourceProfile` and dropping an input fixture there, then:
+
+    python tests/vectors/ingest_v0/_generate.py
+
+and commit the result. `test_committed_vectors_match_fresh_emit` fails if the
+committed pairs drift from a fresh emit, so a forgotten regen cannot land.

--- a/tests/vectors/ingest_v0/_check_independent.py
+++ b/tests/vectors/ingest_v0/_check_independent.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Independent checker for the vaara.ingest/v0 conformance corpus.
+
+Imports no Vaara code. For each committed {record, evidence} pair it
+reproduces, from the envelope rules alone:
+
+  1. the content address  -> sha256 over the RFC 8785 (JCS) canonical
+     bytes of the evidence object, compared to record.evidenceRef.digest;
+  2. the HS256 signature   -> HMAC-SHA256 over the JCS bytes of the
+     envelope (signature field removed), under the published test secret;
+  3. the sourceFormat bind -> envelope sourceFormat == evidence sourceFormat;
+  4. the corpus digest     -> sha256 over the JCS bytes of the manifest.
+
+Steps 1, 2 and 4 are pure stdlib hashlib/hmac; only the JCS canonicalizer
+(rfc8785) is a third-party dependency, and the whole run skips cleanly when
+it is absent. Passing this is conformance to the published vectors, not to
+any one producer's checker.
+
+Run: ``python tests/vectors/ingest_v0/_check_independent.py``.
+Exit 0 means every case and the corpus digest reproduced.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+try:
+    import rfc8785
+except ImportError:  # pragma: no cover - exercised only in a base install
+    print("[SKIP] rfc8785 not installed; the ingest corpus needs JCS to recompute")
+    sys.exit(0)
+
+
+def _digest(obj) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(obj)).hexdigest()
+
+
+def _check_case(name: str, secret: bytes, want: dict) -> list[str]:
+    pair = json.loads((HERE / "cases" / f"{name}.json").read_text())
+    record, evidence = pair["record"], pair["evidence"]
+    fails: list[str] = []
+
+    recomputed = _digest(evidence)
+    if recomputed != record["evidenceRef"]["digest"]:
+        fails.append("content address does not match record.evidenceRef.digest")
+    if recomputed != want["evidenceDigest"]:
+        fails.append("content address does not match corpus manifest")
+
+    body = {k: v for k, v in record.items() if k != "signature"}
+    sig = hmac.new(secret, rfc8785.dumps(body), hashlib.sha256).hexdigest()
+    if sig != record["signature"]:
+        fails.append("HS256 signature does not match record.signature")
+    if sig != want["signature"]:
+        fails.append("HS256 signature does not match corpus manifest")
+
+    if record.get("sourceFormat") != evidence.get("sourceFormat"):
+        fails.append("envelope sourceFormat does not bind evidence sourceFormat")
+    return fails
+
+
+def main() -> int:
+    corpus = json.loads((HERE / "corpus.json").read_text())
+    secret = bytes.fromhex(corpus["sharedSecretHex"])
+    manifest = corpus["manifest"]
+
+    failures = 0
+    for name in corpus["cases"]:
+        fails = _check_case(name, secret, manifest[name])
+        failures += len(fails)
+        print(f"[{'OK' if not fails else 'FAIL'}] {name}")
+        for f in fails:
+            print(f"   {f}")
+
+    if _digest(manifest) != corpus["corpusDigest"]:
+        print("[FAIL] corpusDigest does not reproduce from the manifest")
+        failures += 1
+    else:
+        print(f"[OK] corpusDigest {corpus['corpusDigest']}")
+
+    total = len(corpus["cases"]) + 1
+    print(f"\n{total - failures}/{total} checks passed.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/ingest_v0/_generate.py
+++ b/tests/vectors/ingest_v0/_generate.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate the vaara.ingest/v0 conformance corpus from the registry.
+
+This is the haymaker: the published vector set is not hand-authored. It is
+a loop over the existing normalize input corpus. Each foreign source doc is
+normalized, then sealed into a deterministic (fixed nonce + iat) ingest
+envelope, and the {evidence, record} pair is written under ``cases/``. A
+new SourceProfile that drops an input fixture lands in this corpus by
+re-running this script; there is no per-format vector to write by hand.
+
+The corpus signs with HS256 under a published test secret so the standalone
+checker stays pure stdlib + rfc8785, mirroring the dependency-free ethos of
+the peer did:web corpus. Conformance is recompute-determinism over the
+vectors, not authenticity of this publisher; production identity is
+asymmetric (ES256 / did:web), exactly as the normalize vectors note.
+
+Run: ``python tests/vectors/ingest_v0/_generate.py`` then commit the output.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import rfc8785
+
+from vaara.attestation.receipt import emit_ingest_receipt, normalize
+
+HERE = Path(__file__).resolve().parent
+INPUTS = HERE.parent / "normalize_v0" / "inputs"
+CASES = HERE / "cases"
+
+# Published conformance key. A test secret, never a production credential.
+SECRET = b"ingest-conformance-shared-secret-0001"
+FIXED = {
+    "iss": "did:web:vaara.io",
+    "sub": "sink",
+    "secretVersion": "k1",
+    "nonce": "ingest-fixed-nonce-000000",
+    "iat": "2026-06-23T00:00:00Z",
+}
+
+
+def _emit(name: str):
+    doc = json.loads((INPUTS / f"{name}.json").read_text())
+    return emit_ingest_receipt(
+        normalized=normalize(doc),
+        iss=FIXED["iss"],
+        sub=FIXED["sub"],
+        secret_version=FIXED["secretVersion"],
+        alg="HS256",
+        signing_material=SECRET,
+        nonce=FIXED["nonce"],
+        iat=FIXED["iat"],
+    )
+
+
+def _corpus_digest(manifest: dict) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(manifest)).hexdigest()
+
+
+def main() -> int:
+    CASES.mkdir(exist_ok=True)
+    names = sorted(p.stem for p in INPUTS.glob("*.json"))
+
+    manifest: dict[str, dict[str, str]] = {}
+    for name in names:
+        r = _emit(name)
+        (CASES / f"{name}.json").write_text(
+            json.dumps({"record": r.record, "evidence": r.evidence}, indent=2,
+                       sort_keys=True) + "\n"
+        )
+        manifest[name] = {
+            "evidenceDigest": r.record["evidenceRef"]["digest"],
+            "signature": r.record["signature"],
+        }
+
+    corpus = {
+        "schema": "vaara.ingest-conformance/v0",
+        "alg": "HS256",
+        "sharedSecretHex": SECRET.hex(),
+        "fixed": FIXED,
+        "cases": names,
+        "manifest": manifest,
+        "corpusDigest": _corpus_digest(manifest),
+    }
+    (HERE / "corpus.json").write_text(
+        json.dumps(corpus, indent=2, sort_keys=True) + "\n"
+    )
+    print(f"wrote {len(names)} cases; corpusDigest={corpus['corpusDigest']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/ingest_v0/cases/sep2643_rar_denial.json
+++ b/tests/vectors/ingest_v0/cases/sep2643_rar_denial.json
@@ -1,0 +1,60 @@
+{
+  "evidence": {
+    "advisory": {
+      "authorizationContextId": "authzctx_pay_9f2c",
+      "reason": "insufficient_authorization",
+      "remediationHintTypes": [
+        "oauth_authorization_details"
+      ]
+    },
+    "evidencePlane": "outcome",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived.completedAt"
+    ],
+    "notes": [
+      "a denial is the outcome of a refused call: it maps to outcomeDerived.status = refused",
+      "a refused outcome carries no resultCommitment",
+      "authorizationContextId is a correlation handle, not authorization material",
+      "the denial carries no completedAt, no signing envelope, and no back-link; the recording side supplies those"
+    ],
+    "populated": [
+      "outcomeDerived.status"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "outcomeDerived": {
+        "status": "refused"
+      }
+    },
+    "sourceFormat": "sep2643",
+    "sourceTitle": "SEP-2643 authorization denial"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:06e748273802ade556dac8d705c291af7dc6504ab15f25a31cd9ef102cfe245d",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "4333a5ea4a990207e2a0305890ed7d8cb0722c374be3dba81facd81b8b031395",
+    "sourceFormat": "sep2643",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/cases/sep2643_scope_denial.json
+++ b/tests/vectors/ingest_v0/cases/sep2643_scope_denial.json
@@ -1,0 +1,57 @@
+{
+  "evidence": {
+    "advisory": {
+      "authorizationContextId": "authzctx_8a3e1f4b",
+      "reason": "insufficient_authorization"
+    },
+    "evidencePlane": "outcome",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived.completedAt"
+    ],
+    "notes": [
+      "a denial is the outcome of a refused call: it maps to outcomeDerived.status = refused",
+      "a refused outcome carries no resultCommitment",
+      "authorizationContextId is a correlation handle, not authorization material",
+      "the denial carries no completedAt, no signing envelope, and no back-link; the recording side supplies those"
+    ],
+    "populated": [
+      "outcomeDerived.status"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "outcomeDerived": {
+        "status": "refused"
+      }
+    },
+    "sourceFormat": "sep2643",
+    "sourceTitle": "SEP-2643 authorization denial"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:7a655ee9e74dd6a2661132f3fc95b6d52f7f9f7598b2839289b709d5abe2f47f",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "74a04d2ee855ab3484b35a53fb14620bf39d6d77dc7966d80fdc494c124208c1",
+    "sourceFormat": "sep2643",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/cases/sep2643_url_denial.json
+++ b/tests/vectors/ingest_v0/cases/sep2643_url_denial.json
@@ -1,0 +1,60 @@
+{
+  "evidence": {
+    "advisory": {
+      "authorizationContextId": "authzctx_7c5d1d79",
+      "reason": "insufficient_authorization",
+      "remediationHintTypes": [
+        "url"
+      ]
+    },
+    "evidencePlane": "outcome",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived.completedAt"
+    ],
+    "notes": [
+      "a denial is the outcome of a refused call: it maps to outcomeDerived.status = refused",
+      "a refused outcome carries no resultCommitment",
+      "authorizationContextId is a correlation handle, not authorization material",
+      "the denial carries no completedAt, no signing envelope, and no back-link; the recording side supplies those"
+    ],
+    "populated": [
+      "outcomeDerived.status"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "outcomeDerived": {
+        "status": "refused"
+      }
+    },
+    "sourceFormat": "sep2643",
+    "sourceTitle": "SEP-2643 authorization denial"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:900db896cfb906480651be2c3fab953c08b733f8c911f8d06ba96d66542f1367",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "fc5f9bfa55602c3f7bdc3039d05a3ff8364ac98974a959fab7d7420d76d7db21",
+    "sourceFormat": "sep2643",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/cases/sep2787_attestation.json
+++ b/tests/vectors/ingest_v0/cases/sep2787_attestation.json
@@ -1,0 +1,65 @@
+{
+  "evidence": {
+    "advisory": {
+      "attestation_alg": "HS256",
+      "attestation_iss": "issuer://test",
+      "attestation_sub": "agent:archiver",
+      "intent": "archive obsolete report",
+      "toolCalls": [
+        {
+          "name": "delete_file",
+          "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    },
+    "evidencePlane": "decision-attested",
+    "missing": [
+      "alg",
+      "signature",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "a SEP-2787 attestation is the attested request a SEP-2828 receipt answers; it fixes the exact back-link a conformant receipt must pin",
+      "plannerDeclared.intent is client-declared and bound by the issuer's signature, not asserted true by the issuer",
+      "the record's own signing (alg, signature, receiptAsserted) is a separate event by the recording side, not derived from the attestation"
+    ],
+    "populated": [
+      "backLink.attestationDigest",
+      "backLink.attestationNonce"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "backLink": {
+        "attestationDigest": "sha256:79acdd4bb3c22a688b1c3321b9a26cafb5cb58c990a963874066d04b8497f70b",
+        "attestationNonce": "fixed-attestation-nonce-000"
+      }
+    },
+    "sourceFormat": "sep2787",
+    "sourceTitle": "SEP-2787 tool-call attestation"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:9bd7611b104a86a21e59f03f3ab78f4d9a5e1dca6b6453a6bcf6f780625f8052",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "19451f4c1298d80e57206d3d492a31d4ed28be7d4f85946ae817ff3073852495",
+    "sourceFormat": "sep2787",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/cases/sep2787_attestation_with_extension.json
+++ b/tests/vectors/ingest_v0/cases/sep2787_attestation_with_extension.json
@@ -1,0 +1,65 @@
+{
+  "evidence": {
+    "advisory": {
+      "attestation_alg": "HS256",
+      "attestation_iss": "issuer://test",
+      "attestation_sub": "agent:archiver",
+      "intent": "archive obsolete report",
+      "toolCalls": [
+        {
+          "name": "delete_file",
+          "serverFingerprint": "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ]
+    },
+    "evidencePlane": "decision-attested",
+    "missing": [
+      "alg",
+      "signature",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "a SEP-2787 attestation is the attested request a SEP-2828 receipt answers; it fixes the exact back-link a conformant receipt must pin",
+      "plannerDeclared.intent is client-declared and bound by the issuer's signature, not asserted true by the issuer",
+      "the record's own signing (alg, signature, receiptAsserted) is a separate event by the recording side, not derived from the attestation"
+    ],
+    "populated": [
+      "backLink.attestationDigest",
+      "backLink.attestationNonce"
+    ],
+    "recognized": true,
+    "sep2828": {
+      "backLink": {
+        "attestationDigest": "sha256:79acdd4bb3c22a688b1c3321b9a26cafb5cb58c990a963874066d04b8497f70b",
+        "attestationNonce": "fixed-attestation-nonce-000"
+      }
+    },
+    "sourceFormat": "sep2787",
+    "sourceTitle": "SEP-2787 tool-call attestation"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:9bd7611b104a86a21e59f03f3ab78f4d9a5e1dca6b6453a6bcf6f780625f8052",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "19451f4c1298d80e57206d3d492a31d4ed28be7d4f85946ae817ff3073852495",
+    "sourceFormat": "sep2787",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/cases/sep2817_multiturn.json
+++ b/tests/vectors/ingest_v0/cases/sep2817_multiturn.json
@@ -1,0 +1,52 @@
+{
+  "evidence": {
+    "advisory": {
+      "invocationReason": "Need to inspect available tables before generating a query.",
+      "model": "example-model",
+      "turnId": "2f4f0c9e-8d72-4c66-9c6f-3f7f3e6a1c9f",
+      "userIntentRedacted": true
+    },
+    "evidencePlane": "decision-input",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "SEP-2817 is client-asserted input audit context; per its own specification it MUST NOT be used as authorization evidence",
+      "it maps to the decision-input plane (the agent's stated intent), the unsigned counterpart of an attested rationale, and populates no required SEP-2828 field",
+      "turnId groups requests from one user turn; it is correlation only"
+    ],
+    "populated": [],
+    "recognized": true,
+    "sep2828": {},
+    "sourceFormat": "sep2817",
+    "sourceTitle": "SEP-2817 AI invocation audit context"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:e5e2ff7b6c35e8a9de5086ddb9764ef4c321456ec8aba30dd08bcd8b5f8e68e8",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "1d188537ce03f2c8eb2feac5463a2bcc2093ac68764b44f64fd1f0412ba27af0",
+    "sourceFormat": "sep2817",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/cases/sep2817_single.json
+++ b/tests/vectors/ingest_v0/cases/sep2817_single.json
@@ -1,0 +1,52 @@
+{
+  "evidence": {
+    "advisory": {
+      "invocationReason": "The user asked to view employee rows, and the employees table was identified as the target table.",
+      "model": "example-model",
+      "turnId": "opaque-client-generated-id",
+      "userIntent": "Show me 10 employees"
+    },
+    "evidencePlane": "decision-input",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "SEP-2817 is client-asserted input audit context; per its own specification it MUST NOT be used as authorization evidence",
+      "it maps to the decision-input plane (the agent's stated intent), the unsigned counterpart of an attested rationale, and populates no required SEP-2828 field",
+      "turnId groups requests from one user turn; it is correlation only"
+    ],
+    "populated": [],
+    "recognized": true,
+    "sep2828": {},
+    "sourceFormat": "sep2817",
+    "sourceTitle": "SEP-2817 AI invocation audit context"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:1fe5c7025515dfeaef6cd6e88b4ace4de999511008bb0ca7481390aaff48e371",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "d6fdeb5d30e0923f0202f4ea526ec67d46f72dfa7edd73ae9cf79a4d71677be4",
+    "sourceFormat": "sep2817",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/cases/unknown.json
+++ b/tests/vectors/ingest_v0/cases/unknown.json
@@ -1,0 +1,39 @@
+{
+  "evidence": {
+    "advisory": {},
+    "evidencePlane": null,
+    "missing": [],
+    "notes": [
+      "not a SEP-2643 denial, SEP-2787 attestation, or SEP-2817 invocation audit context; nothing to normalize"
+    ],
+    "populated": [],
+    "recognized": false,
+    "sep2828": {},
+    "sourceFormat": "unknown",
+    "sourceTitle": "unrecognized record"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:51699f76cdeb6fbedf45041ff60720aeaa3a74fe8c846b31990485897638ee69",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "0226a4e0414e58956a822d8317f3130cd91defdac939863fc21a35da6239e646",
+    "sourceFormat": "unknown",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/corpus.json
+++ b/tests/vectors/ingest_v0/corpus.json
@@ -1,0 +1,57 @@
+{
+  "alg": "HS256",
+  "cases": [
+    "sep2643_rar_denial",
+    "sep2643_scope_denial",
+    "sep2643_url_denial",
+    "sep2787_attestation",
+    "sep2787_attestation_with_extension",
+    "sep2817_multiturn",
+    "sep2817_single",
+    "unknown"
+  ],
+  "corpusDigest": "sha256:917e5f5c8f500982b7e5bbe93664db212f6c45a11e8d6297e2dcb7aa62827682",
+  "fixed": {
+    "iat": "2026-06-23T00:00:00Z",
+    "iss": "did:web:vaara.io",
+    "nonce": "ingest-fixed-nonce-000000",
+    "secretVersion": "k1",
+    "sub": "sink"
+  },
+  "manifest": {
+    "sep2643_rar_denial": {
+      "evidenceDigest": "sha256:06e748273802ade556dac8d705c291af7dc6504ab15f25a31cd9ef102cfe245d",
+      "signature": "4333a5ea4a990207e2a0305890ed7d8cb0722c374be3dba81facd81b8b031395"
+    },
+    "sep2643_scope_denial": {
+      "evidenceDigest": "sha256:7a655ee9e74dd6a2661132f3fc95b6d52f7f9f7598b2839289b709d5abe2f47f",
+      "signature": "74a04d2ee855ab3484b35a53fb14620bf39d6d77dc7966d80fdc494c124208c1"
+    },
+    "sep2643_url_denial": {
+      "evidenceDigest": "sha256:900db896cfb906480651be2c3fab953c08b733f8c911f8d06ba96d66542f1367",
+      "signature": "fc5f9bfa55602c3f7bdc3039d05a3ff8364ac98974a959fab7d7420d76d7db21"
+    },
+    "sep2787_attestation": {
+      "evidenceDigest": "sha256:9bd7611b104a86a21e59f03f3ab78f4d9a5e1dca6b6453a6bcf6f780625f8052",
+      "signature": "19451f4c1298d80e57206d3d492a31d4ed28be7d4f85946ae817ff3073852495"
+    },
+    "sep2787_attestation_with_extension": {
+      "evidenceDigest": "sha256:9bd7611b104a86a21e59f03f3ab78f4d9a5e1dca6b6453a6bcf6f780625f8052",
+      "signature": "19451f4c1298d80e57206d3d492a31d4ed28be7d4f85946ae817ff3073852495"
+    },
+    "sep2817_multiturn": {
+      "evidenceDigest": "sha256:e5e2ff7b6c35e8a9de5086ddb9764ef4c321456ec8aba30dd08bcd8b5f8e68e8",
+      "signature": "1d188537ce03f2c8eb2feac5463a2bcc2093ac68764b44f64fd1f0412ba27af0"
+    },
+    "sep2817_single": {
+      "evidenceDigest": "sha256:1fe5c7025515dfeaef6cd6e88b4ace4de999511008bb0ca7481390aaff48e371",
+      "signature": "d6fdeb5d30e0923f0202f4ea526ec67d46f72dfa7edd73ae9cf79a4d71677be4"
+    },
+    "unknown": {
+      "evidenceDigest": "sha256:51699f76cdeb6fbedf45041ff60720aeaa3a74fe8c846b31990485897638ee69",
+      "signature": "0226a4e0414e58956a822d8317f3130cd91defdac939863fc21a35da6239e646"
+    }
+  },
+  "schema": "vaara.ingest-conformance/v0",
+  "sharedSecretHex": "696e676573742d636f6e666f726d616e63652d7368617265642d7365637265742d30303031"
+}


### PR DESCRIPTION
# v1.10.0: the universal evidence sink

Foreign evidence flows in; one canonical signed record flows out. Adjacent formats become source formats rather than rivals.

## What lands

**`vaara.ingest/v0` envelope.** Seals any record `normalize` understands (SEP-2643, SEP-2787, SEP-2817, or an unrecognized record) into one signed, content-addressed record. `evidenceRef.digest` is `sha256:` + JCS(normalized evidence). The honest gap report (`missing`), the established proof fields (`sep2828`), and the non-proof context (`advisory`) all live inside that digested object, so editing the gap report or a proof field breaks the signature.

It asserts nothing the source did not establish: no fabricated verdict, no fabricated back-link. That is why it is a sibling of `vaara.receipt/v1`, not a profile, and cannot reuse the receipt or authorization envelopes. Same JCS + ES256/HS256/RS256 stack, no new crypto. `completeness` carries a per-stream `seq` and `runningCount`, so a dropped record inside a stream stays a provable gap.

**Generated conformance corpus.** `tests/vectors/ingest_v0/` is a loop over the normalize input corpus, not a hand-authored set. `_generate.py` emits deterministic `{record, evidence}` pairs; `_check_independent.py` reproduces every content address and HS256 signature with no Vaara import (standard library plus the JCS canonicalizer). Adding a source format is a `SourceProfile` registration plus one input fixture, and its vector materializes from the loop. A drift guard fails the suite if emit logic changes without a regenerate.

**`vaara ingest` CLI.** Signs with a PEM `--key` (EC P-256 to ES256, RSA to RS256) or `--hs256-secret-file`, and writes the `{record, evidence}` pair.

**Spec.** `SPEC.md` Section 6 specifies the envelope and its conformance run. Conformance and Versioning renumber to Sections 7 and 8.

## Verification

Full suite green. The ingest layer adds 41 tests, including the generative pass over every registered source, the tamper checks that prove the gap report rides under the signature, and the standalone-checker subprocess gate. The independent checker:

    python tests/vectors/ingest_v0/_check_independent.py

reproduces all content addresses, signatures, and the corpus digest, exit 0.

## Not in this release

did:web ARD ingest is deferred until the peer corpus field names settle; it then drops into the registry loop like any other format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `vaara.ingest/v0` signed envelope for deterministically sealing normalized evidence records with content-addressed protection
  * Added CLI `ingest` command supporting ES256, RS256, and HS256 signing methods via `--key` and `--hs256-secret-file` options
  * Implemented independent verification mechanism for published conformance vectors with drift detection

* **Documentation**
  * Updated specification with ingest envelope details, conformance requirements, and verification procedures

* **Chores**
  * Bumped version to 1.10.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->