### PR TITLE
docs: discoverability, README recompute (a) + open-web verify page (b)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Pages
+
+# Publish the open-web verify page (web/) to GitHub Pages.
+# Static upload only: no Jekyll, no build step, the directory ships as-is.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
+        with:
+          path: web
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ vaara verify-bundle evidence-bundle.json
 
 `ok` only when a signature is actually established, not merely present in a log. The same property drives the standards work behind [SEP-2828](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828): evidence that holds up for someone who runs none of your software. The full verifier set, the trust model for each verb, and where trust comes from in each case are in [docs/verifying-evidence.md](docs/verifying-evidence.md).
 
+To check that claim yourself, without installing Vaara, run the standalone checker against the published vectors. Its only dependencies are `cryptography` and `rfc8785`:
+
+```bash
+git clone https://github.com/vaaraio/vaara
+cd vaara
+pip install cryptography rfc8785        # the checker's only dependencies
+python tests/vectors/external_evidence_v0/_check_independent.py
+```
+
+It re-derives every verdict from the receipt bytes and the public key alone. The output shows the property the trail is built for: a receipt dropped from inside a declared boundary is a provable gap from the held set, with no issuer access and no external witness.
+
+```
+[OK] complete.contiguity: {'ok': True, 'present': 3, 'expected': 3, 'missingSeqs': []}
+[OK] dropped.contiguity: {'ok': False, 'present': 2, 'expected': 3, 'missingSeqs': [1]}
+```
+
 ## What the evidence looks like
 
 `vaara compliance report --format json` against a real trail produces an article-level evidence record an auditor reads directly. Articles with no recorded events return `evidence_insufficient`, not a rubber stamp.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,187 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Independently verify what an AI agent did | Vaara</title>
+<meta name="description" content="Vaara turns every action an AI agent takes into a signed, hash-chained record an outside party can verify offline, with no key, no access, and none of the producer's code. Built for EU AI Act Article 12 record-keeping. Open source, no SaaS.">
+<meta name="robots" content="index,follow,max-image-preview:large">
+<link rel="canonical" href="https://vaaraio.github.io/vaara/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Independently verify what an AI agent did">
+<meta property="og:description" content="A signed, hash-chained record of every agent action that an outside party can reproduce offline, with none of your code. Built for EU AI Act Article 12.">
+<meta property="og:url" content="https://vaaraio.github.io/vaara/">
+<meta property="og:site_name" content="Vaara">
+<meta property="og:image" content="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-light.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Independently verify what an AI agent did">
+<meta name="twitter:description" content="A signed, hash-chained record of every agent action, reproducible offline by anyone, with none of your code. EU AI Act Article 12.">
+<style>
+  :root {
+    --bg: #ececec;
+    --ink: #1a1a1a;
+    --rule: #cfcfcf;
+    --muted: #6b6b6b;
+    --accent: #5fb878;
+    --mono: 'JetBrains Mono','Fira Code','Hack','Cascadia Code','SF Mono','Menlo','Consolas','Liberation Mono',monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #2a2a2a;
+      --ink: #eaeaea;
+      --rule: #3a3a3a;
+      --muted: #888;
+      --accent: #5fb878;
+    }
+  }
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0;
+    min-height: 100vh;
+    background: var(--bg); color: var(--ink);
+    font-family: var(--mono); font-size: 15px; line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 740px; margin: 0 auto; padding: 16px 28px 96px; }
+  .wordmark { margin: 0 auto; text-align: center; }
+  .wordmark img { width: min(70vw, 520px); height: auto; display: inline-block; }
+  h1 { font-size: 1.18rem; font-weight: 600; color: var(--ink); margin: 8px 0 14px; letter-spacing: -0.2px; text-align: center; line-height: 1.4; }
+  h2 { font-size: 0.7rem; letter-spacing: 1.8px; text-transform: uppercase; color: var(--muted); font-weight: 600; margin: 48px 0 14px; }
+  h3 { font-size: 0.95rem; font-weight: 600; margin: 24px 0 6px; }
+  p { margin: 0 0 18px; color: var(--ink); }
+  .stance { font-size: 0.86rem; color: var(--muted); margin-bottom: 40px; letter-spacing: 0.2px; text-align: center; }
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px solid transparent; }
+  a:hover { border-bottom-color: var(--accent); }
+  pre { background: #0a0a0a; color: #e7e7e7; border: 1px solid #1f1f1f; margin: 0 0 18px; padding: 16px 18px; font-size: 0.78rem; line-height: 1.6; overflow-x: auto; white-space: pre; }
+  pre .prompt { color: var(--accent); }
+  pre .ok { color: var(--accent); }
+  pre .bad { color: #d98b8b; }
+  pre .dim { color: #888; }
+  code { font-size: 0.82rem; background: rgba(95,184,120,0.12); padding: 1px 5px; border-radius: 3px; }
+  ul { margin: 0 0 18px; padding: 0; list-style: none; border-top: 1px solid var(--rule); }
+  ul li { padding: 12px 0 12px 24px; border-bottom: 1px solid var(--rule); color: var(--ink); position: relative; }
+  ul li::before { content: "\00B7"; color: var(--muted); font-size: 1.2rem; line-height: 1; position: absolute; left: 0; top: 12px; }
+  ul li b { font-weight: 600; }
+  .faq h3 { margin-top: 28px; }
+  .links { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin-top: 8px; }
+  .links a { color: var(--ink); border: 1.5px solid var(--muted); border-bottom: 1.5px solid var(--muted); padding: 14px 16px; font-size: 0.92rem; display: flex; flex-direction: column; gap: 6px; transition: border-color 0.15s ease, color 0.15s ease, transform 0.06s ease, box-shadow 0.15s ease; background: var(--bg); }
+  .links a:hover { border-color: var(--ink); color: var(--accent); box-shadow: 0 2px 0 0 var(--ink); transform: translate(0, -1px); }
+  .links .label { color: var(--muted); font-size: 0.66rem; letter-spacing: 1.8px; text-transform: uppercase; font-weight: 600; }
+  .links a:hover .label { color: var(--ink); }
+  .links .target { font-size: 0.86rem; color: var(--ink); word-break: break-all; }
+  .links a:hover .target { color: var(--accent); }
+  @media (max-width: 520px) { .links { grid-template-columns: 1fr; } }
+  footer { margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--rule); font-size: 0.78rem; color: var(--muted); letter-spacing: 0.2px; }
+</style>
+</head>
+<body>
+<main>
+<div class="wordmark">
+  <picture>
+    <source srcset="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-dark.png" media="(prefers-color-scheme: dark)">
+    <img src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-light.png" alt="Vaara">
+  </picture>
+</div>
+
+<h1>Verify what an AI agent actually did, without trusting whoever ran it.</h1>
+<p class="stance">Open source. No SaaS. No telemetry. EU AI Act Article 12.</p>
+
+<p>Your AI agent transferred the funds, wrote the file, called the tool. Later someone who does not trust you, a regulator, an auditor, a customer after an incident, asks you to prove exactly what it did. Your own logs will not settle it, because you could have edited them.</p>
+
+<p>Vaara is an open-source evidence layer for AI agents. It checks every tool call against your policy, writes the call and its outcome into a hash-chained, signed record, and binds that record to your machine's own TPM 2.0 hardware root. An outside party can verify the whole trail offline, with no access to your system and none of your software.</p>
+
+<h2>Reproduce a verdict yourself</h2>
+<p>Writing a trail is the easy half. The half that matters is letting someone who does not trust you check it, with no key, no access, and none of your code. Every record ships with public conformance vectors and a standalone checker that imports no Vaara code. Its only dependencies are <code>cryptography</code> and <code>rfc8785</code>:</p>
+<pre><span class="prompt">git clone https://github.com/vaaraio/vaara</span>
+<span class="prompt">cd vaara</span>
+<span class="prompt">pip install cryptography rfc8785</span>        <span class="dim"># the checker's only dependencies</span>
+<span class="prompt">python tests/vectors/external_evidence_v0/_check_independent.py</span></pre>
+<p>It re-derives every verdict from the receipt bytes and the public key alone. The output shows the property the trail is built for: a record dropped from inside a declared boundary is a provable gap from the held set, with no issuer access and no external witness.</p>
+<pre>[<span class="ok">OK</span>] complete.contiguity: {'ok': True,  'present': 3, 'expected': 3, 'missingSeqs': []}
+[<span class="ok">OK</span>] dropped.contiguity:  {'ok': <span class="bad">False</span>, 'present': 2, 'expected': 3, 'missingSeqs': [1]}</pre>
+
+<h2>What makes a record verifiable</h2>
+<ul>
+  <li><b>Content-addressed and fail-closed on authenticity.</b> A verdict is <code>ok</code> only when a signature is actually established, not merely present in a log.</li>
+  <li><b>Hash-chained, tamper-evident trail.</b> SHA-256, with optional Ed25519 and optional post-quantum ML-DSA-65. An auditor verifies it offline with a public key.</li>
+  <li><b>Hardware-rooted.</b> The record is bound to the producing machine's TPM 2.0, so it cannot be reattributed to a different system.</li>
+  <li><b>External time anchor.</b> The chain head is anchored to an RFC 3161 / eIDAS qualified timestamp, so a record cannot be backdated against a clock you do not control.</li>
+  <li><b>Gap-evident completeness.</b> A receipt dropped from inside a declared boundary shows up as a provable gap, not a silent omission. This is the part most audit logs cannot do, and the one Article 12 actually turns on.</li>
+</ul>
+
+<h2>The standard underneath</h2>
+<p>The verifiable record is one schema, <code>vaara.receipt/v1</code>, defined in <a href="https://github.com/vaaraio/vaara/blob/main/SPEC.md">SPEC.md</a> and carried forward as the IETF Internet-Draft <a href="https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/">draft-sirkkavaara-vaara-receipt</a>. Payment, identity, and agent-framework formats bind to it by naming their artifact through one slot rather than inventing a new receipt each time: x402 settlement, AP2 checkout, Visa TAP requests, eIDAS qualified timestamps, and CrewAI runs are all instances of the same schema. The Model Context Protocol server-side execution-record proposal, <a href="https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828">SEP-2828</a>, is authored against the same contract.</p>
+
+<div class="faq">
+<h2>Questions</h2>
+<h3>How do I verify what an AI agent did?</h3>
+<p>Take the agent's signed execution records and recompute each verdict from the record bytes and the issuer's public key. With Vaara this is a standalone checker that imports none of the producer's code, so the verification holds even for someone who does not trust the system that produced the records. The command above reproduces it on the published vectors.</p>
+<h3>Can I check an agent's audit log without trusting the system that produced it?</h3>
+<p>Yes. Records are content-addressed and fail-closed on authenticity, and the checker needs no signing key and no access to the producing system. A signature has to be cryptographically established for a record to pass, and a missing record inside a declared boundary is reported as a gap rather than silently dropped.</p>
+<h3>What does EU AI Act Article 12 require for AI logging?</h3>
+<p>Article 12 requires high-risk AI systems to automatically record events (logs) over their lifetime to a degree that enables traceability of the system's functioning. The hard part is making those logs trustworthy to an outside party after the fact: tamper-evident, complete, and bound to a clock and a machine the operator does not control. That is the case Vaara was built for.</p>
+</div>
+
+<h2>Where</h2>
+<div class="links">
+  <a href="https://vaara.io/"><span class="label">home</span><span class="target">vaara.io</span></a>
+  <a href="https://github.com/vaaraio/vaara"><span class="label">code</span><span class="target">github.com/vaaraio/vaara</span></a>
+  <a href="https://github.com/vaaraio/vaara/blob/main/SPEC.md"><span class="label">spec</span><span class="target">vaara.receipt/v1</span></a>
+  <a href="https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/"><span class="label">internet-draft</span><span class="target">draft-sirkkavaara-vaara-receipt</span></a>
+  <a href="https://pypi.org/project/vaara/"><span class="label">pypi</span><span class="target">pypi.org/project/vaara</span></a>
+  <a href="https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828"><span class="label">proposal</span><span class="target">SEP-2828</span></a>
+</div>
+
+<footer>AGPL-3.0. EU-built. Single maintainer. Sigstore-signed releases.</footer>
+</main>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "SoftwareApplication",
+      "name": "Vaara",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "Linux, macOS, Windows",
+      "description": "Open-source evidence layer for AI agents. Turns every agent action into a signed, hash-chained record an outside party can verify offline, with no key, no access, and none of the producer's code. Built for EU AI Act Article 12 record-keeping.",
+      "url": "https://vaara.io/",
+      "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+      "softwareLicense": "AGPL-3.0",
+      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+      "codeRepository": "https://github.com/vaaraio/vaara"
+    },
+    {
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How do I verify what an AI agent did?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Take the agent's signed execution records and recompute each verdict from the record bytes and the issuer's public key. With Vaara this is a standalone checker that imports none of the producer's code, so the verification holds even for someone who does not trust the system that produced the records."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can I check an agent's audit log without trusting the system that produced it?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Records are content-addressed and fail-closed on authenticity, and the checker needs no signing key and no access to the producing system. A signature has to be cryptographically established for a record to pass, and a missing record inside a declared boundary is reported as a gap rather than silently dropped."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What does EU AI Act Article 12 require for AI logging?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Article 12 requires high-risk AI systems to automatically record events over their lifetime to a degree that enables traceability of the system's functioning. The hard part is making those logs trustworthy to an outside party after the fact: tamper-evident, complete, and bound to a clock and a machine the operator does not control."
+          }
+        }
+      ]
+    }
+  ]
+}
+</script>
+</body>
+</html>

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vaaraio.github.io/vaara/sitemap.xml

--- a/web/sitemap.xml
+++ b/web/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://vaaraio.github.io/vaara/</loc>
+    <lastmod>2026-06-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Two legs of one discoverability move, folded together so they ship in one publishment.

**Leg (a), README recompute (commit b6eda6e).** The "Verify it without trusting the producer" section claimed a checker that imports no Vaara code, but only showed `vaara verify-bundle`, which needs an install. This adds the actual zero-install path: clone, `pip install cryptography rfc8785`, run the `external_evidence_v0` standalone checker, with its gap-evident contiguity output. Verified byte-for-byte against the published vector.

**Leg (b), open-web verify page (commit 7f41f29).** A static, indexable page under `web/`, served via GitHub Pages at https://vaaraio.github.io/vaara/, so someone searching "verify what an AI agent did" or "EU AI Act Article 12 audit trail" lands on the substrate rather than on an uncited re-derivation of it. It carries the same code-true recompute and verdict output as the README, plus SoftwareApplication and FAQPage JSON-LD, OpenGraph tags, a canonical link, robots, and a sitemap. License is stated correctly as AGPL-3.0.

`.github/workflows/pages.yml` does a static upload of `web/` with no Jekyll step. Every action is SHA-pinned to match the repo convention. Pages source is set to GitHub Actions.

No behaviour change to the package: docs and one static page only.
