### PR TITLE
feat(corpus): governance_decision_v0 conformance set

### DIFF
--- a/tests/test_governance_decision_vectors.py
+++ b/tests/test_governance_decision_vectors.py
@@ -1,0 +1,30 @@
+"""Gate the governance_decision_v0 vectors through the independent checker.
+
+The checker imports no Vaara: a passing run means the committed CrewAI
+``GovernanceDecision`` / ``GovernanceOutcome`` corpus proves its own derivations,
+its sealed completeness (mid-gap, suffix drop, and the unsealed residual), the
+four fail-closed verdicts, and the non-ASCII canonicalization, from the held
+bytes and the public key alone. This is the conformance bar, run in CI.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
+VECTORS = Path(__file__).resolve().parent / "vectors" / "governance_decision_v0"
+
+
+def test_independent_checker_passes():
+    proc = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr

--- a/tests/vectors/governance_decision_v0/README.md
+++ b/tests/vectors/governance_decision_v0/README.md
@@ -1,0 +1,89 @@
+# governance_decision_v0 conformance corpus
+
+A reproducible vector set over the CrewAI `GovernanceDecision` / `GovernanceOutcome`
+contract proposed in [crewAIInc/crewAI#6030](https://github.com/crewAIInc/crewAI/issues/6030),
+plus the completeness layer that `vaara.integrations.crewai` (vaaraio/vaara#283)
+emits across a crew run. The contract envelope is CrewAI's. What this corpus pins
+is the part an auditor recomputes: the content derivations, the gap-evident
+sequence, the terminal seal, and the fail-closed verdicts.
+
+`_check_independent.py` reproduces every verdict with no Vaara import, only
+`rfc8785` (RFC 8785 JCS) and `cryptography`. A passing run is therefore a
+property of the committed bytes, not of the generator. `_generate.py` rebuilds
+the fixtures; the keys are a fixed test scalar so the bytes are stable.
+
+## Signed bytes
+
+Each record is wrapped as `{"record": {...}, "signature": "<128 hex>"}`. The
+signature is ES256 (P-256 + SHA-256) over `JCS(record)`; the 128 hex chars are
+`r || s`, 32 bytes each. The public key is `keys/es256_public.pem`.
+
+## Derivation preimages
+
+Every digest is `sha256:` + `hex(SHA256(JCS(member_set)))`. JCS (RFC 8785) is the
+canonicalizer, so the preimages below are exact and language-independent:
+
+| field | preimage member set |
+| --- | --- |
+| `params_hash` | `JCS(params)` |
+| `intent_digest` | `JCS({action_type, normalized_scope, params_hash})` |
+| `intent_ref` | `JCS({schema, agent_id, action_type, normalized_scope, intent_digest})` |
+| `target_state_digest` | `JCS(target_state)` |
+| `decision_context_hash` | `JCS({policy_refs, target_state_digest, continuation_id, normalization_id})` |
+| `receipt_ref` | `JCS({intent_ref, target_state_digest, continuation_id, seq, timestamp_ms, idempotency_key})` |
+
+`intent_ref` carries no timestamp, so the same authorized intent recomputes to
+the same identity on a retry. `receipt_ref` carries `seq` and `timestamp_ms`, so
+it is unique per execution attempt. That is what makes a replayed outcome
+detectable. `params_hash` and `target_state_digest` are the committed leaves the
+record carries in place of the raw params / target state; the receipt commits to
+a hash, not the cleartext, so the checker takes them as given and recomputes the
+four refs derived from them.
+
+## Sealed completeness
+
+Each `stream/<case>/` holds `NNNN-decision.json` + `NNNN-outcome.json` per `seq`,
+0-indexed, with `runningCount == seq + 1`. A terminal `GovernanceSeal` carries
+the boundary `total`. The four cases isolate what the seal buys you:
+
+| case | held seqs | seal | verdict |
+| --- | --- | --- | --- |
+| `complete` | 0,1,2,3 | yes | `ok: true` |
+| `dropped` | 0,1,3 | yes | `ok: false`, `missingSeqs: [2]` (mid-gap, caught by the running count alone) |
+| `tail_sealed` | 0,1,2 | yes | `ok: false`, `missingSeqs: [3]` (suffix drop, caught only because the seal pins the total) |
+| `tail_unsealed` | 0,1,2 | no | `ok: true`, the irreducible residual (with no seal, a held prefix looks whole) |
+
+`tail_unsealed` is the point of the seal. A mid-stream gap is self-evident from
+the running count, but a dropped tail is invisible without a boundary total to
+check against. That is why the seal is not optional.
+
+## Fail-closed verdicts
+
+Each `cases/<name>.json` carries the signed records and the verdict a verifier
+reaches by recomputing the mismatch, never by trusting a `decision` field:
+
+| case | recomputed condition | verdict |
+| --- | --- | --- |
+| `exact_intent_mismatch` | `candidate.intent_ref != approved.intent_ref` | `deny` |
+| `target_state_drift` | `intent_ref` equal, `target_state_digest` differs | `revise` |
+| `continuation_mismatch` | `intent_ref` equal, `continuation_id` and `decision_context_hash` differ | `deny` |
+| `duplicate_outcome` | two outcomes share `receipt_ref` and `idempotency_key` | `deny` |
+
+## Non-ASCII canonicalization
+
+`cases/unicode_scope.json` has a `normalized_scope` of `merchant:café/order:Ünïcode-€`.
+A producer that canonicalizes with `json.dumps(sort_keys=True)` escapes the
+non-ASCII bytes to `\uXXXX` and computes a different `intent_ref`; RFC 8785 emits
+raw UTF-8. The checker recomputes `intent_ref` over these bytes, so a non-JCS
+producer fails the vector. This is the cheapest way to catch a canonicalizer that
+is "sorted JSON" but not JCS.
+
+## What this corpus claims
+
+One file set covers: the six derivation preimages, completeness with a seal
+(mid-gap, suffix drop, and the unsealed residual), four fail-closed verdicts, and
+the Unicode trap, checked by a zero-import reproducer. It does **not** claim to
+be byte-identical to any other party's governance vectors (e.g. algovoi / LS);
+those preimages have not been verified here. The claim is completeness and
+reproducibility from the bytes alone. A cross-check against another producer's
+fixtures is welcome.

--- a/tests/vectors/governance_decision_v0/_check_independent.py
+++ b/tests/vectors/governance_decision_v0/_check_independent.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Independent checker for the governance_decision_v0 conformance vectors.
+
+Imports only the standard library plus ``cryptography`` and ``rfc8785``. It does
+NOT import Vaara. The corpus pins the bytes of the CrewAI ``GovernanceDecision``
+/ ``GovernanceOutcome`` contract (crewAIInc/crewAI#6030) and the completeness
+layer over it; a passing run here means each verdict is a property of those
+bytes, recomputable by anyone with the public key.
+
+What it reproduces, from the held records alone:
+
+* every wrapped ``{record, signature}`` verifies under ES256 over ``JCS(record)``;
+* the four *derived* content refs recompute from their stated member sets
+  (``intent_digest``, ``intent_ref``, ``decision_context_hash``, ``receipt_ref``).
+  ``params_hash`` and ``target_state_digest`` are the committed leaves the record
+  carries in place of the raw params / target state (the receipt commits to a
+  hash, not the cleartext), so they are taken as given, not re-hashed;
+* ``sealed_contiguity`` per stream case: ``dropped`` is a provable mid-gap,
+  ``tail_sealed`` is a suffix drop the seal still catches, ``tail_unsealed`` is
+  the irreducible residual where, with no seal, the held prefix looks whole;
+* the four fail-closed verdicts, each forced by the recomputed mismatch;
+* the non-ASCII case, where ``intent_ref`` recomputes over a unicode
+  ``normalized_scope`` that ``json.dumps(sort_keys=True)`` would not canonicalize
+  the same way RFC 8785 does.
+
+Run: tests/vectors/governance_decision_v0/_check_independent.py
+Exit 0 means every verdict matched expected.json.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+HERE = Path(__file__).resolve().parent
+_STREAM_CASES = ("complete", "dropped", "tail_sealed", "tail_unsealed")
+_SEALED = {"complete", "dropped", "tail_sealed"}  # tail_unsealed deliberately has no seal
+
+
+def _sha(obj) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(obj)).hexdigest()
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _verify_sig(pub, wrapped: dict) -> bool:
+    """ES256 over JCS(record); signature is 128 hex == r||s, 32 bytes each."""
+    record = wrapped.get("record")
+    sig = wrapped.get("signature", "")
+    if not isinstance(record, dict) or len(sig) != 128:
+        return False
+    raw = bytes.fromhex(sig)
+    der = encode_dss_signature(
+        int.from_bytes(raw[:32], "big"), int.from_bytes(raw[32:], "big")
+    )
+    try:
+        pub.verify(der, rfc8785.dumps(record), ec.ECDSA(hashes.SHA256()))
+        return True
+    except InvalidSignature:
+        return False
+
+
+def _recompute_refs(record: dict) -> dict:
+    """Recompute the four DERIVED refs from the record's own fields.
+
+    ``params_hash`` and ``target_state_digest`` are committed leaves carried in
+    the record (the raw params / target state are not disclosed), so they feed
+    the recompute as given. Every key here is read off the record, so the check
+    is self-describing: no constant is hardcoded into the checker.
+    """
+    intent_digest = _sha(
+        {
+            "action_type": record["action_type"],
+            "normalized_scope": record["normalized_scope"],
+            "params_hash": record["params_hash"],
+        }
+    )
+    intent_ref = _sha(
+        {
+            "schema": record["schema"],
+            "agent_id": record["agent_id"],
+            "action_type": record["action_type"],
+            "normalized_scope": record["normalized_scope"],
+            "intent_digest": intent_digest,
+        }
+    )
+    decision_context_hash = _sha(
+        {
+            "policy_refs": record["policy_refs"],
+            "target_state_digest": record["target_state_digest"],
+            "continuation_id": record["continuation_id"],
+            "normalization_id": record["normalization_id"],
+        }
+    )
+    receipt_ref = _sha(
+        {
+            "intent_ref": intent_ref,
+            "target_state_digest": record["target_state_digest"],
+            "continuation_id": record["continuation_id"],
+            "seq": record["completeness"]["seq"],
+            "timestamp_ms": record["timestamp_ms"],
+            "idempotency_key": record["idempotency_key"],
+        }
+    )
+    return {
+        "intent_digest": intent_digest,
+        "intent_ref": intent_ref,
+        "decision_context_hash": decision_context_hash,
+        "receipt_ref": receipt_ref,
+    }
+
+
+def _derivations_consistent(record: dict) -> bool:
+    refs = _recompute_refs(record)
+    return all(record[k] == v for k, v in refs.items())
+
+
+# --- contiguity, reproduced from scratch --------------------------------------
+
+
+def _contiguity(records: list[dict]) -> dict:
+    blocks = [r["record"]["completeness"] for r in records]
+    seqs = [int(b["seq"]) for b in blocks]
+    counts = [int(b["runningCount"]) for b in blocks]
+    expected = max((max(seqs) + 1 if seqs else 0), (max(counts) if counts else 0))
+    missing = sorted(set(range(expected)) - set(seqs))
+    mismatch = any(int(b["runningCount"]) != int(b["seq"]) + 1 for b in blocks)
+    present = len(blocks)
+    ok = not missing and not mismatch and len(seqs) == len(set(seqs)) and present == expected
+    return {"ok": ok, "present": present, "expected": expected, "missingSeqs": missing}
+
+
+def _sealed_contiguity(records: list[dict], seal: dict | None) -> dict:
+    base = _contiguity(records)
+    if seal is None:
+        return base
+    total = int(seal["record"]["total"])
+    seqs = {int(r["record"]["completeness"]["seq"]) for r in records}
+    missing = sorted(set(range(total)) - seqs)
+    ok = not missing and base["ok"] and base["expected"] == total
+    return {"ok": ok, "present": len(records), "expected": total, "missingSeqs": missing}
+
+
+def _load_stream(case: str) -> tuple[list[dict], dict | None]:
+    case_dir = HERE / "stream" / case
+    records = [_load(p) for p in sorted(case_dir.glob("*-decision.json"))]
+    seal_path = case_dir / "seal.json"
+    seal = _load(seal_path) if seal_path.exists() else None
+    return records, seal
+
+
+# --- fail-closed verdicts, recomputed from the case bytes ----------------------
+
+
+def _verdict_exact_intent_mismatch(case: dict) -> str:
+    a = _recompute_refs(case["approved"]["record"])["intent_ref"]
+    c = _recompute_refs(case["candidate"]["record"])["intent_ref"]
+    return "deny" if a != c else "allow"
+
+
+def _verdict_target_state_drift(case: dict) -> str:
+    ar, cr = case["approved"]["record"], case["candidate"]["record"]
+    same_intent = _recompute_refs(ar)["intent_ref"] == _recompute_refs(cr)["intent_ref"]
+    drift = ar["target_state_digest"] != cr["target_state_digest"]
+    return "revise" if (same_intent and drift) else "deny"
+
+
+def _verdict_continuation_mismatch(case: dict) -> str:
+    ar, cr = case["approved"]["record"], case["candidate"]["record"]
+    same_intent = _recompute_refs(ar)["intent_ref"] == _recompute_refs(cr)["intent_ref"]
+    moved = (
+        ar["continuation_id"] != cr["continuation_id"]
+        and _recompute_refs(ar)["decision_context_hash"]
+        != _recompute_refs(cr)["decision_context_hash"]
+    )
+    return "deny" if (same_intent and moved) else "allow"
+
+
+def _verdict_duplicate_outcome(case: dict) -> str:
+    f, s = case["first"]["record"], case["second"]["record"]
+    replay = f["receipt_ref"] == s["receipt_ref"] and f["idempotency_key"] == s["idempotency_key"]
+    return "deny" if replay else "allow"
+
+
+_VERDICTS = {
+    "exact_intent_mismatch": _verdict_exact_intent_mismatch,
+    "target_state_drift": _verdict_target_state_drift,
+    "continuation_mismatch": _verdict_continuation_mismatch,
+    "duplicate_outcome": _verdict_duplicate_outcome,
+}
+_CASE_WRAPPED = {  # which wrapped records each case file carries, for the sig pass
+    "exact_intent_mismatch": ("approved", "candidate"),
+    "target_state_drift": ("approved", "candidate"),
+    "continuation_mismatch": ("approved", "candidate"),
+    "duplicate_outcome": ("first", "second"),
+}
+
+
+def main() -> int:
+    pub = load_pem_public_key((HERE / "keys" / "es256_public.pem").read_bytes())
+    expected = json.loads((HERE / "expected.json").read_text(encoding="utf-8"))
+
+    results: list[tuple[str, bool]] = []
+
+    def check(label: str, ok: bool) -> None:
+        results.append((label, ok))
+        print(f"[{'OK' if ok else 'FAIL'}] {label}")
+
+    # 1+3. stream signatures, derivation consistency, sealed contiguity.
+    for case in _STREAM_CASES:
+        records, seal = _load_stream(case)
+        sigs_ok = all(_verify_sig(pub, r) for r in records)
+        check(f"stream.{case}.all_signatures_ok",
+              sigs_ok == expected["stream"][case]["all_signatures_ok"])
+        check(f"stream.{case}.derivations_consistent",
+              all(_derivations_consistent(r["record"]) for r in records))
+        got = _sealed_contiguity(records, seal if case in _SEALED else None)
+        check(f"stream.{case}.sealed_contiguity",
+              got == expected["stream"][case]["sealed_contiguity"])
+
+    # 2+4. fail-closed verdicts, each forced by the recomputed mismatch.
+    for name, fn in _VERDICTS.items():
+        case = _load(HERE / "cases" / f"{name}.json")
+        sigs_ok = all(_verify_sig(pub, case[k]) for k in _CASE_WRAPPED[name])
+        check(f"cases.{name}.signatures_ok",
+              sigs_ok == expected["cases"][name]["signatures_ok"])
+        check(f"cases.{name}.verdict",
+              fn(case) == expected["cases"][name]["expected_verdict"])
+
+    # 5. unicode normalized_scope: sig ok and intent_ref recomputes over the
+    # non-ASCII bytes; params_hash matches its committed leaf.
+    uni = _load(HERE / "cases" / "unicode_scope.json")
+    urec = uni["record"]
+    check("unicode_scope.signature_ok",
+          _verify_sig(pub, uni) == expected["unicode_scope"]["signature_ok"])
+    check("unicode_scope.intent_ref",
+          _recompute_refs(urec)["intent_ref"] == expected["unicode_scope"]["intent_ref"]
+          == urec["intent_ref"])
+    check("unicode_scope.params_hash",
+          urec["params_hash"] == expected["unicode_scope"]["params_hash"])
+
+    ok = all(v for _, v in results)
+    print(f"\n{'all verdicts matched expected' if ok else 'MISMATCH vs expected'}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/governance_decision_v0/_generate.py
+++ b/tests/vectors/governance_decision_v0/_generate.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Regenerate the governance_decision_v0 conformance vectors.
+
+These vectors pin the *bytes* of the CrewAI ``GovernanceDecision`` /
+``GovernanceOutcome`` contract (crewAIInc/crewAI#6030) and the completeness
+layer that ``vaara.integrations.crewai`` (vaaraio/vaara#283) emits over it, as
+one reproducible corpus. The contract envelope is CrewAI's; the recomputable
+derivations, the gap-evident sequence, and the terminal seal are what an auditor
+checks. The sibling ``_check_independent.py`` reproduces every verdict with no
+Vaara import, so a passing check is a property of the bytes, not of this script.
+
+Pinned, per record:
+
+* the five content derivations, each a SHA-256 over the JCS (RFC 8785) canonical
+  bytes of a named member set documented in README.md: ``params_hash``,
+  ``intent_digest``, ``intent_ref`` (stable, no timestamp), ``receipt_ref``
+  (per-record, timestamped), ``decision_context_hash``;
+* a 0-indexed ``seq`` with ``running_count == seq + 1`` and a terminal
+  ``GovernanceSeal`` carrying the boundary total, so a dropped record is a
+  provable gap from the held set alone;
+* the four fail-closed contract cases as verifier-recomputable mismatches:
+  exact-intent mismatch -> deny, target-state drift -> revise, continuation
+  mismatch -> deny, duplicate outcome -> deny;
+* a non-ASCII ``normalized_scope`` case, where a ``json.dumps(sort_keys=True)``
+  shortcut diverges from RFC 8785 and a conformant producer must not.
+
+Run: tests/vectors/governance_decision_v0/_generate.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import rfc8785
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+HERE = Path(__file__).resolve().parent
+
+# Fixed scalar -> stable public key across regenerations. Test-only key.
+_SCALAR = 0x67074E2AC0FFEE5EA10DDF00DABCDEF0123456789998877665544332211000F
+SCHEMA_DECISION = "crewai.governance.decision/v1"
+SCHEMA_OUTCOME = "crewai.governance.outcome/v1"
+SCHEMA_SEAL = "crewai.governance.seal/v1"
+NORMALIZATION_ID = "jcs-rfc8785-v1"
+BOUNDARY = "crew:checkout-run/2026-06-25"
+AGENT = "agent:crewai/checkout-bot"
+POLICY_REFS = ["policy:spend-limit/v3", "policy:eu-ai-act-art14/v1"]
+STREAM_LEN = 4
+DROPPED_SEQ = 2
+
+
+def _sha(obj) -> str:
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(obj)).hexdigest()
+
+
+def _jcs(obj) -> bytes:
+    return rfc8785.dumps(obj)
+
+
+def _derivations(
+    *,
+    action_type: str,
+    normalized_scope: str,
+    params: dict,
+    target_state: dict,
+    continuation_id: str,
+    seq: int,
+    timestamp_ms: int,
+    idempotency_key: str,
+) -> dict:
+    """The five pinned content derivations. Member sets are documented in README.
+
+    intent_digest / intent_ref carry NO timestamp: the same authorized intent
+    recomputes to the same identity on a retry. receipt_ref is per-record and
+    carries seq + timestamp, so it is unique per execution attempt.
+    """
+    params_hash = _sha(params)
+    intent_digest = _sha(
+        {
+            "action_type": action_type,
+            "normalized_scope": normalized_scope,
+            "params_hash": params_hash,
+        }
+    )
+    intent_ref = _sha(
+        {
+            "schema": SCHEMA_DECISION,
+            "agent_id": AGENT,
+            "action_type": action_type,
+            "normalized_scope": normalized_scope,
+            "intent_digest": intent_digest,
+        }
+    )
+    target_state_digest = _sha(target_state)
+    decision_context_hash = _sha(
+        {
+            "policy_refs": POLICY_REFS,
+            "target_state_digest": target_state_digest,
+            "continuation_id": continuation_id,
+            "normalization_id": NORMALIZATION_ID,
+        }
+    )
+    receipt_ref = _sha(
+        {
+            "intent_ref": intent_ref,
+            "target_state_digest": target_state_digest,
+            "continuation_id": continuation_id,
+            "seq": seq,
+            "timestamp_ms": timestamp_ms,
+            "idempotency_key": idempotency_key,
+        }
+    )
+    return {
+        "params_hash": params_hash,
+        "intent_digest": intent_digest,
+        "intent_ref": intent_ref,
+        "target_state_digest": target_state_digest,
+        "decision_context_hash": decision_context_hash,
+        "receipt_ref": receipt_ref,
+    }
+
+
+def _decision_record(
+    *,
+    seq: int,
+    action_type: str,
+    normalized_scope: str,
+    params: dict,
+    target_state: dict,
+    continuation_id: str,
+    decision: str,
+    idempotency_key: str,
+) -> dict:
+    timestamp_ms = 1779200000000 + seq * 1000
+    der = _derivations(
+        action_type=action_type,
+        normalized_scope=normalized_scope,
+        params=params,
+        target_state=target_state,
+        continuation_id=continuation_id,
+        seq=seq,
+        timestamp_ms=timestamp_ms,
+        idempotency_key=idempotency_key,
+    )
+    return {
+        "schema": SCHEMA_DECISION,
+        "decision_id": f"{BOUNDARY}#{seq}",
+        "agent_id": AGENT,
+        "action_type": action_type,
+        "normalization_id": NORMALIZATION_ID,
+        "normalized_scope": normalized_scope,
+        "params_hash": der["params_hash"],
+        "intent_digest": der["intent_digest"],
+        "intent_ref": der["intent_ref"],
+        "target_state_digest": der["target_state_digest"],
+        "decision_context_hash": der["decision_context_hash"],
+        "receipt_ref": der["receipt_ref"],
+        "continuation_id": continuation_id,
+        "policy_refs": POLICY_REFS,
+        "decision": decision,
+        "idempotency_key": idempotency_key,
+        "timestamp_ms": timestamp_ms,
+        "completeness": {"boundaryId": BOUNDARY, "seq": seq, "runningCount": seq + 1},
+    }
+
+
+def _outcome_record(decision: dict, *, status: str, result: dict) -> dict:
+    return {
+        "schema": SCHEMA_OUTCOME,
+        "decision_id": decision["decision_id"],
+        "intent_ref": decision["intent_ref"],
+        "receipt_ref": decision["receipt_ref"],
+        "status": status,
+        "result_digest": _sha(result),
+        "idempotency_key": decision["idempotency_key"],
+        "completeness": dict(decision["completeness"]),
+    }
+
+
+def _seal(total: int, *, max_class: str | None = None) -> dict:
+    seal = {"schema": SCHEMA_SEAL, "boundaryId": BOUNDARY, "sealed": True, "total": total}
+    if max_class is not None:
+        seal["maxClass"] = max_class
+    return seal
+
+
+def _sign(priv, record: dict) -> str:
+    raw = priv.sign(_jcs(record), ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(raw)
+    return r.to_bytes(32, "big").hex() + s.to_bytes(32, "big").hex()
+
+
+def _wrap(priv, record: dict) -> dict:
+    return {"record": record, "signature": _sign(priv, record)}
+
+
+def _write(path: Path, obj) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _contiguity(records: list[dict]) -> dict:
+    blocks = [r["record"]["completeness"] for r in records]
+    seqs = [int(b["seq"]) for b in blocks]
+    counts = [int(b["runningCount"]) for b in blocks]
+    expected = max((max(seqs) + 1 if seqs else 0), (max(counts) if counts else 0))
+    missing = sorted(set(range(expected)) - set(seqs))
+    mismatch = any(int(b["runningCount"]) != int(b["seq"]) + 1 for b in blocks)
+    present = len(blocks)
+    ok = not missing and not mismatch and len(seqs) == len(set(seqs)) and present == expected
+    return {"ok": ok, "present": present, "expected": expected, "missingSeqs": missing}
+
+
+def _sealed_contiguity(records: list[dict], seal: dict | None) -> dict:
+    """Contiguity against the seal total when a seal is held.
+
+    A terminal seal carries the boundary total, so a suffix drop that does not
+    also remove the seal is a provable gap. With no seal, a suffix drop is the
+    irreducible residual: the held prefix looks whole.
+    """
+    base = _contiguity(records)
+    if seal is None:
+        return base
+    total = int(seal["record"]["total"])
+    seqs = {int(r["record"]["completeness"]["seq"]) for r in records}
+    missing = sorted(set(range(total)) - seqs)
+    ok = not missing and base["ok"] and base["expected"] == total
+    return {"ok": ok, "present": len(records), "expected": total, "missingSeqs": missing}
+
+
+def main() -> int:
+    priv = ec.derive_private_key(_SCALAR, ec.SECP256R1())
+    (HERE / "keys").mkdir(parents=True, exist_ok=True)
+    (HERE / "keys" / "es256_public.pem").write_bytes(
+        priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    )
+    target_state = {"cart_total": "42.00", "currency": "USDC", "merchant": "acme"}
+    continuation = "session:abc-123"
+
+    stream = []
+    for seq in range(STREAM_LEN):
+        dec = _decision_record(
+            seq=seq, action_type="purchase.fulfill",
+            normalized_scope=f"merchant:acme/order:INV-{seq}",
+            params={"amount": "42.00", "currency": "USDC", "order": f"INV-{seq}"},
+            target_state=target_state, continuation_id=continuation,
+            decision="allow", idempotency_key=f"idem-{seq}",
+        )
+        out = _outcome_record(dec, status="executed", result={"order": f"INV-{seq}", "state": "fulfilled"})
+        stream.append((dec, out))
+    wrapped_seal = _wrap(priv, _seal(STREAM_LEN, max_class="confidential"))
+
+    complete_records = []
+    for seq, (dec, out) in enumerate(stream):
+        wd, wo = _wrap(priv, dec), _wrap(priv, out)
+        complete_records.append(wd)
+        _write(HERE / "stream" / "complete" / f"{seq:04d}-decision.json", wd)
+        _write(HERE / "stream" / "complete" / f"{seq:04d}-outcome.json", wo)
+        if seq != DROPPED_SEQ:
+            _write(HERE / "stream" / "dropped" / f"{seq:04d}-decision.json", wd)
+            _write(HERE / "stream" / "dropped" / f"{seq:04d}-outcome.json", wo)
+        if seq != STREAM_LEN - 1:
+            _write(HERE / "stream" / "tail_sealed" / f"{seq:04d}-decision.json", wd)
+            _write(HERE / "stream" / "tail_sealed" / f"{seq:04d}-outcome.json", wo)
+            _write(HERE / "stream" / "tail_unsealed" / f"{seq:04d}-decision.json", wd)
+            _write(HERE / "stream" / "tail_unsealed" / f"{seq:04d}-outcome.json", wo)
+    _write(HERE / "stream" / "complete" / "seal.json", wrapped_seal)
+    _write(HERE / "stream" / "dropped" / "seal.json", wrapped_seal)
+    _write(HERE / "stream" / "tail_sealed" / "seal.json", wrapped_seal)
+
+    base = _decision_record(seq=0, action_type="purchase.fulfill",
+        normalized_scope="merchant:acme/order:INV-1",
+        params={"amount": "42.00", "currency": "USDC", "order": "INV-1"},
+        target_state=target_state, continuation_id=continuation,
+        decision="allow", idempotency_key="idem-A")
+    mismatch = _decision_record(seq=0, action_type="purchase.fulfill",
+        normalized_scope="merchant:acme/order:INV-999",
+        params={"amount": "42.00", "currency": "USDC", "order": "INV-999"},
+        target_state=target_state, continuation_id=continuation,
+        decision="allow", idempotency_key="idem-A")
+    _write(HERE / "cases" / "exact_intent_mismatch.json",
+        {"approved": _wrap(priv, base), "candidate": _wrap(priv, mismatch), "expected_verdict": "deny"})
+    drift = _decision_record(seq=0, action_type="purchase.fulfill",
+        normalized_scope="merchant:acme/order:INV-1",
+        params={"amount": "42.00", "currency": "USDC", "order": "INV-1"},
+        target_state={"cart_total": "88.00", "currency": "USDC", "merchant": "acme"},
+        continuation_id=continuation, decision="revise", idempotency_key="idem-A")
+    _write(HERE / "cases" / "target_state_drift.json",
+        {"approved": _wrap(priv, base), "candidate": _wrap(priv, drift), "expected_verdict": "revise"})
+    cont = _decision_record(seq=0, action_type="purchase.fulfill",
+        normalized_scope="merchant:acme/order:INV-1",
+        params={"amount": "42.00", "currency": "USDC", "order": "INV-1"},
+        target_state=target_state, continuation_id="session:hijacked-999",
+        decision="allow", idempotency_key="idem-A")
+    _write(HERE / "cases" / "continuation_mismatch.json",
+        {"approved": _wrap(priv, base), "candidate": _wrap(priv, cont), "expected_verdict": "deny"})
+    out1 = _outcome_record(base, status="executed", result={"order": "INV-1", "state": "fulfilled"})
+    out2 = _outcome_record(base, status="executed", result={"order": "INV-1", "state": "fulfilled"})
+    _write(HERE / "cases" / "duplicate_outcome.json",
+        {"first": _wrap(priv, out1), "second": _wrap(priv, out2), "expected_verdict": "deny"})
+    unicode_dec = _decision_record(seq=0, action_type="purchase.fulfill",
+        normalized_scope="merchant:café/order:Ünïcode-€",
+        params={"amount": "42.00", "merchant": "café", "note": "résumé"},
+        target_state=target_state, continuation_id=continuation,
+        decision="allow", idempotency_key="idem-U")
+    _write(HERE / "cases" / "unicode_scope.json", _wrap(priv, unicode_dec))
+
+    expected = {
+        "stream": {
+            "complete": {"all_signatures_ok": True, "sealed_contiguity": _sealed_contiguity(complete_records, wrapped_seal)},
+            "dropped": {"all_signatures_ok": True, "sealed_contiguity": _sealed_contiguity([r for i, r in enumerate(complete_records) if i != DROPPED_SEQ], wrapped_seal)},
+            "tail_sealed": {"all_signatures_ok": True, "sealed_contiguity": _sealed_contiguity(complete_records[:-1], wrapped_seal)},
+            "tail_unsealed": {"all_signatures_ok": True, "sealed_contiguity": _sealed_contiguity(complete_records[:-1], None)},
+        },
+        "cases": {
+            "exact_intent_mismatch": {"expected_verdict": "deny", "signatures_ok": True},
+            "target_state_drift": {"expected_verdict": "revise", "signatures_ok": True},
+            "continuation_mismatch": {"expected_verdict": "deny", "signatures_ok": True},
+            "duplicate_outcome": {"expected_verdict": "deny", "signatures_ok": True},
+        },
+        "unicode_scope": {"signature_ok": True, "intent_ref": unicode_dec["intent_ref"], "params_hash": unicode_dec["params_hash"]},
+    }
+    _write(HERE / "expected.json", expected)
+    print("wrote governance_decision_v0 vectors")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/governance_decision_v0/cases/continuation_mismatch.json
+++ b/tests/vectors/governance_decision_v0/cases/continuation_mismatch.json
@@ -1,0 +1,63 @@
+{
+  "approved": {
+    "record": {
+      "action_type": "purchase.fulfill",
+      "agent_id": "agent:crewai/checkout-bot",
+      "completeness": {
+        "boundaryId": "crew:checkout-run/2026-06-25",
+        "runningCount": 1,
+        "seq": 0
+      },
+      "continuation_id": "session:abc-123",
+      "decision": "allow",
+      "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+      "decision_id": "crew:checkout-run/2026-06-25#0",
+      "idempotency_key": "idem-A",
+      "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+      "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+      "normalization_id": "jcs-rfc8785-v1",
+      "normalized_scope": "merchant:acme/order:INV-1",
+      "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+      "policy_refs": [
+        "policy:spend-limit/v3",
+        "policy:eu-ai-act-art14/v1"
+      ],
+      "receipt_ref": "sha256:297c7e4498b8a7c99672ba6b6ebf5382240e9f023c81c5689e095ec93f7131e8",
+      "schema": "crewai.governance.decision/v1",
+      "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+      "timestamp_ms": 1779200000000
+    },
+    "signature": "2677b45ce7bd9392ac9734381adb8b43656e0fdf4ba0caf96cead2114ea93e80bad40b2666c1f01943043e5cb3050c088fef839249fd32682b03961060b7a635"
+  },
+  "candidate": {
+    "record": {
+      "action_type": "purchase.fulfill",
+      "agent_id": "agent:crewai/checkout-bot",
+      "completeness": {
+        "boundaryId": "crew:checkout-run/2026-06-25",
+        "runningCount": 1,
+        "seq": 0
+      },
+      "continuation_id": "session:hijacked-999",
+      "decision": "allow",
+      "decision_context_hash": "sha256:51548e91dbfec869f3ce26b6d165c0191322a638bf4c419f286974e484ed072b",
+      "decision_id": "crew:checkout-run/2026-06-25#0",
+      "idempotency_key": "idem-A",
+      "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+      "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+      "normalization_id": "jcs-rfc8785-v1",
+      "normalized_scope": "merchant:acme/order:INV-1",
+      "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+      "policy_refs": [
+        "policy:spend-limit/v3",
+        "policy:eu-ai-act-art14/v1"
+      ],
+      "receipt_ref": "sha256:457b3be624fa4d8838f8a16c3c43bac53243af0ef618a74064f95801e0389752",
+      "schema": "crewai.governance.decision/v1",
+      "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+      "timestamp_ms": 1779200000000
+    },
+    "signature": "0710ceb649e903ea90328155a0ff6e5c259ade0f8eb3bf6badb39aca398862c92c15ce541874dd2b413ad318177cb90e0e44b12f1ebbbd7241cecec7ad126a3a"
+  },
+  "expected_verdict": "deny"
+}

--- a/tests/vectors/governance_decision_v0/cases/duplicate_outcome.json
+++ b/tests/vectors/governance_decision_v0/cases/duplicate_outcome.json
@@ -1,0 +1,37 @@
+{
+  "expected_verdict": "deny",
+  "first": {
+    "record": {
+      "completeness": {
+        "boundaryId": "crew:checkout-run/2026-06-25",
+        "runningCount": 1,
+        "seq": 0
+      },
+      "decision_id": "crew:checkout-run/2026-06-25#0",
+      "idempotency_key": "idem-A",
+      "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+      "receipt_ref": "sha256:297c7e4498b8a7c99672ba6b6ebf5382240e9f023c81c5689e095ec93f7131e8",
+      "result_digest": "sha256:b3f323627efb2569b2080ce37542008d94f713f286c5472cb0fac6de2625991b",
+      "schema": "crewai.governance.outcome/v1",
+      "status": "executed"
+    },
+    "signature": "59cb772f977e4fda176d2a5291952a84bb0bdd2aedf6116bc4418b3f043409e7579ba707124994f000f97e9fbcb978d05ec9958aeccc4c0b57e7d38b2994941b"
+  },
+  "second": {
+    "record": {
+      "completeness": {
+        "boundaryId": "crew:checkout-run/2026-06-25",
+        "runningCount": 1,
+        "seq": 0
+      },
+      "decision_id": "crew:checkout-run/2026-06-25#0",
+      "idempotency_key": "idem-A",
+      "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+      "receipt_ref": "sha256:297c7e4498b8a7c99672ba6b6ebf5382240e9f023c81c5689e095ec93f7131e8",
+      "result_digest": "sha256:b3f323627efb2569b2080ce37542008d94f713f286c5472cb0fac6de2625991b",
+      "schema": "crewai.governance.outcome/v1",
+      "status": "executed"
+    },
+    "signature": "7f5ee32faa141a07411498aa53878830c5f8038c060f075220c56d839ea6a7243dce603a5288013dabac6c751da47b9819e1dccbdf01e9347f44633e965f110b"
+  }
+}

--- a/tests/vectors/governance_decision_v0/cases/exact_intent_mismatch.json
+++ b/tests/vectors/governance_decision_v0/cases/exact_intent_mismatch.json
@@ -1,0 +1,63 @@
+{
+  "approved": {
+    "record": {
+      "action_type": "purchase.fulfill",
+      "agent_id": "agent:crewai/checkout-bot",
+      "completeness": {
+        "boundaryId": "crew:checkout-run/2026-06-25",
+        "runningCount": 1,
+        "seq": 0
+      },
+      "continuation_id": "session:abc-123",
+      "decision": "allow",
+      "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+      "decision_id": "crew:checkout-run/2026-06-25#0",
+      "idempotency_key": "idem-A",
+      "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+      "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+      "normalization_id": "jcs-rfc8785-v1",
+      "normalized_scope": "merchant:acme/order:INV-1",
+      "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+      "policy_refs": [
+        "policy:spend-limit/v3",
+        "policy:eu-ai-act-art14/v1"
+      ],
+      "receipt_ref": "sha256:297c7e4498b8a7c99672ba6b6ebf5382240e9f023c81c5689e095ec93f7131e8",
+      "schema": "crewai.governance.decision/v1",
+      "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+      "timestamp_ms": 1779200000000
+    },
+    "signature": "0f87b67895b31fc99d92311218b1a66aefff31338163c27a185b91d6056a3fe1dd656f44875a43fc18b4ccbf39acc0d67b87e5492074902f85e58964dc601e67"
+  },
+  "candidate": {
+    "record": {
+      "action_type": "purchase.fulfill",
+      "agent_id": "agent:crewai/checkout-bot",
+      "completeness": {
+        "boundaryId": "crew:checkout-run/2026-06-25",
+        "runningCount": 1,
+        "seq": 0
+      },
+      "continuation_id": "session:abc-123",
+      "decision": "allow",
+      "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+      "decision_id": "crew:checkout-run/2026-06-25#0",
+      "idempotency_key": "idem-A",
+      "intent_digest": "sha256:a8e2bf04da508d4a8255b23823f9bbf5ad2fa09c8e574abd0a1f4a948bb0b86d",
+      "intent_ref": "sha256:14d8fdef07f841c8387de092cb665934e51aa31b114a4fa33b0eddef5176fb81",
+      "normalization_id": "jcs-rfc8785-v1",
+      "normalized_scope": "merchant:acme/order:INV-999",
+      "params_hash": "sha256:19a0271e227efcb3a4f7eb5c7ae124c023d91324b6005be518387a52c65632c9",
+      "policy_refs": [
+        "policy:spend-limit/v3",
+        "policy:eu-ai-act-art14/v1"
+      ],
+      "receipt_ref": "sha256:6007ce1b4a716f0d5192e6074bed162ac3a24d097740890792b1d5b6b5ad1a2e",
+      "schema": "crewai.governance.decision/v1",
+      "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+      "timestamp_ms": 1779200000000
+    },
+    "signature": "35554d5a95b2e78ef319d3833e07ab1e52e5f330d807f954f15cfbd552bdf628fc5361fcb8360df796d62d882cbca4c84b22b55edf1360a22c2f845460a18ad3"
+  },
+  "expected_verdict": "deny"
+}

--- a/tests/vectors/governance_decision_v0/cases/target_state_drift.json
+++ b/tests/vectors/governance_decision_v0/cases/target_state_drift.json
@@ -1,0 +1,63 @@
+{
+  "approved": {
+    "record": {
+      "action_type": "purchase.fulfill",
+      "agent_id": "agent:crewai/checkout-bot",
+      "completeness": {
+        "boundaryId": "crew:checkout-run/2026-06-25",
+        "runningCount": 1,
+        "seq": 0
+      },
+      "continuation_id": "session:abc-123",
+      "decision": "allow",
+      "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+      "decision_id": "crew:checkout-run/2026-06-25#0",
+      "idempotency_key": "idem-A",
+      "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+      "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+      "normalization_id": "jcs-rfc8785-v1",
+      "normalized_scope": "merchant:acme/order:INV-1",
+      "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+      "policy_refs": [
+        "policy:spend-limit/v3",
+        "policy:eu-ai-act-art14/v1"
+      ],
+      "receipt_ref": "sha256:297c7e4498b8a7c99672ba6b6ebf5382240e9f023c81c5689e095ec93f7131e8",
+      "schema": "crewai.governance.decision/v1",
+      "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+      "timestamp_ms": 1779200000000
+    },
+    "signature": "940635fd0541e3c23a663bd2ba17fd93ab08bd2551e7acbeb99d1648d26caf37efd200b55c80fee35b4262396e842c2191cd23b1e62f297459c7525bdca8096e"
+  },
+  "candidate": {
+    "record": {
+      "action_type": "purchase.fulfill",
+      "agent_id": "agent:crewai/checkout-bot",
+      "completeness": {
+        "boundaryId": "crew:checkout-run/2026-06-25",
+        "runningCount": 1,
+        "seq": 0
+      },
+      "continuation_id": "session:abc-123",
+      "decision": "revise",
+      "decision_context_hash": "sha256:c7e9187bed6459dc0e19a253d4bcd68df3d102269799e02ece029cf7764a6401",
+      "decision_id": "crew:checkout-run/2026-06-25#0",
+      "idempotency_key": "idem-A",
+      "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+      "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+      "normalization_id": "jcs-rfc8785-v1",
+      "normalized_scope": "merchant:acme/order:INV-1",
+      "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+      "policy_refs": [
+        "policy:spend-limit/v3",
+        "policy:eu-ai-act-art14/v1"
+      ],
+      "receipt_ref": "sha256:2163358f24330f72c246ead5a8a47361a2eb1a69d7be4af7f316d50f9a97e418",
+      "schema": "crewai.governance.decision/v1",
+      "target_state_digest": "sha256:5d2d69b039e27bad368749a5718c4e7b5ee2de50f65435d517509dd0912d7d5c",
+      "timestamp_ms": 1779200000000
+    },
+    "signature": "dfdc91519c70e793f0ac7eaa0723014851e993431b7995be276718ce64be2c0cd9bdd3bf3ecdc8dd06d5bb711ce3851e84098ee459f038da484491d848a15b5d"
+  },
+  "expected_verdict": "revise"
+}

--- a/tests/vectors/governance_decision_v0/cases/unicode_scope.json
+++ b/tests/vectors/governance_decision_v0/cases/unicode_scope.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-U",
+    "intent_digest": "sha256:ede130469b640817de648d11e72e1be371c8d19b4f7e0c946e0c5ac2e28f4b93",
+    "intent_ref": "sha256:c06fd32039743c4a87f5614c7da49d02edc943c8006fd1a3a9ff912fdb958c9d",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:caf\u00e9/order:\u00dcn\u00efcode-\u20ac",
+    "params_hash": "sha256:37fafbd83fd98a4c931fc892408a7595e2f55d100fa806c355c5a8426045f328",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:323cfadbc509e63687a1db269025d773b198f8f0c60a4186454c0f944e0e96ef",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200000000
+  },
+  "signature": "f011582da2e6a53fc5572c827a5039b47c66a7acf019d6d7315798c19ae40f18165822c15b7ad7e1f543e3378997d3bff1512c05bec6da5751a55181d924082c"
+}

--- a/tests/vectors/governance_decision_v0/expected.json
+++ b/tests/vectors/governance_decision_v0/expected.json
@@ -1,0 +1,67 @@
+{
+  "cases": {
+    "continuation_mismatch": {
+      "expected_verdict": "deny",
+      "signatures_ok": true
+    },
+    "duplicate_outcome": {
+      "expected_verdict": "deny",
+      "signatures_ok": true
+    },
+    "exact_intent_mismatch": {
+      "expected_verdict": "deny",
+      "signatures_ok": true
+    },
+    "target_state_drift": {
+      "expected_verdict": "revise",
+      "signatures_ok": true
+    }
+  },
+  "stream": {
+    "complete": {
+      "all_signatures_ok": true,
+      "sealed_contiguity": {
+        "expected": 4,
+        "missingSeqs": [],
+        "ok": true,
+        "present": 4
+      }
+    },
+    "dropped": {
+      "all_signatures_ok": true,
+      "sealed_contiguity": {
+        "expected": 4,
+        "missingSeqs": [
+          2
+        ],
+        "ok": false,
+        "present": 3
+      }
+    },
+    "tail_sealed": {
+      "all_signatures_ok": true,
+      "sealed_contiguity": {
+        "expected": 4,
+        "missingSeqs": [
+          3
+        ],
+        "ok": false,
+        "present": 3
+      }
+    },
+    "tail_unsealed": {
+      "all_signatures_ok": true,
+      "sealed_contiguity": {
+        "expected": 3,
+        "missingSeqs": [],
+        "ok": true,
+        "present": 3
+      }
+    }
+  },
+  "unicode_scope": {
+    "intent_ref": "sha256:c06fd32039743c4a87f5614c7da49d02edc943c8006fd1a3a9ff912fdb958c9d",
+    "params_hash": "sha256:37fafbd83fd98a4c931fc892408a7595e2f55d100fa806c355c5a8426045f328",
+    "signature_ok": true
+  }
+}

--- a/tests/vectors/governance_decision_v0/keys/es256_public.pem
+++ b/tests/vectors/governance_decision_v0/keys/es256_public.pem
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmzJsavIu5AwrTUP88tgYl2oj/Q8i
+rVK0CNbCceDXUaPik3bfLFoSmLa+18fWogMSjLZtbW2gdFC/c+LKfPhMGw==
+-----END PUBLIC KEY-----

--- a/tests/vectors/governance_decision_v0/stream/complete/0000-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/0000-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-0",
+    "intent_digest": "sha256:7e9356e2066034eed418636a540c9f3d02f18e6292017712193ecf938af91694",
+    "intent_ref": "sha256:382d1ad88799418ffcc88e99c8f929e2f79f95ef593581508bbd6f8a8ebb2aae",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-0",
+    "params_hash": "sha256:235fc0dbf40e3324309a5029f504b5a152eedba7cf6fddc82d6adea1e1589b51",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:92dbc55c7a657183fa0106468637e9e4440489a1103b3eadd8a8384d499df22c",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200000000
+  },
+  "signature": "b13c3e5f2addd1f1387ffe642f2e30728823301d256098ee6a3d4cea57ca0201ddeca0fce79328ec8a800b1cea5fd2e082c8fc65d2e21279f88f3c1de1b6285e"
+}

--- a/tests/vectors/governance_decision_v0/stream/complete/0000-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/0000-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-0",
+    "intent_ref": "sha256:382d1ad88799418ffcc88e99c8f929e2f79f95ef593581508bbd6f8a8ebb2aae",
+    "receipt_ref": "sha256:92dbc55c7a657183fa0106468637e9e4440489a1103b3eadd8a8384d499df22c",
+    "result_digest": "sha256:b6dd6f12d8a5e410b99e36b7b14867dc1e47f2965d4fcb363889db70d6f72433",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "2c69a3b5996fd2ad1c3fbed17e2e35c22be9e047d9d17c9139e91c77ac74ff0f67a4eb15054a867307764180c765d11c4cb3d6cddf40d1cbf17db046aa6e84f4"
+}

--- a/tests/vectors/governance_decision_v0/stream/complete/0001-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/0001-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 2,
+      "seq": 1
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#1",
+    "idempotency_key": "idem-1",
+    "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+    "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-1",
+    "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:7532dd5f5837cb92c03fe6d67cbc56d555d91ee83a0b9b58d70b0ca75181aa8f",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200001000
+  },
+  "signature": "c72d6002f503bbbf3a3c9c954a9144bcc02266f2abeebb6fe533d9dd84e59ed597eae81a6b4da29db3b1d6f25065b3fd9fa2039a6a6a5edbc26c4d10bedad23a"
+}

--- a/tests/vectors/governance_decision_v0/stream/complete/0001-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/0001-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 2,
+      "seq": 1
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#1",
+    "idempotency_key": "idem-1",
+    "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+    "receipt_ref": "sha256:7532dd5f5837cb92c03fe6d67cbc56d555d91ee83a0b9b58d70b0ca75181aa8f",
+    "result_digest": "sha256:b3f323627efb2569b2080ce37542008d94f713f286c5472cb0fac6de2625991b",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "2d54739872fda025f61099567fe3362e0ceb0faf78c1101864bfb0c3d73e70b89fd8b0648737a34d6047811ce1ba3f26dc3f56e57b186c6f83eae8e61ee4409e"
+}

--- a/tests/vectors/governance_decision_v0/stream/complete/0002-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/0002-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 3,
+      "seq": 2
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#2",
+    "idempotency_key": "idem-2",
+    "intent_digest": "sha256:7bef476fca0c06f202a08ac94be052188f63eecf38dfadad7bd0ffc3ceeb5fa5",
+    "intent_ref": "sha256:f63235b3c47c5414ff81b8571fc5b6ece584c3d51096de679100201c0000f6d1",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-2",
+    "params_hash": "sha256:baf052eaae3e6b95b178e75085af42dbc652dc40a789b1853d5954c2c6595cdd",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:67ecf5b2b20c7c8924fefc587ae604ca998df58d13beaf6848a04f7975dc2087",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200002000
+  },
+  "signature": "034a3fcf38d7614f24541d07894835aeb476f9d7273bc38d221fc463b67b24e8fd077f5daac49322c322a06c33502be9bd12f572f8f4bdb7d7df54eb7018a7a3"
+}

--- a/tests/vectors/governance_decision_v0/stream/complete/0002-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/0002-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 3,
+      "seq": 2
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#2",
+    "idempotency_key": "idem-2",
+    "intent_ref": "sha256:f63235b3c47c5414ff81b8571fc5b6ece584c3d51096de679100201c0000f6d1",
+    "receipt_ref": "sha256:67ecf5b2b20c7c8924fefc587ae604ca998df58d13beaf6848a04f7975dc2087",
+    "result_digest": "sha256:d056a96d25c0164c38963860352b2cb92fbf5c6f09629f040b4787c8a33aff16",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "ddd7f708f6d3a3dafeabe78f7f69834015dee0ce38223102f212282a5eb18876e47b143441ce2533e56b068813c5c7a42c6a5081bd3dbac019eadcc217ccea95"
+}

--- a/tests/vectors/governance_decision_v0/stream/complete/0003-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/0003-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 4,
+      "seq": 3
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#3",
+    "idempotency_key": "idem-3",
+    "intent_digest": "sha256:d23d5f9ca38bb38bd9267f6738642534712c3d57f5f52bb844d0a41111e65fd3",
+    "intent_ref": "sha256:0226110a90e2a9e652b2829afea74f337689a32d9d7b90801f21d1154453d33a",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-3",
+    "params_hash": "sha256:a8c53f6a12d5d020cf357a7bb11c5b2cc59522dcbfa00d04f1b0595c3ea10cce",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:316e2d07a3458f97f354931172c2f642ebbd3ad5e88c0683dbf686a3122a541c",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200003000
+  },
+  "signature": "f4dad38913d2c688b83f85542c91a32b318a569c2d3885d1bc47f975b7460a68740e6ee76d4eb0f7cb7b2a0189eca180731e380c818559ad117a40980e28283e"
+}

--- a/tests/vectors/governance_decision_v0/stream/complete/0003-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/0003-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 4,
+      "seq": 3
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#3",
+    "idempotency_key": "idem-3",
+    "intent_ref": "sha256:0226110a90e2a9e652b2829afea74f337689a32d9d7b90801f21d1154453d33a",
+    "receipt_ref": "sha256:316e2d07a3458f97f354931172c2f642ebbd3ad5e88c0683dbf686a3122a541c",
+    "result_digest": "sha256:6e9f25980405da1c0edb38ecf3128ed0143b0554ced7f89686b228a46016b431",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "86cf6db7468bfe657bf8b433e39bfa1548b3166cc3618fd1f8cbf42158923cf1131b07cba153ea3d0659188d1ef54940f463a11f7f7cf8b8f1488b76f955cfd7"
+}

--- a/tests/vectors/governance_decision_v0/stream/complete/seal.json
+++ b/tests/vectors/governance_decision_v0/stream/complete/seal.json
@@ -1,0 +1,10 @@
+{
+  "record": {
+    "boundaryId": "crew:checkout-run/2026-06-25",
+    "maxClass": "confidential",
+    "schema": "crewai.governance.seal/v1",
+    "sealed": true,
+    "total": 4
+  },
+  "signature": "c97909fc3b1f83037ba332f850dac0109f3eaf3bc6e5fb890f3b8b93dfa557536c4de957c323a62d48169bec807e9dcf3e0628f78319baa682b8194f050820b2"
+}

--- a/tests/vectors/governance_decision_v0/stream/dropped/0000-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/dropped/0000-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-0",
+    "intent_digest": "sha256:7e9356e2066034eed418636a540c9f3d02f18e6292017712193ecf938af91694",
+    "intent_ref": "sha256:382d1ad88799418ffcc88e99c8f929e2f79f95ef593581508bbd6f8a8ebb2aae",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-0",
+    "params_hash": "sha256:235fc0dbf40e3324309a5029f504b5a152eedba7cf6fddc82d6adea1e1589b51",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:92dbc55c7a657183fa0106468637e9e4440489a1103b3eadd8a8384d499df22c",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200000000
+  },
+  "signature": "b13c3e5f2addd1f1387ffe642f2e30728823301d256098ee6a3d4cea57ca0201ddeca0fce79328ec8a800b1cea5fd2e082c8fc65d2e21279f88f3c1de1b6285e"
+}

--- a/tests/vectors/governance_decision_v0/stream/dropped/0000-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/dropped/0000-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-0",
+    "intent_ref": "sha256:382d1ad88799418ffcc88e99c8f929e2f79f95ef593581508bbd6f8a8ebb2aae",
+    "receipt_ref": "sha256:92dbc55c7a657183fa0106468637e9e4440489a1103b3eadd8a8384d499df22c",
+    "result_digest": "sha256:b6dd6f12d8a5e410b99e36b7b14867dc1e47f2965d4fcb363889db70d6f72433",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "2c69a3b5996fd2ad1c3fbed17e2e35c22be9e047d9d17c9139e91c77ac74ff0f67a4eb15054a867307764180c765d11c4cb3d6cddf40d1cbf17db046aa6e84f4"
+}

--- a/tests/vectors/governance_decision_v0/stream/dropped/0001-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/dropped/0001-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 2,
+      "seq": 1
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#1",
+    "idempotency_key": "idem-1",
+    "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+    "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-1",
+    "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:7532dd5f5837cb92c03fe6d67cbc56d555d91ee83a0b9b58d70b0ca75181aa8f",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200001000
+  },
+  "signature": "c72d6002f503bbbf3a3c9c954a9144bcc02266f2abeebb6fe533d9dd84e59ed597eae81a6b4da29db3b1d6f25065b3fd9fa2039a6a6a5edbc26c4d10bedad23a"
+}

--- a/tests/vectors/governance_decision_v0/stream/dropped/0001-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/dropped/0001-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 2,
+      "seq": 1
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#1",
+    "idempotency_key": "idem-1",
+    "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+    "receipt_ref": "sha256:7532dd5f5837cb92c03fe6d67cbc56d555d91ee83a0b9b58d70b0ca75181aa8f",
+    "result_digest": "sha256:b3f323627efb2569b2080ce37542008d94f713f286c5472cb0fac6de2625991b",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "2d54739872fda025f61099567fe3362e0ceb0faf78c1101864bfb0c3d73e70b89fd8b0648737a34d6047811ce1ba3f26dc3f56e57b186c6f83eae8e61ee4409e"
+}

--- a/tests/vectors/governance_decision_v0/stream/dropped/0003-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/dropped/0003-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 4,
+      "seq": 3
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#3",
+    "idempotency_key": "idem-3",
+    "intent_digest": "sha256:d23d5f9ca38bb38bd9267f6738642534712c3d57f5f52bb844d0a41111e65fd3",
+    "intent_ref": "sha256:0226110a90e2a9e652b2829afea74f337689a32d9d7b90801f21d1154453d33a",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-3",
+    "params_hash": "sha256:a8c53f6a12d5d020cf357a7bb11c5b2cc59522dcbfa00d04f1b0595c3ea10cce",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:316e2d07a3458f97f354931172c2f642ebbd3ad5e88c0683dbf686a3122a541c",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200003000
+  },
+  "signature": "f4dad38913d2c688b83f85542c91a32b318a569c2d3885d1bc47f975b7460a68740e6ee76d4eb0f7cb7b2a0189eca180731e380c818559ad117a40980e28283e"
+}

--- a/tests/vectors/governance_decision_v0/stream/dropped/0003-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/dropped/0003-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 4,
+      "seq": 3
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#3",
+    "idempotency_key": "idem-3",
+    "intent_ref": "sha256:0226110a90e2a9e652b2829afea74f337689a32d9d7b90801f21d1154453d33a",
+    "receipt_ref": "sha256:316e2d07a3458f97f354931172c2f642ebbd3ad5e88c0683dbf686a3122a541c",
+    "result_digest": "sha256:6e9f25980405da1c0edb38ecf3128ed0143b0554ced7f89686b228a46016b431",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "86cf6db7468bfe657bf8b433e39bfa1548b3166cc3618fd1f8cbf42158923cf1131b07cba153ea3d0659188d1ef54940f463a11f7f7cf8b8f1488b76f955cfd7"
+}

--- a/tests/vectors/governance_decision_v0/stream/dropped/seal.json
+++ b/tests/vectors/governance_decision_v0/stream/dropped/seal.json
@@ -1,0 +1,10 @@
+{
+  "record": {
+    "boundaryId": "crew:checkout-run/2026-06-25",
+    "maxClass": "confidential",
+    "schema": "crewai.governance.seal/v1",
+    "sealed": true,
+    "total": 4
+  },
+  "signature": "c97909fc3b1f83037ba332f850dac0109f3eaf3bc6e5fb890f3b8b93dfa557536c4de957c323a62d48169bec807e9dcf3e0628f78319baa682b8194f050820b2"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_sealed/0000-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_sealed/0000-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-0",
+    "intent_digest": "sha256:7e9356e2066034eed418636a540c9f3d02f18e6292017712193ecf938af91694",
+    "intent_ref": "sha256:382d1ad88799418ffcc88e99c8f929e2f79f95ef593581508bbd6f8a8ebb2aae",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-0",
+    "params_hash": "sha256:235fc0dbf40e3324309a5029f504b5a152eedba7cf6fddc82d6adea1e1589b51",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:92dbc55c7a657183fa0106468637e9e4440489a1103b3eadd8a8384d499df22c",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200000000
+  },
+  "signature": "b13c3e5f2addd1f1387ffe642f2e30728823301d256098ee6a3d4cea57ca0201ddeca0fce79328ec8a800b1cea5fd2e082c8fc65d2e21279f88f3c1de1b6285e"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_sealed/0000-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_sealed/0000-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-0",
+    "intent_ref": "sha256:382d1ad88799418ffcc88e99c8f929e2f79f95ef593581508bbd6f8a8ebb2aae",
+    "receipt_ref": "sha256:92dbc55c7a657183fa0106468637e9e4440489a1103b3eadd8a8384d499df22c",
+    "result_digest": "sha256:b6dd6f12d8a5e410b99e36b7b14867dc1e47f2965d4fcb363889db70d6f72433",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "2c69a3b5996fd2ad1c3fbed17e2e35c22be9e047d9d17c9139e91c77ac74ff0f67a4eb15054a867307764180c765d11c4cb3d6cddf40d1cbf17db046aa6e84f4"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_sealed/0001-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_sealed/0001-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 2,
+      "seq": 1
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#1",
+    "idempotency_key": "idem-1",
+    "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+    "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-1",
+    "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:7532dd5f5837cb92c03fe6d67cbc56d555d91ee83a0b9b58d70b0ca75181aa8f",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200001000
+  },
+  "signature": "c72d6002f503bbbf3a3c9c954a9144bcc02266f2abeebb6fe533d9dd84e59ed597eae81a6b4da29db3b1d6f25065b3fd9fa2039a6a6a5edbc26c4d10bedad23a"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_sealed/0001-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_sealed/0001-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 2,
+      "seq": 1
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#1",
+    "idempotency_key": "idem-1",
+    "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+    "receipt_ref": "sha256:7532dd5f5837cb92c03fe6d67cbc56d555d91ee83a0b9b58d70b0ca75181aa8f",
+    "result_digest": "sha256:b3f323627efb2569b2080ce37542008d94f713f286c5472cb0fac6de2625991b",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "2d54739872fda025f61099567fe3362e0ceb0faf78c1101864bfb0c3d73e70b89fd8b0648737a34d6047811ce1ba3f26dc3f56e57b186c6f83eae8e61ee4409e"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_sealed/0002-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_sealed/0002-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 3,
+      "seq": 2
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#2",
+    "idempotency_key": "idem-2",
+    "intent_digest": "sha256:7bef476fca0c06f202a08ac94be052188f63eecf38dfadad7bd0ffc3ceeb5fa5",
+    "intent_ref": "sha256:f63235b3c47c5414ff81b8571fc5b6ece584c3d51096de679100201c0000f6d1",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-2",
+    "params_hash": "sha256:baf052eaae3e6b95b178e75085af42dbc652dc40a789b1853d5954c2c6595cdd",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:67ecf5b2b20c7c8924fefc587ae604ca998df58d13beaf6848a04f7975dc2087",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200002000
+  },
+  "signature": "034a3fcf38d7614f24541d07894835aeb476f9d7273bc38d221fc463b67b24e8fd077f5daac49322c322a06c33502be9bd12f572f8f4bdb7d7df54eb7018a7a3"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_sealed/0002-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_sealed/0002-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 3,
+      "seq": 2
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#2",
+    "idempotency_key": "idem-2",
+    "intent_ref": "sha256:f63235b3c47c5414ff81b8571fc5b6ece584c3d51096de679100201c0000f6d1",
+    "receipt_ref": "sha256:67ecf5b2b20c7c8924fefc587ae604ca998df58d13beaf6848a04f7975dc2087",
+    "result_digest": "sha256:d056a96d25c0164c38963860352b2cb92fbf5c6f09629f040b4787c8a33aff16",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "ddd7f708f6d3a3dafeabe78f7f69834015dee0ce38223102f212282a5eb18876e47b143441ce2533e56b068813c5c7a42c6a5081bd3dbac019eadcc217ccea95"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_sealed/seal.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_sealed/seal.json
@@ -1,0 +1,10 @@
+{
+  "record": {
+    "boundaryId": "crew:checkout-run/2026-06-25",
+    "maxClass": "confidential",
+    "schema": "crewai.governance.seal/v1",
+    "sealed": true,
+    "total": 4
+  },
+  "signature": "c97909fc3b1f83037ba332f850dac0109f3eaf3bc6e5fb890f3b8b93dfa557536c4de957c323a62d48169bec807e9dcf3e0628f78319baa682b8194f050820b2"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_unsealed/0000-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_unsealed/0000-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-0",
+    "intent_digest": "sha256:7e9356e2066034eed418636a540c9f3d02f18e6292017712193ecf938af91694",
+    "intent_ref": "sha256:382d1ad88799418ffcc88e99c8f929e2f79f95ef593581508bbd6f8a8ebb2aae",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-0",
+    "params_hash": "sha256:235fc0dbf40e3324309a5029f504b5a152eedba7cf6fddc82d6adea1e1589b51",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:92dbc55c7a657183fa0106468637e9e4440489a1103b3eadd8a8384d499df22c",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200000000
+  },
+  "signature": "b13c3e5f2addd1f1387ffe642f2e30728823301d256098ee6a3d4cea57ca0201ddeca0fce79328ec8a800b1cea5fd2e082c8fc65d2e21279f88f3c1de1b6285e"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_unsealed/0000-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_unsealed/0000-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 1,
+      "seq": 0
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#0",
+    "idempotency_key": "idem-0",
+    "intent_ref": "sha256:382d1ad88799418ffcc88e99c8f929e2f79f95ef593581508bbd6f8a8ebb2aae",
+    "receipt_ref": "sha256:92dbc55c7a657183fa0106468637e9e4440489a1103b3eadd8a8384d499df22c",
+    "result_digest": "sha256:b6dd6f12d8a5e410b99e36b7b14867dc1e47f2965d4fcb363889db70d6f72433",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "2c69a3b5996fd2ad1c3fbed17e2e35c22be9e047d9d17c9139e91c77ac74ff0f67a4eb15054a867307764180c765d11c4cb3d6cddf40d1cbf17db046aa6e84f4"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_unsealed/0001-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_unsealed/0001-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 2,
+      "seq": 1
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#1",
+    "idempotency_key": "idem-1",
+    "intent_digest": "sha256:0cba8d0055f5d0833c901ed88681616f01ecfadb0c5b88336be709e537e1d73b",
+    "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-1",
+    "params_hash": "sha256:5e74cb8c654dc04978ede9257fb8007a7df3cd52700ad883acd5bdd2b19cd7d5",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:7532dd5f5837cb92c03fe6d67cbc56d555d91ee83a0b9b58d70b0ca75181aa8f",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200001000
+  },
+  "signature": "c72d6002f503bbbf3a3c9c954a9144bcc02266f2abeebb6fe533d9dd84e59ed597eae81a6b4da29db3b1d6f25065b3fd9fa2039a6a6a5edbc26c4d10bedad23a"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_unsealed/0001-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_unsealed/0001-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 2,
+      "seq": 1
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#1",
+    "idempotency_key": "idem-1",
+    "intent_ref": "sha256:a51b72b29097f6c807cfb4a668a0c930cb0fb83c3e1049e1e08986af133ae48a",
+    "receipt_ref": "sha256:7532dd5f5837cb92c03fe6d67cbc56d555d91ee83a0b9b58d70b0ca75181aa8f",
+    "result_digest": "sha256:b3f323627efb2569b2080ce37542008d94f713f286c5472cb0fac6de2625991b",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "2d54739872fda025f61099567fe3362e0ceb0faf78c1101864bfb0c3d73e70b89fd8b0648737a34d6047811ce1ba3f26dc3f56e57b186c6f83eae8e61ee4409e"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_unsealed/0002-decision.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_unsealed/0002-decision.json
@@ -1,0 +1,30 @@
+{
+  "record": {
+    "action_type": "purchase.fulfill",
+    "agent_id": "agent:crewai/checkout-bot",
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 3,
+      "seq": 2
+    },
+    "continuation_id": "session:abc-123",
+    "decision": "allow",
+    "decision_context_hash": "sha256:6110dc18a3da0e728326d4f653edb9f5cc6cc0fb2bcf46079c3b7bbf338bc735",
+    "decision_id": "crew:checkout-run/2026-06-25#2",
+    "idempotency_key": "idem-2",
+    "intent_digest": "sha256:7bef476fca0c06f202a08ac94be052188f63eecf38dfadad7bd0ffc3ceeb5fa5",
+    "intent_ref": "sha256:f63235b3c47c5414ff81b8571fc5b6ece584c3d51096de679100201c0000f6d1",
+    "normalization_id": "jcs-rfc8785-v1",
+    "normalized_scope": "merchant:acme/order:INV-2",
+    "params_hash": "sha256:baf052eaae3e6b95b178e75085af42dbc652dc40a789b1853d5954c2c6595cdd",
+    "policy_refs": [
+      "policy:spend-limit/v3",
+      "policy:eu-ai-act-art14/v1"
+    ],
+    "receipt_ref": "sha256:67ecf5b2b20c7c8924fefc587ae604ca998df58d13beaf6848a04f7975dc2087",
+    "schema": "crewai.governance.decision/v1",
+    "target_state_digest": "sha256:023d46e0f386d0dd3e913380e6cdf685761625c7f6ba6402dc167d00e6159cf3",
+    "timestamp_ms": 1779200002000
+  },
+  "signature": "034a3fcf38d7614f24541d07894835aeb476f9d7273bc38d221fc463b67b24e8fd077f5daac49322c322a06c33502be9bd12f572f8f4bdb7d7df54eb7018a7a3"
+}

--- a/tests/vectors/governance_decision_v0/stream/tail_unsealed/0002-outcome.json
+++ b/tests/vectors/governance_decision_v0/stream/tail_unsealed/0002-outcome.json
@@ -1,0 +1,17 @@
+{
+  "record": {
+    "completeness": {
+      "boundaryId": "crew:checkout-run/2026-06-25",
+      "runningCount": 3,
+      "seq": 2
+    },
+    "decision_id": "crew:checkout-run/2026-06-25#2",
+    "idempotency_key": "idem-2",
+    "intent_ref": "sha256:f63235b3c47c5414ff81b8571fc5b6ece584c3d51096de679100201c0000f6d1",
+    "receipt_ref": "sha256:67ecf5b2b20c7c8924fefc587ae604ca998df58d13beaf6848a04f7975dc2087",
+    "result_digest": "sha256:d056a96d25c0164c38963860352b2cb92fbf5c6f09629f040b4787c8a33aff16",
+    "schema": "crewai.governance.outcome/v1",
+    "status": "executed"
+  },
+  "signature": "ddd7f708f6d3a3dafeabe78f7f69834015dee0ce38223102f212282a5eb18876e47b143441ce2533e56b068813c5c7a42c6a5081bd3dbac019eadcc217ccea95"
+}


### PR DESCRIPTION
Reproducible conformance corpus over the CrewAI `GovernanceDecision`/`GovernanceOutcome` contract (crewAIInc/crewAI#6030) plus the completeness layer (vaaraio/vaara#283).

What it pins, as one corpus:
- six derivation preimages (sha256 over JCS member sets), per the README
- sealed completeness: `complete`, `dropped` (mid-gap at seq 2), `tail_sealed` (suffix drop the seal catches), `tail_unsealed` (the irreducible residual with no seal)
- four fail-closed verdicts (exact-intent mismatch, target-state drift, continuation mismatch, duplicate outcome)
- a non-ASCII canonicalization trap where json.dumps(sort_keys=True) diverges from RFC 8785

`_check_independent.py` reproduces every verdict with no Vaara import (`rfc8785` + `cryptography` only). 23 checks pass; the CI test gates the checker. The vectors are not packaged (tests/ is excluded), so this lands the citable corpus on GitHub without touching the shipped artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new governance decision conformance corpus with reproducible signed examples and expected outcomes.
  * Included stream variants for complete, dropped, tail-sealed, and tail-unsealed cases.
  * Added scenario coverage for intent mismatch, target-state drift, continuation mismatch, duplicate outcome, and Unicode handling.

* **Tests**
  * Added automated checks that verify signatures, completeness rules, and expected verdicts against the vector set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->