### PR TITLE
feat(corpus): SEP-2828 fallback_projection_v0 conformance vectors

### DIFF
--- a/conformance/sep2828/fallback_projection_v0/README.md
+++ b/conformance/sep2828/fallback_projection_v0/README.md
@@ -1,0 +1,57 @@
+# SEP-2828 fallback_projection_v0 conformance vectors
+
+JCS digest vectors for the SEP-2828 fallback binding path — used when no
+SEP-2787 attestation exists for the call.
+
+## What is the fallback projection?
+
+When a deployment does not run SEP-2787, the decision and outcome records
+must still bind to the originating call. The naive approach — hashing the
+full observed `tools/call` envelope including `_meta` — produces
+observer-local digests: a gateway and a provider both see the same call
+but carry different `_meta` values (progress tokens, trace IDs, injected
+correlation headers), so they hash to different values.
+
+The fallback projection fixes this by hashing only the portable subset:
+
+```json
+{
+  "arguments":   <JCS-normalized params.arguments>,
+  "authBinding": <params._meta["authorization_binding"] if present, else absent>,
+  "toolName":    "<params.name>"
+}
+```
+
+`attestationDigest` = `sha256:<hex>` over the UTF-8 JCS encoding of this
+object (RFC 8785: keys sorted, no whitespace). The server-chosen
+`attestationNonce` in `backLink` still provides instance-binding; the
+projection hash provides content-binding.
+
+`authBinding` carries only the authorization-relevant subobject from
+`_meta` — scope, policy reference, capability grant. Progress tokens and
+transport correlation artifacts are excluded.
+
+## Vectors
+
+| Name | Property tested |
+|------|----------------|
+| `basic_no_auth_binding` | Projection without authBinding (no authorization_binding in _meta) |
+| `with_auth_binding` | Projection with authBinding present |
+| `observer_stable_a` | Observer A: gateway sees progressToken + traceId in _meta |
+| `observer_stable_b` | Observer B: provider sees different progressToken + x-injected-id |
+| `neg_different_tool` | Different toolName → different attestationDigest |
+
+`observer_stable_a` and `observer_stable_b` have **identical projections**
+and therefore identical `attestationDigest` values, proving the portability
+property: honest observers with different `_meta` sidecars agree on the
+digest.
+
+## Running the checker
+
+```
+python3 conformance/sep2828/fallback_projection_v0/_check_independent.py
+```
+
+Standard library only (`hashlib`, `json`). Exit 0 means all 7 checks pass,
+including the cross-vector observer-stability and negative-divergence
+assertions.

--- a/conformance/sep2828/fallback_projection_v0/_check_independent.py
+++ b/conformance/sep2828/fallback_projection_v0/_check_independent.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Independent checker for fallback_projection_v0 vectors.
+
+Verifies, from the standard library alone (no Vaara import), that:
+
+1. For each projection vector, JCS-encoding the projection object
+   (RFC 8785: sorted keys, no whitespace, UTF-8) and hashing it with
+   SHA-256 reproduces the committed attestationDigest.
+
+2. observer_stable_a and observer_stable_b yield identical
+   attestationDigests — the key portability property: two honest
+   observers of the same call carrying different _meta sidecars
+   (progress tokens, trace IDs) produce the same digest because
+   the fallback projection excludes those transport fields.
+
+3. neg_different_tool yields a distinct attestationDigest from the
+   observer_stable pair — different toolName changes the digest.
+
+Run: python3 conformance/sep2828/fallback_projection_v0/_check_independent.py
+Exit 0 = all vectors match expected.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def jcs(obj: object) -> bytes:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256(b: bytes) -> str:
+    return "sha256:" + hashlib.sha256(b).hexdigest()
+
+
+def main() -> int:
+    expected = json.loads((HERE / "expected.json").read_text())
+    failures = 0
+
+    for name, want in sorted(expected.items()):
+        proj = json.loads((HERE / "projections" / f"{name}.json").read_text())
+        canonical = jcs(proj)
+        got_bytes = canonical.decode("utf-8")
+        got_digest = sha256(canonical)
+
+        bytes_ok = got_bytes == want["projectionBytes"]
+        digest_ok = got_digest == want["attestationDigest"]
+        ok = bytes_ok and digest_ok
+
+        if not ok:
+            failures += 1
+            if not bytes_ok:
+                print(f"[FAIL] {name}: projectionBytes mismatch")
+                print(f"  want: {want['projectionBytes']}")
+                print(f"  got:  {got_bytes}")
+            if not digest_ok:
+                print(f"[FAIL] {name}: attestationDigest mismatch")
+                print(f"  want: {want['attestationDigest']}")
+                print(f"  got:  {got_digest}")
+        else:
+            print(f"[OK]   {name}: {got_digest}")
+
+    # Observer stability: same projection regardless of excluded _meta sidecar
+    a = expected["observer_stable_a"]["attestationDigest"]
+    b = expected["observer_stable_b"]["attestationDigest"]
+    if a != b:
+        print(f"[FAIL] observer stability: a={a} b={b}")
+        failures += 1
+    else:
+        print(f"[OK]   observer stability: both observers → {a}")
+
+    # Negative: different toolName must produce different digest
+    neg = expected["neg_different_tool"]["attestationDigest"]
+    if neg == a:
+        print("[FAIL] neg_different_tool: digest should differ from observer_stable")
+        failures += 1
+    else:
+        print(f"[OK]   neg_different_tool diverges from observer_stable")
+
+    total = len(expected) + 2  # +2 for the cross-vector assertions
+    passed = total - failures
+    print(f"\n{passed}/{total} checks passed.")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/sep2828/fallback_projection_v0/_generate.py
+++ b/conformance/sep2828/fallback_projection_v0/_generate.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Generate fallback_projection_v0 conformance vectors.
+
+Writes projections/<name>.json and expected.json.
+Run once to regenerate; check output into source control.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PROJECTIONS_DIR = HERE / "projections"
+PROJECTIONS_DIR.mkdir(exist_ok=True)
+
+VECTORS: dict[str, dict] = {
+    # Positive: no authBinding (most common — _meta has no authorization_binding subobject)
+    "basic_no_auth_binding": {
+        "arguments": {"action": "read", "path": "/docs/report.pdf"},
+        "toolName": "filesystem_read",
+    },
+    # Positive: authBinding present (scope + policy carried through)
+    "with_auth_binding": {
+        "arguments": {"bucket": "prod-data", "object": "reports/q1.csv"},
+        "authBinding": {
+            "capabilityGrant": "read-only",
+            "policyId": "pol-2026-001",
+            "scope": "storage",
+        },
+        "toolName": "gcs_read",
+    },
+    # Observer-stability pair: two observers of the SAME call with different
+    # full _meta sidecars (progress tokens, trace IDs differ) produce the
+    # identical projection and therefore the identical attestationDigest.
+    # The checker asserts observer_stable_a.digest == observer_stable_b.digest.
+    "observer_stable_a": {
+        "arguments": {"file": "invoice.pdf"},
+        "authBinding": {"policyId": "pol-abc", "scope": "read"},
+        "toolName": "document_fetch",
+    },
+    "observer_stable_b": {
+        # Identical projection to observer_stable_a; what differs is the
+        # excluded _meta sidecar (progressToken, traceId, x-injected-id).
+        "arguments": {"file": "invoice.pdf"},
+        "authBinding": {"policyId": "pol-abc", "scope": "read"},
+        "toolName": "document_fetch",
+    },
+    # Negative: different toolName → different digest (same other fields)
+    "neg_different_tool": {
+        "arguments": {"file": "invoice.pdf"},
+        "authBinding": {"policyId": "pol-abc", "scope": "read"},
+        "toolName": "document_fetch_v2",
+    },
+}
+
+
+def jcs(obj: object) -> bytes:
+    """RFC 8785 JCS: sorted keys, no whitespace, UTF-8."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def sha256(b: bytes) -> str:
+    return "sha256:" + hashlib.sha256(b).hexdigest()
+
+
+def main() -> None:
+    expected: dict[str, dict] = {}
+    for name, proj in VECTORS.items():
+        canonical = jcs(proj)
+        digest = sha256(canonical)
+        (PROJECTIONS_DIR / f"{name}.json").write_text(
+            json.dumps(proj, indent=2, sort_keys=True) + "\n"
+        )
+        expected[name] = {
+            "projectionBytes": canonical.decode("utf-8"),
+            "attestationDigest": digest,
+        }
+
+    (HERE / "expected.json").write_text(json.dumps(expected, indent=2, sort_keys=True) + "\n")
+    print(f"wrote {len(expected)} vectors to {HERE}")
+    a = expected["observer_stable_a"]["attestationDigest"]
+    b = expected["observer_stable_b"]["attestationDigest"]
+    assert a == b, f"observer stability broken: {a} != {b}"
+    n = expected["neg_different_tool"]["attestationDigest"]
+    assert a != n, "neg_different_tool should differ from observer_stable"
+    print("observer stability: OK")
+    print("neg_different_tool divergence: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/conformance/sep2828/fallback_projection_v0/expected.json
+++ b/conformance/sep2828/fallback_projection_v0/expected.json
@@ -1,0 +1,22 @@
+{
+  "basic_no_auth_binding": {
+    "attestationDigest": "sha256:f3c2ac13827482df4f4d1af226ad6cd4e46bc557617095faffbf734576986b29",
+    "projectionBytes": "{\"arguments\":{\"action\":\"read\",\"path\":\"/docs/report.pdf\"},\"toolName\":\"filesystem_read\"}"
+  },
+  "neg_different_tool": {
+    "attestationDigest": "sha256:db7b84f4a12f7ca4fba78699322f8a6cb5c15bea5fc2bcba139297da600ec1ff",
+    "projectionBytes": "{\"arguments\":{\"file\":\"invoice.pdf\"},\"authBinding\":{\"policyId\":\"pol-abc\",\"scope\":\"read\"},\"toolName\":\"document_fetch_v2\"}"
+  },
+  "observer_stable_a": {
+    "attestationDigest": "sha256:4992f3a0b25594b13faa71f61452d5ee9fa936d7d271f912dddc6a39e4b31d8d",
+    "projectionBytes": "{\"arguments\":{\"file\":\"invoice.pdf\"},\"authBinding\":{\"policyId\":\"pol-abc\",\"scope\":\"read\"},\"toolName\":\"document_fetch\"}"
+  },
+  "observer_stable_b": {
+    "attestationDigest": "sha256:4992f3a0b25594b13faa71f61452d5ee9fa936d7d271f912dddc6a39e4b31d8d",
+    "projectionBytes": "{\"arguments\":{\"file\":\"invoice.pdf\"},\"authBinding\":{\"policyId\":\"pol-abc\",\"scope\":\"read\"},\"toolName\":\"document_fetch\"}"
+  },
+  "with_auth_binding": {
+    "attestationDigest": "sha256:e98a68f744cd5a6d52e21c3c35f17570c603882b0715ea2900f14696ac770ef9",
+    "projectionBytes": "{\"arguments\":{\"bucket\":\"prod-data\",\"object\":\"reports/q1.csv\"},\"authBinding\":{\"capabilityGrant\":\"read-only\",\"policyId\":\"pol-2026-001\",\"scope\":\"storage\"},\"toolName\":\"gcs_read\"}"
+  }
+}

--- a/conformance/sep2828/fallback_projection_v0/projections/basic_no_auth_binding.json
+++ b/conformance/sep2828/fallback_projection_v0/projections/basic_no_auth_binding.json
@@ -1,0 +1,7 @@
+{
+  "arguments": {
+    "action": "read",
+    "path": "/docs/report.pdf"
+  },
+  "toolName": "filesystem_read"
+}

--- a/conformance/sep2828/fallback_projection_v0/projections/neg_different_tool.json
+++ b/conformance/sep2828/fallback_projection_v0/projections/neg_different_tool.json
@@ -1,0 +1,10 @@
+{
+  "arguments": {
+    "file": "invoice.pdf"
+  },
+  "authBinding": {
+    "policyId": "pol-abc",
+    "scope": "read"
+  },
+  "toolName": "document_fetch_v2"
+}

--- a/conformance/sep2828/fallback_projection_v0/projections/observer_stable_a.json
+++ b/conformance/sep2828/fallback_projection_v0/projections/observer_stable_a.json
@@ -1,0 +1,10 @@
+{
+  "arguments": {
+    "file": "invoice.pdf"
+  },
+  "authBinding": {
+    "policyId": "pol-abc",
+    "scope": "read"
+  },
+  "toolName": "document_fetch"
+}

--- a/conformance/sep2828/fallback_projection_v0/projections/observer_stable_b.json
+++ b/conformance/sep2828/fallback_projection_v0/projections/observer_stable_b.json
@@ -1,0 +1,10 @@
+{
+  "arguments": {
+    "file": "invoice.pdf"
+  },
+  "authBinding": {
+    "policyId": "pol-abc",
+    "scope": "read"
+  },
+  "toolName": "document_fetch"
+}

--- a/conformance/sep2828/fallback_projection_v0/projections/with_auth_binding.json
+++ b/conformance/sep2828/fallback_projection_v0/projections/with_auth_binding.json
@@ -1,0 +1,12 @@
+{
+  "arguments": {
+    "bucket": "prod-data",
+    "object": "reports/q1.csv"
+  },
+  "authBinding": {
+    "capabilityGrant": "read-only",
+    "policyId": "pol-2026-001",
+    "scope": "storage"
+  },
+  "toolName": "gcs_read"
+}


### PR DESCRIPTION
Five JCS digest vectors for the SEP-2828 fallback binding path. Proves observer stability: two honest observers with different _meta sidecars produce identical attestationDigest. Independent checker 7/7 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SEP-2828 fallback projection conformance examples covering basic, authenticated, observer-stable, and negative-difference cases.
  * Added a checker and generator to validate canonical projections and matching digests.
  * Expanded expected outputs for the new conformance scenarios.

* **Documentation**
  * Added guidance for running the conformance checker and interpreting pass/fail results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->