### PR TITLE
fix(lint): remove extraneous f-prefix on plain string (ruff F541)

### DIFF
--- a/conformance/sep2828/fallback_projection_v0/_check_independent.py
+++ b/conformance/sep2828/fallback_projection_v0/_check_independent.py
@@ -79,7 +79,7 @@ def main() -> int:
         print("[FAIL] neg_different_tool: digest should differ from observer_stable")
         failures += 1
     else:
-        print(f"[OK]   neg_different_tool diverges from observer_stable")
+        print("[OK]   neg_different_tool diverges from observer_stable")
 
     total = len(expected) + 2  # +2 for the cross-vector assertions
     passed = total - failures


### PR DESCRIPTION
One-line fix: stray f prefix on a string with no placeholders in _check_independent.py:82.