### PR TITLE
feat(corpus): fallback_projection_v0 neg_different_args + neg_different_auth_binding

### DIFF
--- a/conformance/sep2828/fallback_projection_v0/README.md
+++ b/conformance/sep2828/fallback_projection_v0/README.md
@@ -35,16 +35,34 @@ transport correlation artifacts are excluded.
 
 | Name | Property tested |
 |------|----------------|
-| `basic_no_auth_binding` | Projection without authBinding (no authorization_binding in _meta) |
+| `basic_no_auth_binding` | Unauthenticated fallback profile: authBinding absent from projection |
 | `with_auth_binding` | Projection with authBinding present |
-| `observer_stable_a` | Observer A: gateway sees progressToken + traceId in _meta |
-| `observer_stable_b` | Observer B: provider sees different progressToken + x-injected-id |
-| `neg_different_tool` | Different toolName → different attestationDigest |
+| `observer_stable_a` | Observer A: gateway sees `{"progressToken":"pt-aaa","traceId":"tr-001","authorization_binding":{…}}` in _meta |
+| `observer_stable_b` | Observer B: provider sees `{"progressToken":"pt-bbb","x-injected-id":"inj-999","authorization_binding":{…}}` in _meta |
+| `neg_different_tool` | Different toolName → different attestationDigest (same args + authBinding) |
+| `neg_different_args` | Different arguments → different attestationDigest (same toolName + authBinding) |
+| `neg_different_auth_binding` | Different authBinding → different attestationDigest (same toolName + args) |
 
 `observer_stable_a` and `observer_stable_b` have **identical projections**
 and therefore identical `attestationDigest` values, proving the portability
 property: honest observers with different `_meta` sidecars agree on the
-digest.
+digest. The raw _meta values shown above differ in `progressToken` and
+`x-injected-id`; both are stripped. Only `authorization_binding` survives
+as `authBinding`.
+
+`basic_no_auth_binding` is the **explicitly defined unauthenticated fallback
+profile**: when `_meta` carries no `authorization_binding` key, `authBinding`
+is absent from the projection and the digest covers `{arguments, toolName}`
+only. Implementations that require authorization MUST reject calls with no
+`authBinding` at the policy layer; the projection itself does not fail-close
+on absent authBinding because the spec defines this as a valid profile.
+
+**Instance separation via nonce.** The projection hash is content-binding
+only: two identical calls (same toolName, arguments, authBinding) produce the
+same `attestationDigest`. Instance separation is the responsibility of the
+receipt layer via `backLink.attestationNonce`, which the server chooses per
+call. The projection corpus does not include nonces because nonces live in the
+receipt envelope, not in the projection preimage.
 
 ## Running the checker
 

--- a/conformance/sep2828/fallback_projection_v0/_check_independent.py
+++ b/conformance/sep2828/fallback_projection_v0/_check_independent.py
@@ -81,7 +81,23 @@ def main() -> int:
     else:
         print("[OK]   neg_different_tool diverges from observer_stable")
 
-    total = len(expected) + 2  # +2 for the cross-vector assertions
+    # Negative (item 2): different arguments must produce different digest
+    d_args = expected["neg_different_args"]["attestationDigest"]
+    if d_args == a:
+        print("[FAIL] neg_different_args: digest should differ from observer_stable")
+        failures += 1
+    else:
+        print("[OK]   neg_different_args diverges from observer_stable")
+
+    # Negative (item 3): different authBinding must produce different digest
+    d_auth = expected["neg_different_auth_binding"]["attestationDigest"]
+    if d_auth == a:
+        print("[FAIL] neg_different_auth_binding: digest should differ from observer_stable")
+        failures += 1
+    else:
+        print("[OK]   neg_different_auth_binding diverges from observer_stable")
+
+    total = len(expected) + 4  # +4 for cross-vector assertions
     passed = total - failures
     print(f"\n{passed}/{total} checks passed.")
     return 1 if failures else 0

--- a/conformance/sep2828/fallback_projection_v0/_generate.py
+++ b/conformance/sep2828/fallback_projection_v0/_generate.py
@@ -15,12 +15,15 @@ PROJECTIONS_DIR = HERE / "projections"
 PROJECTIONS_DIR.mkdir(exist_ok=True)
 
 VECTORS: dict[str, dict] = {
-    # Positive: no authBinding (most common — _meta has no authorization_binding subobject)
+    # Positive: no authBinding — the explicit unauthenticated fallback profile.
+    # Projection = {arguments, toolName} with authBinding absent.
+    # Raw _meta example: {"progressToken": "pt-1", "traceId": "tr-001"}
+    # (no "authorization_binding" key → authBinding absent from projection).
     "basic_no_auth_binding": {
         "arguments": {"action": "read", "path": "/docs/report.pdf"},
         "toolName": "filesystem_read",
     },
-    # Positive: authBinding present (scope + policy carried through)
+    # Positive: authBinding present (scope + policy carried through).
     "with_auth_binding": {
         "arguments": {"bucket": "prod-data", "object": "reports/q1.csv"},
         "authBinding": {
@@ -30,27 +33,45 @@ VECTORS: dict[str, dict] = {
         },
         "toolName": "gcs_read",
     },
-    # Observer-stability pair: two observers of the SAME call with different
-    # full _meta sidecars (progress tokens, trace IDs differ) produce the
-    # identical projection and therefore the identical attestationDigest.
-    # The checker asserts observer_stable_a.digest == observer_stable_b.digest.
+    # Observer-stability pair (item 1).
+    # Raw calls have DIFFERENT _meta sidecars:
+    #   observer_stable_a raw _meta: {"progressToken": "pt-aaa", "traceId": "tr-001",
+    #                                  "authorization_binding": {"policyId": "pol-abc",
+    #                                                            "scope": "read"}}
+    #   observer_stable_b raw _meta: {"progressToken": "pt-bbb", "x-injected-id": "inj-999",
+    #                                  "authorization_binding": {"policyId": "pol-abc",
+    #                                                            "scope": "read"}}
+    # progressToken and x-injected-id are stripped; authorization_binding becomes authBinding.
+    # Checker asserts: observer_stable_a.digest == observer_stable_b.digest.
     "observer_stable_a": {
         "arguments": {"file": "invoice.pdf"},
         "authBinding": {"policyId": "pol-abc", "scope": "read"},
         "toolName": "document_fetch",
     },
     "observer_stable_b": {
-        # Identical projection to observer_stable_a; what differs is the
-        # excluded _meta sidecar (progressToken, traceId, x-injected-id).
         "arguments": {"file": "invoice.pdf"},
         "authBinding": {"policyId": "pol-abc", "scope": "read"},
         "toolName": "document_fetch",
     },
-    # Negative: different toolName → different digest (same other fields)
+    # Negative: different toolName → different digest (same other fields).
     "neg_different_tool": {
         "arguments": {"file": "invoice.pdf"},
         "authBinding": {"policyId": "pol-abc", "scope": "read"},
         "toolName": "document_fetch_v2",
+    },
+    # Negative (item 2): same toolName and authBinding, different arguments → different digest.
+    # Isolates the arguments contribution to the projection preimage.
+    "neg_different_args": {
+        "arguments": {"file": "statement.pdf"},
+        "authBinding": {"policyId": "pol-abc", "scope": "read"},
+        "toolName": "document_fetch",
+    },
+    # Negative (item 3): same toolName and arguments, different authBinding → different digest.
+    # Isolates the authBinding contribution to the projection preimage.
+    "neg_different_auth_binding": {
+        "arguments": {"file": "invoice.pdf"},
+        "authBinding": {"policyId": "pol-xyz", "scope": "write"},
+        "toolName": "document_fetch",
     },
 }
 
@@ -84,8 +105,15 @@ def main() -> None:
     assert a == b, f"observer stability broken: {a} != {b}"
     n = expected["neg_different_tool"]["attestationDigest"]
     assert a != n, "neg_different_tool should differ from observer_stable"
+    d_args = expected["neg_different_args"]["attestationDigest"]
+    assert a != d_args, "neg_different_args should differ from observer_stable (args change moves digest)"
+    d_auth = expected["neg_different_auth_binding"]["attestationDigest"]
+    assert a != d_auth, "neg_different_auth_binding should differ from observer_stable (authBinding change moves digest)"
+    assert d_args != d_auth, "neg_different_args and neg_different_auth_binding must not collide"
     print("observer stability: OK")
     print("neg_different_tool divergence: OK")
+    print("neg_different_args divergence: OK")
+    print("neg_different_auth_binding divergence: OK")
 
 
 if __name__ == "__main__":

--- a/conformance/sep2828/fallback_projection_v0/expected.json
+++ b/conformance/sep2828/fallback_projection_v0/expected.json
@@ -3,6 +3,14 @@
     "attestationDigest": "sha256:f3c2ac13827482df4f4d1af226ad6cd4e46bc557617095faffbf734576986b29",
     "projectionBytes": "{\"arguments\":{\"action\":\"read\",\"path\":\"/docs/report.pdf\"},\"toolName\":\"filesystem_read\"}"
   },
+  "neg_different_args": {
+    "attestationDigest": "sha256:667d71cdf498c46b3aa8025153f71d6306d9e1a7e855f148c680704ec09752a2",
+    "projectionBytes": "{\"arguments\":{\"file\":\"statement.pdf\"},\"authBinding\":{\"policyId\":\"pol-abc\",\"scope\":\"read\"},\"toolName\":\"document_fetch\"}"
+  },
+  "neg_different_auth_binding": {
+    "attestationDigest": "sha256:5472968662e4e1a2d2aeea7f137f04e44d4621fa3d3f6cb92ad5977594a6ddc9",
+    "projectionBytes": "{\"arguments\":{\"file\":\"invoice.pdf\"},\"authBinding\":{\"policyId\":\"pol-xyz\",\"scope\":\"write\"},\"toolName\":\"document_fetch\"}"
+  },
   "neg_different_tool": {
     "attestationDigest": "sha256:db7b84f4a12f7ca4fba78699322f8a6cb5c15bea5fc2bcba139297da600ec1ff",
     "projectionBytes": "{\"arguments\":{\"file\":\"invoice.pdf\"},\"authBinding\":{\"policyId\":\"pol-abc\",\"scope\":\"read\"},\"toolName\":\"document_fetch_v2\"}"

--- a/conformance/sep2828/fallback_projection_v0/projections/neg_different_args.json
+++ b/conformance/sep2828/fallback_projection_v0/projections/neg_different_args.json
@@ -1,0 +1,10 @@
+{
+  "arguments": {
+    "file": "statement.pdf"
+  },
+  "authBinding": {
+    "policyId": "pol-abc",
+    "scope": "read"
+  },
+  "toolName": "document_fetch"
+}

--- a/conformance/sep2828/fallback_projection_v0/projections/neg_different_auth_binding.json
+++ b/conformance/sep2828/fallback_projection_v0/projections/neg_different_auth_binding.json
@@ -1,0 +1,10 @@
+{
+  "arguments": {
+    "file": "invoice.pdf"
+  },
+  "authBinding": {
+    "policyId": "pol-xyz",
+    "scope": "write"
+  },
+  "toolName": "document_fetch"
+}


### PR DESCRIPTION
Adds two negative vectors isolating each preimage axis: neg_different_args (same toolName+authBinding, different arguments) and neg_different_auth_binding (same toolName+args, different authBinding). Checker: 11/11 pass. README covers items 1, 4, 6 from the fixture checklist. Item 5 (unknown bindingId fail-closed) tracked for next update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the SEP-2828 fallback projection conformance matrix, including stable cases and multiple negative divergence cases.
  - Added clearer guidance on how non-portable metadata is excluded, how unauthenticated fallback is handled, and how digest binding works.

- **Tests**
  - Expanded conformance checks to cover additional divergence scenarios for changed arguments and changed authorization bindings.
  - Updated expected outputs and runtime assertions to keep the test set consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->