### PR TITLE
feat(credential): static tool-constraints config wires capability-mode grants

### DIFF
--- a/src/vaara/integrations/_mcp_attest.py
+++ b/src/vaara/integrations/_mcp_attest.py
@@ -74,6 +74,7 @@ class AttestPairEmitter:
         secret_version: str,
         upstream_commands: dict[str, list[str]],
         exp_seconds: int = 300,
+        tool_constraints: "Optional[dict[str, tuple[Any, ...]]]" = None,
     ) -> None:
         from vaara.attestation._sep2787_types import VALID_ALGS
         if alg not in VALID_ALGS:
@@ -84,6 +85,7 @@ class AttestPairEmitter:
         self._receipts_dir.mkdir(parents=True, exist_ok=True)
         self._secret_version = secret_version
         self._exp_seconds = exp_seconds
+        self._tool_constraints: dict[str, tuple[Any, ...]] = tool_constraints or {}
         self._counter = 0
         # Per-coverage-boundary sequence for authorization receipts, gap-free by
         # construction. Distinct from ``_counter`` (the per-call attestation id):
@@ -238,6 +240,7 @@ class AttestPairEmitter:
             )
             sub = f"{tenant_id}/{upstream_name}" if tenant_id else upstream_name
 
+            capabilities = self._tool_constraints.get(tool_name, ())
             credential = _emit_grant(
                 scope=scope,
                 binding=binding,
@@ -247,6 +250,7 @@ class AttestPairEmitter:
                 alg=self._alg,
                 signing_material=self._signing_key,
                 exp_seconds=grant_exp_seconds,
+                capabilities=capabilities,
             )
 
             nonce_tag = attestation.issuer_asserted.nonce[:8]
@@ -445,6 +449,7 @@ def build_attest_emitter(
     upstream_commands: dict[str, list[str]],
     secret_version: Optional[str] = None,
     exp_seconds: int = 300,
+    tool_constraints_path: Optional[Path] = None,
 ) -> AttestPairEmitter:
     """Load signing key from path and return an ``AttestPairEmitter``.
 
@@ -518,6 +523,15 @@ def build_attest_emitter(
         if secret_version is None:
             secret_version = hashlib.sha256(raw).hexdigest()[:8]
 
+    tool_constraints: dict[str, tuple[Any, ...]] = {}
+    if tool_constraints_path is not None:
+        from vaara.credential._grant_capability import capability_from_dict
+        raw_cfg = json.loads(
+            Path(tool_constraints_path).expanduser().read_text(encoding="utf-8")
+        )
+        for tname, cap_list in raw_cfg.get("tools", {}).items():
+            tool_constraints[tname] = tuple(capability_from_dict(c) for c in cap_list)
+
     return AttestPairEmitter(
         signing_key=signing_material,
         alg=alg,
@@ -525,4 +539,5 @@ def build_attest_emitter(
         secret_version=secret_version,
         upstream_commands=upstream_commands,
         exp_seconds=exp_seconds,
+        tool_constraints=tool_constraints or None,
     )

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -1618,6 +1618,13 @@ def main(argv: Optional[list[str]] = None) -> None:
                         help="Directory to write paired attestation + receipt JSON files "
                              "({n}-attest.json / {n}-receipt.json). Required when "
                              "--attest-signing-key is set.")
+    parser.add_argument("--tool-constraints", type=Path, default=None,
+                        metavar="PATH",
+                        help="JSON file mapping tool names to capability constraints for "
+                             "credential grants. Keys are tool names; values are lists of "
+                             "{arg, op, value} objects (op: le/ge/eq/in). Grants for listed "
+                             "tools carry typed constraints; unlisted tools get exact-args "
+                             "grants. Has no effect without --attest-signing-key.")
     parser.add_argument("--overt-signing-key", type=Path, default=None,
                         help="Ed25519 PEM private key used to sign OVERT 1.0 Base "
                              "Envelopes for every governed MCP interaction. Off when "
@@ -1856,6 +1863,7 @@ def _build_attest_emitter_from_args(
             signing_key_path=args.attest_signing_key,
             receipts_dir=args.attest_receipts_dir,
             upstream_commands=upstreams,
+            tool_constraints_path=getattr(args, "tool_constraints", None),
         )
     except AttestConfigError as exc:
         print(f"vaara-mcp-proxy: {exc}", file=sys.stderr)

--- a/tests/credential/test_grant_proxy_integration.py
+++ b/tests/credential/test_grant_proxy_integration.py
@@ -181,3 +181,58 @@ def test_authorization_receipt_off_by_default(monkeypatch, emitter, receipts_dir
     })
     assert len(_grants(receipts_dir)) == 1
     assert _authzs(receipts_dir) == []
+
+
+def test_tool_constraints_minted_as_capabilities(monkeypatch, tmp_path, receipts_dir):
+    """Capabilities from tool_constraints appear in the grant for the matching tool."""
+    from vaara.integrations._mcp_attest import build_attest_emitter
+
+    key = tmp_path / "attest.key"
+    key.write_bytes(KEY)
+    cfg = tmp_path / "constraints.json"
+    cfg.write_text(json.dumps({
+        "tools": {
+            "read_file": [
+                {"arg": "path", "op": "in", "value": ["/tmp", "/var/data"]},
+            ]
+        }
+    }))
+    em = build_attest_emitter(
+        signing_key_path=key,
+        receipts_dir=receipts_dir,
+        upstream_commands={"default": ["echo"]},
+        tool_constraints_path=cfg,
+    )
+    p = _make_proxy(monkeypatch, emitter=em, mint=True)
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": "/tmp/x"}},
+    })
+    grants = _grants(receipts_dir)
+    assert len(grants) == 1
+    caps = grants[0].get("capabilities", [])
+    assert caps == [{"arg": "path", "op": "in", "value": ["/tmp", "/var/data"]}]
+
+
+def test_unconstrained_tool_gets_no_capabilities(monkeypatch, tmp_path, receipts_dir):
+    """A tool not in the constraints map gets an exact-args grant with no capabilities."""
+    from vaara.integrations._mcp_attest import build_attest_emitter
+
+    key = tmp_path / "attest.key"
+    key.write_bytes(KEY)
+    cfg = tmp_path / "constraints.json"
+    cfg.write_text(json.dumps({"tools": {"other_tool": [{"arg": "x", "op": "eq", "value": "y"}]}}))
+    em = build_attest_emitter(
+        signing_key_path=key,
+        receipts_dir=receipts_dir,
+        upstream_commands={"default": ["echo"]},
+        tool_constraints_path=cfg,
+    )
+    p = _make_proxy(monkeypatch, emitter=em, mint=True)
+    p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": "/tmp/x"}},
+    })
+    grants = _grants(receipts_dir)
+    assert len(grants) == 1
+    assert "capabilities" not in grants[0]


### PR DESCRIPTION
Load a JSON tool->constraints map at proxy init (--tool-constraints PATH). Tools listed in the map get capability-mode grants; unlisted tools get exact-args grants. No behaviour change when the flag is absent. 88 credential tests passing.