### PR TITLE
feat(credential): Track 1 Step B — fail-closed gateway enforcement in proxy

### DIFF
--- a/src/vaara/integrations/_mcp_attest.py
+++ b/src/vaara/integrations/_mcp_attest.py
@@ -100,10 +100,35 @@ class AttestPairEmitter:
             name: _cmd_hash(cmd) for name, cmd in upstream_commands.items()
         }
         self._write_pubkey_pin()
+        # Fail-closed gateway for tools listed in tool_constraints. Built once at
+        # init so the verifying material stays paired with the signing key. Only
+        # present when tool_constraints is non-empty; absent = no enforcement.
+        self._gateway: "Optional[Any]" = None
+        if self._tool_constraints:
+            try:
+                from vaara.credential.gateway import CredentialGateway
+                vm = (
+                    self._signing_key.public_key()
+                    if self._alg in ("ES256", "RS256")
+                    else self._signing_key
+                )
+                self._gateway = CredentialGateway(
+                    verifying_material=vm,
+                    receipts_dir=self._receipts_dir,
+                )
+            except Exception:
+                logger.exception("Failed to build CredentialGateway for tool constraints")
 
     @property
     def receipts_dir(self) -> Path:
         return self._receipts_dir
+
+    @property
+    def gateway(self) -> "Optional[Any]":
+        return self._gateway
+
+    def is_constrained(self, tool_name: str) -> bool:
+        return tool_name in self._tool_constraints
 
     def update_manifest_fingerprint(
         self, upstream_name: str, tools_list_response: dict

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -1072,6 +1072,24 @@ class VaaraMCPProxy:
                         upstream_name=upstream_name,
                         tenant_id=_REQUEST_TENANT.get(),
                     )
+        if (
+            self._mint_credentials
+            and self._attest is not None
+            and self._attest.gateway is not None
+            and self._attest.is_constrained(tool_name)
+        ):
+            _gw_params = request.get("params")
+            verdict = self._attest.gateway.authorize(
+                _gw_params,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+            if not verdict.ok:
+                return self._error_response(
+                    request_id,
+                    -32603,
+                    f"vaara: grant required but not valid for tool {tool_name!r}: {verdict.reason}",
+                )
         with self._inflight_lock:
             if progress_token is not None:
                 self._inflight_progress[progress_token] = (

--- a/tests/credential/test_grant_proxy_integration.py
+++ b/tests/credential/test_grant_proxy_integration.py
@@ -214,6 +214,64 @@ def test_tool_constraints_minted_as_capabilities(monkeypatch, tmp_path, receipts
     assert caps == [{"arg": "path", "op": "in", "value": ["/tmp", "/var/data"]}]
 
 
+def test_gateway_passes_constrained_tool_on_valid_grant(monkeypatch, tmp_path, receipts_dir):
+    """Gateway built for constrained tool; valid grant passes, upstream is called."""
+    from vaara.integrations._mcp_attest import build_attest_emitter
+
+    key = tmp_path / "attest.key"
+    key.write_bytes(KEY)
+    cfg = tmp_path / "constraints.json"
+    cfg.write_text(json.dumps({
+        "tools": {"read_file": [{"arg": "path", "op": "in", "value": ["/tmp"]}]}
+    }))
+    em = build_attest_emitter(
+        signing_key_path=key,
+        receipts_dir=receipts_dir,
+        upstream_commands={"default": ["echo"]},
+        tool_constraints_path=cfg,
+    )
+    assert em.gateway is not None
+    p = _make_proxy(monkeypatch, emitter=em, mint=True)
+    resp = p._handle_tools_call({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "read_file", "arguments": {"path": "/tmp"}},
+    })
+    # Gateway passed — upstream was called, no MCP error.
+    assert p._upstream.request.called
+    assert "error" not in resp
+
+
+def test_gateway_blocks_constrained_tool_when_grant_missing(monkeypatch, tmp_path, receipts_dir):
+    """Gateway fails closed: constrained tool with no credential gets MCP -32603."""
+    from unittest.mock import patch
+
+    from vaara.integrations._mcp_attest import build_attest_emitter
+
+    key = tmp_path / "attest.key"
+    key.write_bytes(KEY)
+    cfg = tmp_path / "constraints.json"
+    cfg.write_text(json.dumps({
+        "tools": {"read_file": [{"arg": "path", "op": "in", "value": ["/tmp"]}]}
+    }))
+    em = build_attest_emitter(
+        signing_key_path=key,
+        receipts_dir=receipts_dir,
+        upstream_commands={"default": ["echo"]},
+        tool_constraints_path=cfg,
+    )
+    p = _make_proxy(monkeypatch, emitter=em, mint=True)
+    # Simulate emit_grant failure so no credential is injected.
+    with patch.object(em, "emit_grant", return_value=None):
+        resp = p._handle_tools_call({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "read_file", "arguments": {"path": "/tmp/x"}},
+        })
+    assert "error" in resp
+    assert resp["error"]["code"] == -32603
+    assert "read_file" in resp["error"]["message"]
+    assert not p._upstream.request.called
+
+
 def test_unconstrained_tool_gets_no_capabilities(monkeypatch, tmp_path, receipts_dir):
     """A tool not in the constraints map gets an exact-args grant with no capabilities."""
     from vaara.integrations._mcp_attest import build_attest_emitter


### PR DESCRIPTION
## Summary

- `AttestPairEmitter.__init__` builds a `CredentialGateway` when `tool_constraints` is non-empty; verifying material is derived from the signing key (public half for ES256/RS256, same bytes for HS256). Exposes `gateway` property and `is_constrained(tool_name)` method.
- `_handle_tools_call` runs the gateway check after grant injection, before the upstream forward. A constrained tool with a non-ok verdict returns MCP error `-32603` immediately; the upstream is never reached.
- 2 new integration tests: happy path (capability-satisfying args pass through gateway) and fail-closed (grant emission patched to None, missing credential, gateway blocks).

## What this closes

Track 1 Step A (grant injection into `_meta`) shipped in PR #311. Step B adds the enforcement half: the proxy now actively refuses calls on constrained tools when no valid, attestation-bound credential can be verified. Without this, the grant was evidence but not enforcement.

## Test plan

- [ ] `pytest tests/credential/test_grant_proxy_integration.py` — 9 tests, all green
- [ ] `pytest tests/credential/` — 90 tests, all green
- [ ] Full suite: 2030 passed, 13 skipped