### PR TITLE
chore(release): v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - 2026-06-25
+
+Minor release: Track 1 authority-layer enforcement. The proxy now mints a short-lived credential per allowed tool call and enforces it fail-closed at the chokepoint before any upstream forward occurs.
+
+- **Credential injection (Step A).** When the proxy is started with `--tool-constraints PATH`, `AttestPairEmitter` mints a scoped, attestation-bound JWT per allowed `tools/call` and injects it at `params._meta["vaara/credential"]` on the forwarded request. The JWT binds the attestation digest, the tool name, the argument commitment (`ArgsProjection.projection_digest`), and the tenant ID, signed with the same key used for attestation (ES256, RS256, or HS256). Capabilities from the constraints file travel in the `capabilities` array. A downstream `CredentialGateway` can verify the credential independently without contacting the proxy.
+- **Fail-closed enforcement (Step B).** `_handle_tools_call` now runs a `CredentialGateway` check after grant injection and before the upstream forward. Tools listed in the constraints file are fail-closed: a missing, malformed, expired, scope-mismatched, or attestation-unbound credential returns MCP error `-32603` and the upstream is never reached. The gateway is built once at proxy init, verifying material derived from the signing key (public half for asymmetric algorithms, same bytes for HS256).
+- **Config wire.** `--tool-constraints PATH` accepts a JSON file of the form `{"tools": {"tool_name": [{arg, op, value}]}}`. Each capability constrains one argument of the named tool; the grant carries the full list so a downstream enforcer can apply them without re-reading the config.
+- 2 new integration tests covering the enforcement path: valid grant passes the gateway; absent grant (simulated emit failure) is blocked with `-32603`.
+
 ## [1.14.0] - 2026-06-23
 
 Minor release: independent producibility for the two conformance carriers. Each vector now reproduces from scratch with a second generator that shares no code with the one that minted it and imports nothing from Vaara, so the bytes stand on the declared canonicalization alone, with no generator and no issuer in the loop.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.14.0"
+version = "1.15.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.14.0"
+__version__ = "1.15.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Track 1 authority-layer enforcement: credential injection (Step A, PR #311) + fail-closed gateway enforcement (Step B, PR #312). Both merged to main; this PR carries the version bump and CHANGELOG entry.

## Checklist
- [ ] `pyproject.toml` → 1.15.0
- [ ] `src/vaara/__init__.py` → 1.15.0
- [ ] `clients/ts/package.json` → 1.15.0
- [ ] CHANGELOG entry for [1.15.0]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enforcing tool call constraints through a configuration file.
  * Introduced short-lived, attested credentials for allowed tool calls, with failed or invalid credentials blocked before forwarding.

* **Bug Fixes**
  * Tool call requests now fail safely when credentials are missing, expired, mismatched, or unbound.

* **Chores**
  * Updated package versions to **1.15.0** across the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->