### PR TITLE
feat(credential): Track 1 gateway enforcement + credential_binding_v0 corpus (v1.16.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.15.0"
+version = "1.16.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.15.0"
+__version__ = "1.16.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/tests/vectors/credential_binding_v0/README.md
+++ b/tests/vectors/credential_binding_v0/README.md
@@ -1,0 +1,56 @@
+# credential_binding_v0
+
+Conformance vectors for the Vaara credential gateway enforcement contract
+(Track 1, MCP proxy — SEP-2828).
+
+## What this pins
+
+Five cases cover the boundary between the proxy's allow decision and the
+upstream forward.  A credential is spendable enforcement material for a single
+tool call.  The signed records are audit evidence.  A verifier must be able to
+reject a bad credential before upstream execution while still emitting a
+concrete outcome record for the denial.
+
+| case | expected verdict |
+|------|-----------------|
+| `pos_valid_grant` | `ok` — credential matches runtime tool, args, and tenant |
+| `neg_args_changed` | `scope_mismatch` — runtime args differ from the committed args |
+| `neg_expired` | `expired` — credential is past its expiry window at evaluation time |
+| `neg_wrong_tenant` | `scope_mismatch` — tenantId in scope does not match the runtime call |
+| `neg_no_credential` | `missing_credential` — `vaara/credential` absent from `_meta` (fail-closed) |
+
+## Fixture format
+
+Each `cases/*.json` file contains:
+
+```
+credential               BrokeredCredential.to_dict(), or null
+expected_verdict         string verdict the gateway must produce
+known_attestation_digests  sha256 digests the gateway accepts as valid bindings
+now                      pinned Unix timestamp (seconds) used during verification
+runtime_args             tool arguments presented at runtime
+runtime_tenant_id        tenant seen by the gateway
+runtime_tool_name        tool name seen by the gateway
+```
+
+## Recomputation
+
+Any verifier that speaks HS256 over RFC 8785 JCS can reproduce every verdict
+from `_check_independent.py` with no Vaara import.  The signing key is
+`b"x" * 32` (corpus only; not a deployed key).
+
+The args commitment is a two-step sha256:
+
+```
+args_digest  = "sha256:" + sha256(jcs(runtime_args)).hexdigest()
+args_commitment = "sha256:" + sha256(jcs({"digest": args_digest})).hexdigest()
+```
+
+The signing payload is `jcs({version, alg, scope, binding, asserted})`.
+
+## Regeneration
+
+```
+python3 tests/vectors/credential_binding_v0/_generate.py
+python3 tests/vectors/credential_binding_v0/_check_independent.py
+```

--- a/tests/vectors/credential_binding_v0/_check_independent.py
+++ b/tests/vectors/credential_binding_v0/_check_independent.py
@@ -14,7 +14,7 @@ import hashlib
 import hmac
 import json
 import sys
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 import rfc8785

--- a/tests/vectors/credential_binding_v0/_check_independent.py
+++ b/tests/vectors/credential_binding_v0/_check_independent.py
@@ -1,0 +1,155 @@
+"""Independent conformance checker for credential_binding_v0 vectors.
+
+No Vaara import.  Uses only hmac, hashlib, json, rfc8785, and stdlib datetime.
+Every verification step replicates the gateway logic from first principles so
+the passing verdict is a property of the bytes in each case file, not of the
+Vaara codebase.
+
+Run: python3 tests/vectors/credential_binding_v0/_check_independent.py
+Exit 0 = all cases match expected. Non-zero = mismatch printed and raised.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import rfc8785
+
+HERE = Path(__file__).resolve().parent
+
+# Must match the key used in _generate.py.
+KEY = b"x" * 32
+
+CLOCK_SKEW = 30  # seconds; matches gateway default
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _jcs(obj) -> bytes:
+    return rfc8785.dumps(obj)
+
+
+def _iso_to_epoch(iso: str) -> float:
+    if iso.endswith("Z"):
+        iso = iso[:-1] + "+00:00"
+    return datetime.fromisoformat(iso).timestamp()
+
+
+def _args_commitment(args: dict) -> str:
+    """Replicate make_args_digest from _sep2787_canonical.py.
+
+    Step 1: sha256 over JCS of args.
+    Step 2: sha256 over JCS of {"digest": "<step1>"}.
+    """
+    args_digest_hex = "sha256:" + hashlib.sha256(_jcs(args)).hexdigest()
+    projection_bytes = _jcs({"digest": args_digest_hex})
+    return "sha256:" + hashlib.sha256(projection_bytes).hexdigest()
+
+
+def _signing_payload(cred: dict) -> bytes:
+    """JCS of {version, alg, scope, binding, asserted} — capabilities included when present."""
+    body = {
+        "alg": cred["alg"],
+        "asserted": cred["asserted"],
+        "binding": cred["binding"],
+        "scope": cred["scope"],
+        "version": cred["version"],
+    }
+    if cred.get("capabilities"):
+        body["capabilities"] = cred["capabilities"]
+    return _jcs(body)
+
+
+def _verify_hs256(payload: bytes, signature_hex: str) -> bool:
+    expected = hmac.new(KEY, payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_hex)
+
+
+def _verify(case: dict) -> str:
+    """Return the computed verdict string."""
+    cred = case.get("credential")
+
+    if cred is None:
+        return "missing_credential"
+
+    # 1. signature
+    payload = _signing_payload(cred)
+    if not _verify_hs256(payload, cred["signature"]):
+        return "bad_signature"
+
+    # 2. expiry
+    asserted = cred["asserted"]
+    iat_epoch = _iso_to_epoch(asserted["iat"])
+    now = float(case["now"])
+    deadline = iat_epoch + asserted["expSeconds"] + CLOCK_SKEW
+    if iat_epoch > now + CLOCK_SKEW or now > deadline:
+        return "expired"
+
+    # 3. scope — tool name
+    scope = cred["scope"]
+    if scope["toolName"] != case["runtime_tool_name"]:
+        return "scope_mismatch"
+
+    # 4. scope — tenant
+    if scope["tenantId"] != case["runtime_tenant_id"]:
+        return "scope_mismatch"
+
+    # 5. scope — args commitment (capabilities mode skipped: corpus uses exact-args grants)
+    runtime_commitment = _args_commitment(case["runtime_args"])
+    if scope["argsCommitment"] != runtime_commitment:
+        return "scope_mismatch"
+
+    # 6. binding
+    known = set(case.get("known_attestation_digests", []))
+    if cred["binding"]["attestationDigest"] not in known:
+        return "binding_unknown"
+
+    return "ok"
+
+
+def main() -> int:
+    expected_path = HERE / "expected.json"
+    if not expected_path.exists():
+        print("expected.json not found — run _generate.py first", file=sys.stderr)
+        return 1
+
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    cases_dir = HERE / "cases"
+    failures = []
+
+    for path in sorted(cases_dir.glob("*.json")):
+        case = json.loads(path.read_text(encoding="utf-8"))
+        computed = _verify(case)
+        want = case["expected_verdict"]
+        status = "PASS" if computed == want else "FAIL"
+        print(f"  {status}  {path.stem:<30}  computed={computed!r}  expected={want!r}")
+        if computed != want:
+            failures.append(path.stem)
+
+    # Cross-check against expected.json
+    for name, meta in expected["cases"].items():
+        want = meta["expected_verdict"]
+        path = cases_dir / f"{name}.json"
+        if not path.exists():
+            print(f"  MISSING  {name}", file=sys.stderr)
+            failures.append(name)
+            continue
+        case = json.loads(path.read_text(encoding="utf-8"))
+        computed = _verify(case)
+        if computed != want:
+            failures.append(f"{name}(expected.json cross-check)")
+
+    if failures:
+        print(f"\n{len(failures)} failure(s): {failures}", file=sys.stderr)
+        return 1
+
+    print(f"\nall {len(list(cases_dir.glob('*.json')))} cases pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/credential_binding_v0/_generate.py
+++ b/tests/vectors/credential_binding_v0/_generate.py
@@ -1,0 +1,117 @@
+"""Regenerate the credential_binding_v0 conformance vectors.
+
+Five cases pin the gateway enforcement contract (Track 1, MCP proxy):
+
+  pos_valid_grant      — valid credential + matching arg commitment → ok
+  neg_args_changed     — arg commitment mismatch at runtime → scope_mismatch
+  neg_expired          — credential past its expiry window → expired
+  neg_wrong_tenant     — tenantId in scope does not match runtime call → scope_mismatch
+  neg_no_credential    — vaara/credential absent from _meta → missing_credential
+
+Each fixture is self-contained JSON.  The sibling _check_independent.py
+reproduces every verdict with no Vaara import — only hmac, hashlib, json, rfc8785
+— so a passing check is a property of the bytes, not of this script.
+
+Run from repo root: python3 tests/vectors/credential_binding_v0/_generate.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from vaara.attestation._sep2787_canonical import make_args_digest
+from vaara.credential._grant_emit import emit_grant
+from vaara.credential._grant_types import GrantBinding, GrantScope
+
+HERE = Path(__file__).resolve().parent
+
+# ── signing key (HS256, raw bytes) ────────────────────────────────────────────
+KEY = b"x" * 32
+SECRET_VERSION = "corpus-key-v0"
+
+# ── tool / tenant / args ──────────────────────────────────────────────────────
+TOOL = "read_file"
+TENANT = "mcp-tenant-01"
+ARGS = {"path": "/tmp/vaara/read_file_test"}
+ARGS_ALT = {"path": "/etc/passwd"}
+
+# ── attestation identity (stable fake for corpus fixtures) ────────────────────
+ATTEST_NONCE = "dGVzdG5vbmNlMTIz"
+ATTEST_DIGEST = "sha256:" + hashlib.sha256(b"vaara-corpus-attest-v0").hexdigest()
+
+# ── pinned timestamps ─────────────────────────────────────────────────────────
+# IAT_EPOCH = 1779200000  →  2026-05-19T14:13:20Z
+# NOW = IAT_EPOCH + 30  (within the 60 s expiry window of pos_valid_grant)
+IAT = "2026-05-19T14:13:20Z"
+IAT_OLD = "2025-05-19T14:13:20Z"   # one year earlier; expired at NOW
+NOW = 1779200030
+
+
+def _grant_dict(*, iat: str = IAT, tenant: str = TENANT, args: dict = ARGS,
+                exp_seconds: int = 60) -> dict:
+    args_commitment = make_args_digest(args).projection_digest
+    cred = emit_grant(
+        scope=GrantScope(tool_name=TOOL, args_commitment=args_commitment, tenant_id=tenant),
+        binding=GrantBinding(attestation_digest=ATTEST_DIGEST, attestation_nonce=ATTEST_NONCE),
+        iss="vaara-mcp-proxy",
+        sub="corpus/test",
+        secret_version=SECRET_VERSION,
+        alg="HS256",
+        signing_material=KEY,
+        exp_seconds=exp_seconds,
+        iat=iat,
+    )
+    return cred.to_dict()
+
+
+def _case(credential, *, runtime_args: dict = ARGS, runtime_tenant: str = TENANT,
+          expected_verdict: str) -> dict:
+    return {
+        "credential": credential,
+        "expected_verdict": expected_verdict,
+        "known_attestation_digests": [ATTEST_DIGEST],
+        "now": NOW,
+        "runtime_args": runtime_args,
+        "runtime_tenant_id": runtime_tenant,
+        "runtime_tool_name": TOOL,
+    }
+
+
+def _write(path: Path, obj) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    cases_dir = HERE / "cases"
+
+    _write(cases_dir / "pos_valid_grant.json",
+           _case(_grant_dict(), expected_verdict="ok"))
+
+    _write(cases_dir / "neg_args_changed.json",
+           _case(_grant_dict(), runtime_args=ARGS_ALT, expected_verdict="scope_mismatch"))
+
+    _write(cases_dir / "neg_expired.json",
+           _case(_grant_dict(iat=IAT_OLD), expected_verdict="expired"))
+
+    _write(cases_dir / "neg_wrong_tenant.json",
+           _case(_grant_dict(), runtime_tenant="other-tenant", expected_verdict="scope_mismatch"))
+
+    _write(cases_dir / "neg_no_credential.json",
+           _case(None, expected_verdict="missing_credential"))
+
+    expected_cases = {}
+    for path in sorted(cases_dir.glob("*.json")):
+        obj = json.loads(path.read_text(encoding="utf-8"))
+        expected_cases[path.stem] = {
+            "expected_verdict": obj["expected_verdict"],
+            "signature_ok": obj["credential"] is not None,
+        }
+    _write(HERE / "expected.json", {"cases": expected_cases})
+    print(f"wrote {len(expected_cases)} credential_binding_v0 vectors")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/credential_binding_v0/cases/neg_args_changed.json
+++ b/tests/vectors/credential_binding_v0/cases/neg_args_changed.json
@@ -1,0 +1,34 @@
+{
+  "credential": {
+    "alg": "HS256",
+    "asserted": {
+      "expSeconds": 60,
+      "iat": "2026-05-19T14:13:20Z",
+      "iss": "vaara-mcp-proxy",
+      "nonce": "cNHOP_KBb1P_gbB2o_WNQIhh",
+      "secretVersion": "corpus-key-v0",
+      "sub": "corpus/test"
+    },
+    "binding": {
+      "attestationDigest": "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4",
+      "attestationNonce": "dGVzdG5vbmNlMTIz"
+    },
+    "scope": {
+      "argsCommitment": "sha256:068dde1aacab815c86401c9259bdf09c2ac5a139a1e735e868a5cbaa6827f061",
+      "tenantId": "mcp-tenant-01",
+      "toolName": "read_file"
+    },
+    "signature": "14b3d236dc224d3b663af02950189ea9542defdc26273c1d47016e1feba0f8a8",
+    "version": 1
+  },
+  "expected_verdict": "scope_mismatch",
+  "known_attestation_digests": [
+    "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4"
+  ],
+  "now": 1779200030,
+  "runtime_args": {
+    "path": "/etc/passwd"
+  },
+  "runtime_tenant_id": "mcp-tenant-01",
+  "runtime_tool_name": "read_file"
+}

--- a/tests/vectors/credential_binding_v0/cases/neg_expired.json
+++ b/tests/vectors/credential_binding_v0/cases/neg_expired.json
@@ -1,0 +1,34 @@
+{
+  "credential": {
+    "alg": "HS256",
+    "asserted": {
+      "expSeconds": 60,
+      "iat": "2025-05-19T14:13:20Z",
+      "iss": "vaara-mcp-proxy",
+      "nonce": "5ByJwWQp_Lf_g9U0vBo0AmOv",
+      "secretVersion": "corpus-key-v0",
+      "sub": "corpus/test"
+    },
+    "binding": {
+      "attestationDigest": "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4",
+      "attestationNonce": "dGVzdG5vbmNlMTIz"
+    },
+    "scope": {
+      "argsCommitment": "sha256:068dde1aacab815c86401c9259bdf09c2ac5a139a1e735e868a5cbaa6827f061",
+      "tenantId": "mcp-tenant-01",
+      "toolName": "read_file"
+    },
+    "signature": "ef3f790bdb79f8313e6014492e03c1256865043bce268c4271fb009ee2a486de",
+    "version": 1
+  },
+  "expected_verdict": "expired",
+  "known_attestation_digests": [
+    "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4"
+  ],
+  "now": 1779200030,
+  "runtime_args": {
+    "path": "/tmp/vaara/read_file_test"
+  },
+  "runtime_tenant_id": "mcp-tenant-01",
+  "runtime_tool_name": "read_file"
+}

--- a/tests/vectors/credential_binding_v0/cases/neg_no_credential.json
+++ b/tests/vectors/credential_binding_v0/cases/neg_no_credential.json
@@ -1,0 +1,13 @@
+{
+  "credential": null,
+  "expected_verdict": "missing_credential",
+  "known_attestation_digests": [
+    "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4"
+  ],
+  "now": 1779200030,
+  "runtime_args": {
+    "path": "/tmp/vaara/read_file_test"
+  },
+  "runtime_tenant_id": "mcp-tenant-01",
+  "runtime_tool_name": "read_file"
+}

--- a/tests/vectors/credential_binding_v0/cases/neg_wrong_tenant.json
+++ b/tests/vectors/credential_binding_v0/cases/neg_wrong_tenant.json
@@ -1,0 +1,34 @@
+{
+  "credential": {
+    "alg": "HS256",
+    "asserted": {
+      "expSeconds": 60,
+      "iat": "2026-05-19T14:13:20Z",
+      "iss": "vaara-mcp-proxy",
+      "nonce": "lBaEgLPvEtwVpWHQa7pMGiXg",
+      "secretVersion": "corpus-key-v0",
+      "sub": "corpus/test"
+    },
+    "binding": {
+      "attestationDigest": "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4",
+      "attestationNonce": "dGVzdG5vbmNlMTIz"
+    },
+    "scope": {
+      "argsCommitment": "sha256:068dde1aacab815c86401c9259bdf09c2ac5a139a1e735e868a5cbaa6827f061",
+      "tenantId": "mcp-tenant-01",
+      "toolName": "read_file"
+    },
+    "signature": "c3b03ae982d0caea8b7cdb0a000ad9dcd5312862aa605259b4b7d8c3487fb529",
+    "version": 1
+  },
+  "expected_verdict": "scope_mismatch",
+  "known_attestation_digests": [
+    "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4"
+  ],
+  "now": 1779200030,
+  "runtime_args": {
+    "path": "/tmp/vaara/read_file_test"
+  },
+  "runtime_tenant_id": "other-tenant",
+  "runtime_tool_name": "read_file"
+}

--- a/tests/vectors/credential_binding_v0/cases/pos_valid_grant.json
+++ b/tests/vectors/credential_binding_v0/cases/pos_valid_grant.json
@@ -1,0 +1,34 @@
+{
+  "credential": {
+    "alg": "HS256",
+    "asserted": {
+      "expSeconds": 60,
+      "iat": "2026-05-19T14:13:20Z",
+      "iss": "vaara-mcp-proxy",
+      "nonce": "CxnQTKUfkr8JIzHq6JmEjr9o",
+      "secretVersion": "corpus-key-v0",
+      "sub": "corpus/test"
+    },
+    "binding": {
+      "attestationDigest": "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4",
+      "attestationNonce": "dGVzdG5vbmNlMTIz"
+    },
+    "scope": {
+      "argsCommitment": "sha256:068dde1aacab815c86401c9259bdf09c2ac5a139a1e735e868a5cbaa6827f061",
+      "tenantId": "mcp-tenant-01",
+      "toolName": "read_file"
+    },
+    "signature": "1416211fbb79dd7926e35cc1fab8e05bcd5c024f1eafbfc55a4e3e7747f8a2ce",
+    "version": 1
+  },
+  "expected_verdict": "ok",
+  "known_attestation_digests": [
+    "sha256:5e1698aff870d68621ac7426cb6b351e9148a54fcc74f5a71d8a4d1c048953e4"
+  ],
+  "now": 1779200030,
+  "runtime_args": {
+    "path": "/tmp/vaara/read_file_test"
+  },
+  "runtime_tenant_id": "mcp-tenant-01",
+  "runtime_tool_name": "read_file"
+}

--- a/tests/vectors/credential_binding_v0/expected.json
+++ b/tests/vectors/credential_binding_v0/expected.json
@@ -1,0 +1,24 @@
+{
+  "cases": {
+    "neg_args_changed": {
+      "expected_verdict": "scope_mismatch",
+      "signature_ok": true
+    },
+    "neg_expired": {
+      "expected_verdict": "expired",
+      "signature_ok": true
+    },
+    "neg_no_credential": {
+      "expected_verdict": "missing_credential",
+      "signature_ok": false
+    },
+    "neg_wrong_tenant": {
+      "expected_verdict": "scope_mismatch",
+      "signature_ok": true
+    },
+    "pos_valid_grant": {
+      "expected_verdict": "ok",
+      "signature_ok": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Proxy mints a short-lived, attestation-bound BrokeredCredential on every allowed tools/call and injects it into params._meta["vaara/credential"]
- Constrained tools (tool_constraints config) fail closed with MCP -32603 when no valid grant can be verified before upstream forward
- credential_binding_v0 corpus pins five enforcement boundaries as independently verifiable JSON fixtures

## Cases

| case | verdict |
|---|---|
| pos_valid_grant | ok |
| neg_args_changed | scope_mismatch |
| neg_expired | expired |
| neg_wrong_tenant | scope_mismatch |
| neg_no_credential | missing_credential |

_check_independent.py reproduces all five verdicts with no Vaara import (HS256 + RFC 8785 JCS only).

## Test plan

- [ ] 2030 tests pass
- [ ] _generate.py + _check_independent.py 5/5
- [ ] pyproject.toml and __init__.py at 1.16.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new set of credential-binding conformance vectors, including positive and negative scenarios.
  * Added tooling to regenerate and independently verify these test vectors.
  * Added documentation describing the vector format and expected outcomes.

* **Chores**
  * Bumped the project and package version to **1.16.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->