### PR TITLE
fix(release): skip-existing on PyPI publish to allow re-runs without 400

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           attestations: true
+          skip-existing: true
 
   github-release:
     name: Sign and attach to GitHub Release


### PR DESCRIPTION
Adds `skip-existing: true` to the pypa/gh-action-pypi-publish step. When a version is already on PyPI the step exits 0 instead of 400, so Sign+Attach and MCP Registry downstream jobs are no longer blocked on re-runs.