### PR TITLE
chore: bump MCP manifest versions to 1.17.0

### DIFF
--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.14.0",
+  "version": "1.17.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.14.0",
+      "version": "1.17.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.14.0",
+  "version": "1.17.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.14.0",
+      "version": "1.17.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Updates server.json and server-vaara-server.json from 1.14.0 to 1.17.0. MCP Registry publish was failing because these manifests were not bumped when the v1.17.0 corpus was merged.