### PR TITLE
chore(mcp): bump server.json to 1.18.0 (manifest version sync)

### DIFF
--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.17.0",
+  "version": "1.18.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Sync MCP manifest version to 1.18.0 so republish.yml can publish the MCP Registry manifest. PyPI/npm/GH Release already shipped 1.18.0 from the v1.18.0 tag; server.json was missed in that push.