### PR TITLE
chore(mcp): bump server-vaara-server.json to 1.18.0 (alias manifest sync)

### DIFF
--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.17.0",
+  "version": "1.18.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.17.0",
+      "version": "1.18.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
PR #322 bumped server.json (io.github.vaaraio/vaara) to 1.18.0 but left the alias manifest server-vaara-server.json (io.github.vaaraio/vaara-server) at 1.17.0. The republish job then 400s on the alias publish (cannot publish duplicate version) and the registry assert fails. This bumps both version fields on the alias manifest to 1.18.0 so the MCP Registry reaches parity across both server entries.