### PR TITLE
docs: Vaara Conformance Profile v1 + README runner pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,6 @@ pip install vaara
 
 Releases ship SLSA Build Level 3 provenance, verifiable with `slsa-verifier verify-artifact`. Optional ML classifier: `pip install 'vaara[ml]'`.
 
-### One line
-
-The smallest way in. Decorate a function and every call is governed: classified, risk-scored, decided allow/deny/escalate, and written to the audit trail, with zero setup.
-
-```python
-import vaara
-
-@vaara.govern
-def transfer_funds(to: str, amount: float) -> str:
-    ...
-```
-
-A blocked call raises `vaara.Blocked` before the body runs, carrying the decision, reason, and risk. An allowed call runs and reports its outcome back so the scorer keeps calibrating. `@vaara.govern(shadow=True)` audits every call without blocking, so you can see what would be denied before you enforce. When you need signed receipts, the MCP proxy, or the credential gateway, reach for the full `InterceptionPipeline` below. Same engine, smaller surface.
-
 ```python
 from vaara.pipeline import InterceptionPipeline
 
@@ -83,6 +69,15 @@ python tests/vectors/external_evidence_v0/_check_independent.py
 
 It re-derives every verdict from the receipt bytes and the public key alone. The output shows the property the trail is built for: a receipt dropped from inside a declared boundary is a provable gap from the held set, with no issuer access and no external witness.
 
+The aggregate runner grades every suite at once, and grades another implementation's vectors the same way:
+
+```bash
+python scripts/conformance_runner.py                                 # grade the reference corpus
+python scripts/conformance_runner.py --vectors-dir ./your_vectors    # grade your own
+```
+
+The named, versioned rule set, what a pass does and does not establish, and the full suite list are in [docs/conformance-profile.md](docs/conformance-profile.md).
+
 ```
 [OK] complete.contiguity: {'ok': True, 'present': 3, 'expected': 3, 'missingSeqs': []}
 [OK] dropped.contiguity: {'ok': False, 'present': 2, 'expected': 3, 'missingSeqs': [1]}
@@ -116,6 +111,7 @@ Each verdict carries the threshold-versus-observed snapshot, the rationale, and 
 - **Governance of the model call itself**, not only the tools around it: a hardware-rooted inference receipt that a second, different local model cross-checks. This is the sovereign inference harness, new in v1.0.
 - **Enforcement, not only a record** (v1.1.0): a credential broker mints a signed, short-lived credential bound to the attestation digest and scoped to one tool, its argument commitment, and tenant, with typed capability scopes that bound what a call may do. A gateway in front of a protected tool refuses any call without a valid, attestation-bound grant, so a bypass stops being silent. Off by default.
 - **Gap-evident completeness** (v1.4.0): each authorization receipt can carry a signed per-boundary sequence and running count, so a dropped receipt inside a declared boundary is a provable gap from the held receipts alone, with no issuer access and no external witness (`vaara verify-contiguity`). Off by default.
+- **Independent re-mint** (v1.14.0): a second generator in each public vector set reproduces the signed carrier byte-exact from the declared canonicalization alone, with no Vaara import. A verifier that has never run Vaara software reproduces the same bytes.
 
 ## Where it plugs in
 
@@ -159,7 +155,7 @@ Method and per-cell breakdown: [docs/architecture.md](docs/architecture.md) and 
 ## Standards and attestation
 
 - **[vaara.receipt/v1](SPEC.md)** is the canonical parent spec for the signed receipt format: hash-chained, canonicalized with JCS (RFC 8785), verifiable offline from a public key. The x402 settlement binding and an eIDAS qualified-timestamp profile are downstream profiles that pin to it rather than competing formats. Receipts can carry a self-hosted RFC 3161 timestamp that Vaara mints offline.
-- **[SEP-2828](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828)** signed execution records and **SEP-2787** request-attestation test vectors, in the MCP standards process. A second independent implementation has reproduced the SEP-2828 conformance vectors from a clean checkout with no shared code.
+- **[SEP-2828](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828)** signed execution records and **SEP-2787** request-attestation test vectors, in the MCP standards process. A second independent implementation has reproduced the SEP-2828 conformance vectors from a clean checkout with no shared code. Published corpora with independent checkers cover the fallback binding path ([`conformance/sep2828/fallback_projection_v0/`](conformance/sep2828/fallback_projection_v0/)) and CrewAI governance decisions ([`tests/vectors/governance_decision_v0/`](tests/vectors/governance_decision_v0/)).
 - **OVERT 1.0** ([overt.is](https://overt.is/)): Vaara is the Arbiter and emits Protocol Profile 1.0 Base Envelopes (canonical CBOR, Ed25519) alongside every record when attestation is on.
 - **Post-quantum**: an optional parallel ML-DSA-65 / FIPS 204 signature over the same preimage, so a stripped post-quantum signature is a detectable downgrade rather than a silent loss.
 - **Root-agnostic evidence**: the same Article 12 record is provable with or without a hardware TEE and re-expressible as an IETF RATS EAR (AR4SI vector), whether rooted in a TPM 2.0 host, an AMD SEV-SNP confidential VM, or no TEE at all.

--- a/docs/conformance-profile.md
+++ b/docs/conformance-profile.md
@@ -1,0 +1,124 @@
+# Vaara Conformance Profile v1
+
+Vaara Conformance Profile v1 is a fixed, versioned target. An outside party runs
+against it to decide, on its own machine, whether an implementation agrees with
+Vaara on every published vector, with no access to the producer, no producer key,
+and none of the producer's software.
+
+This document is the profile. The corpus and its checkers are the normative
+content; this page names them, fixes a version, and states what a pass does and
+does not establish.
+
+## What the profile is
+
+Each suite under `tests/vectors/<name>/` ships:
+
+- a set of case files (the published vectors),
+- an `expected.json` recording the verdict for each case, and
+- `_check_independent.py`, a checker that recomputes every verdict from the
+  bytes of the case files and **imports no Vaara code**.
+
+An implementation conforms to Profile v1 when, for every suite, its own vectors
+reproduce the published verdicts under the same checker. The aggregate runner
+`scripts/conformance_runner.py` discovers every suite, runs each checker in a
+subprocess, and returns a single pass/fail.
+
+Profile v1 covers the 36 suites listed below, at the `v0` vector format. The
+authoritative, always-current enumeration for any tagged release is the runner's
+own `--list` output at that tag.
+
+## What you need
+
+The runner itself is standard-library Python. The checkers are not Vaara, but
+they are not dependency-free either: they recompute signatures and canonical
+bytes using public libraries.
+
+```
+pip install rfc8785 cryptography
+```
+
+`rfc8785` is JCS canonicalization (RFC 8785); `cryptography` covers the Ed25519
+and ECDSA signature paths. The `pq_hybrid_v0` suite additionally needs
+`dilithium_py`. None of these is Vaara. The point of the profile is that you run
+standard public crypto, never the producer's stack.
+
+## The one command
+
+Grade the reference corpus from a clean checkout:
+
+```
+python scripts/conformance_runner.py
+```
+
+Grade your own implementation's vectors by pointing the runner at their
+directory:
+
+```
+python scripts/conformance_runner.py --vectors-dir ./your_vectors
+```
+
+Useful flags:
+
+- `--list` prints the discovered suites (the authoritative profile membership).
+- `--corpus NAME` runs a single suite; repeatable.
+- `--json PATH` writes a dated machine report (Python version, per-suite status,
+  totals, `all_passed`).
+
+Exit code is `0` only when no suite failed.
+
+## Required, advisory, and skipped
+
+Inside a checker, two kinds of assertion are distinguished:
+
+- **Required** checks gate conformance. Any required failure fails the suite.
+- **Advisory** checks report a deviation without failing the suite (for example,
+  a signature that is well-formed but not the expected length for its algorithm).
+
+One suite is reported `SKIP`, not pass, in an aggregate run:
+
+- `article12_fold_v0` validates a bundle handed to it on the command line rather
+  than a bare directory of case files. The runner lists it explicitly so the gap
+  reads as a gap, not as silent coverage.
+
+## What a pass means, and what it does not
+
+A pass means: an independent party, running standard public libraries and none
+of the producer's code, reproduced every published verdict from the case bytes
+alone.
+
+A pass does **not** mean the implementation is correct for inputs outside the
+corpus, that the corpus is complete, or that any party has endorsed it. It is a
+reproducibility result over a fixed, published set, nothing wider. The corpus
+grows; conformance is always against a named version.
+
+## Suites in Profile v1
+
+```
+agent_identity_v0            enforcement_attestation_v0
+ap2_v0                       enforcement_set_v0
+article12_fold_v0            evidence_bundle_v0
+atlas_threat_v0              evidence_ref_v0
+attestation_result_v0        execution_receipt_v0
+audit_summary_v0             external_evidence_v0
+authorization_v0             governance_decision_v0
+build_bundle_v0              handoff_set_v0
+bundle_doc_v0                ingest_v0
+bundle_set_v0                key_rotation_v0
+capability_scope_v0          normalize_v0
+class_gate_v0                pq_hybrid_v0
+conformance_statement_v0     record_conformance_v0
+contiguity_v0                record_set_v0
+credential_binding_v0        sep2787_attestation_v0
+cross_org_handoff_v0         tap_v0
+cross_stack_revocation_v0    transparency_consistency_v0
+decision_pairing_v0          x402_settlement_v0
+```
+
+## Related
+
+- [docs/verifying-evidence.md](verifying-evidence.md) covers each verifier verb
+  and where trust comes from in each case.
+- `vaara conformance-statement` is the producer-side keyless self-statement
+  against a corpus. It is a different job: the statement is what a producer
+  publishes about its own records; this profile is what an outside party runs to
+  check an implementation.


### PR DESCRIPTION
Names and versions the existing conformance corpus as a citable target an outside party can run against, with no Vaara software and no producer key.

- `docs/conformance-profile.md`: Conformance Profile v1 over the 36 checker suites; the one-command grade path (`scripts/conformance_runner.py`, already shipped); required/advisory/skip semantics; what a pass does and does not establish.
- README verify section: pointer to the aggregate runner and the profile.

Docs only. No code, no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the getting-started guide by removing an extra governance example and moving directly to the first-call walkthrough.
  * Expanded verification guidance with clearer command-line examples for running conformance checks, grading reference data, and using a custom vectors directory.
  * Added a new conformance profile guide covering supported suites, result meanings, setup requirements, and report output.
  * Updated the feature overview with a new “Independent re-mint” capability and broader standards/attestation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->