### PR TITLE
docs(readme): surface-stability note

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Method and per-cell breakdown: [docs/architecture.md](docs/architecture.md) and 
 
 Details and the offline checkers for each: [docs/standards.md](docs/standards.md).
 
+## Surface stability
+
+The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capability constraints, the credential grant and gateway, and the `@vaara.govern` entry point. No new primitives are planned. New behavior ships as profiles that pin to `vaara.receipt/v1`, not as new core types, and no new format bindings will be added (the last was v1.13.0). From here the work is hardening and subtraction within this surface, so anyone building on it has a stable target.
+
 ## Docs
 
 | Path | Contents |


### PR DESCRIPTION
Adds a "Surface stability" section after Standards and attestation.

Names the public surface as fixed (envelope / capability / credential / @vaara.govern) and states that new behavior ships as profiles pinning to `vaara.receipt/v1`, not as new primitives or format bindings (last binding was v1.13.0). Docs-only, no version bump. A maturity signal for an institutional reader doing diligence: the spec surface does not churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Surface stability” section clarifying that the public API is now fixed.
  * Noted that future updates will build on the existing stable surface rather than introduce new core types or format bindings.
  * Set expectations that upcoming work will focus on hardening and reducing complexity within the current release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->