### PR TITLE
docs(readme): lead with the one-liner, fold the rest into dropdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Vaara helps deployers assemble evidence for their own conformity work. It does n
 
 ## License
 
-AGPL-3.0-or-later. See [LICENSE](LICENSE).
+Copyright © 2026 Henri Sirkkavaara. Licensed under AGPL-3.0-or-later. See [LICENSE](LICENSE).
 
 <!-- mcp-name: io.github.vaaraio/vaara -->
 <!-- mcp-name: io.github.vaaraio/vaara-server -->

--- a/README.md
+++ b/README.md
@@ -14,19 +14,30 @@
   <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
 </p>
 
-Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why. A regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
+Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
 
-Vaara is an open-source evidence layer for AI governance. It checks every agent tool call against your policy, writes the call and its outcome into a hash-chained, signed record, and binds that record to your machine's own TPM 2.0 hardware root. An outside party can verify the whole trail offline, with no access to your system and none of your software. EU AI Act Article 12 record-keeping is what it was built for; it answers any "show me what the agent actually did" just as well.
+Vaara checks every agent tool call against your policy and writes the call and its outcome into a signed, hash-chained record an outside party can verify offline, with no access to your system and none of your software. It needs no special hardware, and binds to your machine's TPM 2.0 or confidential-VM root when you have one. It runs entirely in your own environment. No SaaS, no telemetry. EU AI Act Article 12 is what it was built for; it answers any "show me what the agent actually did" just as well.
 
-It runs entirely in your own environment. No SaaS, no telemetry. Python 3.10+, zero runtime dependencies.
-
-## Install and first call
+## Quick start
 
 ```bash
 pip install vaara
 ```
 
-Releases ship SLSA Build Level 3 provenance, verifiable with `slsa-verifier verify-artifact`. Optional ML classifier: `pip install 'vaara[ml]'`.
+```python
+import vaara
+
+@vaara.govern
+def transfer_funds(to: str, amount: float) -> str:
+    ...
+```
+
+That is the whole thing. Every call to a governed function is risk-scored and decided against your policy before the body runs. A blocked call raises `vaara.Blocked`; an allowed call runs, and the decision, the call, and the outcome land in a signed record anyone can verify offline. Python 3.10+, zero runtime dependencies.
+
+<details>
+<summary><b>Prefer the explicit pipeline?</b></summary>
+
+The decorator drives the same engine you can call directly when you want the decision object in hand.
 
 ```python
 from vaara.pipeline import InterceptionPipeline
@@ -44,11 +55,11 @@ else:
     print(result.reason)
 ```
 
-Every call gets a risk score and an allow / block / escalate decision against your policy, then the call, the decision, and the real outcome are written to the audit trail. `report_outcome` closes the loop: the scorer reweights based on which signals actually predicted the outcome.
+Every call gets a risk score and an allow / block / escalate decision against your policy, then the call, the decision, and the real outcome are written to the audit trail. `report_outcome` closes the loop: the scorer reweights based on which signals actually predicted the outcome. Releases ship SLSA Build Level 3 provenance, verifiable with `slsa-verifier verify-artifact`. Optional ML classifier: `pip install 'vaara[ml]'`.
+</details>
 
-That is the whole loop. The rest of this page is what makes the record worth keeping.
-
-## Verify it without trusting the producer
+<details>
+<summary><b>Verify it without trusting the producer</b></summary>
 
 Writing a trail is the easy half. The half that matters is letting someone who does not trust you check it, with no key, no access, and none of your code. Every Vaara record is content-addressed and fail-closed on authenticity, and ships with public conformance vectors plus a standalone checker that imports no Vaara code, so an independent party reproduces every verdict offline.
 
@@ -77,13 +88,10 @@ python scripts/conformance_runner.py --vectors-dir ./your_vectors    # grade you
 ```
 
 The named, versioned rule set, what a pass does and does not establish, and the full suite list are in [docs/conformance-profile.md](docs/conformance-profile.md).
+</details>
 
-```
-[OK] complete.contiguity: {'ok': True, 'present': 3, 'expected': 3, 'missingSeqs': []}
-[OK] dropped.contiguity: {'ok': False, 'present': 2, 'expected': 3, 'missingSeqs': [1]}
-```
-
-## What the evidence looks like
+<details>
+<summary><b>What the evidence looks like</b></summary>
 
 `vaara compliance report --format json` against a real trail produces an article-level evidence record an auditor reads directly. Articles with no recorded events return `evidence_insufficient`, not a rubber stamp.
 
@@ -102,8 +110,10 @@ The named, versioned rule set, what a pass does and does not establish, and the 
 ```
 
 Each verdict carries the threshold-versus-observed snapshot, the rationale, and the underlying records, so a reviewer traces `status` back to a concrete event. The same data renders as a Notified-Body PDF, a static HTML dashboard, or a Sigstore-signed handoff envelope. See [docs/COMPLIANCE.md](docs/COMPLIANCE.md).
+</details>
 
-## What you get
+<details>
+<summary><b>What you get</b></summary>
 
 - **Gate every tool call** against your own policy: allow, block, or escalate.
 - **A tamper-evident trail** an outside party verifies without trusting your stack, with the chain head anchorable to an external RFC 3161 / eIDAS timestamp so its existence is provable against a clock you do not control.
@@ -112,8 +122,10 @@ Each verdict carries the threshold-versus-observed snapshot, the rationale, and 
 - **Enforcement, not only a record** (v1.1.0): a credential broker mints a signed, short-lived credential bound to the attestation digest and scoped to one tool, its argument commitment, and tenant, with typed capability scopes that bound what a call may do. A gateway in front of a protected tool refuses any call without a valid, attestation-bound grant, so a bypass stops being silent. Off by default.
 - **Gap-evident completeness** (v1.4.0): each authorization receipt can carry a signed per-boundary sequence and running count, so a dropped receipt inside a declared boundary is a provable gap from the held receipts alone, with no issuer access and no external witness (`vaara verify-contiguity`). Off by default.
 - **Independent re-mint** (v1.14.0): a second generator in each public vector set reproduces the signed carrier byte-exact from the declared canonicalization alone, with no Vaara import. A verifier that has never run Vaara software reproduces the same bytes.
+</details>
 
-## Where it plugs in
+<details>
+<summary><b>Where it plugs in</b></summary>
 
 Native adapters route the major Python agent frameworks through the same pipeline, each via the framework's own hook, emitting identical audit events:
 
@@ -133,13 +145,12 @@ vaara-mcp-proxy \
 ```
 
 Point your MCP client (Claude Code, Cursor, any host) at the proxy instead of the upstream. There is also an HTTP API (`pip install 'vaara[server]'`, `vaara serve`) and a first-party TypeScript client on npm ([`@vaara/client`](clients/ts)) for non-Python agents. Framework details, the cloud and OSS guardrail adapters (Bedrock, Azure, GCP, NeMo, Guardrails AI, LLM Guard, Rebuff), and the multi-tenant proxy are in [docs/adapters.md](docs/adapters.md).
-
-## How it scores
-
-Each risk score blends five expert signals and keeps adapting as outcomes come back, and it carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. On a held-out adversarial corpus the classifier reaches **84.7%** recall (95% Wilson [82.4, 86.7]) at a **4.1%** false-positive rate, and **1.2%** FPR on benign calls under live injection pressure. The hot-path rule scorer adds 140 µs mean per call on commodity CPU; the ML classifier is opt-in (`vaara[ml]`) and off that path. Every figure is reproducible via `make bench`.
+</details>
 
 <details>
-<summary>Full numbers, corpus, calibration, and chain of custody</summary>
+<summary><b>How it scores</b></summary>
+
+Each risk score blends five expert signals and keeps adapting as outcomes come back, and it carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. On a held-out adversarial corpus the classifier reaches **84.7%** recall (95% Wilson [82.4, 86.7]) at a **4.1%** false-positive rate, and **1.2%** FPR on benign calls under live injection pressure. The hot-path rule scorer adds 140 µs mean per call on commodity CPU; the ML classifier is opt-in (`vaara[ml]`) and off that path. Every figure is reproducible via `make bench`.
 
 - 12,155-entry adversarial corpus (250 hand-curated + 11,905 LLM-generated), 70/15/15 split stratified by (category, source).
 - Classifier v9 (236 hand-features + 384-dim MiniLM embeddings) at calibrated threshold 0.9150 on held-out TEST n=1,827: recall 84.7% [82.4, 86.7] at FPR 4.1% [2.9, 5.7].
@@ -152,7 +163,8 @@ Each risk score blends five expert signals and keeps adapting as outcomes come b
 Method and per-cell breakdown: [docs/architecture.md](docs/architecture.md) and [bench/](bench/).
 </details>
 
-## Standards and attestation
+<details>
+<summary><b>Standards and attestation</b></summary>
 
 - **[vaara.receipt/v1](SPEC.md)** is the canonical parent spec for the signed receipt format: hash-chained, canonicalized with JCS (RFC 8785), verifiable offline from a public key. The x402 settlement binding and an eIDAS qualified-timestamp profile are downstream profiles that pin to it rather than competing formats. Receipts can carry a self-hosted RFC 3161 timestamp that Vaara mints offline.
 - **[SEP-2828](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2828)** signed execution records and **SEP-2787** request-attestation test vectors, in the MCP standards process. A second independent implementation has reproduced the SEP-2828 conformance vectors from a clean checkout with no shared code. Published corpora with independent checkers cover the fallback binding path ([`conformance/sep2828/fallback_projection_v0/`](conformance/sep2828/fallback_projection_v0/)) and CrewAI governance decisions ([`tests/vectors/governance_decision_v0/`](tests/vectors/governance_decision_v0/)).
@@ -162,12 +174,16 @@ Method and per-cell breakdown: [docs/architecture.md](docs/architecture.md) and 
 - **Sovereign inference harness** (v1.0): a local model behind a signing proxy that emits a hardware-rooted inference receipt a second local model cross-checks. Developed privately, published here under AGPL-3.0.
 
 Details and the offline checkers for each: [docs/standards.md](docs/standards.md).
+</details>
 
-## Surface stability
+<details>
+<summary><b>Surface stability</b></summary>
 
 The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capability constraints, the credential grant and gateway, and the `@vaara.govern` entry point. No new primitives are planned. New behavior ships as profiles that pin to `vaara.receipt/v1`, not as new core types, and no new format bindings will be added (the last was v1.13.0). From here the work is hardening and subtraction within this surface, so anyone building on it has a stable target.
+</details>
 
-## Docs
+<details>
+<summary><b>Docs</b></summary>
 
 | Path | Contents |
 |---|---|
@@ -179,14 +195,17 @@ The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capabilit
 | [docs/COMPLIANCE.md](docs/COMPLIANCE.md) | EU AI Act and DORA article mapping, eval numbers |
 | [CHANGELOG.md](CHANGELOG.md) | Version-by-version evolution |
 | [docs/PRIOR_ART.md](docs/PRIOR_ART.md) | When each concept first shipped, plus adjacent work |
+</details>
 
-## Acknowledgements
+<details>
+<summary><b>Acknowledgements</b></summary>
 
 - Listed in the industry acknowledgements of the [IMDA Model AI Governance Framework for Agentic AI v1.5](https://www.imda.gov.sg/-/media/imda/files/about/emerging-tech-and-research/artificial-intelligence/mgf-for-agentic-ai.pdf) (Singapore, 20 May 2026).
 - The [AMD AI Developer Program](https://www.linkedin.com/posts/amd-developer_meet-henri-sirkkavaara-henri-created-vaara-activity-7459667676555132928-QFSd) ran a developer testimonial of Vaara in May 2026.
 - [Article 14 runtime: why oversight of agentic AI has to be evidenced as action, not model](https://futurium.ec.europa.eu/ga/apply-ai-alliance/community-content/article-14-runtime-why-oversight-agentic-ai-has-be-evidenced-action-not-model), the position post on the EU Apply AI Alliance Futurium.
+</details>
 
-> Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.
+Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.
 
 ## License
 


### PR DESCRIPTION
Restructures the README so the visible surface is the hook, the @vaara.govern one-liner, and the license, with everything else (the explicit pipeline form, verification, evidence format, adapters, scoring numbers, standards, docs, acknowledgements) folded into collapsed dropdowns. Content is preserved verbatim inside the dropdowns. The opening now states the root-agnostic property correctly: no special hardware required, binds to a TPM 2.0 or confidential-VM root when present. License unchanged (AGPL-3.0-or-later); copyright line made explicit.