### PR TITLE
ci: auto-sync server.json versions before MCP Registry publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,24 @@ jobs:
         # the GitHub identity of this repository.
         run: ./mcp-publisher login github-oidc
 
+      - name: Sync manifest versions to the released tag
+        # The registry publishes whatever version is committed in the manifests,
+        # and nothing else bumps them on release. Rewrite both to the tag here so
+        # a forgotten manual manifest bump cannot make the publish + assertion
+        # below fail (the recurring failure mode for v1.17.0/v1.18.0). jq is
+        # pre-installed on ubuntu-latest runners.
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${RELEASE_TAG#v}"
+          for manifest in server.json server-vaara-server.json; do
+            tmp="$(mktemp)"
+            jq --arg v "$VERSION" '.version = $v | (.packages[]?.version) |= $v' "$manifest" > "$tmp"
+            mv "$tmp" "$manifest"
+            echo "Set ${manifest} version to ${VERSION}"
+          done
+
       - name: Publish both manifests
         # The publish subcommand takes the manifest path as a positional arg
         # (defaults to ./server.json). We publish both listings. A version

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -93,6 +93,19 @@ jobs:
           ./mcp-publisher --version || true
       - name: Authenticate to the MCP Registry (GitHub OIDC)
         run: ./mcp-publisher login github-oidc
+      - name: Sync manifest versions to the requested version
+        # The registry publishes whatever version is committed in the manifests.
+        # Rewrite both to the requested version so a stale manifest cannot make
+        # the publish + assertion below fail. jq is pre-installed on ubuntu-latest.
+        run: |
+          set -euo pipefail
+          VERSION="${EXPECTED_VERSION#v}"
+          for manifest in server.json server-vaara-server.json; do
+            tmp="$(mktemp)"
+            jq --arg v "$VERSION" '.version = $v | (.packages[]?.version) |= $v' "$manifest" > "$tmp"
+            mv "$tmp" "$manifest"
+            echo "Set ${manifest} version to ${VERSION}"
+          done
       - name: Publish both manifests
         run: |
           set -uo pipefail


### PR DESCRIPTION
## Problem
The MCP Registry publishes whatever version is committed in `server.json` and `server-vaara-server.json`. Nothing bumps those files on release, so a forgotten manual manifest bump publishes a stale version and the post-publish assertion fails. This is the cause of the failed `Release` runs for v1.17.0 / v1.18.0 and the 3 straight `Republish` failures. PyPI and npm were fine, so the failures were invisible externally while the MCP manifest fell behind.

## Fix
Add a step in both `release.yml` and `republish.yml`, right before publishing, that rewrites `.version` and `.packages[].version` in both manifests to the released tag (release) or the requested input (republish). The manifests are now always in sync at publish time regardless of what is committed. `jq` is pre-installed on `ubuntu-latest` runners.

No effect on the current registry state (already at 1.19.0, isLatest, active for both listings). This prevents the next release from recurring the failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release and republish workflows to automatically align published manifest versions with the target release version.
  * Prevents version mismatches that could block publishing or cause post-publish checks to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->