### PR TITLE
Correct MS-AGT evidence cells: it now ships an audit layer

### DIFF
--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -26,8 +26,8 @@ prose, read the sections below it.
 | Validates tool-call **arguments** at runtime     |   ✓   |        ✗        |       ✗       |         ✗         |    observes only    |   not software   |         ✗         |              ✓              | partial (hook escalation) |
 | Probabilistic / conformal risk scoring per call  |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |        ✗         |         ✗         |              ✗              | ✗ (rubric grading) |
 | Detects temporal **sequence** patterns           |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |        ✗         |         ✗         |              ✗              | partial (session drift) |
-| Hash-chained, regulator-exportable audit trail   |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |        ✗         |  partial (Merkle) |      partial (logging)      | ✗ |
-| EU AI Act Art. 12 / 14 / 26 evidence mapping     |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |        ✗         |         ✗         |              ✗              | ✗ |
+| Hash-chained, regulator-exportable audit trail   |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |        ✗         |  partial (Merkle) | partial (Merkle, self-keyed)| ✗ |
+| EU AI Act Art. 12 / 14 / 26 evidence mapping     |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |        ✗         |         ✗         |           partial           | ✗ |
 | Independently-recomputable conformance corpus    |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |        ✗         |         ✗         |              ✗              | ✗ |
 | Spec in a standards process (IETF / MCP)         |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |     taxonomy     |  OVERT (self-pub) |              ✗              | ✗ |
 | OVERT 1.0 Base Envelope emission (RFC 8949 CBOR) |   ✓   |        ✗        |       ✗       |         ✗         |          ✗          |        ✗         |         ✗         |              ✗              | ✗ |
@@ -123,7 +123,7 @@ provides runtime risk scoring and Article 14 audit evidence, AGT
 provides agent identity primitives and the sandboxing layer that
 isolates agent execution from the host environment. The two tools
 cover different layers of the same governance stack: deployers running
-production agents typically want both wired in.
+production agents typically want both wired in. Recent versions add an audit layer with a Merkle audit chain, signed entries, and an EU AI Act compliance mapping. By the toolkit's own documentation that integrity is partial. One chain verifier is a stub that always returns true, audit entries are signed with symmetric HMAC keys an insider could forge, and the default retention falls short of Article 26(6). The audit is verified with Microsoft's own keys, with no public conformance corpus and no way for an outside party to recompute a record without trusting the vendor.
 
 **Apollo Watcher.** A real-time oversight layer for coding agents from
 Apollo Research, a Delaware public-benefit corporation with servers in
@@ -211,7 +211,7 @@ or source code. Verified as of 2026-06-29.
 - **LangChain callback handlers**: [python.langchain.com/docs/concepts/callbacks/](https://python.langchain.com/docs/concepts/callbacks/).
 - **OWASP LLM Top 10**: [genai.owasp.org/llm-top-10/](https://genai.owasp.org/llm-top-10/).
 - **Glacis Python SDK**: [github.com/Glacis-io/glacis-python](https://github.com/Glacis-io/glacis-python). Capabilities recorded by source-read of the repository on 2026-05-16.
-- **Microsoft Agent Governance Toolkit**: [github.com/microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit).
+- **Microsoft Agent Governance Toolkit**: [github.com/microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit). Audit-chain and EU AI Act mapping features verified by source-read on 2026-06-29.
 - **Apollo Watcher**: [github.com/ApolloResearch/watcher](https://github.com/ApolloResearch/watcher) and the [product page](https://www.apolloresearch.ai/products/introducing-watcher-for-ai-oversight/). License reported by the GitHub API as NOASSERTION (no open-source license) on 2026-06-29; alpha status, cloud-hosted monitoring, and EU-based servers per the product page and docs.
 
 ## Numbers we publish


### PR DESCRIPTION
Microsoft Agent Governance Toolkit added a Merkle audit chain, signed entries, and an EU AI Act compliance mapping since the matrix was last source-read (2026-05-16). The prior cells understated this.

Changes:
- Art 12/14/26 evidence mapping: MS-AGT no to partial (it maps the Act now, with self-documented integrity gaps).
- Hash-chained audit trail: MS-AGT partial (logging) to partial (Merkle, self-keyed).
- A grounded note in the MS-AGT paragraph: stub chain verifier, forgeable symmetric HMAC keys, retention short of Art 26(6), all from their own eu-ai-act-checklist.md.
- Verification date on the source line.

Vaara stays the only column with an independently-recomputable record and a public conformance corpus, so the one-column-filled framing holds. Verified against the toolkit own docs on 2026-06-29.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the benchmark comparison notes with more accurate audit-trail details.
  * Expanded the Microsoft Agent Governance Toolkit description to reflect recent audit-chain and compliance-related improvements.
  * Added clarifications about current verification limits and source-check timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->