### PR TITLE
docs(readme): open Acknowledgements + add Article 12 article

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,13 @@ The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capabilit
 | [docs/PRIOR_ART.md](docs/PRIOR_ART.md) | When each concept first shipped, plus adjacent work |
 </details>
 
-<details>
+<details open>
 <summary><b>Acknowledgements</b></summary>
 
 - Listed in the industry acknowledgements of the [IMDA Model AI Governance Framework for Agentic AI v1.5](https://www.imda.gov.sg/-/media/imda/files/about/emerging-tech-and-research/artificial-intelligence/mgf-for-agentic-ai.pdf) (Singapore, 20 May 2026).
 - The [AMD AI Developer Program](https://www.linkedin.com/posts/amd-developer_meet-henri-sirkkavaara-henri-created-vaara-activity-7459667676555132928-QFSd) ran a developer testimonial of Vaara in May 2026.
 - [Article 14 runtime: why oversight of agentic AI has to be evidenced as action, not model](https://futurium.ec.europa.eu/ga/apply-ai-alliance/community-content/article-14-runtime-why-oversight-agentic-ai-has-be-evidenced-action-not-model), the position post on the EU Apply AI Alliance Futurium.
+- [Article 12 and the difference between a log and evidence](https://futurium.ec.europa.eu/en/apply-ai-alliance/community-content/article-12-and-difference-between-log-and-evidence), the companion position post on the EU Apply AI Alliance Futurium.
 </details>
 
 Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.


### PR DESCRIPTION
Expand the Acknowledgements section by default so the IMDA AMGF acknowledgement is indexable from the web, and add the Article 12 positioning article next to the Article 14 one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the acknowledgements section in the README to expand by default and include an additional reference.
  * Kept the existing acknowledgements intact while adding one more related link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->