### PR TITLE
feat: data-locality evidence profile + corpus (v1.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.21.0] - 2026-07-02
+
+Minor release: the data-locality evidence profile and its conformance corpus. A signed record binds an agent action's cross-border transfer facts to the enforced decision, so a recipient can check where data went without trusting the exporter.
+
+- `data_locality_v0` conformance corpus (`tests/vectors/data_locality_v0/`): eight cases pin a two-tier evidence contract. Tier A recomputes the issuer signature, the payload digest, and the allow/block decision from the transfer facts under a named policy with no trusted party (`ok_asserted`). Tier B verifies a carried region attestation signed by a party distinct from the issuer and checks it agrees with the claimed region (`ok_attested`). The load-bearing case records `allow` for personal data to a US region and is caught as `policy_mismatch`, because the independent checker recomputes the decision rather than trusting it. The checker imports no Vaara code (Ed25519 over RFC 8785 JCS).
+- `vaara.attestation.data_locality` reference emitter builds and signature-verifies these records over the shipped receipt primitives. It is deliberately policy-agnostic: it records the decision the pipeline made, and recomputing correctness is the checker's job. Tests grade every emitted record with the corpus's dependency-free checker, so a format drift fails the build.
+- `docs/data-locality-profile.md` maps the record to GDPR Chapter V transfer accountability and states what it does not establish: it is evidence for a Transfer Impact Assessment, never an adequacy finding. Registered as the 37th suite in Vaara Conformance Profile v1.
+
 ## [1.20.0] - 2026-06-27
 
 Minor release: the eIDAS 2.0 Qualified Electronic Ledger (QEL) profile. A new downstream profile maps a Vaara receipt chain to the QEL record model without adding a primitive.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/conformance-profile.md
+++ b/docs/conformance-profile.md
@@ -23,7 +23,7 @@ reproduce the published verdicts under the same checker. The aggregate runner
 `scripts/conformance_runner.py` discovers every suite, runs each checker in a
 subprocess, and returns a single pass/fail.
 
-Profile v1 covers the 36 suites listed below, at the `v0` vector format. The
+Profile v1 covers the 37 suites listed below, at the `v0` vector format. The
 authoritative, always-current enumeration for any tagged release is the runner's
 own `--list` output at that tag.
 
@@ -111,7 +111,8 @@ contiguity_v0                record_set_v0
 credential_binding_v0        sep2787_attestation_v0
 cross_org_handoff_v0         tap_v0
 cross_stack_revocation_v0    transparency_consistency_v0
-decision_pairing_v0          x402_settlement_v0
+data_locality_v0             x402_settlement_v0
+decision_pairing_v0
 ```
 
 ## Related

--- a/docs/data-locality-profile.md
+++ b/docs/data-locality-profile.md
@@ -1,0 +1,79 @@
+# Vaara Data-Locality Profile v0
+
+A downstream profile of `vaara.receipt/v1`. It maps a signed data-locality
+record to the EU transfer-accountability frame, and it states plainly what the
+record proves and what it does not. The profile adds no new primitive: the
+record is built from the shipped receipt and decision-record primitives plus a
+policy recompute.
+
+The conformance corpus for this profile is `tests/vectors/data_locality_v0/`,
+graded by the aggregate runner alongside the rest of Profile v1.
+
+## The problem it addresses
+
+When an agent action sends personal data to a model endpoint outside the EU, the
+GDPR Chapter V question is: where did the data go, under what rule, and can that
+be checked without trusting the party that sent it. After *Schrems II* the
+practical burden is a Transfer Impact Assessment plus supplementary measures,
+documented per transfer under the accountability principle (Art. 5(2)). This
+profile produces evidence that feeds that assessment. It does not, and cannot,
+establish that a transfer is lawful.
+
+## The record
+
+`vaara.data-locality/v0` binds one action's transfer facts (data class,
+endpoint, endpoint region, TLS cert fingerprint, payload digest) to the enforced
+allow/block decision, and optionally carries a region attestation signed by a
+party distinct from the issuer. Canonicalization is RFC 8785 JCS; signing is via
+the `vaara.audit.signer` `Signer` protocol (Ed25519 default, ML-DSA-65
+optional), the same stack the receipt uses.
+
+## Two tiers, named in the verdict
+
+The corpus checker recomputes each verdict from bytes, and the verdict names how
+far the evidence reaches:
+
+- **Tier A — proof, no trusted party.** The issuer signature verifies, the
+  payload digest recomputes from the payload bytes, and the recorded allow/block
+  decision recomputes from the transfer facts under the named policy. An outside
+  party reproduces all of it from bytes alone (`ok_asserted`).
+- **Tier B — carried claim.** A region attestation signed by an attester key
+  distinct from the issuer is verified against that key and checked to agree with
+  the claimed region (`ok_attested`). Its absence is stated, not hidden:
+  location asserted by the client, not attested.
+
+## Crosswalk to GDPR Chapter V
+
+| Requirement | What the record supplies | Tier |
+|-------------|--------------------------|------|
+| Art. 5(2) accountability — demonstrate the transfer control operated | Signed, recomputable record of the enforced decision per action | A |
+| Art. 44/46 — transfers only under appropriate safeguards | Policy recompute shows the enforced allow/block for the data class and region | A |
+| TIA supplementary-measure evidence (post-*Schrems II*) | Payload-class binding + endpoint region + optional processing-region attestation | A + B |
+| Independent verifiability without trusting the exporter | The dependency-free corpus checker reproduces every verdict | A |
+
+## What the profile does NOT establish
+
+- **Not an adequacy finding.** A genuine attestation of an EU processing region
+  does not prove legal safety from onward access; an EU endpoint operated by a
+  non-EU-controlled provider remains exposed under foreign-access law. Tier B
+  attests the observed region, nothing more.
+- **Not lawfulness of the transfer.** Whether a transfer is permitted is a legal
+  determination for the controller and its DPA. The record is evidence for that
+  assessment, not a substitute for it.
+- **Not proof of physical location by itself.** Without a Tier-B attestation the
+  region is the client's assertion. The verdict says so (`ok_asserted`).
+
+## Why the honesty is the point
+
+The 2026 pressure on the EU-U.S. Data Privacy Framework turns on whether a US
+oversight authority is independent enough to be trusted. When trust in an
+authority can be revoked, the only locality claim that survives is one the
+relying party recomputes itself (Tier A) plus an attestation it verifies against
+the attester's own key (Tier B). This profile is built so a record never claims
+more than a recipient can check.
+
+## Status
+
+Profile v0, downstream of `vaara.receipt/v1`. The record format and corpus are
+open. Acquiring genuine TEE or provider region attestations at runtime is an
+operational concern outside this profile.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.20.0"
+version = "1.21.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.20.0"
+__version__ = "1.21.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_data_locality.py
+++ b/src/vaara/attestation/_data_locality.py
@@ -1,0 +1,180 @@
+"""Emit and signature-verify data-locality records (``vaara.data-locality/v0``).
+
+Internal module. Public surface is in ``vaara.attestation.data_locality``.
+
+A data-locality record binds one agent action's cross-border transfer facts
+(data class, endpoint, endpoint region, TLS cert fingerprint, payload digest) to
+the enforced allow/block decision, and optionally carries a region attestation
+signed by a party distinct from the issuer (a TEE or the receiving provider).
+
+The record is byte-compatible with the ``data_locality_v0`` conformance corpus:
+the signature is Ed25519 over the RFC 8785 JCS encoding of the record with the
+``signature`` field removed, and the carried attestation signs the JCS of
+``{attestedRegion, attester, nonce}``. An outside party grades any record this
+module emits with the corpus's dependency-free checker.
+
+This module is deliberately policy-agnostic. It records the decision the
+pipeline already made; recomputing whether that decision was correct under a
+named policy is the verifier's job (see the corpus checker), not the emitter's.
+Turning a *claimed* region into an *attested* one — real TEE/provider
+attestation acquisition — is out of scope here by design.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from vaara.attestation._sep2787_canonical import canonical_json, new_nonce
+from vaara.attestation._sep2787_types import AttestationError
+from vaara.audit.signer import Signer, Verifier
+
+SCHEMA = "vaara.data-locality/v0"
+
+
+@dataclass(frozen=True)
+class TransferFacts:
+    """Observable facts about one cross-border transfer.
+
+    ``payload_digest`` and ``tls_cert_sha256`` are ``sha256:<hex>`` strings;
+    build the payload digest with :func:`payload_digest`. ``endpoint_region`` is
+    the region the endpoint claims — its truth is a Tier-B attestation concern,
+    not something this record asserts.
+    """
+
+    action_id: str
+    data_class: str
+    endpoint: str
+    endpoint_region: str
+    payload_digest: str
+    tls_cert_sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "actionId": self.action_id,
+            "dataClass": self.data_class,
+            "endpoint": self.endpoint,
+            "endpointRegion": self.endpoint_region,
+            "payloadDigest": self.payload_digest,
+            "tlsCertSha256": self.tls_cert_sha256,
+        }
+
+
+def payload_digest(payload: Any) -> str:
+    """``sha256:<hex>`` over the RFC 8785 JCS bytes of ``payload``."""
+    return "sha256:" + hashlib.sha256(canonical_json(payload)).hexdigest()
+
+
+def region_attestation(
+    signer: Signer, *, attester: str, attested_region: str, nonce: Optional[str] = None
+) -> dict[str, Any]:
+    """Build a carried region attestation, signed by ``signer`` (the attester).
+
+    The attester is a party distinct from the record issuer; a relying party
+    verifies this signature against the attester's own public key, never the
+    issuer's. In production the attestation comes from a TEE or the provider;
+    this helper covers the reference and test paths.
+    """
+    body = {"attestedRegion": attested_region, "attester": attester,
+            "nonce": nonce or new_nonce()}
+    sig = signer.sign(canonical_json(body)).hex()
+    return {**body, "sig": sig}
+
+
+def _record_signing_bytes(record: dict[str, Any]) -> bytes:
+    """JCS of the record with the ``signature`` field removed."""
+    return canonical_json({k: v for k, v in record.items() if k != "signature"})
+
+
+def emit_data_locality_record(
+    *,
+    signer: Signer,
+    issuer: str,
+    transfer: TransferFacts,
+    decision: str,
+    policy_id: str,
+    region_attestation: Optional[dict[str, Any]] = None,
+    version: int = 1,
+) -> dict[str, Any]:
+    """Build, JCS-canonicalize, and sign a data-locality record.
+
+    ``decision`` is the enforced verdict for the transfer (``"allow"`` or
+    ``"block"``); ``policy_id`` names the policy that produced it.
+    ``region_attestation`` is an optional carried attestation from
+    :func:`region_attestation`. Returns the wire-form record dict.
+    """
+    if decision not in ("allow", "block"):
+        raise AttestationError(f"decision must be 'allow' or 'block', got {decision!r}")
+    for field in ("payload_digest", "tls_cert_sha256"):
+        if not getattr(transfer, field).startswith("sha256:"):
+            raise AttestationError(f"transfer.{field} MUST be a 'sha256:' digest")
+
+    record: dict[str, Any] = {
+        "alg": signer.algorithm,
+        "decision": {"decision": decision, "policyId": policy_id},
+        "issuer": issuer,
+        "schema": SCHEMA,
+        "transfer": transfer.to_dict(),
+        "version": version,
+    }
+    if region_attestation is not None:
+        record["regionAttestation"] = region_attestation
+    record["signature"] = signer.sign(_record_signing_bytes(record)).hex()
+    return record
+
+
+def verify_record_signature(record: dict[str, Any], *, verifier: Verifier) -> bool:
+    """Verify the record's issuer signature only (Tier-A integrity).
+
+    Returns True iff the signature matches the JCS encoding of the record minus
+    ``signature`` under ``verifier``. Payload-digest, policy, and carried
+    attestation checks are composed separately; the corpus checker recomputes
+    all of them from bytes.
+    """
+    sig_hex = record.get("signature")
+    if not isinstance(sig_hex, str):
+        return False
+    try:
+        return verifier.verify(_record_signing_bytes(record), bytes.fromhex(sig_hex))
+    except ValueError:
+        return False
+
+
+def emit_from_interception(
+    result: Any,
+    *,
+    signer: Signer,
+    issuer: str,
+    data_class: str,
+    endpoint: str,
+    endpoint_region: str,
+    payload: Any,
+    tls_cert_sha256: str,
+    policy_id: str,
+    region_attestation: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    """Emit a locality record from an ``InterceptionResult`` and transfer metadata.
+
+    The seam between the governed decision and a signed locality record:
+    ``result.allowed`` maps to ``allow``/``block`` and ``result.action_id``
+    identifies the action. The transfer metadata (endpoint, region, data class,
+    payload, observed cert fingerprint) comes from the integration that owns the
+    outbound call. Acquiring a genuine region attestation for
+    ``region_attestation`` is the closed-side concern, left to the caller.
+    """
+    transfer = TransferFacts(
+        action_id=result.action_id,
+        data_class=data_class,
+        endpoint=endpoint,
+        endpoint_region=endpoint_region,
+        payload_digest=payload_digest(payload),
+        tls_cert_sha256=tls_cert_sha256,
+    )
+    return emit_data_locality_record(
+        signer=signer,
+        issuer=issuer,
+        transfer=transfer,
+        decision="allow" if result.allowed else "block",
+        policy_id=policy_id,
+        region_attestation=region_attestation,
+    )

--- a/src/vaara/attestation/data_locality.py
+++ b/src/vaara/attestation/data_locality.py
@@ -1,0 +1,51 @@
+"""Data-locality records: signed evidence of where an agent action's data went.
+
+When personal data leaves for a model endpoint, the accountability question is
+where it went, under what rule, and whether the answer can be checked without
+trusting the party that sent it. A data-locality record
+(``vaara.data-locality/v0``) binds one action's transfer facts — data class,
+endpoint, endpoint region, TLS cert fingerprint, payload digest — to the
+enforced allow/block decision, and optionally carries a region attestation
+signed by a party distinct from the issuer.
+
+The evidence is two-tier, and the corpus checker names which tier a record
+reaches:
+
+- Tier A (proof, no trusted party): the issuer signature verifies, the payload
+  digest recomputes, and the recorded decision recomputes from the transfer
+  facts under the named policy. Reproducible from bytes alone.
+- Tier B (carried claim): a ``regionAttestation`` signed by an attester key
+  distinct from the issuer, verified against that key and checked to agree with
+  the claimed region. Present and valid it attests the observed region; it is
+  never an adequacy finding, and its absence is stated (location asserted, not
+  attested), not hidden.
+
+This module emits and signature-verifies records that the dependency-free
+``data_locality_v0`` conformance corpus grades. Canonicalization is RFC 8785
+JCS; signing is via the ``vaara.audit.signer`` ``Signer`` protocol (Ed25519 by
+default, ML-DSA-65 optional). Acquiring a genuine region attestation is out of
+scope by design.
+
+Install: ``pip install 'vaara[attestation]'``.
+"""
+from __future__ import annotations
+
+from vaara.attestation._data_locality import (
+    SCHEMA,
+    TransferFacts,
+    emit_data_locality_record,
+    emit_from_interception,
+    payload_digest,
+    region_attestation,
+    verify_record_signature,
+)
+
+__all__ = [
+    "SCHEMA",
+    "TransferFacts",
+    "emit_data_locality_record",
+    "emit_from_interception",
+    "payload_digest",
+    "region_attestation",
+    "verify_record_signature",
+]

--- a/tests/test_data_locality.py
+++ b/tests/test_data_locality.py
@@ -1,0 +1,160 @@
+"""The reference emitter produces records the independent corpus checker grades.
+
+This is the tie between the open ``data_locality_v0`` vector corpus and the
+in-tree emitter: rather than trusting the emitter's own verifier, every record
+it produces here is handed to the corpus's dependency-free
+``_check_independent.py`` and must earn the expected verdict. The emitter signs
+with the same seeds the checker derives, so a mismatch means the emitter drifted
+from the published format.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vaara.attestation.data_locality import (
+    TransferFacts,
+    emit_data_locality_record,
+    emit_from_interception,
+    payload_digest,
+    region_attestation,
+    verify_record_signature,
+)
+from vaara.audit.signer import Ed25519Signer, Ed25519Verifier
+
+REPO = Path(__file__).resolve().parent.parent
+CHECKER_PATH = REPO / "tests" / "vectors" / "data_locality_v0" / "_check_independent.py"
+
+# Same seed labels the corpus checker derives its trust anchors from.
+ISSUER_SEED = b"vaara-data-locality-issuer/v0"
+ATTESTER_SEED = b"vaara-region-attester/v0"
+
+PII = {"subject": "user-42", "text": "personal data payload"}
+POLICY = "eu-inference-only@v1"
+
+
+def _signer(seed_label: bytes) -> Ed25519Signer:
+    key = Ed25519PrivateKey.from_private_bytes(hashlib.sha256(seed_label).digest())
+    return Ed25519Signer(key)
+
+
+@pytest.fixture(scope="module")
+def checker():
+    spec = importlib.util.spec_from_file_location("dl_checker", CHECKER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def issuer():
+    return _signer(ISSUER_SEED)
+
+
+@pytest.fixture(scope="module")
+def attester():
+    return _signer(ATTESTER_SEED)
+
+
+def _transfer(region: str, payload=PII, data_class: str = "personal_data") -> TransferFacts:
+    return TransferFacts(
+        action_id="act-test",
+        data_class=data_class,
+        endpoint=f"https://api.{region}.model.example/v1/infer",
+        endpoint_region=region,
+        payload_digest=payload_digest(payload),
+        tls_cert_sha256="sha256:" + "0" * 64,
+    )
+
+
+def _case(record, payload=PII):
+    return {"record": record, "payload": payload, "expected_verdict": None}
+
+
+def test_attested_eu_grades_ok_attested(checker, issuer, attester):
+    att = region_attestation(attester, attester="provider-tee-01",
+                             attested_region="eu-central-1", nonce="n1")
+    record = emit_data_locality_record(
+        signer=issuer, issuer="vaara-locality-emitter",
+        transfer=_transfer("eu-central-1"), decision="allow",
+        policy_id=POLICY, region_attestation=att,
+    )
+    assert checker._verify(_case(record)) == "ok_attested"
+
+
+def test_no_attestation_grades_ok_asserted(checker, issuer):
+    record = emit_data_locality_record(
+        signer=issuer, issuer="vaara-locality-emitter",
+        transfer=_transfer("eu-west-1"), decision="allow", policy_id=POLICY,
+    )
+    assert checker._verify(_case(record)) == "ok_asserted"
+
+
+def test_wrong_decision_caught_by_independent_policy_recompute(checker, issuer):
+    # Emitter records allow for PII to a US region; the checker recomputes block.
+    record = emit_data_locality_record(
+        signer=issuer, issuer="vaara-locality-emitter",
+        transfer=_transfer("us-east-1"), decision="allow", policy_id=POLICY,
+    )
+    assert checker._verify(_case(record)) == "policy_mismatch"
+
+
+def test_tampered_signature_caught(checker, issuer):
+    record = emit_data_locality_record(
+        signer=issuer, issuer="vaara-locality-emitter",
+        transfer=_transfer("eu-central-1"), decision="allow", policy_id=POLICY,
+    )
+    record["transfer"]["endpointRegion"] = "us-east-1"  # mutate a signed field
+    assert checker._verify(_case(record)) == "bad_signature"
+
+
+def test_runtime_payload_mismatch_caught(checker, issuer):
+    record = emit_data_locality_record(
+        signer=issuer, issuer="vaara-locality-emitter",
+        transfer=_transfer("eu-central-1"), decision="allow", policy_id=POLICY,
+    )
+    # A different payload than the one whose digest was committed.
+    assert checker._verify(_case(record, payload={"other": 1})) == "payload_mismatch"
+
+
+def test_attester_region_contradiction_caught(checker, issuer, attester):
+    att = region_attestation(attester, attester="provider-tee-01",
+                             attested_region="us-east-1", nonce="n8")
+    record = emit_data_locality_record(
+        signer=issuer, issuer="vaara-locality-emitter",
+        transfer=_transfer("eu-central-1"), decision="allow",
+        policy_id=POLICY, region_attestation=att,
+    )
+    assert checker._verify(_case(record)) == "attestation_region_mismatch"
+
+
+def test_verify_record_signature_roundtrip(issuer):
+    record = emit_data_locality_record(
+        signer=issuer, issuer="vaara-locality-emitter",
+        transfer=_transfer("eu-central-1"), decision="allow", policy_id=POLICY,
+    )
+    verifier = Ed25519Verifier(issuer.public_key_bytes())
+    assert verify_record_signature(record, verifier=verifier) is True
+    record["signature"] = record["signature"][:-2] + ("00" if record["signature"][-2:] != "00" else "11")
+    assert verify_record_signature(record, verifier=verifier) is False
+
+
+def test_emit_from_interception_maps_block(issuer):
+    class _Result:
+        allowed = False
+        action_id = "act-99"
+
+    record = emit_from_interception(
+        _Result(), signer=issuer, issuer="vaara-locality-emitter",
+        data_class="personal_data",
+        endpoint="https://api.us-east-1.model.example/v1/infer",
+        endpoint_region="us-east-1", payload=PII,
+        tls_cert_sha256="sha256:" + "0" * 64, policy_id=POLICY,
+    )
+    assert record["decision"]["decision"] == "block"
+    assert record["transfer"]["actionId"] == "act-99"

--- a/tests/test_data_locality.py
+++ b/tests/test_data_locality.py
@@ -15,6 +15,9 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from vaara.attestation.data_locality import (

--- a/tests/vectors/data_locality_v0/README.md
+++ b/tests/vectors/data_locality_v0/README.md
@@ -1,0 +1,107 @@
+# data_locality_v0
+
+Conformance vectors for a data-locality evidence record: a signed statement that
+binds one agent action's cross-border transfer facts to the policy decision that
+ran, and optionally carries a region attestation signed by a party other than
+the issuer.
+
+## Why this exists
+
+When personal data leaves the EU to a model endpoint, the compliance question is
+"where did it go, under what rule, and can I prove it without trusting the party
+that sent it." A locality record answers the first two by recompute and the
+third only as far as the evidence honestly allows. The suite is deliberately
+two-tier, and the verdicts name which tier a record reaches. It does not, and
+cannot, establish legal adequacy of a transfer; it establishes what was observed
+and what policy was enforced.
+
+## The two tiers
+
+**Tier A — proof, no trusted party.** The record signature verifies, the payload
+digest recomputes from the payload bytes, and the recorded allow/block decision
+recomputes from the transfer facts under the named policy. An outside party
+reproduces all of this from bytes alone.
+
+**Tier B — carried claim.** A `regionAttestation`, signed by an *attester* key
+distinct from the issuer, asserts the processing region. The checker verifies
+that signature against the attester's public key and checks it agrees with the
+claimed endpoint region. A valid attestation upgrades the verdict to
+`ok_attested`; its absence yields `ok_asserted` — location asserted by the
+client, not independently attested. That distinction is stated in the verdict,
+never smoothed over.
+
+A genuine attestation of an EU region still does not prove legal safety from
+onward access (an EU endpoint operated by a non-EU provider remains exposed).
+Tier B attests the observable region; it is not an adequacy finding.
+
+## Cases
+
+| case | verdict | what it pins |
+|------|---------|--------------|
+| `pos_attested_eu` | `ok_attested` | PII to an EU endpoint, allow, valid attester signature for the same region |
+| `pos_asserted_eu_no_attestation` | `ok_asserted` | PII to an EU endpoint, allow, no attestation — location asserted only |
+| `pos_nonpersonal_us` | `ok_asserted` | non-personal data to a US endpoint, allow (policy unconstrained), no attestation |
+| `neg_policy_mismatch_pii_us` | `policy_mismatch` | record claims allow for PII to a US endpoint; the independent recompute says block |
+| `neg_bad_signature` | `bad_signature` | a covered field mutated after signing |
+| `neg_payload_tampered` | `payload_mismatch` | runtime payload differs from the committed digest |
+| `neg_attestation_bad_sig` | `attestation_bad_sig` | attestation present, signature does not verify |
+| `neg_attestation_region_mismatch` | `attestation_region_mismatch` | attester signs a different region than the endpoint claims |
+
+`neg_policy_mismatch_pii_us` is the load-bearing case: the record carries a valid
+issuer signature and a matching payload digest, so it clears every integrity
+check, and is caught only because the checker recomputes the decision itself
+rather than trusting the recorded one.
+
+## Fixture format
+
+Each `cases/*.json` contains:
+
+```
+record              the signed data-locality record (see schema below)
+payload             the payload object presented at runtime (its digest is recomputed)
+expected_verdict    the verdict the checker must produce
+attested            whether a valid Tier-B attestation is expected
+```
+
+Record schema (`vaara.data-locality/v0`):
+
+```
+version, alg, schema, issuer
+transfer            { actionId, dataClass, endpoint, endpointRegion,
+                      payloadDigest, tlsCertSha256 }
+decision            { decision, policyId }
+regionAttestation   { attester, attestedRegion, nonce, sig }   (optional, Tier B)
+signature           Ed25519 over JCS of the record minus `signature`
+```
+
+## Policy
+
+`eu-inference-only@v1`: personal data may leave only to an EU region
+(`eu-central-1`, `eu-north-1`, `eu-west-1`); non-personal data is unconstrained.
+The checker recomputes this from `transfer.dataClass` and
+`transfer.endpointRegion`.
+
+## Recomputation
+
+Any verifier that speaks Ed25519 over RFC 8785 JCS reproduces every verdict from
+`_check_independent.py` with no Vaara import. Both keypairs are Ed25519, derived
+by `sha256` over published corpus-only seed labels:
+
+```
+issuer seed label    b"vaara-data-locality-issuer/v0"
+attester seed label  b"vaara-region-attester/v0"
+```
+
+The checker derives the keys and verifies against the **public** half only; a
+real deployment ships public keys or trust anchors, never the seed. Public keys
+are also recorded in `expected.json` under `keys` for convenience.
+
+Attestation signing payload: `jcs({attestedRegion, attester, nonce})`.
+Record signing payload: `jcs(record without "signature")`.
+
+## Regeneration
+
+```
+.venv/bin/python tests/vectors/data_locality_v0/_generate.py
+.venv/bin/python tests/vectors/data_locality_v0/_check_independent.py
+```

--- a/tests/vectors/data_locality_v0/_check_independent.py
+++ b/tests/vectors/data_locality_v0/_check_independent.py
@@ -1,0 +1,150 @@
+"""Independent conformance checker for data_locality_v0 vectors.
+
+No Vaara import. Uses only hashlib, json, rfc8785, and cryptography (Ed25519).
+Every verdict is a property of the bytes in each case file, not of the Vaara
+codebase. The checker derives the public keys from the same published seed
+labels the generator used, then verifies against the PUBLIC key only: a real
+relying party ships trust anchors, not seeds.
+
+Two tiers, in evaluation order:
+  1. record signature (Tier A integrity) ....... bad_signature
+  2. payload digest recompute (Tier A) ......... payload_mismatch
+  3. policy decision recompute (Tier A) ........ policy_mismatch
+  4. carried region attestation (Tier B) ....... attestation_bad_sig,
+                                                 attestation_region_mismatch,
+                                                 ok_attested
+     no attestation ............................ ok_asserted
+
+Run: .venv/bin/python tests/vectors/data_locality_v0/_check_independent.py
+Exit 0 = all cases match expected. Non-zero = mismatch printed and raised.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+HERE = Path(__file__).resolve().parent
+
+# Published corpus seeds (see README). Derive keys, keep only the public half.
+ISSUER_SEED = b"vaara-data-locality-issuer/v0"
+ATTESTER_SEED = b"vaara-region-attester/v0"
+
+POLICY_ID = "eu-inference-only@v1"
+EU_REGIONS = frozenset({"eu-central-1", "eu-north-1", "eu-west-1"})
+
+
+def _public_key(seed_label: bytes) -> Ed25519PublicKey:
+    priv = Ed25519PrivateKey.from_private_bytes(hashlib.sha256(seed_label).digest())
+    return priv.public_key()
+
+
+ISSUER_PUB = _public_key(ISSUER_SEED)
+ATTESTER_PUB = _public_key(ATTESTER_SEED)
+
+
+def _jcs(obj) -> bytes:
+    return rfc8785.dumps(obj)
+
+
+def _sha256_jcs(obj) -> str:
+    return "sha256:" + hashlib.sha256(_jcs(obj)).hexdigest()
+
+
+def _verify_ed25519(pub: Ed25519PublicKey, payload: bytes, sig_hex: str) -> bool:
+    try:
+        pub.verify(bytes.fromhex(sig_hex), payload)
+        return True
+    except (InvalidSignature, ValueError):
+        return False
+
+
+def _policy_decision(data_class: str, endpoint_region: str) -> str:
+    """Recompute eu-inference-only@v1 from transfer facts alone."""
+    if data_class != "personal_data":
+        return "allow"
+    return "allow" if endpoint_region in EU_REGIONS else "block"
+
+
+def _verify(case: dict) -> str:
+    record = case.get("record")
+    if not isinstance(record, dict) or "signature" not in record:
+        return "missing_record"
+
+    # 1. record signature over JCS of everything but the signature itself.
+    signed = {k: v for k, v in record.items() if k != "signature"}
+    if not _verify_ed25519(ISSUER_PUB, _jcs(signed), record["signature"]):
+        return "bad_signature"
+
+    transfer = record["transfer"]
+
+    # 2. payload digest binds the record to the payload presented at runtime.
+    if transfer["payloadDigest"] != _sha256_jcs(case["payload"]):
+        return "payload_mismatch"
+
+    # 3. recorded decision must equal the independently recomputed verdict.
+    recomputed = _policy_decision(transfer["dataClass"], transfer["endpointRegion"])
+    if record["decision"]["decision"] != recomputed:
+        return "policy_mismatch"
+
+    # 4. Tier B: carried region attestation, verified against the attester key.
+    att = record.get("regionAttestation")
+    if att is None:
+        return "ok_asserted"
+    body = {"attestedRegion": att["attestedRegion"], "attester": att["attester"],
+            "nonce": att["nonce"]}
+    if not _verify_ed25519(ATTESTER_PUB, _jcs(body), att["sig"]):
+        return "attestation_bad_sig"
+    if att["attestedRegion"] != transfer["endpointRegion"]:
+        return "attestation_region_mismatch"
+    return "ok_attested"
+
+
+def main() -> int:
+    expected_path = HERE / "expected.json"
+    if not expected_path.exists():
+        print("expected.json not found — run _generate.py first", file=sys.stderr)
+        return 1
+
+    expected = json.loads(expected_path.read_text(encoding="utf-8"))
+    cases_dir = HERE / "cases"
+    failures = []
+
+    for path in sorted(cases_dir.glob("*.json")):
+        case = json.loads(path.read_text(encoding="utf-8"))
+        computed = _verify(case)
+        want = case["expected_verdict"]
+        status = "PASS" if computed == want else "FAIL"
+        print(f"  {status}  {path.stem:<34}  computed={computed!r}  expected={want!r}")
+        if computed != want:
+            failures.append(path.stem)
+
+    # Cross-check every declared case exists and matches.
+    for name, meta in expected["cases"].items():
+        path = cases_dir / f"{name}.json"
+        if not path.exists():
+            print(f"  MISSING  {name}", file=sys.stderr)
+            failures.append(name)
+            continue
+        case = json.loads(path.read_text(encoding="utf-8"))
+        if _verify(case) != meta["expected_verdict"]:
+            failures.append(f"{name}(expected.json cross-check)")
+
+    if failures:
+        print(f"\n{len(failures)} failure(s): {failures}", file=sys.stderr)
+        return 1
+
+    print(f"\nall {len(list(cases_dir.glob('*.json')))} cases pass")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/data_locality_v0/_generate.py
+++ b/tests/vectors/data_locality_v0/_generate.py
@@ -1,0 +1,174 @@
+"""Regenerate the data_locality_v0 conformance vectors.
+
+Eight cases pin the data-locality evidence contract: a signed record binds an
+agent action's cross-border transfer facts (data class, endpoint, endpoint
+region, TLS cert fingerprint, payload digest) to the policy decision that ran,
+and optionally carries a region attestation signed by a party distinct from the
+issuer (a TEE or the receiving provider).
+
+The suite is two-tier and the verdicts name the tier a record reaches:
+
+  Tier A (proof, no trusted party) — record signature verifies, payload digest
+    recomputes from the payload bytes, and the recorded allow/block decision
+    recomputes from the transfer facts under the named policy.
+  Tier B (carried claim) — a region attestation signed by an attester key
+    verifies against that key and agrees with the claimed region. Present and
+    valid -> ok_attested; absent -> ok_asserted (location asserted, not
+    attested, stated plainly).
+
+Both keys are Ed25519, derived deterministically from published seed labels so
+the corpus carries no randomness; the seeds are corpus-only. The sibling
+_check_independent.py reproduces every verdict with no Vaara import.
+
+Run: .venv/bin/python tests/vectors/data_locality_v0/_generate.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import rfc8785
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+HERE = Path(__file__).resolve().parent
+CASES = HERE / "cases"
+SCHEMA = "vaara.data-locality/v0"
+
+# Corpus-only seed labels. sha256 -> 32-byte Ed25519 seed. Not deployed keys.
+ISSUER_SEED = b"vaara-data-locality-issuer/v0"
+ATTESTER_SEED = b"vaara-region-attester/v0"
+
+# Policy eu-inference-only@v1: personal data may only leave to an EU region;
+# non-personal data is unconstrained.
+POLICY_ID = "eu-inference-only@v1"
+EU_REGIONS = ("eu-central-1", "eu-north-1", "eu-west-1")
+
+PII = {"subject": "user-42", "text": "personal data payload"}
+NONPII = {"metric": "latency_ms", "value": 12}
+
+
+def _key(seed_label: bytes) -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.from_private_bytes(hashlib.sha256(seed_label).digest())
+
+
+ISSUER = _key(ISSUER_SEED)
+ATTESTER = _key(ATTESTER_SEED)
+
+
+def _pub_hex(key: Ed25519PrivateKey) -> str:
+    return key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
+
+
+def _jcs(obj) -> bytes:
+    return rfc8785.dumps(obj)
+
+
+def _sha256_jcs(obj) -> str:
+    return "sha256:" + hashlib.sha256(_jcs(obj)).hexdigest()
+
+
+def _attestation(region: str, nonce: str, *, corrupt: bool = False) -> dict:
+    body = {"attestedRegion": region, "attester": "provider-tee-01", "nonce": nonce}
+    sig = ATTESTER.sign(_jcs(body)).hex()
+    if corrupt:
+        sig = sig[:-1] + ("0" if sig[-1] != "0" else "1")
+    return {**body, "sig": sig}
+
+
+def _record(spec: dict) -> dict:
+    region = spec["region"]
+    payload = spec["payload"]
+    transfer = {
+        "actionId": spec["action_id"],
+        "dataClass": spec["data_class"],
+        "endpoint": f"https://api.{region}.model.example/v1/infer",
+        "endpointRegion": region,
+        "payloadDigest": _sha256_jcs(payload),
+        "tlsCertSha256": _sha256_jcs({"cert": region}),  # stand-in fingerprint
+    }
+    record = {
+        "alg": "Ed25519",
+        "decision": {"decision": spec["decision"], "policyId": POLICY_ID},
+        "issuer": "vaara-locality-emitter",
+        "schema": SCHEMA,
+        "transfer": transfer,
+        "version": 1,
+    }
+    att = spec.get("att")
+    if att is not None:
+        record["regionAttestation"] = _attestation(*att[:2], corrupt=att[2])
+    signed = {k: v for k, v in record.items() if k != "signature"}
+    record["signature"] = ISSUER.sign(_jcs(signed)).hex()
+    if spec.get("tamper"):
+        record["transfer"]["endpointRegion"] = "us-east-1"  # break the signature
+    return record
+
+
+# (name, data_class, region, payload, decision, att|None, flags, runtime_payload,
+#  expected_verdict, attested). att = (region, nonce, corrupt_bool).
+SPECS = [
+    dict(name="pos_attested_eu", action_id="act-001", data_class="personal_data",
+         region="eu-central-1", payload=PII, decision="allow",
+         att=("eu-central-1", "nonce-eu-1", False),
+         expected="ok_attested", attested=True),
+    dict(name="pos_asserted_eu_no_attestation", action_id="act-002",
+         data_class="personal_data", region="eu-west-1", payload=PII,
+         decision="allow", att=None, expected="ok_asserted", attested=False),
+    dict(name="pos_nonpersonal_us", action_id="act-003", data_class="non_personal",
+         region="us-east-1", payload=NONPII, decision="allow", att=None,
+         expected="ok_asserted", attested=False),
+    dict(name="neg_policy_mismatch_pii_us", action_id="act-004",
+         data_class="personal_data", region="us-east-1", payload=PII,
+         decision="allow", att=None, expected="policy_mismatch", attested=False),
+    dict(name="neg_bad_signature", action_id="act-005", data_class="personal_data",
+         region="eu-central-1", payload=PII, decision="allow", att=None,
+         tamper=True, expected="bad_signature", attested=False),
+    dict(name="neg_payload_tampered", action_id="act-006", data_class="personal_data",
+         region="eu-central-1", payload=PII, decision="allow", att=None,
+         runtime_payload=NONPII, expected="payload_mismatch", attested=False),
+    dict(name="neg_attestation_bad_sig", action_id="act-007",
+         data_class="personal_data", region="eu-central-1", payload=PII,
+         decision="allow", att=("eu-central-1", "nonce-eu-7", True),
+         expected="attestation_bad_sig", attested=False),
+    dict(name="neg_attestation_region_mismatch", action_id="act-008",
+         data_class="personal_data", region="eu-central-1", payload=PII,
+         decision="allow", att=("us-east-1", "nonce-us-8", False),
+         expected="attestation_region_mismatch", attested=True),
+]
+
+
+def _write(path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build() -> None:
+    expected_cases = {}
+    for spec in SPECS:
+        record = _record(spec)
+        case = {
+            "record": record,
+            "payload": spec.get("runtime_payload") or spec["payload"],
+            "expected_verdict": spec["expected"],
+            "attested": spec["attested"],
+        }
+        _write(CASES / f"{spec['name']}.json", case)
+        expected_cases[spec["name"]] = {
+            "expected_verdict": spec["expected"], "attested": spec["attested"]
+        }
+
+    _write(HERE / "expected.json", {
+        "keys": {
+            "issuerPublicKey": _pub_hex(ISSUER),
+            "attesterPublicKey": _pub_hex(ATTESTER),
+        },
+        "policy": {"id": POLICY_ID, "euRegions": list(EU_REGIONS)},
+        "cases": expected_cases,
+    })
+    print(f"wrote {len(SPECS)} cases + expected.json to {HERE}")
+
+
+if __name__ == "__main__":
+    build()

--- a/tests/vectors/data_locality_v0/cases/neg_attestation_bad_sig.json
+++ b/tests/vectors/data_locality_v0/cases/neg_attestation_bad_sig.json
@@ -1,0 +1,33 @@
+{
+  "attested": false,
+  "expected_verdict": "attestation_bad_sig",
+  "payload": {
+    "subject": "user-42",
+    "text": "personal data payload"
+  },
+  "record": {
+    "alg": "Ed25519",
+    "decision": {
+      "decision": "allow",
+      "policyId": "eu-inference-only@v1"
+    },
+    "issuer": "vaara-locality-emitter",
+    "regionAttestation": {
+      "attestedRegion": "eu-central-1",
+      "attester": "provider-tee-01",
+      "nonce": "nonce-eu-7",
+      "sig": "73bfcecd59adc2887d50e71abd4bf425eec6bf712a5b050375adb62e8962d678227b1fd63e8077617ad853ca462f2f74612d52a5130c1b7d20ca383e2c976900"
+    },
+    "schema": "vaara.data-locality/v0",
+    "signature": "fe7ed9c46197d52f5893fda47b5b152c36ad24a4cc76b037408669ec497f88fb9a497ae43a2f486ec7368df0e7cdcefd7f6f68c26f97b28236c23a45415bb60e",
+    "transfer": {
+      "actionId": "act-007",
+      "dataClass": "personal_data",
+      "endpoint": "https://api.eu-central-1.model.example/v1/infer",
+      "endpointRegion": "eu-central-1",
+      "payloadDigest": "sha256:fba55d08632dd5ba1a0b8007f28b05e19f000cac068965ad4d5767a9cc756f06",
+      "tlsCertSha256": "sha256:90b583a43a94daf255b60c2abbdbf1e411b020321740237b265ea0899df2c7a2"
+    },
+    "version": 1
+  }
+}

--- a/tests/vectors/data_locality_v0/cases/neg_attestation_region_mismatch.json
+++ b/tests/vectors/data_locality_v0/cases/neg_attestation_region_mismatch.json
@@ -1,0 +1,33 @@
+{
+  "attested": true,
+  "expected_verdict": "attestation_region_mismatch",
+  "payload": {
+    "subject": "user-42",
+    "text": "personal data payload"
+  },
+  "record": {
+    "alg": "Ed25519",
+    "decision": {
+      "decision": "allow",
+      "policyId": "eu-inference-only@v1"
+    },
+    "issuer": "vaara-locality-emitter",
+    "regionAttestation": {
+      "attestedRegion": "us-east-1",
+      "attester": "provider-tee-01",
+      "nonce": "nonce-us-8",
+      "sig": "4fe6941bafed171366efa7f513dbbea65077a390342c60cb45c2c2ea99324073659764dfd6d7c08e3fa661ca2117429dcb1f8758198e3d1dab9b6d61321e8c06"
+    },
+    "schema": "vaara.data-locality/v0",
+    "signature": "dec115e662d5b1bdacb3540440bdfce4a6bdb4d0bfb5e74dda4fa0363de966f89bd04872694c211e4fa53476617dc2b542a10e0a7fb056d152dfbb93318c6f0e",
+    "transfer": {
+      "actionId": "act-008",
+      "dataClass": "personal_data",
+      "endpoint": "https://api.eu-central-1.model.example/v1/infer",
+      "endpointRegion": "eu-central-1",
+      "payloadDigest": "sha256:fba55d08632dd5ba1a0b8007f28b05e19f000cac068965ad4d5767a9cc756f06",
+      "tlsCertSha256": "sha256:90b583a43a94daf255b60c2abbdbf1e411b020321740237b265ea0899df2c7a2"
+    },
+    "version": 1
+  }
+}

--- a/tests/vectors/data_locality_v0/cases/neg_bad_signature.json
+++ b/tests/vectors/data_locality_v0/cases/neg_bad_signature.json
@@ -1,0 +1,27 @@
+{
+  "attested": false,
+  "expected_verdict": "bad_signature",
+  "payload": {
+    "subject": "user-42",
+    "text": "personal data payload"
+  },
+  "record": {
+    "alg": "Ed25519",
+    "decision": {
+      "decision": "allow",
+      "policyId": "eu-inference-only@v1"
+    },
+    "issuer": "vaara-locality-emitter",
+    "schema": "vaara.data-locality/v0",
+    "signature": "cb4cebec84dcd1e9dbd5408c76024855c190e40b2b0fe6faae69e124eadca57fef0c0258867ad88bd02484bee9b49b9acba3cdc0450f86f3a533fbb4dbda3905",
+    "transfer": {
+      "actionId": "act-005",
+      "dataClass": "personal_data",
+      "endpoint": "https://api.eu-central-1.model.example/v1/infer",
+      "endpointRegion": "us-east-1",
+      "payloadDigest": "sha256:fba55d08632dd5ba1a0b8007f28b05e19f000cac068965ad4d5767a9cc756f06",
+      "tlsCertSha256": "sha256:90b583a43a94daf255b60c2abbdbf1e411b020321740237b265ea0899df2c7a2"
+    },
+    "version": 1
+  }
+}

--- a/tests/vectors/data_locality_v0/cases/neg_payload_tampered.json
+++ b/tests/vectors/data_locality_v0/cases/neg_payload_tampered.json
@@ -1,0 +1,27 @@
+{
+  "attested": false,
+  "expected_verdict": "payload_mismatch",
+  "payload": {
+    "metric": "latency_ms",
+    "value": 12
+  },
+  "record": {
+    "alg": "Ed25519",
+    "decision": {
+      "decision": "allow",
+      "policyId": "eu-inference-only@v1"
+    },
+    "issuer": "vaara-locality-emitter",
+    "schema": "vaara.data-locality/v0",
+    "signature": "6cfb8074c25dfacd376f896c083b04e4ba685a56285dc2f7737bc3cca418a128b44bb3fd9fb5633990c13f607fac12822c439d8398d5edae64d31c2bdffe1c0c",
+    "transfer": {
+      "actionId": "act-006",
+      "dataClass": "personal_data",
+      "endpoint": "https://api.eu-central-1.model.example/v1/infer",
+      "endpointRegion": "eu-central-1",
+      "payloadDigest": "sha256:fba55d08632dd5ba1a0b8007f28b05e19f000cac068965ad4d5767a9cc756f06",
+      "tlsCertSha256": "sha256:90b583a43a94daf255b60c2abbdbf1e411b020321740237b265ea0899df2c7a2"
+    },
+    "version": 1
+  }
+}

--- a/tests/vectors/data_locality_v0/cases/neg_policy_mismatch_pii_us.json
+++ b/tests/vectors/data_locality_v0/cases/neg_policy_mismatch_pii_us.json
@@ -1,0 +1,27 @@
+{
+  "attested": false,
+  "expected_verdict": "policy_mismatch",
+  "payload": {
+    "subject": "user-42",
+    "text": "personal data payload"
+  },
+  "record": {
+    "alg": "Ed25519",
+    "decision": {
+      "decision": "allow",
+      "policyId": "eu-inference-only@v1"
+    },
+    "issuer": "vaara-locality-emitter",
+    "schema": "vaara.data-locality/v0",
+    "signature": "0befdc7a244cec64c384a9e4f7497493e7b687ea325f292d87b13a1916894c3aaac4f78a26bbb6544b22cc752e269909a0f8520b6be409f59109f0cf46bd080b",
+    "transfer": {
+      "actionId": "act-004",
+      "dataClass": "personal_data",
+      "endpoint": "https://api.us-east-1.model.example/v1/infer",
+      "endpointRegion": "us-east-1",
+      "payloadDigest": "sha256:fba55d08632dd5ba1a0b8007f28b05e19f000cac068965ad4d5767a9cc756f06",
+      "tlsCertSha256": "sha256:ded5928f7b33056fe700399d00784dc9e015bf3d09fac9c0e82d2b0378d6e0af"
+    },
+    "version": 1
+  }
+}

--- a/tests/vectors/data_locality_v0/cases/pos_asserted_eu_no_attestation.json
+++ b/tests/vectors/data_locality_v0/cases/pos_asserted_eu_no_attestation.json
@@ -1,0 +1,27 @@
+{
+  "attested": false,
+  "expected_verdict": "ok_asserted",
+  "payload": {
+    "subject": "user-42",
+    "text": "personal data payload"
+  },
+  "record": {
+    "alg": "Ed25519",
+    "decision": {
+      "decision": "allow",
+      "policyId": "eu-inference-only@v1"
+    },
+    "issuer": "vaara-locality-emitter",
+    "schema": "vaara.data-locality/v0",
+    "signature": "6befdc604cd7265a98b81b070fcdd7a8cb8a8f4f26eeced3653b79e66c5e0d689baa1c109dadbfb860a9f97efc9122f68710b68c0e57f12b58fb4dce9923a10d",
+    "transfer": {
+      "actionId": "act-002",
+      "dataClass": "personal_data",
+      "endpoint": "https://api.eu-west-1.model.example/v1/infer",
+      "endpointRegion": "eu-west-1",
+      "payloadDigest": "sha256:fba55d08632dd5ba1a0b8007f28b05e19f000cac068965ad4d5767a9cc756f06",
+      "tlsCertSha256": "sha256:890d4f51abef62d5c1beba0fc7af0897abfc48e22cb490d04812a3b0ed15f823"
+    },
+    "version": 1
+  }
+}

--- a/tests/vectors/data_locality_v0/cases/pos_attested_eu.json
+++ b/tests/vectors/data_locality_v0/cases/pos_attested_eu.json
@@ -1,0 +1,33 @@
+{
+  "attested": true,
+  "expected_verdict": "ok_attested",
+  "payload": {
+    "subject": "user-42",
+    "text": "personal data payload"
+  },
+  "record": {
+    "alg": "Ed25519",
+    "decision": {
+      "decision": "allow",
+      "policyId": "eu-inference-only@v1"
+    },
+    "issuer": "vaara-locality-emitter",
+    "regionAttestation": {
+      "attestedRegion": "eu-central-1",
+      "attester": "provider-tee-01",
+      "nonce": "nonce-eu-1",
+      "sig": "fbaa06cdecedb4e451a9650ba7abb6f9983c71813af472d21963411e2eb5f821d0330f4eb8c875fccaad4a1e5a4f2987e85fbff9fc6ee5a4764c44c3f5be5b06"
+    },
+    "schema": "vaara.data-locality/v0",
+    "signature": "255125b38974a456649ff689852b7290eb7b88a5f039b4a2ccf3c2dc835afe9bbfae5c44bacf351ee56dda0957effa28d542f5c0fa109c120696ff5fd38bb603",
+    "transfer": {
+      "actionId": "act-001",
+      "dataClass": "personal_data",
+      "endpoint": "https://api.eu-central-1.model.example/v1/infer",
+      "endpointRegion": "eu-central-1",
+      "payloadDigest": "sha256:fba55d08632dd5ba1a0b8007f28b05e19f000cac068965ad4d5767a9cc756f06",
+      "tlsCertSha256": "sha256:90b583a43a94daf255b60c2abbdbf1e411b020321740237b265ea0899df2c7a2"
+    },
+    "version": 1
+  }
+}

--- a/tests/vectors/data_locality_v0/cases/pos_nonpersonal_us.json
+++ b/tests/vectors/data_locality_v0/cases/pos_nonpersonal_us.json
@@ -1,0 +1,27 @@
+{
+  "attested": false,
+  "expected_verdict": "ok_asserted",
+  "payload": {
+    "metric": "latency_ms",
+    "value": 12
+  },
+  "record": {
+    "alg": "Ed25519",
+    "decision": {
+      "decision": "allow",
+      "policyId": "eu-inference-only@v1"
+    },
+    "issuer": "vaara-locality-emitter",
+    "schema": "vaara.data-locality/v0",
+    "signature": "142c9d769c16c3e1f956287e8b55d1cba8cda9942af90799382713f0ec4dcc073571c8538fd337826ecbcaf7b3b7ad9503cee289b5dd1ea67cf7989c2d02af08",
+    "transfer": {
+      "actionId": "act-003",
+      "dataClass": "non_personal",
+      "endpoint": "https://api.us-east-1.model.example/v1/infer",
+      "endpointRegion": "us-east-1",
+      "payloadDigest": "sha256:6a54b81c72cc2f5a0ec251b18a9be0da0716e5b18941f30551ce491b0e25834b",
+      "tlsCertSha256": "sha256:ded5928f7b33056fe700399d00784dc9e015bf3d09fac9c0e82d2b0378d6e0af"
+    },
+    "version": 1
+  }
+}

--- a/tests/vectors/data_locality_v0/expected.json
+++ b/tests/vectors/data_locality_v0/expected.json
@@ -1,0 +1,48 @@
+{
+  "cases": {
+    "neg_attestation_bad_sig": {
+      "attested": false,
+      "expected_verdict": "attestation_bad_sig"
+    },
+    "neg_attestation_region_mismatch": {
+      "attested": true,
+      "expected_verdict": "attestation_region_mismatch"
+    },
+    "neg_bad_signature": {
+      "attested": false,
+      "expected_verdict": "bad_signature"
+    },
+    "neg_payload_tampered": {
+      "attested": false,
+      "expected_verdict": "payload_mismatch"
+    },
+    "neg_policy_mismatch_pii_us": {
+      "attested": false,
+      "expected_verdict": "policy_mismatch"
+    },
+    "pos_asserted_eu_no_attestation": {
+      "attested": false,
+      "expected_verdict": "ok_asserted"
+    },
+    "pos_attested_eu": {
+      "attested": true,
+      "expected_verdict": "ok_attested"
+    },
+    "pos_nonpersonal_us": {
+      "attested": false,
+      "expected_verdict": "ok_asserted"
+    }
+  },
+  "keys": {
+    "attesterPublicKey": "c6c7848783b4a580d89e424f25b5881eb9051b3f3692550a13208acf9d2a31eb",
+    "issuerPublicKey": "b91edfb5ace2fb9930529aecd23019ce5a8e2b3b0e4f2d137349488245f7bce9"
+  },
+  "policy": {
+    "euRegions": [
+      "eu-central-1",
+      "eu-north-1",
+      "eu-west-1"
+    ],
+    "id": "eu-inference-only@v1"
+  }
+}


### PR DESCRIPTION
Adds the `data_locality_v0` conformance corpus (8 cases, two-tier: Tier A recompute / Tier B carried attestation), the `vaara.attestation.data_locality` reference emitter graded by the dependency-free checker, and `docs/data-locality-profile.md` mapping the record to GDPR Chapter V transfer accountability. Registered as the 37th Profile v1 suite. Bumps pyproject / __init__ / TS client to 1.21.0 and adds the CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new data-locality profile and documentation for signed transfer evidence and GDPR accountability.
  * Introduced a public data-locality API for creating, signing, and verifying locality records.
  * Added a conformance corpus with positive and negative example cases plus independent validation tooling.
* **Tests**
  * Added coverage for signature checks, payload mismatches, policy mismatches, and attestation consistency.
* **Chores**
  * Bumped the package version to 1.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->