### PR TITLE
chore(release): anchor-tool follow-ups (fetch hint + qualified-only README)

### DIFF
--- a/release-anchors/README.md
+++ b/release-anchors/README.md
@@ -1,0 +1,25 @@
+# release-anchors/
+
+Qualified RFC 3161 timestamp anchors, one per release tag.
+
+Each `v<x.y.z>.json` binds a release to an **eIDAS-qualified** trusted timestamp:
+a sha256 fingerprint of the release tree (`git ls-tree -r --full-tree <tag>`,
+publicly recomputable) plus a qualified TSA token over that fingerprint. This is
+the Article 41 legal-grade priority proof, on top of the Sigstore/SLSA
+provenance and the PyPI/npm/GitHub publish records.
+
+**Only qualified anchors belong here.** A file in this directory asserts the
+token came from a QTSP listed on an EU Trusted List. Do not commit a
+non-qualified token (e.g. a free public TSA used for a smoke test) — the
+directory would then claim more than it proves.
+
+Generate and verify with `scripts/anchor_release.py`:
+
+```
+python scripts/anchor_release.py --tag v<x.y.z> --tsa-url <qualified-QTSP-TSA>
+python scripts/anchor_release.py --verify release-anchors/v<x.y.z>.json
+```
+
+`--verify` recomputes the tree fingerprint from the tag and checks the token
+offline against the TSA's own key, so anyone can confirm the release tree
+existed no later than the attested time without trusting us.

--- a/scripts/anchor_release.py
+++ b/scripts/anchor_release.py
@@ -42,9 +42,16 @@ def tree_fingerprint(tag: str) -> str:
     path, mode, and blob id in the release tree, so the digest fingerprints the
     exact tree state without depending on archive/timestamp quirks.
     """
-    out = subprocess.check_output(
-        ["git", "-C", str(REPO), "ls-tree", "-r", "--full-tree", tag])
-    return hashlib.sha256(out).hexdigest()
+    proc = subprocess.run(
+        ["git", "-C", str(REPO), "ls-tree", "-r", "--full-tree", tag],
+        capture_output=True)
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"cannot resolve tag {tag!r} locally. Release tags are created on the "
+            f"remote and are not fetched automatically — run:\n"
+            f"    git fetch origin tag {tag}\n"
+            f"then retry.")
+    return hashlib.sha256(proc.stdout).hexdigest()
 
 
 def _recompute_cmd(tag: str) -> str:


### PR DESCRIPTION
Two small follow-ups to scripts/anchor_release.py: (1) a missing local tag now prints `git fetch origin tag <tag>` instead of a raw git traceback (release tags live on the remote and are not auto-fetched); (2) release-anchors/README.md documents that the directory holds eIDAS-qualified anchors only, so a committed file never overstates its status. Tooling/docs only, no version bump.