### PR TITLE
chore(gitignore): ignore local-only webpage/ build source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ docs/grant/
 dist_verify/
 research/
 research/sfs_sr315/
+webpage/
 **/sfs_sr315/
 .claude/
 


### PR DESCRIPTION
webpage/ is the hand-deployed site source for the vaara.io droplet, not repo-served. Ignoring it keeps the local build out of the public tree, same as research/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files so the `webpage/` directory is no longer included in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->