### PR TITLE
feat(attestation): per-receipt CycloneDX-CBOM crypto posture (v1.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.22.0] - 2026-07-02
+
+Minor release: a per-receipt CycloneDX-CBOM crypto-posture block. An execution receipt can now carry, inside its signed preimage, a record of which signature algorithms protect it and the NIST post-quantum security level they reach, so an auditor reads the record's quantum resistance from the signed bytes alone.
+
+- `receiptAsserted.cryptoPosture` (optional, additive): a CycloneDX 1.6 / ECMA-424 shaped block naming each signing algorithm, its primitive, and its `nistQuantumSecurityLevel` (0 for the classical suites, 3 for ML-DSA-65 under FIPS 204), plus the effective floor as the max over the legs. It rides inside `receiptAsserted`, next to `sigSuite`, so it is covered by the signature. An inflated quantum-resistance claim or a stripped ML-DSA leg is recomputable from the signed record. Absent means the record predates the block and the envelope is byte-for-byte unchanged.
+- `crypto_posture_for(alg, sig_suite)` derives the block from a closed algorithm-to-level table and fails closed on an unknown algorithm or suite. `verify_crypto_posture(receipt)` recomputes the expected posture with no keying material and returns one of `crypto_posture_ok`, `crypto_posture_absent`, `crypto_posture_mismatch`, `crypto_posture_downgrade`, so an independent checker reproduces the verdict offline. `emit_receipt` gains an optional `crypto_posture` argument.
+- `docs/design/cbom-crypto-posture-spec.md` specifies the block, the level table, and the verdicts, and states the scope limit: it records the posture of the one algorithm set that signed the record, and is not a host or dependency scanner.
+
 ## [1.21.0] - 2026-07-02
 
 Minor release: the data-locality evidence profile and its conformance corpus. A signed record binds an agent action's cross-border transfer facts to the enforced decision, so a recipient can check where data went without trusting the exporter.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/design/cbom-crypto-posture-spec.md
+++ b/docs/design/cbom-crypto-posture-spec.md
@@ -1,0 +1,99 @@
+# CycloneDX-CBOM crypto posture for execution receipts (v0)
+
+Status: v0, additive. The classical receipt envelope, canonicalization, and every
+existing conformance vector are untouched. A receipt carries a crypto-posture block
+only when an emitter opts in.
+
+## The problem: the record has to say how it is protected
+
+A SEP-2828 execution receipt is a durable EU AI Act Article 12 record, kept across a
+retention window measured in years. Whoever audits it years from now needs to answer,
+from the signed bytes alone, a question the signature itself does not spell out: *what
+cryptography protects this record, and is it quantum-resistant?* The `alg` field names
+the classical suite, and `sigSuite` names a hybrid one, but neither states the security
+posture in a vocabulary an auditor's tooling already reads.
+
+A Cryptographic Bill of Materials (CBOM) is that vocabulary. CycloneDX 1.6 (ECMA-424)
+models cryptographic assets with `cryptoProperties.algorithmProperties`, including a
+`primitive`, and a `nistQuantumSecurityLevel` giving the NIST post-quantum security
+category. This aligns with the CBOM direction in NIST SP 1800-38 and the migration
+inventories the EU PQC roadmap (2035) and CNSA 2.0 (2030) will expect.
+
+This is **not a scanner**. It records the posture of the one algorithm set that signed
+this one record. It does not inventory a host's crypto.
+
+## The block, and where it lives
+
+`receiptAsserted.cryptoPosture` (optional object, **inside the signed preimage**):
+
+```json
+"cryptoPosture": {
+  "assetType": "algorithm",
+  "nistQuantumSecurityLevel": 3,
+  "algorithms": [
+    {"algorithm": "ES256",     "primitive": "signature", "nistQuantumSecurityLevel": 0},
+    {"algorithm": "ML-DSA-65", "primitive": "signature", "nistQuantumSecurityLevel": 3}
+  ]
+}
+```
+
+It rides inside `receiptAsserted`, so it is covered by the JCS (RFC 8785) preimage the
+classical (and, when present, the ML-DSA) signature covers, right next to `sigSuite`.
+Absent means the record predates the block: the envelope is byte-for-byte what it was
+before, and every existing vector verifies unchanged.
+
+The top-level `nistQuantumSecurityLevel` is the **effective floor**: the max over
+`algorithms`. A hybrid reaches its ML-DSA leg's category (3) because an attacker must
+still forge that leg; a classical-only receipt reports 0.
+
+## The algorithm-to-level table
+
+A closed table. An unknown algorithm fails closed rather than defaulting to a reassuring
+0, which would understate risk by omission.
+
+| algorithm  | primitive | nistQuantumSecurityLevel |
+|------------|-----------|--------------------------|
+| HS256      | mac       | 0                        |
+| ES256      | signature | 0                        |
+| RS256      | signature | 0                        |
+| Ed25519    | signature | 0                        |
+| ML-DSA-65  | signature | 3                        |
+
+ML-DSA-65 is FIPS 204, NIST security Category 3. The classical suites carry no quantum
+resistance (level 0). HS256 is a keyed MAC, so its primitive is `mac`.
+
+## Verification: pure recomputation, no keys
+
+`verify_crypto_posture(receipt)` recomputes the expected posture from the receipt's own
+`alg` + `sigSuite` and compares. No keying material, so an independent, Vaara-free
+checker reproduces the verdict from the receipt bytes alone:
+
+- `crypto_posture_ok`: the committed posture equals the recomputed one, and any claimed
+  ML-DSA leg is backed by a present `pqSignature`.
+- `crypto_posture_absent`: no block committed (a classical, pre-CBOM record). Not an
+  error; the block is optional and its absence claims nothing.
+- `crypto_posture_mismatch`: the committed posture does not match the recomputed one
+  (a forged or drifted quantum-resistance claim, e.g. an ML-DSA leg asserted with no
+  `sigSuite` to commit it). Because the block is inside the preimage, on a
+  signature-verified record this only fires on an internally inconsistent claim, never
+  on plain tampering, which breaks the signature first.
+- `crypto_posture_downgrade`: the posture commits to an ML-DSA leg (level > 0) but
+  `pqSignature` is absent: a signed claim of quantum resistance the record cannot back.
+
+## Relationship to `sigSuite` and `pq_verdict`
+
+`sigSuite` closes the strip-the-`pqSignature` downgrade at the signing layer;
+`pq_verdict` grades quantum-resistance tiers against a DID document and its keys. The
+crypto posture is the auditor-facing lens on the same facts: it restates them in the
+CycloneDX CBOM vocabulary and checks them with zero keying material, so a CBOM consumer
+reads the record's posture without a Vaara-specific parser or any key resolution. The
+`crypto_posture_downgrade` verdict mirrors the `sigSuite` downgrade commitment in CBOM
+terms.
+
+## What v0 does not do
+
+- No SLH-DSA (FIPS 205), ML-DSA-44/87, or classical-key-strength bits: the table covers
+  only the suites the receipt path signs with today. Extending it is an explicit version
+  bump, not a silent addition.
+- No host or dependency inventory. One record, one algorithm set.
+- No re-canonicalization or new crypto. The block is data inside the existing preimage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.21.0"
+version = "1.22.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.21.0"
+__version__ = "1.22.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_receipt_cbom.py
+++ b/src/vaara/attestation/_receipt_cbom.py
@@ -1,0 +1,154 @@
+"""CycloneDX-CBOM crypto-posture derivation and verification (v0).
+
+Internal module. Public surface re-exports ``crypto_posture_for`` and
+``verify_crypto_posture`` from ``vaara.attestation.receipt``.
+
+An execution receipt is a durable Article 12 record kept for years, so the
+crypto that protects it is itself audit-relevant: a reader years from now needs
+to know, from the signed bytes alone, whether the record is quantum-resistant
+and by what algorithm. This module records that as a small CycloneDX-CBOM
+(ECMA-424) crypto-posture block committed *inside* the receipt preimage, next
+to ``receiptAsserted.sigSuite``.
+
+Two properties fall out of putting the block inside the preimage:
+
+- Tamper-evidence: the classical signature already covers the block, so editing
+  the posture breaks the signature before this module is consulted.
+- Downgrade-evidence: the posture is recomputed from the receipt's own ``alg``
+  and ``sigSuite``. A posture that commits to an ML-DSA leg while ``pqSignature``
+  has been stripped is a signed claim of quantum resistance the record cannot
+  back, and ``verify_crypto_posture`` reports it. This mirrors the ``sigSuite``
+  downgrade commitment, in the CycloneDX vocabulary an auditor's CBOM tooling
+  already speaks.
+
+This is not a scanner. It records the posture of the one algorithm set that
+signed this one record; it does not inventory a host's crypto. The verdict is
+pure recomputation over the receipt bytes with no keying material, so a
+Vaara-free checker reproduces it offline. See
+``docs/design/cbom-crypto-posture-spec.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from vaara.attestation._receipt_pq import _HYBRID_SUITES, _PQ_ALG_MLDSA65
+from vaara.attestation._receipt_types import (
+    CryptoAlgorithm,
+    CryptoPosture,
+    ExecutionReceipt,
+)
+from vaara.attestation._sep2787_types import AttestationError
+
+# alg -> (CycloneDX primitive, NIST post-quantum security category).
+# Classical suites carry no quantum resistance (level 0); ML-DSA-65 is FIPS 204
+# Category 3. HS256 is a keyed MAC so its primitive is "mac"; the rest are
+# asymmetric signatures. A closed table: an unknown alg fails closed rather than
+# defaulting to a reassuring 0, which would understate risk by omission.
+_NIST_QUANTUM_LEVEL: dict[str, tuple[str, int]] = {
+    "HS256": ("mac", 0),
+    "ES256": ("signature", 0),
+    "RS256": ("signature", 0),
+    "Ed25519": ("signature", 0),
+    _PQ_ALG_MLDSA65: ("signature", 3),
+}
+
+CBOM_OK = "crypto_posture_ok"
+CBOM_ABSENT = "crypto_posture_absent"
+CBOM_MISMATCH = "crypto_posture_mismatch"
+CBOM_DOWNGRADE = "crypto_posture_downgrade"
+
+
+def _algorithm_entry(alg: str) -> CryptoAlgorithm:
+    entry = _NIST_QUANTUM_LEVEL.get(alg)
+    if entry is None:
+        raise AttestationError(
+            f"no CBOM crypto-posture mapping for algorithm {alg!r}"
+        )
+    primitive, level = entry
+    return CryptoAlgorithm(
+        algorithm=alg, primitive=primitive, nist_quantum_security_level=level
+    )
+
+
+def crypto_posture_for(
+    *, alg: str, sig_suite: Optional[str] = None
+) -> CryptoPosture:
+    """Derive the CBOM crypto posture for a receipt's signing algorithms.
+
+    ``alg`` is the receipt's classical signing algorithm. ``sig_suite``, when
+    set, names an allowlisted hybrid suite (the same closed set the PQ signing
+    path uses) whose ML-DSA leg is added as a second algorithm. The effective
+    ``nistQuantumSecurityLevel`` is the max over the algorithms, so a hybrid
+    reaches its ML-DSA leg's category and a classical-only receipt reports 0.
+
+    Fails closed on an unknown algorithm, an unknown suite, or a suite whose
+    classical member disagrees with ``alg`` (which would let the posture
+    describe a different key than the one that signed).
+    """
+    entries = [_algorithm_entry(alg)]
+    if sig_suite is not None:
+        members = _HYBRID_SUITES.get(sig_suite)
+        if members is None:
+            raise AttestationError(f"unknown hybrid suite {sig_suite!r}")
+        classical_alg, pq_alg = members
+        if classical_alg != alg:
+            raise AttestationError(
+                f"sigSuite {sig_suite!r} names classical member "
+                f"{classical_alg!r} but alg is {alg!r}"
+            )
+        entries.append(_algorithm_entry(pq_alg))
+    effective = max(e.nist_quantum_security_level for e in entries)
+    return CryptoPosture(
+        asset_type="algorithm",
+        nist_quantum_security_level=effective,
+        algorithms=tuple(entries),
+    )
+
+
+def verify_crypto_posture(receipt: ExecutionReceipt) -> str:
+    """Check a receipt's committed crypto posture against what it actually uses.
+
+    Returns one of:
+
+    - ``crypto_posture_absent`` — no posture committed (a classical, pre-CBOM
+      record). Not an error: the block is optional and its absence claims
+      nothing.
+    - ``crypto_posture_ok`` — the committed posture equals the posture
+      recomputed from the receipt's own ``alg`` + ``sigSuite``, and any claimed
+      ML-DSA leg is backed by a present ``pqSignature``.
+    - ``crypto_posture_mismatch`` — the committed posture does not match the
+      recomputed one (a forged or drifted quantum-resistance claim, e.g. an
+      ML-DSA leg asserted with no ``sigSuite`` to commit it). The posture is
+      inside the signed preimage, so on a signature-verified record this only
+      fires on an internally inconsistent claim, never on plain tampering
+      (which breaks the signature first).
+    - ``crypto_posture_downgrade`` — the posture commits to an ML-DSA leg
+      (level > 0) but ``pqSignature`` is absent: a signed claim of quantum
+      resistance the record cannot back. Mirrors the ``sigSuite`` downgrade
+      check in CBOM terms.
+
+    Pure recomputation with no keying material, so an independent checker
+    reproduces this verdict from the receipt bytes alone.
+    """
+    posture = receipt.receipt_asserted.crypto_posture
+    if posture is None:
+        return CBOM_ABSENT
+    try:
+        expected = crypto_posture_for(
+            alg=receipt.receipt_asserted.alg,
+            sig_suite=receipt.receipt_asserted.sig_suite,
+        )
+    except AttestationError:
+        # The record commits a posture the alg/suite pair cannot legitimately
+        # produce (unknown alg, or a suite/alg disagreement). Treat as a bad
+        # claim rather than propagate.
+        return CBOM_MISMATCH
+    if posture != expected:
+        return CBOM_MISMATCH
+    has_pq_leg = any(
+        e.nist_quantum_security_level > 0 for e in posture.algorithms
+    )
+    if has_pq_leg and receipt.pq_signature is None:
+        return CBOM_DOWNGRADE
+    return CBOM_OK

--- a/src/vaara/attestation/_receipt_emit.py
+++ b/src/vaara/attestation/_receipt_emit.py
@@ -15,6 +15,7 @@ from typing import Any, Optional
 
 from vaara.attestation._receipt_types import (
     BackLink,
+    CryptoPosture,
     ExecutionReceipt,
     OutcomeDerived,
     ReceiptAsserted,
@@ -74,6 +75,7 @@ def emit_receipt(
     iat: Optional[str] = None,
     version: int = 1,
     sig_suite: Optional[str] = None,
+    crypto_posture: Optional[CryptoPosture] = None,
 ) -> ExecutionReceipt:
     """Build, JCS-canonicalize, and sign an ExecutionReceipt envelope.
 
@@ -84,6 +86,11 @@ def emit_receipt(
 
     ``signing_material`` is either a bytes shared secret (HS256) or a
     private-key object from ``cryptography.hazmat`` (ES256 / RS256).
+
+    ``crypto_posture`` is the optional CycloneDX-CBOM crypto-posture block.
+    Derive it with ``crypto_posture_for(alg=..., sig_suite=...)`` so it stays
+    consistent with the signing algorithm and any hybrid suite; it is written
+    into ``receiptAsserted`` and so covered by the signature.
     """
     if alg not in VALID_ALGS:
         raise AttestationError(f"unsupported alg: {alg!r}")
@@ -102,6 +109,7 @@ def emit_receipt(
         secret_version=secret_version,
         alg=alg,
         sig_suite=sig_suite,
+        crypto_posture=crypto_posture,
     )
 
     payload = _signing_payload(

--- a/src/vaara/attestation/_receipt_types.py
+++ b/src/vaara/attestation/_receipt_types.py
@@ -117,6 +117,15 @@ class ReceiptAsserted:
     (e.g. ``"ES256+ML-DSA-65"``), committing the issuer's intent *inside*
     the signed preimage so a stripped ``pqSignature`` is a detectable
     downgrade. See ``docs/design/pq-hybrid-signing-spec.md``.
+
+    ``crypto_posture`` (``cryptoPosture`` on the wire) is the optional
+    CycloneDX-CBOM crypto-posture block: the signature algorithms protecting
+    the record and the effective NIST post-quantum security level they reach.
+    Like ``sig_suite`` it rides inside the signed preimage, so an inflated
+    quantum-resistance claim or a stripped ML-DSA leg is recomputable from the
+    signed bytes. Absent means the record predates the block and the envelope
+    is byte-for-byte what it was before. See
+    ``docs/design/cbom-crypto-posture-spec.md``.
     """
 
     iss: str
@@ -126,6 +135,7 @@ class ReceiptAsserted:
     secret_version: str
     alg: Algorithm
     sig_suite: Optional[str] = None
+    crypto_posture: Optional["CryptoPosture"] = None
 
 
 @dataclass(frozen=True)
@@ -187,6 +197,131 @@ def pq_signature_from_dict(d: dict[str, Any]) -> PqSignature:
 
 
 @dataclass(frozen=True)
+class CryptoAlgorithm:
+    """One cryptographic algorithm protecting a receipt, CycloneDX-CBOM shaped.
+
+    ``algorithm`` is the JOSE / Vaara suite name (``"ES256"``, ``"ML-DSA-65"``).
+    ``primitive`` is the CycloneDX cryptographic primitive: ``"signature"`` for
+    the asymmetric suites, ``"mac"`` for the HS256 keyed-MAC path.
+    ``nist_quantum_security_level`` is the NIST post-quantum security category
+    the algorithm reaches: 0 for the classical suites (no quantum resistance),
+    3 for ML-DSA-65 (FIPS 204, Category 3). Field names track CycloneDX 1.6
+    ``cryptoProperties.algorithmProperties`` (ECMA-424).
+    """
+
+    algorithm: str
+    primitive: str
+    nist_quantum_security_level: int
+
+
+@dataclass(frozen=True)
+class CryptoPosture:
+    """CycloneDX-CBOM crypto posture committed inside the receipt preimage.
+
+    A signed, tamper-evident declaration of which signature algorithms protect
+    the record and the effective NIST post-quantum security level they reach.
+    It rides inside ``receiptAsserted`` (so inside the signed preimage) next to
+    ``sigSuite``: a verifier recomputes the expected posture from the receipt's
+    own ``alg`` + ``sigSuite``, so an inflated quantum-resistance claim, or a
+    stripped ML-DSA leg, is a signed statement the record cannot back.
+
+    ``nist_quantum_security_level`` is the effective floor for the record: the
+    max over ``algorithms``. A hybrid reaches its ML-DSA leg's category because
+    an attacker must still forge that leg; a classical-only receipt reports 0.
+    """
+
+    asset_type: str
+    nist_quantum_security_level: int
+    algorithms: tuple[CryptoAlgorithm, ...]
+
+
+def crypto_algorithm_to_dict(ca: CryptoAlgorithm) -> dict[str, Any]:
+    return {
+        "algorithm": ca.algorithm,
+        "primitive": ca.primitive,
+        "nistQuantumSecurityLevel": ca.nist_quantum_security_level,
+    }
+
+
+def crypto_posture_to_dict(cp: CryptoPosture) -> dict[str, Any]:
+    return {
+        "assetType": cp.asset_type,
+        "nistQuantumSecurityLevel": cp.nist_quantum_security_level,
+        "algorithms": [crypto_algorithm_to_dict(a) for a in cp.algorithms],
+    }
+
+
+_CRYPTO_ALGORITHM_KEYS = frozenset(
+    {"algorithm", "primitive", "nistQuantumSecurityLevel"}
+)
+_CRYPTO_POSTURE_KEYS = frozenset(
+    {"assetType", "nistQuantumSecurityLevel", "algorithms"}
+)
+
+
+def _crypto_level(value: Any, where: str) -> int:
+    """A NIST quantum-security level: an integer 0..5, rejecting bool.
+
+    ``bool`` is an ``int`` subclass, so ``True``/``False`` would otherwise slip
+    through and canonicalize to ``1``/``0``, letting a boolean masquerade as a
+    level. Reject it explicitly.
+    """
+    if not isinstance(value, int) or isinstance(value, bool) or not (0 <= value <= 5):
+        raise AttestationError(f"{where} must be an integer 0..5")
+    return value
+
+
+def crypto_algorithm_from_dict(d: dict[str, Any]) -> CryptoAlgorithm:
+    _reject_unknown_keys(d, _CRYPTO_ALGORITHM_KEYS, "cryptoPosture.algorithms[]")
+    for required in ("algorithm", "primitive", "nistQuantumSecurityLevel"):
+        if required not in d:
+            raise AttestationError(
+                f"cryptoPosture algorithm missing required field {required!r}"
+            )
+    algorithm = d["algorithm"]
+    primitive = d["primitive"]
+    if not isinstance(algorithm, str) or not algorithm:
+        raise AttestationError(
+            "cryptoPosture.algorithms[].algorithm must be a non-empty string"
+        )
+    if not isinstance(primitive, str) or not primitive:
+        raise AttestationError(
+            "cryptoPosture.algorithms[].primitive must be a non-empty string"
+        )
+    return CryptoAlgorithm(
+        algorithm=algorithm,
+        primitive=primitive,
+        nist_quantum_security_level=_crypto_level(
+            d["nistQuantumSecurityLevel"],
+            "cryptoPosture.algorithms[].nistQuantumSecurityLevel",
+        ),
+    )
+
+
+def crypto_posture_from_dict(d: dict[str, Any]) -> CryptoPosture:
+    _reject_unknown_keys(d, _CRYPTO_POSTURE_KEYS, "cryptoPosture")
+    for required in ("assetType", "nistQuantumSecurityLevel", "algorithms"):
+        if required not in d:
+            raise AttestationError(
+                f"cryptoPosture missing required field {required!r}"
+            )
+    if d["assetType"] != "algorithm":
+        raise AttestationError("cryptoPosture.assetType must be 'algorithm'")
+    algorithms = d["algorithms"]
+    if not isinstance(algorithms, list) or not algorithms:
+        raise AttestationError(
+            "cryptoPosture.algorithms must be a non-empty array"
+        )
+    return CryptoPosture(
+        asset_type="algorithm",
+        nist_quantum_security_level=_crypto_level(
+            d["nistQuantumSecurityLevel"], "cryptoPosture.nistQuantumSecurityLevel"
+        ),
+        algorithms=tuple(crypto_algorithm_from_dict(a) for a in algorithms),
+    )
+
+
+@dataclass(frozen=True)
 class ExecutionReceipt:
     """Execution-receipt envelope.
 
@@ -243,6 +378,8 @@ def receipt_asserted_to_dict(ra: ReceiptAsserted) -> dict[str, Any]:
     }
     if ra.sig_suite is not None:
         out["sigSuite"] = ra.sig_suite
+    if ra.crypto_posture is not None:
+        out["cryptoPosture"] = crypto_posture_to_dict(ra.crypto_posture)
     return out
 
 
@@ -262,7 +399,8 @@ _BACK_LINK_KEYS = frozenset(
     {"attestationDigest", "attestationNonce", "fallbackProjection"}
 )
 _RECEIPT_ASSERTED_KEYS = frozenset(
-    {"alg", "iat", "iss", "nonce", "secretVersion", "sub", "sigSuite"}
+    {"alg", "iat", "iss", "nonce", "secretVersion", "sub", "sigSuite",
+     "cryptoPosture"}
 )
 _OUTCOME_KEYS = frozenset(
     {"status", "completedAt", "resultCommitment", "decisionDigest"}
@@ -297,6 +435,14 @@ def receipt_asserted_from_dict(d: dict[str, Any]) -> ReceiptAsserted:
     sig_suite = d.get("sigSuite")
     if sig_suite is not None and not isinstance(sig_suite, str):
         raise AttestationError("receiptAsserted.sigSuite must be a string or absent")
+    crypto_posture_raw = d.get("cryptoPosture")
+    crypto_posture = None
+    if crypto_posture_raw is not None:
+        if not isinstance(crypto_posture_raw, dict):
+            raise AttestationError(
+                "receiptAsserted.cryptoPosture must be an object or absent"
+            )
+        crypto_posture = crypto_posture_from_dict(crypto_posture_raw)
     return ReceiptAsserted(
         alg=d["alg"],
         iat=d["iat"],
@@ -305,6 +451,7 @@ def receipt_asserted_from_dict(d: dict[str, Any]) -> ReceiptAsserted:
         secret_version=d["secretVersion"],
         sub=d["sub"],
         sig_suite=sig_suite,
+        crypto_posture=crypto_posture,
     )
 
 

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -185,8 +185,18 @@ from vaara.attestation._receipt_retention import (
     RetentionResult,
     verify_receipt_retained,
 )
+from vaara.attestation._receipt_cbom import (
+    CBOM_ABSENT,
+    CBOM_DOWNGRADE,
+    CBOM_MISMATCH,
+    CBOM_OK,
+    crypto_posture_for,
+    verify_crypto_posture,
+)
 from vaara.attestation._receipt_types import (
     BackLink,
+    CryptoAlgorithm,
+    CryptoPosture,
     ExecutionReceipt,
     OutcomeDerived,
     PqSignature,
@@ -298,6 +308,14 @@ __all__ = [
     "IngestReceipt",
     "emit_ingest_receipt",
     "verify_ingest_signature",
+    "CryptoAlgorithm",
+    "CryptoPosture",
+    "CBOM_OK",
+    "CBOM_ABSENT",
+    "CBOM_MISMATCH",
+    "CBOM_DOWNGRADE",
+    "crypto_posture_for",
+    "verify_crypto_posture",
     "DidDocumentCache",
     "EvidenceBundle",
     "ExecutionReceipt",

--- a/tests/test_receipt_cbom.py
+++ b/tests/test_receipt_cbom.py
@@ -1,0 +1,314 @@
+"""CycloneDX-CBOM crypto-posture derivation and verification (v0).
+
+Covers ``crypto_posture_for`` derivation (classical / HS256 keyed-MAC / hybrid),
+the effective NIST post-quantum level, the closed-schema serialization
+round-trips and rejections, the ``verify_crypto_posture`` verdicts (ok / absent
+/ mismatch / downgrade), the preimage binding (tampering the block breaks the
+signature), and an independent recompute of the CBOM block from the receipt
+wire bytes using only the published algorithm-to-level table.
+
+See ``docs/design/cbom-crypto-posture-spec.md``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from vaara.attestation._receipt_cbom import (
+    CBOM_ABSENT,
+    CBOM_DOWNGRADE,
+    CBOM_MISMATCH,
+    CBOM_OK,
+    crypto_posture_for,
+    verify_crypto_posture,
+)
+from vaara.attestation._receipt_types import (
+    BackLink,
+    CryptoAlgorithm,
+    ExecutionReceipt,
+    OutcomeDerived,
+    PqSignature,
+    ReceiptAsserted,
+    crypto_posture_from_dict,
+    crypto_posture_to_dict,
+    receipt_asserted_from_dict,
+    receipt_asserted_to_dict,
+)
+from vaara.attestation._sep2787_types import AttestationError
+
+
+def _receipt(*, alg="ES256", sig_suite=None, crypto_posture=None, pq=False):
+    """A structurally valid receipt for verdict tests. Signature is a stub;
+    ``verify_crypto_posture`` is pure recomputation and never touches it."""
+    ra = ReceiptAsserted(
+        iss="did:web:issuer.example",
+        sub="tenant/upstream",
+        iat="2026-07-02T00:00:00Z",
+        nonce="n" * 16,
+        secret_version="k1",
+        alg=alg,
+        sig_suite=sig_suite,
+        crypto_posture=crypto_posture,
+    )
+    back_link = BackLink(
+        attestation_digest="sha256:" + "0" * 64, attestation_nonce="a" * 16
+    )
+    outcome = OutcomeDerived(status="executed", completed_at="2026-07-02T00:00:01Z")
+    pq_sig = (
+        PqSignature(alg="ML-DSA-65", keyid="did:web:issuer.example#pq", sig="ab")
+        if pq
+        else None
+    )
+    return ExecutionReceipt(
+        version=1,
+        alg=alg,
+        back_link=back_link,
+        receipt_asserted=ra,
+        outcome_derived=outcome,
+        signature="00",
+        pq_signature=pq_sig,
+    )
+
+
+# --- derivation -----------------------------------------------------------
+
+
+def test_derive_classical_es256():
+    p = crypto_posture_for(alg="ES256")
+    assert p.asset_type == "algorithm"
+    assert p.nist_quantum_security_level == 0
+    assert p.algorithms == (
+        CryptoAlgorithm(
+            algorithm="ES256", primitive="signature", nist_quantum_security_level=0
+        ),
+    )
+
+
+def test_derive_hs256_is_mac_primitive():
+    p = crypto_posture_for(alg="HS256")
+    assert p.algorithms[0].primitive == "mac"
+    assert p.nist_quantum_security_level == 0
+
+
+def test_derive_hybrid_reaches_mldsa_level():
+    p = crypto_posture_for(alg="ES256", sig_suite="ES256+ML-DSA-65")
+    assert [a.algorithm for a in p.algorithms] == ["ES256", "ML-DSA-65"]
+    assert p.algorithms[1].nist_quantum_security_level == 3
+    # Effective level is the max: the ML-DSA leg carries quantum resistance.
+    assert p.nist_quantum_security_level == 3
+
+
+def test_derive_unknown_alg_fails_closed():
+    with pytest.raises(AttestationError):
+        crypto_posture_for(alg="XYZ999")
+
+
+def test_derive_unknown_suite_fails_closed():
+    with pytest.raises(AttestationError):
+        crypto_posture_for(alg="ES256", sig_suite="ES256+NOPE")
+
+
+def test_derive_suite_alg_disagreement_fails_closed():
+    # sigSuite's classical member (ES256) must equal the receipt alg (RS256).
+    with pytest.raises(AttestationError):
+        crypto_posture_for(alg="RS256", sig_suite="ES256+ML-DSA-65")
+
+
+# --- serialization --------------------------------------------------------
+
+
+@pytest.mark.parametrize("sig_suite", [None, "ES256+ML-DSA-65"])
+def test_posture_roundtrips(sig_suite):
+    p = crypto_posture_for(alg="ES256", sig_suite=sig_suite)
+    assert crypto_posture_from_dict(crypto_posture_to_dict(p)) == p
+
+
+def test_from_dict_rejects_unknown_key():
+    d = crypto_posture_to_dict(crypto_posture_for(alg="ES256"))
+    d["extra"] = "nope"
+    with pytest.raises(AttestationError):
+        crypto_posture_from_dict(d)
+
+
+def test_from_dict_rejects_bad_asset_type():
+    d = crypto_posture_to_dict(crypto_posture_for(alg="ES256"))
+    d["assetType"] = "certificate"
+    with pytest.raises(AttestationError):
+        crypto_posture_from_dict(d)
+
+
+def test_from_dict_rejects_bool_level():
+    # bool is an int subclass; True must not slip through as level 1.
+    d = crypto_posture_to_dict(crypto_posture_for(alg="ES256"))
+    d["nistQuantumSecurityLevel"] = True
+    with pytest.raises(AttestationError):
+        crypto_posture_from_dict(d)
+
+
+@pytest.mark.parametrize("level", [-1, 6, 42])
+def test_from_dict_rejects_out_of_range_level(level):
+    d = crypto_posture_to_dict(crypto_posture_for(alg="ES256"))
+    d["nistQuantumSecurityLevel"] = level
+    with pytest.raises(AttestationError):
+        crypto_posture_from_dict(d)
+
+
+def test_from_dict_rejects_empty_algorithms():
+    d = crypto_posture_to_dict(crypto_posture_for(alg="ES256"))
+    d["algorithms"] = []
+    with pytest.raises(AttestationError):
+        crypto_posture_from_dict(d)
+
+
+def test_receipt_asserted_carries_posture_through_serialization():
+    posture = crypto_posture_for(alg="ES256", sig_suite="ES256+ML-DSA-65")
+    ra = _receipt(
+        alg="ES256", sig_suite="ES256+ML-DSA-65", crypto_posture=posture
+    ).receipt_asserted
+    wire = receipt_asserted_to_dict(ra)
+    assert wire["cryptoPosture"]["nistQuantumSecurityLevel"] == 3
+    assert receipt_asserted_from_dict(wire) == ra
+
+
+def test_receipt_asserted_without_posture_omits_key():
+    # Absent posture keeps the envelope byte-for-byte what it was before.
+    ra = _receipt(alg="ES256").receipt_asserted
+    assert "cryptoPosture" not in receipt_asserted_to_dict(ra)
+
+
+# --- verdicts -------------------------------------------------------------
+
+
+def test_verify_absent_when_no_posture():
+    assert verify_crypto_posture(_receipt(alg="ES256")) == CBOM_ABSENT
+
+
+def test_verify_ok_classical():
+    posture = crypto_posture_for(alg="ES256")
+    assert (
+        verify_crypto_posture(_receipt(alg="ES256", crypto_posture=posture))
+        == CBOM_OK
+    )
+
+
+def test_verify_ok_hybrid_with_pq_signature():
+    posture = crypto_posture_for(alg="ES256", sig_suite="ES256+ML-DSA-65")
+    r = _receipt(
+        alg="ES256", sig_suite="ES256+ML-DSA-65", crypto_posture=posture, pq=True
+    )
+    assert verify_crypto_posture(r) == CBOM_OK
+
+
+def test_verify_downgrade_when_pq_signature_stripped():
+    posture = crypto_posture_for(alg="ES256", sig_suite="ES256+ML-DSA-65")
+    r = _receipt(
+        alg="ES256", sig_suite="ES256+ML-DSA-65", crypto_posture=posture, pq=False
+    )
+    assert verify_crypto_posture(r) == CBOM_DOWNGRADE
+
+
+def test_verify_mismatch_when_quantum_claim_inflated():
+    # Posture asserts an ML-DSA leg, but no sigSuite commits it: the recomputed
+    # (classical-only) posture differs, so the inflated claim is caught.
+    inflated = crypto_posture_for(alg="ES256", sig_suite="ES256+ML-DSA-65")
+    r = _receipt(alg="ES256", sig_suite=None, crypto_posture=inflated, pq=True)
+    assert verify_crypto_posture(r) == CBOM_MISMATCH
+
+
+def test_verify_mismatch_when_level_tampered():
+    posture = crypto_posture_for(alg="ES256")
+    tampered = dataclasses.replace(posture, nist_quantum_security_level=3)
+    r = _receipt(alg="ES256", crypto_posture=tampered)
+    assert verify_crypto_posture(r) == CBOM_MISMATCH
+
+
+# --- independent recompute (Vaara-free reconstruction) --------------------
+
+# The published algorithm-to-level table, restated here with NO Vaara import so
+# the recompute is genuinely independent: a third party reconstructs the CBOM
+# block from the receipt's alg + sigSuite and this public table alone.
+_PUBLISHED_TABLE = {
+    "HS256": ("mac", 0),
+    "ES256": ("signature", 0),
+    "RS256": ("signature", 0),
+    "Ed25519": ("signature", 0),
+    "ML-DSA-65": ("signature", 3),
+}
+
+
+def _independent_posture(receipt_asserted_wire):
+    """Rebuild the expected cryptoPosture dict from the wire, Vaara-free."""
+    alg = receipt_asserted_wire["alg"]
+    algs = [alg]
+    suite = receipt_asserted_wire.get("sigSuite")
+    if suite is not None:
+        members = suite.split("+")
+        assert members[0] == alg, "suite classical member must equal alg"
+        algs = members
+    entries = []
+    for a in algs:
+        primitive, level = _PUBLISHED_TABLE[a]
+        entries.append(
+            {
+                "algorithm": a,
+                "primitive": primitive,
+                "nistQuantumSecurityLevel": level,
+            }
+        )
+    return {
+        "assetType": "algorithm",
+        "nistQuantumSecurityLevel": max(
+            e["nistQuantumSecurityLevel"] for e in entries
+        ),
+        "algorithms": entries,
+    }
+
+
+@pytest.mark.parametrize("sig_suite", [None, "ES256+ML-DSA-65"])
+def test_independent_recompute_matches_committed_posture(sig_suite):
+    posture = crypto_posture_for(alg="ES256", sig_suite=sig_suite)
+    ra_wire = receipt_asserted_to_dict(
+        _receipt(
+            alg="ES256", sig_suite=sig_suite, crypto_posture=posture
+        ).receipt_asserted
+    )
+    assert ra_wire["cryptoPosture"] == _independent_posture(ra_wire)
+
+
+# --- preimage binding (needs the JCS/rfc8785 signing path) ----------------
+
+
+def test_posture_is_inside_preimage_and_tamper_breaks_signature():
+    pytest.importorskip("rfc8785")
+    from vaara.attestation.receipt import emit_receipt, verify_receipt_signature
+
+    secret = b"a-shared-secret-32-bytes-long!!!"
+    posture = crypto_posture_for(alg="HS256")
+    template = _receipt()
+
+    receipt = emit_receipt(
+        back_link=template.back_link,
+        outcome_derived=template.outcome_derived,
+        iss="did:web:issuer.example",
+        sub="tenant/upstream",
+        secret_version="k1",
+        alg="HS256",
+        signing_material=secret,
+        crypto_posture=posture,
+    )
+    assert receipt.receipt_asserted.crypto_posture == posture
+    assert "cryptoPosture" in receipt.to_dict()["receiptAsserted"]
+    assert verify_receipt_signature(receipt, verifying_material=secret) is True
+
+    # Editing the committed posture must invalidate the signature: proof the
+    # block rides inside the signed preimage, not outside it.
+    tampered_posture = dataclasses.replace(
+        posture, nist_quantum_security_level=3
+    )
+    tampered_ra = dataclasses.replace(
+        receipt.receipt_asserted, crypto_posture=tampered_posture
+    )
+    tampered = dataclasses.replace(receipt, receipt_asserted=tampered_ra)
+    assert verify_receipt_signature(tampered, verifying_material=secret) is False


### PR DESCRIPTION
Adds an optional per-receipt CycloneDX-CBOM crypto-posture block.

`receiptAsserted.cryptoPosture` records, inside the signed preimage, which signature algorithms protect a receipt and the NIST post-quantum security level they reach. An auditor reads the record's quantum resistance from the signed bytes alone, in the CBOM (ECMA-424) vocabulary their tooling already speaks.

- Committed inside `receiptAsserted`, next to `sigSuite`, so the signature covers it. A stripped ML-DSA leg or an inflated quantum-resistance claim is recomputable from the signed record.
- `crypto_posture_for(alg, sig_suite)` derives the block from a closed algorithm-to-level table (ML-DSA-65 is NIST Category 3, the classical suites are 0) and fails closed on an unknown algorithm or suite.
- `verify_crypto_posture(receipt)` recomputes the expected posture with no keying material and returns one of `crypto_posture_ok`, `crypto_posture_absent`, `crypto_posture_mismatch`, `crypto_posture_downgrade`, reproducible by an independent checker offline.
- Additive and optional: classical receipts are byte-for-byte unchanged and every existing vector verifies as before.

Tests: `tests/test_receipt_cbom.py` covers derivation, closed-schema serialization, the four verdicts, the preimage binding, and an independent Vaara-free recompute. Spec: `docs/design/cbom-crypto-posture-spec.md`.