### PR TITLE
docs: add CITATION.cff and specification citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+title: Vaara
+message: >-
+  If you use Vaara, please cite this repository and the
+  specification it implements.
+type: software
+authors:
+  - family-names: Sirkkavaara
+    given-names: Henri
+    email: hello@vaara.io
+repository-code: https://github.com/vaaraio/vaara
+url: https://vaara.io
+license: AGPL-3.0-or-later
+references:
+  - type: standard
+    title: >-
+      The Vaara Receipt: A Recomputable Receipt Format for
+      Decisions About Agent Actions
+    authors:
+      - family-names: Sirkkavaara
+        given-names: Henri
+    institution:
+      name: Internet Engineering Task Force (IETF)
+    number: draft-sirkkavaara-vaara-receipt-04
+    url: https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/

--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capabilit
 
 Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.
 
+## Citation
+
+If you build on Vaara or its receipt format, cite the repository (see [CITATION.cff](CITATION.cff)) and the specification it implements:
+
+Henri Sirkkavaara. *The Vaara Receipt: A Recomputable Receipt Format for Decisions About Agent Actions.* IETF Internet-Draft [draft-sirkkavaara-vaara-receipt](https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/).
+
 ## License
 
 Copyright © 2026 Henri Sirkkavaara. Licensed under AGPL-3.0-or-later. See [LICENSE](LICENSE).


### PR DESCRIPTION
Adds a CITATION.cff (GitHub renders a Cite this repository box from it) and a short Citation section in the README, binding the author and the IETF Internet-Draft draft-sirkkavaara-vaara-receipt to the repository as structured provenance. Docs only; no code or behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added citation metadata for the project, making it easier to reference the repository in academic and professional work.
  * Expanded the README with a new citation section, including guidance on how to cite the project and its related specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->