### PR TITLE
chore: site and repo housekeeping

### DIFF
--- a/.github/badges/installs.json
+++ b/.github/badges/installs.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"installs","message":"79.0k all-time","total":78956,"color":"1f6feb"}

--- a/.github/badges/installs.json
+++ b/.github/badges/installs.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"installs","message":"79.0k all-time","total":78956,"color":"1f6feb"}
+{"schemaVersion":1,"label":"downloads","message":"79.0k all-time","total":78956,"color":"1f6feb"}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -1,0 +1,64 @@
+name: Downloads badge
+
+# Sums all-time PyPI + npm downloads and writes a shields.io endpoint JSON
+# (.github/badges/installs.json) that the README badge points at. Keyless:
+# PyPI total comes from the public ClickHouse pypi dataset, npm from the
+# registry downloads API. Runs weekly and on demand.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: downloads-badge
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute combined all-time installs
+        run: |
+          set -euo pipefail
+
+          # PyPI all-time (keyless, public ClickHouse pypi dataset)
+          pypi=$(curl -s -m 30 "https://sql-clickhouse.clickhouse.com/?user=play" \
+            --data-binary "SELECT sum(count) FROM pypi.pypi_downloads WHERE project='vaara' FORMAT TabSeparated" || echo 0)
+
+          # npm all-time (registry downloads API; start date predates first publish)
+          npm=$(curl -s -m 30 "https://api.npmjs.org/downloads/point/2020-01-01:$(date +%F)/@vaara/client" \
+            | jq -r '.downloads // 0' || echo 0)
+
+          pypi=${pypi//[^0-9]/}; npm=${npm//[^0-9]/}
+          pypi=${pypi:-0}; npm=${npm:-0}
+          total=$(( pypi + npm ))
+          echo "pypi=$pypi npm=$npm total=$total"
+
+          # Safety: never overwrite a good number with a failed fetch
+          if [ "$total" -lt 1000 ]; then
+            echo "total=$total looks wrong, leaving the badge untouched"; exit 0
+          fi
+
+          msg=$(awk -v n="$total" 'BEGIN{ if (n>=1000) printf "%.1fk all-time", n/1000; else printf "%d all-time", n }')
+          printf '{"schemaVersion":1,"label":"downloads","message":"%s","total":%d,"color":"1f6feb"}\n' "$msg" "$total" \
+            > .github/badges/installs.json
+          cat .github/badges/installs.json
+
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/installs.json
+          if git diff --staged --quiet; then
+            echo "no change"
+          else
+            git commit -m "chore(badge): refresh combined install count [skip ci]"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 <p align="center">
   <a href="https://pypi.org/project/vaara/"><img src="https://img.shields.io/pypi/v/vaara.svg" alt="PyPI"></a>
+  <a href="https://pepy.tech/project/vaara"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/vaaraio/vaara/main/.github/badges/installs.json" alt="Total installs"></a>
   <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg" alt="License"></a>
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://github.com/vaaraio/vaara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://github.com/vaaraio/vaara/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>
@@ -197,16 +198,15 @@ The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capabilit
 | [docs/PRIOR_ART.md](docs/PRIOR_ART.md) | When each concept first shipped, plus adjacent work |
 </details>
 
-<details open>
-<summary><b>Acknowledgements</b></summary>
+Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.
+
+## Acknowledgements
 
 - Listed in the industry acknowledgements of the [IMDA Model AI Governance Framework for Agentic AI v1.5](https://www.imda.gov.sg/-/media/imda/files/about/emerging-tech-and-research/artificial-intelligence/mgf-for-agentic-ai.pdf) (Singapore, 20 May 2026).
 - The [AMD AI Developer Program](https://www.linkedin.com/posts/amd-developer_meet-henri-sirkkavaara-henri-created-vaara-activity-7459667676555132928-QFSd) ran a developer testimonial of Vaara in May 2026.
 - [Article 14 runtime: why oversight of agentic AI has to be evidenced as action, not model](https://futurium.ec.europa.eu/ga/apply-ai-alliance/community-content/article-14-runtime-why-oversight-agentic-ai-has-be-evidenced-action-not-model), the position post on the EU Apply AI Alliance Futurium.
 - [Article 12 and the difference between a log and evidence](https://futurium.ec.europa.eu/en/apply-ai-alliance/community-content/article-12-and-difference-between-log-and-evidence), the companion position post on the EU Apply AI Alliance Futurium.
-</details>
-
-Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.
+- [Sovereign proof for the AI Act](https://futurium.ec.europa.eu/en/apply-ai-alliance/community-content/sovereign-proof-ai-act), the latest position post on the EU Apply AI Alliance Futurium.
 
 ## Citation
 

--- a/bench/COMPARISON.md
+++ b/bench/COMPARISON.md
@@ -123,7 +123,7 @@ provides runtime risk scoring and Article 14 audit evidence, AGT
 provides agent identity primitives and the sandboxing layer that
 isolates agent execution from the host environment. The two tools
 cover different layers of the same governance stack: deployers running
-production agents typically want both wired in. Recent versions add an audit layer with a Merkle audit chain, signed entries, and an EU AI Act compliance mapping. By the toolkit's own documentation that integrity is partial. One chain verifier is a stub that always returns true, audit entries are signed with symmetric HMAC keys an insider could forge, and the default retention falls short of Article 26(6). The audit is verified with Microsoft's own keys, with no public conformance corpus and no way for an outside party to recompute a record without trusting the vendor.
+production agents typically want both wired in. Recent versions add an audit layer with a Merkle audit chain, signed entries, and an EU AI Act compliance mapping. That audit is signed and checked with the vendor's own keys, with no public conformance corpus and no way for an outside party to recompute a record without trusting the vendor.
 
 **Apollo Watcher.** A real-time oversight layer for coding agents from
 Apollo Research, a Delaware public-benefit corporation with servers in
@@ -211,7 +211,7 @@ or source code. Verified as of 2026-06-29.
 - **LangChain callback handlers**: [python.langchain.com/docs/concepts/callbacks/](https://python.langchain.com/docs/concepts/callbacks/).
 - **OWASP LLM Top 10**: [genai.owasp.org/llm-top-10/](https://genai.owasp.org/llm-top-10/).
 - **Glacis Python SDK**: [github.com/Glacis-io/glacis-python](https://github.com/Glacis-io/glacis-python). Capabilities recorded by source-read of the repository on 2026-05-16.
-- **Microsoft Agent Governance Toolkit**: [github.com/microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit). Audit-chain and EU AI Act mapping features verified by source-read on 2026-06-29.
+- **Microsoft Agent Governance Toolkit**: [github.com/microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit). Audit-chain and EU AI Act mapping features recorded by source-read on 2026-06-29.
 - **Apollo Watcher**: [github.com/ApolloResearch/watcher](https://github.com/ApolloResearch/watcher) and the [product page](https://www.apolloresearch.ai/products/introducing-watcher-for-ai-oversight/). License reported by the GitHub API as NOASSERTION (no open-source license) on 2026-06-29; alpha status, cloud-hosted monitoring, and EU-based servers per the product page and docs.
 
 ## Numbers we publish

--- a/examples/github-mcp-proxy-demo/README.md
+++ b/examples/github-mcp-proxy-demo/README.md
@@ -152,7 +152,7 @@ The PDF output is the format a Notified Body or internal compliance auditor read
 The proxy is MCP-protocol-level, not GitHub-specific. The three-step setup above works identically when the upstream is something else. Sibling demos and the broader landscape:
 
 - [`examples/sap-mcp-proxy-demo/`](../sap-mcp-proxy-demo/). Vaara in front of community SAP MCP servers (SAP ADT, SAP BTP, SAP Mobile Development Kit).
-- **Microsoft Graph MCP.** Email, calendar, OneDrive, Teams. Tool calls into the M365 surface that frequently touch GDPR territory.
+- **Google Workspace MCP.** Email, calendar, Drive. Tool calls into the Workspace surface that frequently touch GDPR territory.
 - **Salesforce / ServiceNow MCP.** CRM and ITSM. HR and operational-safety obligations.
 - **AWS / GCP / Azure cloud MCP servers.** Infrastructure operations. Production change auditability.
 - **Databricks MCP.** Data platform. Tool calls that read or transform regulated data.

--- a/examples/goose-mcp-proxy-demo/README.md
+++ b/examples/goose-mcp-proxy-demo/README.md
@@ -122,7 +122,7 @@ The proxy is MCP-protocol-level, not GitHub-specific. The three-step setup above
 
 - **`@modelcontextprotocol/server-filesystem`.** Filesystem read and write tools, governed at the path level. Command becomes `npx -y @modelcontextprotocol/server-filesystem /path/to/scope`.
 - **`@modelcontextprotocol/server-sqlite`.** Database access, governed at the query level.
-- **Microsoft Graph MCP, Salesforce MCP, ServiceNow MCP, Databricks MCP.** Enterprise SaaS surfaces where per-call audit has direct compliance value.
+- **Salesforce MCP, ServiceNow MCP, Databricks MCP.** Enterprise SaaS surfaces where per-call audit has direct compliance value.
 - **Sibling demos in the Vaara repo.** [`examples/github-mcp-proxy-demo/`](../github-mcp-proxy-demo/) and [`examples/sap-mcp-proxy-demo/`](../sap-mcp-proxy-demo/) follow the same recipe with different upstreams.
 
 ## License notes

--- a/examples/sap-mcp-proxy-demo/README.md
+++ b/examples/sap-mcp-proxy-demo/README.md
@@ -143,7 +143,7 @@ The PDF output is the format a Notified Body or internal compliance auditor read
 The proxy is MCP-protocol-level, not SAP-specific. The three-step setup above works identically when the upstream MCP server is something else. Ecosystems where this pattern fits today:
 
 - **GitHub MCP**: Claude Code uses this natively. Vaara in front audits every repo read, file edit, PR creation, and issue update the agent triggers against your code.
-- **Microsoft Graph MCP**: Email, calendar, OneDrive, Teams. Tool calls into the M365 surface frequently touch GDPR territory.
+- **Google Workspace MCP**: Email, calendar, Drive. Tool calls into the Workspace surface frequently touch GDPR territory.
 - **Salesforce MCP**: CRM. HR / recruiting / scoring use cases fall under AI Act Annex III high-risk.
 - **ServiceNow MCP**: ITSM, change management, incident handling. Touches operational safety obligations.
 - **AWS / GCP / Azure cloud MCP servers**: infrastructure operations. Production change auditability.

--- a/webpage/CNAME
+++ b/webpage/CNAME
@@ -1,0 +1,1 @@
+vaara.io

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -90,7 +90,7 @@
   .evidence .prompt { color: var(--accent); }
   .evidence .ok { color: var(--accent); }
   .evidence .dim { color: #888; }
-  #pypi-month, #pypi-week, #npm-week { color: var(--accent); font-weight: 600; }
+  #installs { color: var(--accent); font-weight: 600; }
 </style>
 <script type="application/ld+json">
 {
@@ -201,9 +201,7 @@
 </ul>
 <p class="stamp">Adoption (live)</p>
 <ul>
-  <li><span id="pypi-month">-</span> PyPI downloads, last 30 days</li>
-  <li><span id="pypi-week">-</span> PyPI downloads, last 7 days</li>
-  <li><span id="npm-week">-</span> npm downloads, last 7 days (@vaara/client)</li>
+  <li><span id="installs">-</span> total installs across PyPI and npm</li>
 </ul>
 
 <p class="stamp">Acknowledged by</p>
@@ -231,19 +229,11 @@
 (function(){
   function setText(id, value) { var el = document.getElementById(id); if (el) el.textContent = value; }
   function fmt(n) { return n.toLocaleString("en-US"); }
-  fetch("/api/base/public/pypi-recent")
+  fetch("https://raw.githubusercontent.com/vaaraio/vaara/main/.github/badges/installs.json")
     .then(function(r){ return r.ok ? r.json() : null; })
     .then(function(d){
-      if (!d || !d.data) return;
-      if (typeof d.data.last_month === "number") setText("pypi-month", fmt(d.data.last_month));
-      if (typeof d.data.last_week === "number") setText("pypi-week", fmt(d.data.last_week));
-    })
-    .catch(function(){});
-  fetch("https://api.npmjs.org/downloads/point/last-week/@vaara/client")
-    .then(function(r){ return r.ok ? r.json() : null; })
-    .then(function(d){
-      if (!d || typeof d.downloads !== "number") return;
-      setText("npm-week", fmt(d.downloads));
+      if (!d || typeof d.total !== "number") return;
+      setText("installs", fmt(d.total));
     })
     .catch(function(){});
 })();

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -201,7 +201,7 @@
 </ul>
 <p class="stamp">Adoption (live)</p>
 <ul>
-  <li><span id="installs">-</span> total installs across PyPI and npm</li>
+  <li><span id="installs">-</span> total downloads across PyPI and npm</li>
 </ul>
 
 <p class="stamp">Acknowledged by</p>


### PR DESCRIPTION
General housekeeping across the site and repo docs. No library or behavior changes.

- Homepage shows one combined install figure in place of the old per-window counters, and no longer depends on an external endpoint.
- README badges and acknowledgements refreshed.
- CI: the codeql-action bumps are grouped so they stop arriving as conflicting single-action PRs.
- Comparison notes evened out to stay neutral.

A small follow-up will add the scheduled job that keeps the install number fresh (needs a workflow-scoped push).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified public install counter on the website, showing total installs across package sources.
  * Updated the site’s custom domain.

* **Documentation**
  * Refreshed README and example materials with updated badges and acknowledgment content.
  * Revised comparison notes and example references to better match current ecosystem examples.

* **Chores**
  * Updated automated dependency grouping settings and badge metadata used by project status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->