### PR TITLE
chore: surface the downloads badge and sync the MCP manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 </p>
 
 <p align="center">
+  <a href="https://pepy.tech/project/vaara"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/vaaraio/vaara/main/.github/badges/installs.json" alt="Downloads"></a>
   <a href="https://pypi.org/project/vaara/"><img src="https://img.shields.io/pypi/v/vaara.svg" alt="PyPI"></a>
-  <a href="https://pepy.tech/project/vaara"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/vaaraio/vaara/main/.github/badges/installs.json" alt="Total installs"></a>
   <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg" alt="License"></a>
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://github.com/vaaraio/vaara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://github.com/vaaraio/vaara/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.20.0",
+  "version": "1.23.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.20.0",
+      "version": "1.23.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Two small follow-ups from the housekeeping pass:

- Downloads badge moved to the front of the badge row so it reads first.
- server.json bumped to 1.23.1 so the repo manifest matches the published version (PyPI, npm, and the MCP registry are all 1.23.1).