### PR TITLE
feat(audit): multi-agent delegation attribution and privilege attenuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.24.0] - 2026-07-10
+
+Minor release: multi-agent delegation attribution and delegated-privilege attenuation. Additive and backward-compatible; existing single-agent behaviour and the audit schema wire format are unchanged.
+
+- Delegation-chain reconstruction: `vaara.audit.delegation` walks the hash-covered `parent_action_id` edge already recorded on each request into the full delegation chain (`chain_for`, `descendants`, `root_of`, `depth_of`). Reconstruction is defensive against dangling parents and cycles. Because the edge is hash-covered, tampering with a delegation link breaks `verify_chain()`. `AuditTrail.snapshot()` is added as the read accessor.
+- Delegated-privilege attenuation: `vaara.credential.capability_subsumes` and `chain_is_attenuating` decide whether a child capability grant permits a subset of what its parent grant permits, so authority cannot grow down a delegation chain. The check is sound and fail-closed: it never approves a broadening.
+- Runtime enforcement: `Pipeline.intercept(capabilities=...)` denies, fail-closed, any child action whose grant broadens the grant of the parent that delegated to it, regardless of risk score, and records the denial in the audit trail. With no capabilities the behaviour is unchanged. The credential import is lazy, so a base install without the attestation extra is unaffected.
+- OWASP Top 10 for Agentic Applications 2026 mapping updated (ASI03, ASI07, ASI08) and the audit event schema now documents the delegation keys.
+
 ## [1.23.1] - 2026-07-07
 
 Patch: robustness fixes to the 1.23.0 verification-hardening surfaces, from post-release review.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.23.1",
+  "version": "1.24.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/OWASP_AGENTIC.md
+++ b/docs/OWASP_AGENTIC.md
@@ -43,12 +43,12 @@ classes, OVERT 1.0 Part 3 names enforcement controls.
 |---|---|---|
 | ASI01 Agent Goal Hijack | ◐ | Intercept boundary, classifier, audit chain, OVERT envelope |
 | ASI02 Tool Misuse and Exploitation | ✅ | Policy DSL, intercept boundary, audit chain, commit-prove receipts |
-| ASI03 Identity and Privilege Abuse | ◐ | Caller identity in audit, taxonomy scopes, review queue |
+| ASI03 Identity and Privilege Abuse | ◐ | Caller identity in audit, taxonomy scopes, review queue, delegation-chain reconstruction |
 | ASI04 Agentic Supply Chain Vulnerabilities | ◐ | SLSA provenance, Sigstore signing, ClusterFuzzLite, policy hash binding |
 | ASI05 Unexpected Code Execution (RCE) | ◐ | Policy DSL allowlists, intercept-time approval gates |
 | ASI06 Memory and Context Poisoning | ◯ | Adaptive scorer drift signal only |
 | ASI07 Insecure Inter-Agent Communication | ◐ | OVERT signing per call, audit chain integrity |
-| ASI08 Cascading Failures | ◐ | Hash-chained audit, circuit breakers, FACI drift signal |
+| ASI08 Cascading Failures | ◐ | Hash-chained audit, delegation lineage, circuit breakers, FACI drift signal |
 | ASI09 Human-Agent Trust Exploitation | ◐ | Conformal interval, signed narratives, escalation queue |
 | ASI10 Rogue Agents | ◐ | Hash-chained audit, per-agent identity, drift signals |
 
@@ -127,18 +127,37 @@ agent context.
   routes `ESCALATE` verdicts, records `ESCALATION_RESOLVED` events
   with reviewer identity, timestamp, decision.
 - ◐ Enforce Task-Scoped, Time-Bound Permissions: policy DSL declares
-  per-tool scopes. Vaara does not issue or rotate the tokens.
+  per-tool scopes, and `vaara.credential.capability_subsumes` /
+  `chain_is_attenuating` verify delegated-privilege attenuation — a
+  child grant must permit a subset of what its parent grant permits, so
+  authority provably never grows down a delegation chain (checked
+  against the reconstructed chain from `vaara.audit.delegation`). The
+  check is sound and fail-closed: it never approves a broadening.
+  `Pipeline.intercept(capabilities=...)` enforces this at runtime — a
+  child action whose grant broadens the delegating parent's grant is
+  denied and audited regardless of risk score. Vaara still does not
+  issue or rotate the underlying tokens.
 - ◐ Isolate Agent Identities and Contexts: Vaara records active
   `agent_id` per call. Memory segmentation is a deployer
   architecture choice.
+- ✅ Reconstruct and verify delegation chains: `parent_action_id` is
+  recorded per action inside the hash-covered audit `data`, and
+  `vaara.audit.delegation` walks those edges into the full delegation
+  chain (`chain_for`, `descendants`, `root_of`, `depth_of`).
+  Manipulating a delegation edge after the fact — forging who
+  authorized a downstream action — changes the record's `data` and
+  breaks `verify_chain()`, so delegation-chain tampering is detectable
+  rather than silent.
 - ◐ Define Intent, bind tokens to signed intent: partial via OVERT
   Base Envelope. External OAuth token binding is deployer-owned.
 - ◯ Evaluate Agentic Identity Management Platforms (Entra, Bedrock
   Agents, Agentforce): deployer concern.
 
 **Deployer-owned:** identity provider, token issuance and rotation,
-per-session memory segmentation, federated delegation chain
-integrity.
+per-session memory segmentation. (Federated delegation-chain integrity
+is now reconstructable and tamper-evident via the hash-covered
+`parent_action_id` edge; live identity binding of each hop still relies
+on the deployer's IdP.)
 
 ## ASI04 Agentic Supply Chain Vulnerabilities ◐
 
@@ -241,6 +260,11 @@ downgrade, and descriptor forgery.
 - ◐ Agent-aware anti-replay (nonces, session identifiers,
   timestamps): the audit chain carries timestamps and per-record
   hash. Dedicated session nonces are deployer concern.
+- ◐ Inter-agent hand-off provenance: the `parent_action_id` edge ties
+  each agent's action to the delegator inside the hash-covered trail,
+  so a hand-off between agents is reconstructable and tamper-evident
+  after the fact (`vaara.audit.delegation`). Live channel
+  authentication (mTLS, signed agent cards) remains deployer-owned.
 - ◐ Discovery and routing protection (authenticate discovery using
   cryptographic identity): OVERT Base Envelope carries the
   governing Vaara instance identity. Cross-agent discovery is
@@ -280,6 +304,11 @@ into system-wide harm.
   cryptographic agent identities with lineage metadata: exactly the
   hash-chained `AuditTrail`, OVERT Base Envelope, and Article 12
   commit-prove receipt pair.
+- ✅ Fault lineage and blast radius: `vaara.audit.delegation`
+  reconstructs the delegation forest from the tamper-evident trail, so
+  a fault's downstream spread is enumerable (`descendants`) and its
+  origin traceable (`root_of`). Lineage is a queryable structure, not
+  just per-record metadata.
 - ◐ JIT one-time tool access with runtime checks: the intercept is
   the runtime check. JIT credential issuance is deployer-owned.
 - ◐ Blast-radius guardrails (quotas, progress caps, circuit

--- a/docs/audit_event_schema.md
+++ b/docs/audit_event_schema.md
@@ -111,7 +111,10 @@ after the fact breaks chain verification.
 `event_type` is non-exhaustive at 1.0 (consumers MUST accept unknown
 keys). Reserved top-level keys:
 
-- `action_requested`: `action_request` (object), `context` (object, optional).
+- `action_requested`: `parameters` (object), `context` (object, optional), and
+  the delegation keys `session_id` (string), `parent_action_id` (string or
+  null), `sequence_position` (integer). The delegation keys link this action
+  to the one that spawned it; see [§ Delegation linkage](#delegation-linkage).
 - `risk_scored`: `risk_score` (number in [0, 1]), `interval` (`[low, high]`), `classifier_version` (string), `contributing_signals` (array).
 - `decision_made`: `decision` (`allow` | `escalate` | `deny`), `threshold_set` (string), `verdict_inputs` (array).
 - `action_executed`: `executor` (string), `duration_ms` (number).
@@ -125,6 +128,32 @@ Caller-controlled strings in `data` (`agent_id`, `reason`,
 `override_reason`) MUST be treated as untrusted at narrative-rendering
 time. The hash chain still covers original values; the renderer
 sanitizes for display only.
+
+## Delegation linkage
+
+Multi-agent systems delegate: agent A's action spawns agent B's action, which
+spawns agent C's. The `action_requested` event carries that edge in three
+`data` keys:
+
+- `parent_action_id`: the `action_id` of the action that spawned this one, or
+  `null`/absent for a root action.
+- `session_id`: groups actions belonging to one agent session.
+- `sequence_position`: this action's ordinal within its session.
+
+`parent_action_id` is populated automatically by the LangChain integration
+(from `parent_run_id`) and by the MCP proxy (which tracks nested calls), or
+explicitly via `Pipeline.intercept(parent_action_id=...)`.
+
+Because these keys live inside `data`, they are covered by the hash chain (see
+[§ Hash chain](#hash-chain)). Rewriting a delegation edge after the fact —
+forging who authorized a downstream action — changes the record's `data` and
+therefore breaks `record_hash`, which `verify_chain()` detects. The edge is
+tamper-evident with no additional mechanism.
+
+A consumer reconstructs the delegation forest by walking `parent_action_id ->
+action_id`; the reference walker is `vaara.audit.delegation` (`chain_for`,
+`descendants`, `root_of`, `depth_of`). `root_action_id` and depth are computed
+from the walk, not stored, so no schema field is added for them.
 
 ## Numeric and string discipline
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.23.1"
+version = "1.24.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/scripts/demo_multiagent_attribution.py
+++ b/scripts/demo_multiagent_attribution.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Demo: reconstruct a multi-agent delegation chain and prove it can't be forged.
+
+Runs a three-agent chain through Vaara's governance pipeline:
+
+    planner (A)  ->  researcher (B)  ->  executor (C)
+
+The executor calls a high-blast-radius "production" tool. Vaara records every
+step in its hash-chained audit trail, carrying the delegation edge
+(parent_action_id) in the hash-covered data of each request.
+
+The demo then does two things no runtime-enforcement tool does:
+
+  1. Reconstructs the delegation chain from the trail — "who authorized the
+     production write?" answered as a single lineage, root to leaf.
+  2. Forges the authorization trail (rewrites who spawned the executor) and
+     shows Vaara's existing hash chain catch the tamper immediately.
+
+This is the evidence wedge: not blocking the action, but proving — after the
+fact, tamper-evidently — exactly who set it in motion.
+
+Run:  python scripts/demo_multiagent_attribution.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from vaara import Pipeline  # noqa: E402
+from vaara.audit.delegation import graph_from_trail  # noqa: E402
+from vaara.audit.trail import EventType  # noqa: E402
+from vaara.credential import Capability, chain_is_attenuating  # noqa: E402
+
+
+def _short(action_id: str) -> str:
+    return action_id[:8]
+
+
+def _render_tree(graph, action_id: str, indent: int = 0) -> None:
+    agent = graph.agent_of.get(action_id, "?")
+    tool = graph.tool_of.get(action_id, "?")
+    prefix = "    " * indent + ("└─ " if indent else "")
+    print(f"{prefix}{agent} :: {tool}  [{_short(action_id)}]")
+    for child in graph.children.get(action_id, []):
+        _render_tree(graph, child, indent + 1)
+
+
+def main() -> int:
+    pipe = Pipeline()
+
+    print("== 1. Three agents act, each delegating to the next ==\n")
+    a = pipe.intercept(agent_id="planner", tool_name="plan_incident_response",
+                       parameters={"ticket": "INC-4471"})
+    b = pipe.intercept(agent_id="researcher", tool_name="query_customer_db",
+                       parameters={"scope": "affected_accounts"},
+                       parent_action_id=a.action_id)
+    c = pipe.intercept(agent_id="executor", tool_name="update_production_record",
+                       parameters={"table": "accounts", "op": "write"},
+                       parent_action_id=b.action_id)
+    print(f"  planner    -> {_short(a.action_id)}  ({a.decision})")
+    print(f"  researcher -> {_short(b.action_id)}  ({b.decision})")
+    print(f"  executor   -> {_short(c.action_id)}  ({c.decision})")
+
+    graph = graph_from_trail(pipe.trail)
+
+    print("\n== 2. Reconstructed delegation tree ==\n")
+    for root in graph.roots():
+        _render_tree(graph, root)
+
+    print("\n== 3. Who authorized the production write? ==\n")
+    chain = graph.chain_for(c.action_id)
+    lineage = " -> ".join(
+        f"{graph.agent_of.get(aid, '?')}({_short(aid)})" for aid in chain
+    )
+    print(f"  {lineage}")
+    print(f"  depth: {graph.depth_of(c.action_id)} hops from root "
+          f"{graph.agent_of.get(graph.root_of(c.action_id), '?')}")
+    print(f"  blast radius of planner's action: "
+          f"{[graph.agent_of.get(x, '?') for x in graph.descendants(a.action_id)]}")
+
+    print("\n== 4. Try to forge the authorization trail ==\n")
+    print(f"  chain intact before tamper:  {pipe.trail.verify_chain() is None}")
+    target = next(
+        r for r in pipe.trail.snapshot()
+        if r.event_type == EventType.ACTION_REQUESTED
+        and r.data.get("parent_action_id") == b.action_id
+    )
+    print(f"  rewriting executor's parent {_short(b.action_id)} -> 'forged-authorizer'")
+    target.data["parent_action_id"] = "forged-authorizer"
+    err = pipe.trail.verify_chain()
+    print(f"  chain intact after tamper:   {err is None}")
+    print(f"  tamper caught:               {err is not None}")
+    if err is not None:
+        print(f"  verifier says: {err.splitlines()[0]}")
+
+    print("\nThe forged authorization did not survive the hash chain.")
+
+    # ── Second act: privilege cannot grow as it is delegated ──────────────
+    print("\n== 5. Delegated-privilege attenuation ==\n")
+    grants = {
+        a.action_id: (
+            Capability("amount", "le", "1000"),
+            Capability("vendor", "in", ("acme", "globex")),
+        ),
+        b.action_id: (  # researcher: narrower -> ok
+            Capability("amount", "le", "500"),
+            Capability("vendor", "eq", "acme"),
+        ),
+        c.action_id: (  # executor: tries to raise its own ceiling -> broadens
+            Capability("amount", "le", "900"),
+            Capability("vendor", "eq", "acme"),
+        ),
+    }
+    chain = graph.chain_for(c.action_id)
+    print("  granted amount ceilings down the chain:")
+    for aid in chain:
+        ceiling = next(cap.value for cap in grants[aid] if cap.arg == "amount")
+        print(f"    {graph.agent_of.get(aid, '?'):11} le {ceiling}")
+
+    report = chain_is_attenuating([grants[aid] for aid in chain])
+    if report.ok:
+        print("  chain attenuates cleanly: authority only narrows.")
+    else:
+        hop = chain[report.first_broadening_index]
+        print(f"  VIOLATION: {graph.agent_of.get(hop, '?')} broadened its grant "
+              f"({report.reason}) beyond what it was delegated.")
+
+    # And a compliant executor (stays within researcher's grant) passes.
+    grants[c.action_id] = (
+        Capability("amount", "le", "100"),
+        Capability("vendor", "eq", "acme"),
+    )
+    fixed = chain_is_attenuating([grants[aid] for aid in chain])
+    print(f"  with executor kept within scope (le 100): "
+          f"{'clean' if fixed.ok else 'still violating'}")
+
+    print("\nAuthority never grew as it was handed down — and when it tried, "
+          "Vaara caught it.")
+    return 0 if (err is not None and not report.ok and fixed.ok) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.23.1",
+  "version": "1.24.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.23.1",
+      "version": "1.24.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/audit/delegation.py
+++ b/src/vaara/audit/delegation.py
@@ -1,0 +1,210 @@
+"""Reconstruct multi-agent delegation chains from the audit trail.
+
+Read-side only. The delegation edge — ``parent_action_id`` — is captured at
+ingest (``Pipeline.intercept`` threads it, the LangChain and MCP proxy
+integrations populate it automatically) and lands inside the hash-covered
+``data`` of each ``action_requested`` event. Because ``compute_hash`` covers
+``data``, tampering with a parent link breaks ``verify_chain()``: the edge is
+already tamper-evident.
+
+What was missing is the read back. When agent A delegates to agent B which
+delegates to agent C, nothing walked those edges into a chain, so an auditor
+could not reconstruct "who authorized C's action" as a single lineage. This
+module does exactly that, over a list of records or a whole trail, without
+touching the stored schema (``root`` and ``depth`` are computed, not stored).
+
+The reconstruction is deliberately defensive: a forged, pruned, or cyclic
+parent link never crashes or hangs the walk. Dangling and cyclic action_ids
+are surfaced on the graph rather than silently dropped, so an anomaly in the
+delegation structure is itself visible evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from vaara.audit.trail import AuditRecord, EventType
+
+# Upper bound on a single parent walk. Guards against pathological depth and
+# is the backstop that makes cycle handling terminate even if the pre-computed
+# cycle set is somehow bypassed. Delegation trees in practice are shallow;
+# 10k is far beyond any real agent topology.
+_MAX_WALK = 10_000
+
+
+@dataclass
+class DelegationGraph:
+    """Reconstructed delegation forest over a set of audit records.
+
+    Nodes are ``action_id`` strings. ``effective_parent`` is acyclic by
+    construction — a recorded parent that is unknown (dangling) or part of a
+    cycle is cut to ``None`` (making that node a local root) and reported in
+    :attr:`dangling` / :attr:`cycles`. Every traversal method therefore
+    terminates.
+    """
+
+    effective_parent: dict[str, Optional[str]] = field(default_factory=dict)
+    children: dict[str, list[str]] = field(default_factory=dict)
+    dangling: set[str] = field(default_factory=set)
+    cycles: set[str] = field(default_factory=set)
+    agent_of: dict[str, str] = field(default_factory=dict)
+    tool_of: dict[str, str] = field(default_factory=dict)
+
+    def __contains__(self, action_id: str) -> bool:
+        return action_id in self.effective_parent
+
+    def roots(self) -> list[str]:
+        """Action_ids with no (effective) parent, in first-seen order."""
+        return [a for a, p in self.effective_parent.items() if p is None]
+
+    def root_of(self, action_id: str) -> str:
+        """Top of ``action_id``'s delegation chain. Self if unknown or root."""
+        cur = action_id
+        for _ in range(_MAX_WALK):
+            parent = self.effective_parent.get(cur)
+            if parent is None:
+                return cur
+            cur = parent
+        return cur
+
+    def depth_of(self, action_id: str) -> int:
+        """Hops from ``action_id`` up to its root. A root has depth 0."""
+        depth = 0
+        cur = action_id
+        for _ in range(_MAX_WALK):
+            parent = self.effective_parent.get(cur)
+            if parent is None:
+                return depth
+            depth += 1
+            cur = parent
+        return depth
+
+    def chain_for(self, action_id: str) -> list[str]:
+        """Ordered root -> ... -> ``action_id`` path of action_ids.
+
+        Returns ``[action_id]`` for an unknown node, so a caller always gets
+        the node itself back rather than an empty list.
+        """
+        if action_id not in self.effective_parent:
+            return [action_id]
+        reverse: list[str] = []
+        cur: Optional[str] = action_id
+        for _ in range(_MAX_WALK):
+            if cur is None:
+                break
+            reverse.append(cur)
+            cur = self.effective_parent.get(cur)
+        reverse.reverse()
+        return reverse
+
+    def descendants(self, action_id: str) -> list[str]:
+        """All action_ids delegated (transitively) from ``action_id``.
+
+        Breadth-first, excluding ``action_id`` itself. This is the blast
+        radius of an action: everything downstream it set in motion.
+        """
+        out: list[str] = []
+        seen = {action_id}
+        queue = list(self.children.get(action_id, []))
+        while queue:
+            node = queue.pop(0)
+            if node in seen:
+                continue
+            seen.add(node)
+            out.append(node)
+            queue.extend(self.children.get(node, []))
+        return out
+
+
+def _parent_link(record: AuditRecord) -> Optional[str]:
+    """Read the recorded parent_action_id off an action_requested record."""
+    parent = record.data.get("parent_action_id")
+    if isinstance(parent, str) and parent:
+        return parent
+    return None
+
+
+def build_delegation_graph(records: Iterable[AuditRecord]) -> DelegationGraph:
+    """Reconstruct the delegation forest from an iterable of audit records.
+
+    A node exists for every ``action_id`` seen on any event type, so an action
+    that only carries later-lifecycle events (e.g. a skeleton reload) still
+    appears — as a root, since only ``action_requested`` carries the parent
+    link. Recorded parents that point at an unknown action are cut and listed
+    in ``dangling``; cyclic and self-parent links are cut and listed in
+    ``cycles``. The resulting ``effective_parent`` map is acyclic.
+    """
+    seen: dict[str, None] = {}  # ordered set of every action_id
+    raw_parent: dict[str, Optional[str]] = {}
+    agent_of: dict[str, str] = {}
+    tool_of: dict[str, str] = {}
+
+    for rec in records:
+        aid = rec.action_id
+        seen.setdefault(aid, None)
+        if rec.event_type == EventType.ACTION_REQUESTED:
+            # The action_requested event is authoritative for the edge and the
+            # originating agent. If two somehow exist for one action_id, the
+            # first wins (append order), matching the trail's own ordering.
+            if aid not in raw_parent:
+                raw_parent[aid] = _parent_link(rec)
+                agent_of[aid] = rec.agent_id
+                tool_of[aid] = rec.tool_name
+
+    dangling: set[str] = set()
+    cycles: set[str] = set()
+    effective_parent: dict[str, Optional[str]] = {}
+
+    for aid in seen:
+        parent = raw_parent.get(aid)
+        if parent is None:
+            effective_parent[aid] = None
+        elif parent not in seen:
+            # Forged or pruned ancestor: keep the node, expose the break.
+            dangling.add(aid)
+            effective_parent[aid] = None
+        else:
+            effective_parent[aid] = parent
+
+    # Cycle detection over the functional parent graph (each node has <= 1
+    # parent). Walk up from each node; a revisit means a loop. Every node on
+    # the loop is recorded and cut to a root so traversals stay finite.
+    for start in seen:
+        path: list[str] = []
+        path_set: set[str] = set()
+        cur: Optional[str] = start
+        steps = 0
+        while cur is not None and steps < _MAX_WALK:
+            if cur in cycles:
+                break
+            if cur in path_set:
+                idx = path.index(cur)
+                for node in path[idx:]:
+                    cycles.add(node)
+                    effective_parent[node] = None
+                break
+            path.append(cur)
+            path_set.add(cur)
+            cur = effective_parent.get(cur)
+            steps += 1
+
+    children: dict[str, list[str]] = {aid: [] for aid in seen}
+    for aid in seen:
+        parent = effective_parent.get(aid)
+        if parent is not None:
+            children[parent].append(aid)
+
+    return DelegationGraph(
+        effective_parent=effective_parent,
+        children=children,
+        dangling=dangling,
+        cycles=cycles,
+        agent_of=agent_of,
+        tool_of=tool_of,
+    )
+
+
+def graph_from_trail(trail) -> DelegationGraph:
+    """Reconstruct the delegation forest from a live :class:`AuditTrail`."""
+    return build_delegation_graph(trail.snapshot())

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -1148,6 +1148,17 @@ class AuditTrail:
 
     # ── Querying ──────────────────────────────────────────────────
 
+    def snapshot(self) -> list[AuditRecord]:
+        """Return a point-in-time list of every record, in append order.
+
+        Read-only view for consumers that need the whole trail at once
+        (e.g. delegation-chain reconstruction). Taken under the chain lock
+        so it never races a concurrent ``_append``; the returned list is a
+        fresh container, though the ``AuditRecord`` objects are shared.
+        """
+        with self._lock:
+            return list(self._records)
+
     def get_action_trail(self, action_id: str) -> list[AuditRecord]:
         """Get all events for a specific action, in order."""
         with self._lock:

--- a/src/vaara/credential/__init__.py
+++ b/src/vaara/credential/__init__.py
@@ -29,6 +29,11 @@ from vaara.credential._contiguity import (
     evidence_binding_ok,
     verify_contiguity,
 )
+from vaara.credential._grant_attenuation import (
+    AttenuationReport,
+    capability_subsumes,
+    chain_is_attenuating,
+)
 from vaara.credential._grant_capability import Capability
 from vaara.credential._grant_emit import emit_grant, verify_grant_signature
 from vaara.credential._grant_parse import (
@@ -49,9 +54,12 @@ from vaara.credential.gateway import CredentialGateway
 
 __all__ = [
     "AUTHORIZATION_SCHEMA",
+    "AttenuationReport",
     "AuthorizationReceipt",
     "BrokeredCredential",
     "Capability",
+    "capability_subsumes",
+    "chain_is_attenuating",
     "ClassGateDecision",
     "ContiguityReport",
     "CredentialGateway",

--- a/src/vaara/credential/_grant_attenuation.py
+++ b/src/vaara/credential/_grant_attenuation.py
@@ -1,0 +1,170 @@
+"""Delegated-privilege attenuation over capability grants.
+
+Internal module. Public surface is re-exported from ``vaara.credential``.
+
+A delegation chain is safe only if authority never *grows* as it is handed
+down: agent B, acting on A's behalf, must not be able to do anything A could
+not, and C (delegated by B) must not exceed B. This module decides that
+relation over the typed ``Capability`` grants in ``_grant_capability``.
+
+The core is ``capability_subsumes(parent, child)``: does the child grant allow
+a *subset* of the calls the parent grant allows? Equivalently, is every runtime
+-args dict the child would accept also accepted by the parent? If yes, the
+child is an attenuation (narrowing) of the parent and the hand-off is safe.
+
+The check is deliberately **sound and conservative**: it returns ``True`` only
+when subsumption is provable, and ``False`` (fail closed) on anything it cannot
+prove — mixed numeric/string domains, unbounded child ranges, differing arg
+sets. It will never approve a broadening; at worst it conservatively rejects a
+narrowing it cannot verify. That is the correct bias for an authority control.
+
+This is an evidence/verification primitive, not a credential issuer: it decides
+whether one grant attenuates another. Minting and rotating the grants stays in
+the deployer's identity layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Optional, Sequence
+
+from vaara.credential._grant_capability import Capability, _as_decimal
+
+
+def _names(caps: Sequence[Capability]) -> set[str]:
+    return {c.arg for c in caps}
+
+
+def _child_finite_set(caps: Sequence[Capability]) -> Optional[frozenset[str]]:
+    """The finite set of values the child permits for one arg, or None.
+
+    Returns None when the child places no ``eq``/``in`` constraint (so the
+    permitted set is not finite — it is a numeric interval or unconstrained).
+    Any ``le``/``ge`` bounds present are applied to filter the finite set;
+    non-numeric members are dropped against a numeric bound (they cannot
+    satisfy it), which can yield the empty set — a child that permits nothing.
+    """
+    universe: Optional[set[str]] = None
+    for c in caps:
+        if c.op == "eq":
+            s = {c.value}
+        elif c.op == "in":
+            s = set(c.value)
+        else:
+            continue
+        universe = s if universe is None else (universe & s)
+    if universe is None:
+        return None
+    for c in caps:
+        if c.op in ("le", "ge"):
+            bound = _as_decimal(c.value)
+            if bound is None:
+                return frozenset()  # malformed bound: child permits nothing
+            kept = set()
+            for m in universe:
+                md = _as_decimal(m)
+                if md is None:
+                    continue
+                if (c.op == "le" and md <= bound) or (c.op == "ge" and md >= bound):
+                    kept.add(m)
+            universe = kept
+    return frozenset(universe)
+
+
+def _child_bounds(caps: Sequence[Capability]) -> tuple[Optional[Decimal], Optional[Decimal]]:
+    """Tightest (lower, upper) numeric bounds the child imposes via le/ge."""
+    lo: Optional[Decimal] = None
+    hi: Optional[Decimal] = None
+    for c in caps:
+        b = _as_decimal(c.value)
+        if b is None:
+            continue
+        if c.op == "le":
+            hi = b if hi is None else min(hi, b)
+        elif c.op == "ge":
+            lo = b if lo is None else max(lo, b)
+    return lo, hi
+
+
+def _child_guarantees(child_caps: Sequence[Capability], parent_cap: Capability) -> bool:
+    """Does every value the child permits (for this arg) satisfy parent_cap?"""
+    finite = _child_finite_set(child_caps)
+    if finite is not None and len(finite) == 0:
+        return True  # child permits nothing here -> vacuously within parent
+
+    if parent_cap.op == "eq":
+        return finite is not None and finite <= {parent_cap.value}
+    if parent_cap.op == "in":
+        return finite is not None and finite <= set(parent_cap.value)
+
+    # Numeric parent bound (le / ge).
+    bound = _as_decimal(parent_cap.value)
+    if bound is None:
+        return False
+    if finite is not None:
+        decs = [_as_decimal(m) for m in finite]
+        if any(d is None for d in decs):
+            return False  # a non-numeric permitted value cannot meet a numeric bound
+        if parent_cap.op == "le":
+            return all(d <= bound for d in decs)  # type: ignore[operator]
+        return all(d >= bound for d in decs)  # type: ignore[operator]
+    # Child is an interval: it guarantees the bound only if its own bound is
+    # at least as tight. An unbounded side (None) cannot guarantee anything.
+    lo, hi = _child_bounds(child_caps)
+    if parent_cap.op == "le":
+        return hi is not None and hi <= bound
+    return lo is not None and lo >= bound
+
+
+def capability_subsumes(
+    parent: Sequence[Capability], child: Sequence[Capability]
+) -> tuple[bool, str]:
+    """Is ``child`` no broader than ``parent`` (child-allowed ⊆ parent-allowed)?
+
+    Returns ``(True, "ok")`` when the child grant attenuates the parent, else
+    ``(False, reason)`` — ``arg_set_mismatch`` when the two grants constrain
+    different argument sets (not a clean narrowing, rejected fail-closed), or
+    ``broadens:<arg>`` when the child would permit a value the parent forbids.
+    """
+    np_, nc_ = _names(parent), _names(child)
+    if np_ != nc_:
+        return (False, "arg_set_mismatch")
+    for arg in np_:
+        parent_caps = [c for c in parent if c.arg == arg]
+        child_caps = [c for c in child if c.arg == arg]
+        for pc in parent_caps:
+            if not _child_guarantees(child_caps, pc):
+                return (False, f"broadens:{arg}")
+    return (True, "ok")
+
+
+@dataclass(frozen=True)
+class AttenuationReport:
+    """Result of checking privilege attenuation down a delegation chain.
+
+    ``ok`` is True when every hop attenuates (or holds) the prior grant.
+    ``first_broadening_index`` is the index of the first child grant that
+    broadens its parent (>=1), or -1 when the chain is clean. ``reason``
+    carries the subsumption reason at that hop.
+    """
+
+    ok: bool
+    first_broadening_index: int
+    reason: str
+
+
+def chain_is_attenuating(
+    grants: Sequence[Sequence[Capability]],
+) -> AttenuationReport:
+    """Verify authority never grows along an ordered chain of grants.
+
+    ``grants`` is ordered root -> leaf (e.g. the capability sets aligned to
+    ``DelegationGraph.chain_for``). Each grant must subsume the next. A chain
+    of length 0 or 1 is trivially attenuating.
+    """
+    for i in range(1, len(grants)):
+        ok, reason = capability_subsumes(grants[i - 1], grants[i])
+        if not ok:
+            return AttenuationReport(False, i, reason)
+    return AttenuationReport(True, -1, "ok")

--- a/src/vaara/pipeline.py
+++ b/src/vaara/pipeline.py
@@ -36,10 +36,18 @@ import threading
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from vaara._sanitize import json_safe
 from vaara.audit.trail import AuditTrail
+
+if TYPE_CHECKING:
+    # Capability appears only in annotations, which `from __future__ import
+    # annotations` leaves as strings. capability_subsumes is imported lazily
+    # inside intercept() so the core pipeline never pulls the credential
+    # package's optional attestation/crypto dependency at import time — a base
+    # `pip install vaara` (no extras) must still `import vaara.Pipeline`.
+    from vaara.credential._grant_capability import Capability
 from vaara.compliance.engine import ComplianceEngine, ConformityReport
 from vaara.scorer.adaptive import AdaptiveScorer
 from vaara.taxonomy.actions import (
@@ -57,6 +65,14 @@ logger = logging.getLogger(__name__)
 # agent session. Evicting the oldest entry keeps memory bounded;
 # late report_outcome calls after eviction no-op with a warning.
 _MAX_PENDING_OUTCOMES = 50_000
+
+# Cap on the action -> granted-capability map used for delegated-privilege
+# attenuation. Same unbounded-growth concern as pending outcomes: an agent
+# session that threads capabilities through many intercepts would grow the
+# map one entry per action. Oldest-first eviction keeps it bounded; a child
+# whose parent grant was evicted simply cannot be attenuation-checked and is
+# handled fail-open on the lookup (the parent grant is unknown, not broadened).
+_MAX_TRACKED_GRANTS = 50_000
 
 
 # Length caps on caller-supplied string fields at the pipeline ingress.
@@ -253,6 +269,15 @@ class InterceptionPipeline:
             str, tuple[float, dict[str, float]]
         ] = OrderedDict()
         self._pending_outcomes_lock = threading.Lock()
+
+        # Delegated-privilege attenuation: action_id -> the capability grant
+        # under which that action ran. A child action carrying its own grant
+        # plus a parent_action_id is checked so its authority never exceeds
+        # the parent grant (see capability_subsumes). Bounded FIFO eviction.
+        self._grants_for_action: OrderedDict[
+            str, tuple[Capability, ...]
+        ] = OrderedDict()
+        self._grants_lock = threading.Lock()
         self._metrics = PipelineMetrics()
         self._metrics_lock = threading.Lock()
 
@@ -267,11 +292,19 @@ class InterceptionPipeline:
         parent_action_id: Optional[str] = None,
         sequence_position: int = 0,
         tenant_id: str = "",
+        capabilities: Optional[Sequence[Capability]] = None,
     ) -> InterceptionResult:
         """Intercept an agent action request.
 
         This is the single function that agents/frameworks call.
         It classifies, scores, decides, and audits in one shot.
+
+        ``capabilities`` is the optional capability grant this action runs
+        under. When supplied together with ``parent_action_id``, the pipeline
+        enforces delegated-privilege attenuation: the action's grant must be a
+        subset of the parent action's grant, so authority never grows down a
+        delegation chain. A broadening grant is denied fail-closed regardless
+        of risk score. With no capabilities the behaviour is unchanged.
 
         Returns an InterceptionResult — check .allowed before executing.
         """
@@ -320,6 +353,30 @@ class InterceptionPipeline:
 
         # 3. Record the request in audit trail
         action_id = self.trail.record_action_requested(request)
+
+        # 3b. Delegated-privilege attenuation. Record this action's grant for
+        # its own children to check against, then verify this action does not
+        # exceed the grant of the parent that delegated to it. Fail-closed on a
+        # broadening grant; fail-open when the parent grant is unknown (never
+        # recorded, or evicted) — absence of a parent grant is not evidence of
+        # a violation. Applied to the decision at step 6b.
+        child_caps = tuple(capabilities) if capabilities else None
+        attenuation_reason: Optional[str] = None
+        if child_caps is not None:
+            # Lazy import: only when a caller actually uses capability grants,
+            # which already live in the credential/attestation extra.
+            from vaara.credential._grant_attenuation import capability_subsumes
+            with self._grants_lock:
+                self._grants_for_action[action_id] = child_caps
+                if len(self._grants_for_action) > _MAX_TRACKED_GRANTS:
+                    self._grants_for_action.popitem(last=False)
+            if parent_action_id:
+                with self._grants_lock:
+                    parent_caps = self._grants_for_action.get(parent_action_id)
+                if parent_caps is not None:
+                    ok, why = capability_subsumes(parent_caps, child_caps)
+                    if not ok:
+                        attenuation_reason = why
 
         # 4. Score the risk. If the scorer raises — corrupt model bundle,
         # feature pipeline exception, any library bug — we've already
@@ -508,6 +565,19 @@ class InterceptionPipeline:
         # output as a caller-controlled ingress point like any other
         # string that lands on the hash chain (see Loop 47/50 caps).
         reason = _cap_str(reason, _MAX_DECISION_REASON_LEN, "reason")
+
+        # 6b. Attenuation override. A child grant that broadens its parent
+        # forces a fail-closed deny regardless of the scored risk — authority
+        # must never grow across a delegation hop. Prepend the reason so the
+        # audit decision record and the returned result both name it.
+        if attenuation_reason is not None:
+            decision_str = "deny"
+            allowed = False
+            reason = _cap_str(
+                f"privilege attenuation violation ({attenuation_reason})"
+                + (f"; {reason}" if reason else ""),
+                _MAX_DECISION_REASON_LEN, "reason",
+            )
 
         # 7. Record the decision in audit
         self.trail.record_decision(

--- a/tests/test_delegation.py
+++ b/tests/test_delegation.py
@@ -1,0 +1,170 @@
+"""Reconstruction of multi-agent delegation chains + tamper-evidence.
+
+Covers the read-side reconstruction in vaara.audit.delegation (linear,
+branching, dangling, cycle, self-parent, multi-event, empty) and the end-to-
+end guarantee that a forged parent link is caught by the existing hash chain.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from vaara.audit.delegation import build_delegation_graph, graph_from_trail
+from vaara.audit.trail import AuditRecord, EventType
+
+
+def _req(action_id: str, parent, agent: str = "agent", tool: str = "tool") -> AuditRecord:
+    """An action_requested record carrying a parent_action_id in data."""
+    return AuditRecord(
+        record_id=str(uuid.uuid4()),
+        action_id=action_id,
+        event_type=EventType.ACTION_REQUESTED,
+        timestamp=0.0,
+        agent_id=agent,
+        tool_name=tool,
+        data={"parent_action_id": parent},
+    )
+
+
+def _evt(action_id: str, event_type: EventType) -> AuditRecord:
+    """A non-action_requested lifecycle event for an existing action."""
+    return AuditRecord(
+        record_id=str(uuid.uuid4()),
+        action_id=action_id,
+        event_type=event_type,
+        timestamp=0.0,
+        agent_id="agent",
+        tool_name="tool",
+        data={},
+    )
+
+
+# ── Linear chain A -> B -> C ──────────────────────────────────────────────
+
+def test_linear_chain_reconstructs_root_to_leaf():
+    g = build_delegation_graph([
+        _req("A", None, agent="planner"),
+        _req("B", "A", agent="researcher"),
+        _req("C", "B", agent="executor"),
+    ])
+    assert g.chain_for("C") == ["A", "B", "C"]
+    assert g.root_of("C") == "A"
+    assert g.depth_of("C") == 2
+    assert g.depth_of("A") == 0
+    assert g.roots() == ["A"]
+    assert g.descendants("A") == ["B", "C"]
+    assert g.descendants("C") == []
+    assert g.agent_of["C"] == "executor"
+
+
+# ── Branching A -> {B, C} ─────────────────────────────────────────────────
+
+def test_branching_blast_radius():
+    g = build_delegation_graph([
+        _req("A", None),
+        _req("B", "A"),
+        _req("C", "A"),
+    ])
+    assert g.roots() == ["A"]
+    assert sorted(g.descendants("A")) == ["B", "C"]
+    assert g.chain_for("B") == ["A", "B"]
+    assert g.chain_for("C") == ["A", "C"]
+    assert g.depth_of("B") == 1
+
+
+# ── Dangling parent (forged / pruned ancestor) ────────────────────────────
+
+def test_dangling_parent_is_surfaced_not_dropped():
+    g = build_delegation_graph([
+        _req("B", "ghost"),  # parent never appears
+    ])
+    assert "B" in g
+    assert "B" in g.dangling
+    assert g.root_of("B") == "B"
+    assert g.chain_for("B") == ["B"]
+    assert g.depth_of("B") == 0
+
+
+# ── Cycle A -> B -> A ─────────────────────────────────────────────────────
+
+def test_cycle_is_detected_and_terminates():
+    g = build_delegation_graph([
+        _req("A", "B"),
+        _req("B", "A"),
+    ])
+    assert "A" in g.cycles and "B" in g.cycles
+    # Traversals must terminate and not raise.
+    assert g.root_of("A") in {"A", "B"}
+    assert isinstance(g.depth_of("A"), int)
+    assert isinstance(g.chain_for("B"), list)
+
+
+def test_self_parent_is_a_cycle():
+    g = build_delegation_graph([_req("A", "A")])
+    assert "A" in g.cycles
+    assert g.root_of("A") == "A"
+    assert g.depth_of("A") == 0
+
+
+# ── Multiple events per action collapse to one node ───────────────────────
+
+def test_multiple_events_one_node():
+    g = build_delegation_graph([
+        _req("A", None),
+        _req("B", "A"),
+        _evt("B", EventType.DECISION_MADE),
+        _evt("B", EventType.ACTION_EXECUTED),
+    ])
+    assert g.chain_for("B") == ["A", "B"]
+    assert g.descendants("A") == ["B"]
+
+
+def test_action_with_only_later_events_is_a_root():
+    # A decision event with no preceding action_requested (e.g. skeleton
+    # reload) still yields a node, as a root with unknown parent.
+    g = build_delegation_graph([_evt("X", EventType.DECISION_MADE)])
+    assert "X" in g
+    assert g.root_of("X") == "X"
+
+
+# ── Empty ─────────────────────────────────────────────────────────────────
+
+def test_empty_trail():
+    g = build_delegation_graph([])
+    assert g.roots() == []
+    assert g.chain_for("nope") == ["nope"]
+    assert g.descendants("nope") == []
+
+
+# ── End-to-end via the pipeline + tamper-evidence ─────────────────────────
+
+def test_pipeline_chain_reconstructs_and_tamper_is_caught():
+    from vaara import Pipeline
+
+    pipe = Pipeline()
+    a = pipe.intercept(agent_id="planner", tool_name="plan_task", parameters={})
+    b = pipe.intercept(
+        agent_id="researcher", tool_name="search_docs",
+        parameters={}, parent_action_id=a.action_id,
+    )
+    c = pipe.intercept(
+        agent_id="executor", tool_name="write_record",
+        parameters={}, parent_action_id=b.action_id,
+    )
+
+    # Chain intact and reconstructable end to end.
+    assert pipe.trail.verify_chain() is None
+    g = graph_from_trail(pipe.trail)
+    assert g.chain_for(c.action_id) == [a.action_id, b.action_id, c.action_id]
+    assert g.root_of(c.action_id) == a.action_id
+    assert set(g.descendants(a.action_id)) == {b.action_id, c.action_id}
+
+    # Forge the authorization trail: rewrite who spawned C. Because
+    # parent_action_id is hash-covered, verify_chain must now fail.
+    target = next(
+        r for r in pipe.trail.snapshot()
+        if r.event_type == EventType.ACTION_REQUESTED
+        and r.data.get("parent_action_id") == b.action_id
+    )
+    target.data["parent_action_id"] = "forged-authorizer"
+    assert pipe.trail.verify_chain() is not None

--- a/tests/test_grant_attenuation.py
+++ b/tests/test_grant_attenuation.py
@@ -1,0 +1,161 @@
+"""Delegated-privilege attenuation: capability subsumption + chain check.
+
+The subsumption predicate is sound and conservative — it must NEVER approve a
+broadening, and may conservatively reject a narrowing it cannot prove. These
+tests pin both the true-narrowings it accepts and the broadenings/ambiguities
+it rejects.
+"""
+
+from __future__ import annotations
+
+from vaara.credential import (
+    Capability,
+    capability_subsumes,
+    chain_is_attenuating,
+)
+
+
+def _subsumes(parent, child) -> bool:
+    ok, _ = capability_subsumes(parent, child)
+    return ok
+
+
+# ── Numeric bounds ────────────────────────────────────────────────────────
+
+def test_tighter_upper_bound_is_attenuation():
+    parent = (Capability("amount", "le", "500"),)
+    child = (Capability("amount", "le", "200"),)
+    assert _subsumes(parent, child)
+
+
+def test_looser_upper_bound_broadens():
+    parent = (Capability("amount", "le", "500"),)
+    child = (Capability("amount", "le", "1000"),)
+    ok, reason = capability_subsumes(parent, child)
+    assert not ok and reason == "broadens:amount"
+
+
+def test_unbounded_child_broadens_a_bounded_parent():
+    # Child constrains a *lower* bound only -> unbounded above -> can exceed le.
+    parent = (Capability("amount", "le", "500"),)
+    child = (Capability("amount", "ge", "0"),)
+    assert not _subsumes(parent, child)
+
+
+def test_eq_within_numeric_bound_is_attenuation():
+    parent = (Capability("amount", "le", "500"),)
+    child = (Capability("amount", "eq", "300"),)
+    assert _subsumes(parent, child)
+
+
+def test_eq_outside_numeric_bound_broadens():
+    parent = (Capability("amount", "le", "500"),)
+    child = (Capability("amount", "eq", "900"),)
+    assert not _subsumes(parent, child)
+
+
+def test_ge_tighter_lower_bound_is_attenuation():
+    parent = (Capability("amount", "ge", "100"),)
+    child = (Capability("amount", "ge", "250"),)
+    assert _subsumes(parent, child)
+
+
+# ── Membership / equality ─────────────────────────────────────────────────
+
+def test_in_subset_is_attenuation():
+    parent = (Capability("vendor", "in", ("acme", "globex", "initech")),)
+    child = (Capability("vendor", "in", ("acme", "globex")),)
+    assert _subsumes(parent, child)
+
+
+def test_in_superset_broadens():
+    parent = (Capability("vendor", "in", ("acme", "globex")),)
+    child = (Capability("vendor", "in", ("acme", "globex", "evilcorp")),)
+    assert not _subsumes(parent, child)
+
+
+def test_eq_within_parent_in_set_is_attenuation():
+    parent = (Capability("vendor", "in", ("acme", "globex")),)
+    child = (Capability("vendor", "eq", "acme"),)
+    assert _subsumes(parent, child)
+
+
+def test_eq_outside_parent_in_set_broadens():
+    parent = (Capability("vendor", "in", ("acme", "globex")),)
+    child = (Capability("vendor", "eq", "evilcorp"),)
+    assert not _subsumes(parent, child)
+
+
+def test_child_interval_cannot_satisfy_parent_membership():
+    # Parent pins a string set; child offers a numeric range -> not provable.
+    parent = (Capability("vendor", "in", ("acme", "globex")),)
+    child = (Capability("vendor", "le", "500"),)
+    assert not _subsumes(parent, child)
+
+
+# ── Arg-set alignment ─────────────────────────────────────────────────────
+
+def test_differing_arg_sets_fail_closed():
+    parent = (Capability("amount", "le", "500"),)
+    child = (
+        Capability("amount", "le", "200"),
+        Capability("vendor", "eq", "acme"),
+    )
+    ok, reason = capability_subsumes(parent, child)
+    assert not ok and reason == "arg_set_mismatch"
+
+
+def test_multi_arg_all_must_attenuate():
+    parent = (
+        Capability("amount", "le", "500"),
+        Capability("vendor", "in", ("acme", "globex")),
+    )
+    ok_child = (
+        Capability("amount", "le", "200"),
+        Capability("vendor", "eq", "acme"),
+    )
+    bad_child = (
+        Capability("amount", "le", "200"),
+        Capability("vendor", "eq", "evilcorp"),
+    )
+    assert _subsumes(parent, ok_child)
+    assert not _subsumes(parent, bad_child)
+
+
+def test_identical_grants_subsume():
+    caps = (Capability("amount", "le", "500"),)
+    assert _subsumes(caps, caps)
+
+
+def test_empty_grants_subsume():
+    assert _subsumes((), ())
+
+
+# ── Chain-level attenuation ───────────────────────────────────────────────
+
+def test_chain_all_narrowing_is_clean():
+    chain = [
+        (Capability("amount", "le", "1000"),),  # planner
+        (Capability("amount", "le", "500"),),   # researcher
+        (Capability("amount", "le", "100"),),   # executor
+    ]
+    report = chain_is_attenuating(chain)
+    assert report.ok
+    assert report.first_broadening_index == -1
+
+
+def test_chain_flags_first_broadening_hop():
+    chain = [
+        (Capability("amount", "le", "500"),),   # planner
+        (Capability("amount", "le", "200"),),   # researcher (ok)
+        (Capability("amount", "le", "900"),),   # executor exceeds researcher
+    ]
+    report = chain_is_attenuating(chain)
+    assert not report.ok
+    assert report.first_broadening_index == 2
+    assert report.reason == "broadens:amount"
+
+
+def test_single_and_empty_chains_are_trivially_clean():
+    assert chain_is_attenuating([]).ok
+    assert chain_is_attenuating([(Capability("amount", "le", "5"),)]).ok

--- a/tests/test_pipeline_attenuation.py
+++ b/tests/test_pipeline_attenuation.py
@@ -1,0 +1,96 @@
+"""Intercept-time enforcement of delegated-privilege attenuation.
+
+A child action whose capability grant broadens the grant of the parent that
+delegated to it is denied fail-closed, regardless of risk score, and the deny
+is recorded in the audit trail. Actions with no capabilities behave exactly as
+before (backward compatibility).
+"""
+
+from __future__ import annotations
+
+from vaara import Pipeline
+from vaara.audit.trail import EventType
+from vaara.credential import Capability
+
+PARENT_GRANT = (
+    Capability("amount", "le", "500"),
+    Capability("vendor", "in", ("acme", "globex")),
+)
+NARROWER = (  # subset of PARENT_GRANT -> attenuation, allowed
+    Capability("amount", "le", "100"),
+    Capability("vendor", "eq", "acme"),
+)
+BROADER = (  # raises the amount ceiling above the parent -> denied
+    Capability("amount", "le", "5000"),
+    Capability("vendor", "eq", "acme"),
+)
+
+
+def _parent(pipe: Pipeline):
+    return pipe.intercept(
+        agent_id="planner", tool_name="plan_task",
+        parameters={}, capabilities=PARENT_GRANT,
+    )
+
+
+def test_attenuating_child_is_not_forced_denied():
+    pipe = Pipeline()
+    p = _parent(pipe)
+    child = pipe.intercept(
+        agent_id="worker", tool_name="read_document",
+        parameters={}, parent_action_id=p.action_id, capabilities=NARROWER,
+    )
+    assert "privilege attenuation" not in child.reason
+
+
+def test_broadening_child_is_denied_fail_closed():
+    pipe = Pipeline()
+    p = _parent(pipe)
+    child = pipe.intercept(
+        agent_id="worker", tool_name="read_document",
+        parameters={}, parent_action_id=p.action_id, capabilities=BROADER,
+    )
+    assert child.allowed is False
+    assert child.decision == "deny"
+    assert "privilege attenuation violation" in child.reason
+    assert "broadens:amount" in child.reason
+
+
+def test_denial_is_recorded_in_audit_trail():
+    pipe = Pipeline()
+    p = _parent(pipe)
+    child = pipe.intercept(
+        agent_id="worker", tool_name="read_document",
+        parameters={}, parent_action_id=p.action_id, capabilities=BROADER,
+    )
+    decisions = [
+        r for r in pipe.trail.snapshot()
+        if r.action_id == child.action_id
+        and r.event_type == EventType.ACTION_BLOCKED
+    ]
+    assert decisions, "a blocked decision record should exist for the child"
+    assert "privilege attenuation violation" in decisions[0].data.get("reason", "")
+    # The tamper-evident chain still verifies.
+    assert pipe.trail.verify_chain() is None
+
+
+def test_no_capabilities_is_unchanged_behavior():
+    pipe = Pipeline()
+    p = pipe.intercept(agent_id="planner", tool_name="plan_task", parameters={})
+    child = pipe.intercept(
+        agent_id="worker", tool_name="read_document",
+        parameters={}, parent_action_id=p.action_id,
+    )
+    assert "privilege attenuation" not in child.reason
+
+
+def test_unknown_parent_grant_fails_open():
+    # Parent action carried no capabilities, so there is no parent grant to
+    # check against. The child is not denied on attenuation grounds.
+    pipe = Pipeline()
+    p = pipe.intercept(agent_id="planner", tool_name="plan_task", parameters={})
+    child = pipe.intercept(
+        agent_id="worker", tool_name="read_document",
+        parameters={}, parent_action_id=p.action_id, capabilities=BROADER,
+    )
+    assert "privilege attenuation" not in child.reason


### PR DESCRIPTION
Adds multi-agent delegation attribution and delegated-privilege attenuation.

Reconstruct A to B to C delegation chains from the hash-covered `parent_action_id` edge already recorded on each request (`vaara.audit.delegation`: `chain_for`, `descendants`, `root_of`, `depth_of`), defensive against dangling parents and cycles. Capability subsumption (`vaara.credential.capability_subsumes`, `chain_is_attenuating`) decides whether a child grant permits a subset of the parent grant; the check is sound and fail-closed and never approves a broadening. `Pipeline.intercept(capabilities=...)` enforces it at runtime and records the denial in the audit trail. Docs updated for the OWASP Agentic 2026 mapping (ASI03, ASI07, ASI08) and the audit event schema.

Because the delegation edge lives in hash-covered audit data, tampering with a link breaks `verify_chain()`.

Tests: full suite 2094 passed, 30 skipped, with 32 new tests across reconstruction, subsumption edge cases, and intercept enforcement. Demo: `scripts/demo_multiagent_attribution.py`.

Compatibility: additive minor bump 1.23.1 to 1.24.0. Audit wire format unchanged. No new base dependency; the attenuation path pulls the existing credential/attestation extra lazily, only when capabilities are used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delegation-chain reconstruction for tracing action origins, depth, descendants, and delegation paths.
  * Added delegated-privilege attenuation checks to prevent child actions from broadening granted capabilities.
  * Broadening attempts are denied automatically and recorded in the audit trail.
  * Added tamper-evident delegation linkage and audit-trail snapshots.
  * Added a multi-agent delegation and attribution demo.

* **Documentation**
  * Updated audit event schema and OWASP guidance for delegation, privilege attenuation, and lineage tracing.

* **Release**
  * Updated the release to version 1.24.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->