### PR TITLE
chore: gitignore local-only private paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,15 @@ tests/adversarial/traces/
 # developer-local site source and scratch directories (never published)
 .vaara-site/
 .local-brain/
+
+# Local-only working dirs and docs that live in the workspace but must never
+# be published: competitive intel and cloned competitor repos, the private
+# file-exchange drop, Serena/tooling caches, reference material (PDFs), local
+# operating rules, and dated local audit notes. None are tracked; these rules
+# exist so an accidental `git add -A` cannot stage them.
+.intel/
+.shared/
+.serena/
+.reference/
+CLAUDE.md
+/AUDIT-*.md


### PR DESCRIPTION
Adds ignore rules for workspace paths that must never be published: `.intel/` (competitive intel and cloned competitor repos), `.shared/` (private file-exchange drop), `.serena/` and tooling caches, `.reference/` (PDFs), `CLAUDE.md` (local operating rules), and `AUDIT-*.md` (dated local audit notes). None were tracked; nothing had leaked. These rules exist so an accidental `git add -A` cannot stage them.