### PR TITLE
fix(types): green the mypy strict-set check

### DIFF
--- a/src/vaara/attestation/_tpm_bundle.py
+++ b/src/vaara/attestation/_tpm_bundle.py
@@ -17,6 +17,7 @@ Schema ``vaara.tpm-evidence-bundle/v0``.
 from __future__ import annotations
 
 import base64
+import binascii
 from typing import Any, Optional
 
 from vaara.attestation._tpm import IMA_PCR
@@ -106,7 +107,7 @@ def verify_tpm_bundle(
             _require(quote, "signature_b64", str, "quote.signature_b64"),
             validate=True,
         )
-    except (ValueError, base64.binascii.Error) as exc:
+    except (ValueError, binascii.Error) as exc:
         raise ValueError(f"TPM bundle has a non-base64 quote field: {exc}") from exc
     ak_pub_pem = _require(quote, "akPubPem", str, "quote.akPubPem").encode("ascii")
 

--- a/src/vaara/attestation/_tpm_chain_bundle.py
+++ b/src/vaara/attestation/_tpm_chain_bundle.py
@@ -21,6 +21,7 @@ Schema ``vaara.tpm-evidence-chain/v0``.
 from __future__ import annotations
 
 import base64
+import binascii
 from typing import Any, Optional
 
 from vaara.attestation._tpm_chain import (
@@ -109,7 +110,7 @@ def _parse_link(entry: dict[str, Any], idx: int) -> TPMChainLink:
             ),
             validate=True,
         )
-    except (ValueError, base64.binascii.Error) as exc:
+    except (ValueError, binascii.Error) as exc:
         raise ValueError(
             f"TPM chain link {idx} has a non-base64 quote field: {exc}"
         ) from exc

--- a/src/vaara/credential/_authorization_receipt.py
+++ b/src/vaara/credential/_authorization_receipt.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Literal, Optional, cast
 
 from vaara.attestation._sep2787_canonical import canonical_json, now_iso8601
 from vaara.attestation.decision import (
@@ -229,7 +229,7 @@ def mint_authorization_receipt(
         iss=iss,
         sub=sub,
         secret_version=secret_version,
-        alg=alg,
+        alg=cast(Literal["HS256", "ES256", "RS256"], alg),
         signing_material=signing_material,
         nonce=nonce,
     )


### PR DESCRIPTION
Fixes the three pre-existing type errors that fail the deps-free mypy job and paint main red. Catch `binascii.Error` directly instead of `base64.binascii.Error` (typeshed does not declare the attribute) in the TPM bundle parsers, and cast `alg` to its `Literal` in the authorization receipt. No behaviour change. Verified in a mypy-only env identical to CI: no issues; 402 related tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TPM bundle verification and chain parsing when quote fields contain invalid Base64 data.
  * Preserved clear, consistent error messages for malformed quote fields.

* **Maintenance**
  * Improved internal type validation for authorization receipt generation without changing its external behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->