### PR TITLE
Pilot-readiness release v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.26.0] - 2026-07-12
+
+Pilot-readiness release: shadow-first onboarding, fail-closed retention rotation, starter perimeters for common MCP servers, and release hygiene. All additive; wire formats unchanged.
+
+- Fixed: `vaara.__version__` said "1.22.0" since v1.23.0; wheels for 1.23.0 through 1.25.0 self-report the wrong version. The string is corrected, a test pins it to pyproject, and the preflight smoke test now fails on any future drift between the wheel version and the installed package.
+- Fixed: the wheel now ships `py.typed`, backing the "Typing :: Typed" classifier so type checkers read the package's annotations (PEP 561).
+- Security: the shipped adversarial-classifier bundle is verified against a pinned SHA-256 before `joblib.load` unpickles it, and `AdversarialClassifier` accepts `expected_sha256` for caller-supplied bundles. A tampered bundle raises `ValueError` instead of executing.
+- Security: the base rule scorer now blocks a cloud-metadata SSRF fetch (169.254.169.254 and its IPv6, dotless-decimal, and hex encodings, recursed through nested parameters) in a zero-config install. Previously only the opt-in ML classifier caught it. A deterministic decision floor is applied for this one unambiguous case, mirroring the egress guard's boundary; legitimate private and loopback hosts are unaffected.
+- Per-action-class policy thresholds are now enforced. A `thresholds` override keyed to an action class (for example `tx.sign`) resolves by the call's tool name at decision time, composing over the policy default; before, overrides parsed and validated but were silently ignored. Applies to both the single-policy and per-tenant paths.
+- MCP proxy: `--policy` loads a YAML/JSON policy (thresholds, sequences) into the interception pipeline, failing closed on validation errors; the policy bytes feed the attested OVERT policy hash, so a silent policy swap is detectable from receipts. Perimeter-only deployments keep their historical hash.
+- MCP proxy: `--shadow` runs the pipeline non-enforcing: every call is classified, scored, and recorded, nothing is blocked. `vaara trail shadow-report --db X [--days N] [--format json]` summarises what enforcement would have done, grouped by tool.
+- `vaara trail rotate --db X --out archive.zip --key K --retention-days N` runs the documented export-then-purge retention workflow as one fail-closed command: the purge never executes unless the signed archive re-verified from its own bytes.
+- Starter perimeters for five MCP servers (GitHub, filesystem, Slack, Postgres, Google Workspace) under `examples/policies/mcp-starters/`, with exact tool names checked against each server's current catalog and a shared starter policy file.
+- `docs/multi-replica-deployment.md` states the supported scale-out pattern: one chain per process, per-replica DBs and rotation, operator-signed archive index; with the honest limits of each.
+- `examples/quickstart.py` now leads with `@vaara.govern`, matching the README, and no longer implies the zero-config trail is persistent.
+
 ## [1.25.0] - 2026-07-12
 
 Minor release: SCITT-compatible COSE Receipts over the transparency log. Additive and backward-compatible; the `vaara.receipt/v1` wire format and existing verification surfaces are unchanged.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
 
-Vaara checks every agent tool call against your policy and writes the call and its outcome into a signed, hash-chained record an outside party can verify offline, with no access to your system and none of your software. It needs no special hardware, and binds to your machine's TPM 2.0 or confidential-VM root when you have one. It runs entirely in your own environment. No SaaS, no telemetry. EU AI Act Article 12 is what it was built for; it answers any "show me what the agent actually did" just as well.
+Vaara checks every agent tool call against your policy and writes the call and its outcome into a signed, hash-chained record an outside party can verify offline, with no access to your system and none of your software. It needs no special hardware, and binds to your machine's TPM 2.0 or confidential-VM root when you have one. It runs entirely in your own environment. No SaaS, no telemetry. It answers "show me what the agent actually did" wherever that question lands: after an incident, in procurement, in a dispute. And when EU AI Act record-keeping obligations reach your systems, the same trail is the Article 12 evidence, already running.
 
 ## Quick start
 
@@ -145,10 +145,10 @@ To put Vaara **in front of** an MCP server, run it as a proxy. Every `tools/call
 ```bash
 vaara-mcp-proxy \
   --upstream npx --upstream-arg -y --upstream-arg @sap/mdk-mcp-server \
-  --db ./mcp_audit.db
+  --db ./mcp_audit.db --shadow
 ```
 
-Point your MCP client (Claude Code, Cursor, any host) at the proxy instead of the upstream. There is also an HTTP API (`pip install 'vaara[server]'`, `vaara serve`) and a first-party TypeScript client on npm ([`@vaara/client`](clients/ts)) for non-Python agents. Framework details, the cloud and OSS guardrail adapters (Bedrock, Azure, GCP, NeMo, Guardrails AI, LLM Guard, Rebuff), and the multi-tenant proxy are in [docs/adapters.md](docs/adapters.md).
+Start with `--shadow`: every call is classified, scored, and recorded, nothing is blocked. After a few days, `vaara trail shadow-report --db ./mcp_audit.db` shows what enforcement would have done; then drop the flag and enforce, starting from a ready-made perimeter for common MCP servers in [examples/policies/mcp-starters/](examples/policies/mcp-starters/README.md). Point your MCP client (Claude Code, Cursor, any host) at the proxy instead of the upstream. There is also an HTTP API (`pip install 'vaara[server]'`, `vaara serve`) and a first-party TypeScript client on npm ([`@vaara/client`](clients/ts)) for non-Python agents. Framework details, the cloud and OSS guardrail adapters (Bedrock, Azure, GCP, NeMo, Guardrails AI, LLM Guard, Rebuff), and the multi-tenant proxy are in [docs/adapters.md](docs/adapters.md).
 </details>
 
 <details>
@@ -197,11 +197,14 @@ The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capabilit
 | [docs/standards.md](docs/standards.md) | SEP-2828, SEP-2787, OVERT, the sovereign inference harness |
 | [docs/adapters.md](docs/adapters.md) | Framework and cloud/OSS guardrail adapters, multi-tenant proxy |
 | [docs/COMPLIANCE.md](docs/COMPLIANCE.md) | EU AI Act and DORA article mapping, eval numbers |
+| [docs/multi-replica-deployment.md](docs/multi-replica-deployment.md) | Scaling past one proxy process: per-replica chains, rotation, archive index |
 | [CHANGELOG.md](CHANGELOG.md) | Version-by-version evolution |
 | [docs/PRIOR_ART.md](docs/PRIOR_ART.md) | When each concept first shipped, plus adjacent work |
 </details>
 
 Vaara helps deployers assemble evidence for their own conformity work. It does not certify compliance or constitute legal advice. Deployers own their obligations under the EU AI Act and other applicable law.
+
+Commercial license and paid pilots available: see [vaara.io](https://vaara.io/#pilots) or contact [hello@vaara.io](mailto:hello@vaara.io). Licensing terms are in [LICENSING.md](LICENSING.md).
 
 ## Acknowledgements
 

--- a/docs/multi-replica-deployment.md
+++ b/docs/multi-replica-deployment.md
@@ -1,0 +1,96 @@
+# Running more than one proxy: the multi-replica pattern
+
+Vaara's audit trail is a hash chain: every record binds to its predecessor, so a
+chain has exactly one writer at a time. That is a feature, not a limitation, but
+it means "three proxy replicas writing one trail" is not a thing Vaara does, and
+this page tells you what to do instead.
+
+## The unit of trust is one chain in one process
+
+One `SQLiteAuditBackend` in one process owns one chain (or one chain per tenant,
+when tenant IDs are in play). Within that process, writes from any thread are
+serialized and safe. Everything on this page follows from that.
+
+Do not point two processes at the same SQLite file. The write lock that protects
+the chain is in-process; a second process interleaving records will produce a
+chain neither process can verify. Nothing stops you from doing this today except
+this paragraph, so treat it as load-bearing.
+
+## Supported today
+
+**One replica, many tenants.** A single proxy process fans out to multiple
+upstream MCP servers (`--upstream name=cmd`, repeatable) and separates tenants
+by header on the HTTP transport. Records carry `tenant_id`, purge and export
+are tenant-scoped, and one process handles a fleet of agents as long as one
+process can carry the traffic. This is the simplest deployment that gives you
+a single DB to report from, and it is the one to exhaust first.
+
+**Many replicas, one DB each.** When you scale past one process (multiple
+hosts, one proxy per agent runtime, blast-radius isolation), give every replica
+its own `--db` path and its own signing key or a shared operator key. Each
+replica's trail is independently complete and independently verifiable: chain
+verification, `vaara compliance report`, `vaara trail shadow-report`, and
+`vaara trail rotate` all operate per DB and need nothing from the other
+replicas.
+
+Name the DBs so provenance is obvious in the archive:
+
+```
+/var/lib/vaara/audit-{host}-{service}.db
+```
+
+and set `--agent-id` per replica so records say which fleet slice produced them.
+
+## Aggregating evidence across replicas
+
+An auditor asking "what did your agents do" gets N signed archives, not one.
+That is normal, and it mirrors how any distributed system hands over logs. The
+workflow:
+
+1. Rotate each replica on the same schedule:
+
+   ```bash
+   vaara trail rotate --db /var/lib/vaara/audit-host1-github.db \
+     --out /archive/2026-07/host1-github.zip \
+     --key /etc/vaara/signer.pem --retention-days 90 --all-tenants
+   ```
+
+   Rotate exports the whole trail, re-verifies the archive from its own bytes,
+   and only then purges. A rotation whose archive fails verification purges
+   nothing.
+
+2. Keep an operator-level index of the archives: path, replica identity, and
+   the SHA-256 of each zip. A plain manifest file, updated on each rotation and
+   stored with the archives, is enough. Sign it with the same operator key if
+   you want the index itself to be evidence.
+
+3. Verification on the receiving side is per archive: `vaara trail verify
+   --zip host1-github.zip` for each entry in the index, plus a check that the
+   index covers every replica you claim to run.
+
+What the per-replica model does not give you is a cryptographic proof that the
+set of replicas is complete. If you run three proxies and hand over two
+archives, each archive still verifies. Completeness across replicas is an
+inventory statement by the operator, made checkable by the signed index, the
+same way it works for any fleet of log-producing systems. State it in those
+terms to an auditor and nobody is surprised.
+
+## What this costs and when to revisit
+
+The per-replica pattern trades a single query surface for horizontal scale.
+Reports run per DB; a fleet-wide count is a loop over archives. For most
+pilots, one process per upstream service is plenty, and the loop is a
+five-line script.
+
+Revisit when either of these stops being true:
+
+- one process can carry the write load of one chain (the audit write is
+  synchronous on the tool-call path; measured at roughly 0.2 ms per decision
+  record on local disk, WAL mode, single writer), or
+- your auditor requires one continuous chain across the fleet rather than N
+  verifiable chains plus an index.
+
+The primitives for a stronger roll-up already exist in the codebase (the RFC
+6962 transparency log that backs inclusion proofs and COSE receipts), and a
+fleet-level log anchoring each replica's archive hashes is the natural next
+step. It is not shipped today, and this page will change when it is.

--- a/examples/github-mcp-proxy-demo/README.md
+++ b/examples/github-mcp-proxy-demo/README.md
@@ -121,12 +121,11 @@ For organisations subject to EU AI Act high-risk-use obligations on agentic syst
 
 The default policy ships fail-closed for unknown tool names. To tune for the GitHub MCP catalog:
 
-- Start with a read-only policy that allows `get_*`, `list_*`, `search_*` tools and routes mutating tools (`create_*`, `update_*`, `delete_*`, `merge_*`, `push_*`) to ESCALATE.
-- Tighten further on the destructive end: any `delete_*` or force-push-equivalent operation goes DENY unless explicitly approved.
+- Start from the ready-made GitHub perimeter in [`examples/policies/mcp-starters/`](../policies/mcp-starters/README.md): an exact-name read-only allowlist plus a denylist of the destructive tools, built against the current tool catalog.
+- Pass a policy file with `--policy /path/to/policy.json` to set the risk thresholds the pipeline enforces (see [`mcp-starter.policy.json`](../policies/mcp-starters/mcp-starter.policy.json) for a stricter-than-default starting point).
+- Per-tool allow/deny is exact-name matching via `--allow-tool` / `--deny-tool` (repeatable; denylist wins on overlap).
 - Override the default agent_id by passing `--agent-id <your-id>` to the proxy.
 - Per-call overrides via the `_vaara_agent_id` argument key on a `tools/call` request (the proxy strips it before forwarding).
-
-See the main Vaara README "Policy" section for the full policy file shape.
 
 ## Generating evidence for AI Act conformity
 
@@ -144,7 +143,7 @@ The PDF output is the format a Notified Body or internal compliance auditor read
 
 - **The proxy hangs on startup.** The upstream is probably failing its initialize handshake. Check the proxy's stderr (the upstream's stderr is forwarded through). Common cause: missing or invalid `GITHUB_PERSONAL_ACCESS_TOKEN`.
 - **`github-mcp-server: command not found`.** Build it with `go install github.com/github/github-mcp-server/cmd/github-mcp-server@latest` and point `--upstream` at the resulting binary in `$(go env GOBIN)` or `$(go env GOPATH)/bin`.
-- **Every tool call is blocked.** Default fail-closed policy. Define a policy file scoped to the GitHub MCP tool catalog, or relax for read-only tools as a starting point.
+- **Every tool call is blocked.** Default fail-closed policy. Start from the GitHub perimeter in [`examples/policies/mcp-starters/`](../policies/mcp-starters/README.md), or relax for read-only tools as a starting point.
 - **Rate limits surface as upstream errors.** GitHub rate limits hit the upstream, not the proxy. The proxy records the failure in the audit chain and returns the upstream's error to the client.
 
 ## The same pattern in front of any MCP server

--- a/examples/intercept.py
+++ b/examples/intercept.py
@@ -1,4 +1,8 @@
-"""Minimal Vaara demo — risky action intercepted."""
+"""The explicit pipeline API — same engine as `@vaara.govern`, decision object in hand.
+
+Start with examples/quickstart.py for the one-decorator path; use this when
+you want the InterceptionResult itself. Needs `pip install rich` for output.
+"""
 from rich import box
 from rich.console import Console
 from rich.panel import Panel

--- a/examples/policies/mcp-starters/README.md
+++ b/examples/policies/mcp-starters/README.md
@@ -1,0 +1,225 @@
+# Starter policies for common MCP servers
+
+The Vaara MCP proxy is fail-closed: with no configuration, unknown tools score against
+default thresholds and risky calls get blocked or escalated. These starters give you a
+working perimeter for five widely used MCP servers so the first run is a config flip,
+not a policy-authoring project.
+
+Each starter has two parts:
+
+1. A perimeter: `--allow-tool` / `--deny-tool` flags with exact tool names. This is
+   where per-tool control lives. An empty allowlist means "no restriction"; a non-empty
+   allowlist restricts to exactly those names; the denylist always wins on overlap.
+2. A policy file: [`mcp-starter.policy.json`](mcp-starter.policy.json), passed with
+   `--policy`. It sets the default risk thresholds (escalate at 0.35, deny at 0.65,
+   slightly stricter than the built-ins) and is covered by the attested policy hash.
+   Tune the numbers after you have looked at your own traffic.
+
+Scope notes, so you know exactly what each knob does:
+
+- The policy file's `thresholds.default`, per-action-class `thresholds` overrides, and
+  `sequences` are all enforced. A per-class override resolves by the call's tool name, so
+  `thresholds: {"tx.sign": {"deny": 0.20}}` tightens that class while others keep the
+  default. Exact-name allow/deny still belongs to the perimeter flags; the policy file
+  tunes how strict the risk decision is per class. (`vaara policy validate` warns
+  `no_action_classes` on the starter file because it declares none. That is expected;
+  the starter relies on `thresholds` plus the perimeter, not on taxonomy routing.)
+- Several servers bundle create, update, and delete behind one tool name (GitHub's
+  `*_write` tools, Google's `manage_*` tools). A name-level allowlist cannot separate
+  the safe verb from the destructive one, so the starters deny those tools rather than
+  allowlist them. If you need the safe half, relax deliberately.
+- Tool catalogs verified against each server's documentation on 2026-07-12. Catalogs
+  change; if the upstream renames a tool, an allowlisted name that no longer exists is
+  harmless, but a renamed destructive tool falls out of your denylist. Re-check the
+  upstream's README when you update it.
+
+Two modes, in the order you should run them:
+
+- Observe first: add `--shadow`. Every call is classified, scored, and recorded but
+  nothing is blocked. After a few days, read what enforcement would have done:
+
+  ```bash
+  vaara trail shadow-report --db /path/to/audit.db --days 7
+  ```
+
+- Enforce: drop `--shadow`, apply the perimeter below, keep the denylist.
+
+All examples follow the same shape as the
+[GitHub proxy demo](../../github-mcp-proxy-demo/README.md); swap the upstream command
+for your own setup.
+
+## GitHub (github/github-mcp-server)
+
+The current server groups tools into toolsets and bundles mutations into `*_write`
+tools. Shrink the surface upstream first with `--toolsets context,repos,issues,pull_requests`,
+then apply the Vaara perimeter.
+
+Read-only perimeter (strict start):
+
+```
+--allow-tool get_me --allow-tool get_team_members --allow-tool get_teams
+--allow-tool get_repository_tree --allow-tool get_file_contents --allow-tool get_commit
+--allow-tool list_branches --allow-tool list_commits --allow-tool list_tags
+--allow-tool list_releases --allow-tool get_latest_release --allow-tool get_release_by_tag
+--allow-tool search_code --allow-tool search_repositories --allow-tool search_commits
+--allow-tool list_issues --allow-tool issue_read --allow-tool search_issues
+--allow-tool list_pull_requests --allow-tool pull_request_read --allow-tool search_pull_requests
+--allow-tool list_notifications --allow-tool get_notification_details
+```
+
+Denylist to keep even after you allow mutations (destructive or bundled-delete tools):
+
+```
+--deny-tool delete_file --deny-tool push_files --deny-tool create_or_update_file
+--deny-tool merge_pull_request --deny-tool label_write --deny-tool projects_write
+--deny-tool pull_request_review_write --deny-tool discussion_comment_write
+--deny-tool actions_run_trigger
+```
+
+`create_or_update_file` and `push_files` overwrite file content and `merge_pull_request`
+is irreversible; route them through escalation review before allowing. `label_write`,
+`projects_write`, `pull_request_review_write`, and `discussion_comment_write` each hide
+a delete operation behind the same name as create.
+
+Full client config:
+
+```json
+{
+  "mcpServers": {
+    "github-via-vaara": {
+      "command": "python",
+      "args": [
+        "-m", "vaara.integrations.mcp_proxy",
+        "--upstream", "/path/to/github-mcp-server",
+        "--upstream-arg", "stdio",
+        "--db", "/path/to/github_audit.db",
+        "--policy", "/path/to/mcp-starter.policy.json",
+        "--deny-tool", "delete_file",
+        "--deny-tool", "push_files",
+        "--deny-tool", "create_or_update_file",
+        "--deny-tool", "merge_pull_request",
+        "--deny-tool", "label_write",
+        "--deny-tool", "projects_write",
+        "--deny-tool", "pull_request_review_write",
+        "--deny-tool", "discussion_comment_write",
+        "--deny-tool", "actions_run_trigger"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_your_token_here"
+      }
+    }
+  }
+}
+```
+
+## Filesystem (@modelcontextprotocol/server-filesystem)
+
+The server publishes its own tool annotations; the three tools it marks destructive are
+the three in the denylist. `create_directory` mutates but is idempotent and
+non-destructive, so it stays allowed in the enforcing tier.
+
+Read-only perimeter:
+
+```
+--allow-tool read_text_file --allow-tool read_media_file --allow-tool read_multiple_files
+--allow-tool list_directory --allow-tool list_directory_with_sizes --allow-tool directory_tree
+--allow-tool search_files --allow-tool get_file_info --allow-tool list_allowed_directories
+```
+
+Denylist for enforcing mode:
+
+```
+--deny-tool write_file --deny-tool edit_file --deny-tool move_file
+```
+
+Note: older docs mention a `read_file` tool; the current server ships
+`read_text_file` and `read_media_file` instead.
+
+## Slack (korotovsky/slack-mcp-server)
+
+The maintained community server (the reference `@modelcontextprotocol/server-slack` is
+archived). Its message-posting tools are disabled by default upstream and must be
+enabled with `SLACK_MCP_ADD_MESSAGE_TOOL`; leave them off until you have reviewed the
+trail. Be aware the server also supports unofficial browser-session tokens (xoxc/xoxd);
+prefer a proper bot token so the recorded identity is real.
+
+Read-only perimeter:
+
+```
+--allow-tool conversations_history --allow-tool conversations_replies
+--allow-tool conversations_search_messages --allow-tool conversations_unreads
+--allow-tool channels_list --allow-tool users_search --allow-tool usergroups_list
+--allow-tool saved_list
+```
+
+Denylist for enforcing mode:
+
+```
+--deny-tool saved_clear_completed --deny-tool usergroups_users_update
+--deny-tool reactions_remove
+```
+
+`usergroups_users_update` replaces a group's entire membership in one call, and
+`saved_clear_completed` bulk-deletes saved items.
+
+## Postgres (crystaldba/postgres-mcp)
+
+Everything this server exposes is read-only except `execute_sql`, whose semantics
+depend entirely on the server's own `--access-mode` flag: `restricted` wraps it
+read-only, unrestricted allows arbitrary DML and DDL. Run the upstream in restricted
+mode and still deny `execute_sql` at the Vaara layer until you have a reason not to;
+the analysis tools cover most agent needs.
+
+Read-only perimeter:
+
+```
+--allow-tool list_schemas --allow-tool list_objects --allow-tool get_object_details
+--allow-tool explain_query --allow-tool get_top_queries
+--allow-tool analyze_workload_indexes --allow-tool analyze_query_indexes
+--allow-tool analyze_db_health
+```
+
+Denylist:
+
+```
+--deny-tool execute_sql
+```
+
+The archived reference server (`@modelcontextprotocol/server-postgres`) exposes a
+single read-only `query` tool; if you still run it, `--allow-tool query` is the whole
+perimeter.
+
+## Google Workspace (taylorwilsdon/google_workspace_mcp)
+
+No official Google server exists; this is the dominant community one. It ships its own
+risk controls: set `WORKSPACE_MCP_READ_ONLY=true` and `WORKSPACE_MCP_TOOL_TIER=core`
+upstream first, then let Vaara record and gate what remains. The catalog is large
+(100+ tools across 12 services), so the starter is a denylist of the highest-risk
+tools rather than an allowlist.
+
+Denylist for enforcing mode:
+
+```
+--deny-tool run_script_function --deny-tool update_script_content --deny-tool manage_deployment
+--deny-tool manage_drive_access --deny-tool set_drive_file_permissions
+--deny-tool send_gmail_message --deny-tool manage_gmail_filter --deny-tool manage_gmail_label
+```
+
+Why these: `run_script_function` executes arbitrary Apps Script (treat it like shell
+access to the Google account), `update_script_content` and `manage_deployment` let an
+agent persist code, `manage_drive_access` can transfer ownership and revoke
+permissions, and Gmail filter manipulation is a classic silent-exfiltration and
+persistence vector. `send_gmail_message` sends as the account owner; allow it only
+with escalation review.
+
+## Verifying what the perimeter did
+
+Every filtered call lands in the audit trail like any other decision. After a session:
+
+```bash
+vaara compliance report --db /path/to/audit.db --format json
+sqlite3 /path/to/audit.db "select count(*) from audit_records where event_type='action_blocked'"
+```
+
+The `--policy` file is hashed into the attested policy hash when OVERT attestation is
+enabled, so a silent policy swap between sessions is detectable from the receipts.

--- a/examples/policies/mcp-starters/mcp-starter.policy.json
+++ b/examples/policies/mcp-starters/mcp-starter.policy.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.1",
+  "domains": ["eu_ai_act"],
+  "action_classes": {},
+  "thresholds": {
+    "default": {"escalate": 0.35, "deny": 0.65}
+  }
+}

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,16 +1,44 @@
-from rich import print
+"""The 60-second Vaara quickstart. Zero config, zero dependencies.
 
-from vaara import Pipeline
+`@vaara.govern` is the whole integration: every call to a governed function
+is classified, risk-scored, and decided allow/escalate/deny before the body
+runs. A blocked call raises `vaara.Blocked`; every decision lands in the
+hash-chained audit trail either way.
 
-pipeline = Pipeline()
+Run:  python examples/quickstart.py
 
-result = pipeline.intercept(
-    agent_id="agent-1",
-    tool_name="transfer",
-)
+Want the decision object in hand instead of an exception? The explicit
+pipeline behind the decorator is in examples/intercept.py.
+"""
+
+import vaara
+
+
+@vaara.govern
+def read_file(path: str) -> str:
+    return f"(pretend contents of {path})"
+
+
+@vaara.govern
+def shell_exec(command: str) -> str:
+    return "(pretend the shell ran)"
+
+
+# A boring read is allowed and the function body runs.
+print(read_file(path="README.md"))
+
+# A destructive command never reaches the body.
+try:
+    shell_exec(command="rm -rf /")
+except vaara.Blocked as blocked:
+    print(f"blocked: {blocked}")
 
 print()
-color = {"allow": "bold green", "escalate": "bold yellow", "deny": "bold red"}[result.decision]
-print(f"  [dim]decision[/]   [{color}]{result.decision.upper()}[/]")
-print(f"  [dim]risk[/]       [cyan]{result.risk_score:.3f}[/]")
+print("Both decisions were scored and recorded in the process-wide trail")
+print("(in-memory by default; wire a signing SQLite trail via")
+print("vaara.govern.set_default_pipeline for a persistent, verifiable record).")
 print()
+print("Next steps:")
+print("  examples/intercept.py               # the explicit pipeline API")
+print("  examples/github-mcp-proxy-demo/     # persistent trail in front of a real MCP server")
+print("  examples/policies/                  # write your own policy")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.25.0"
+version = "1.26.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
@@ -77,7 +77,7 @@ where = ["src"]
 # Ship only the production bundle. v9 is the sole bundle loaded at runtime
 # (_DEFAULT_BUNDLE in adversarial_classifier.py); v1-v8 are retained in the
 # repo for bench/cross-eval but were ~7MB of dead weight in every wheel.
-vaara = ["data/adversarial_classifier_v9.joblib"]
+vaara = ["data/adversarial_classifier_v9.joblib", "py.typed"]
 # Declarative source-profile specs loaded at runtime by _declarative.py.
 "vaara.attestation" = ["profiles/*.json"]
 

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -24,6 +24,11 @@ rm -rf dist_preflight
 }
 WHEEL=$(ls dist_preflight/vaara-*.whl)
 echo "[preflight] built: $(basename "$WHEEL")"
+# The version the wheel was built as (from pyproject). The installed package
+# must report exactly this; v1.23.0-v1.25.0 shipped with a stale __version__
+# because nothing compared the two.
+WHEEL_VERSION="$(basename "$WHEEL" | sed -E 's/^vaara-([^-]+)-.*/\1/')"
+export VAARA_EXPECTED_VERSION="$WHEEL_VERSION"
 
 echo "[preflight] install wheel + [ml] extras in fresh venv..."
 python3 -m venv "$VDIR/test"
@@ -32,9 +37,15 @@ python3 -m venv "$VDIR/test"
 
 echo "[preflight] import + classifier load + smoke scoring..."
 "$VDIR/test/bin/python" - <<'PY'
+import os
 import sys
+from pathlib import Path
 import vaara
-assert vaara.__version__, "missing __version__"
+expected = os.environ["VAARA_EXPECTED_VERSION"]
+assert vaara.__version__ == expected, (
+    f"version drift: installed package reports {vaara.__version__!r}, wheel is {expected!r}"
+)
+assert Path(vaara.__file__).with_name("py.typed").is_file(), "py.typed missing from wheel"
 print(f"    vaara=={vaara.__version__}")
 
 from vaara.adversarial_classifier import AdversarialClassifier

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.22.0"
+__version__ = "1.26.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/adversarial_classifier.py
+++ b/src/vaara/adversarial_classifier.py
@@ -24,6 +24,7 @@ All stay out of the default install.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from pathlib import Path
@@ -149,6 +150,12 @@ _DST_PATTERNS = [
 ]
 
 _DEFAULT_BUNDLE = Path(__file__).parent / "data" / "adversarial_classifier_v9.joblib"
+# Pinned digest of the shipped bundle, verified before unpickling. joblib.load
+# is pickle, so a swapped bundle file is arbitrary code execution; the pin
+# turns that into a clean ValueError. Regenerate with
+# `sha256sum src/vaara/data/adversarial_classifier_v9.joblib` when the
+# production bundle changes.
+_DEFAULT_BUNDLE_SHA256 = "2566da22bf5229a3982f5b6ac2a1bb6ca36d13177a32bbbffcc251d8e4fb16c1"
 
 _STATIC_FEATURES = [f"ip__{n}" for n,_ in _IP_PATTERNS] + [f"cred__{n}" for n,_ in _CRED_PATTERNS] + [f"sql__{n}" for n,_ in _SQL_PATTERNS] + [f"shell__{n}" for n,_ in _SHELL_PATTERNS] + [f"scheme__{s}" for s in _URL_SCHEMES] + ["ctx_source_injected", "param_blob_len", "has_wildcard_star", "has_all_keyword", "has_recursive_flag"]
 _DST_STATIC = [f"dst__{n}" for n, _ in _DST_PATTERNS]
@@ -225,7 +232,12 @@ class AdversarialClassifier:
     install with ``pip install vaara[ml]``.
     """
 
-    def __init__(self, bundle_path: Optional[str] = None, threshold: Optional[float] = None) -> None:
+    def __init__(
+        self,
+        bundle_path: Optional[str] = None,
+        threshold: Optional[float] = None,
+        expected_sha256: Optional[str] = None,
+    ) -> None:
         try:
             import joblib  # noqa: F401
             import xgboost  # noqa: F401
@@ -237,6 +249,18 @@ class AdversarialClassifier:
         path = Path(bundle_path) if bundle_path else _DEFAULT_BUNDLE
         if not path.exists():
             raise FileNotFoundError(f"bundle not found: {path}")
+        # Verify before unpickling: the shipped bundle against its pinned
+        # digest always, a caller-supplied bundle only when the caller
+        # declares one. joblib.load on a tampered file is code execution,
+        # so a mismatch must never reach it.
+        expected = expected_sha256 if bundle_path else (expected_sha256 or _DEFAULT_BUNDLE_SHA256)
+        if expected:
+            actual = hashlib.sha256(path.read_bytes()).hexdigest()
+            if actual != expected:
+                raise ValueError(
+                    f"bundle integrity check failed for {path}: "
+                    f"sha256 {actual} != expected {expected}"
+                )
         bundle = joblib.load(path)
         self._model = bundle["model"]
         self._vocab = bundle["vocab"]

--- a/src/vaara/audit/rotate.py
+++ b/src/vaara/audit/rotate.py
@@ -1,0 +1,107 @@
+"""Retention rotation: export a signed archive, verify it, then purge.
+
+``purge_older_than`` leaves a documented hash-chain seam at the retention
+boundary, and the documented workflow around it (export a signed zip first,
+archive it externally, then purge) was manual. ``rotate`` is that workflow
+as one fail-closed operation: the purge never runs unless the archive was
+written AND re-verified from its own bytes. A rotation that cannot prove
+its archive is a rotation that did not happen.
+
+Requires the [export] extra (cryptography) via ``export_signed``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Union
+
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+
+logger = logging.getLogger("vaara.audit.rotate")
+
+
+@dataclass
+class RotateResult:
+    """Return value of :func:`rotate`.
+
+    ``ok``: archive written, verified, and (unless dry_run) purge applied.
+    ``exported_records``: records in the signed archive (whole trail).
+    ``purged_records``: records purged, or that would be purged in dry_run.
+    ``archive_path``: the written zip, when export succeeded.
+    ``errors``: human-readable failure reasons (empty if ``ok``).
+    """
+    ok: bool
+    exported_records: int = 0
+    purged_records: int = 0
+    archive_path: Union[Path, None] = None
+    errors: list[str] = field(default_factory=list)
+
+
+def rotate(
+    db_path: Union[str, Path],
+    out_path: Union[str, Path],
+    signer_key: Union[str, Path, bytes],
+    retention_days: int,
+    *,
+    tenant_id: str = "",
+    dry_run: bool = False,
+) -> RotateResult:
+    """Export the whole trail as a signed zip, verify it, then purge.
+
+    The archive always covers the full trail (export is whole-trail), so the
+    external archive chain stays self-consistent forever while the live DB
+    keeps only the retention window. Purging is skipped entirely when the
+    export or its verification fails, and in ``dry_run`` mode the purge
+    count is reported without deleting anything.
+    """
+    from vaara.audit.export import export_signed
+    from vaara.audit.verify import verify_signed
+
+    if retention_days <= 0:
+        return RotateResult(ok=False, errors=[f"retention_days must be > 0, got {retention_days}"])
+
+    out = Path(out_path)
+    backend = SQLiteAuditBackend(db_path, tenant_id=tenant_id)
+    try:
+        exported = backend.count()
+
+        try:
+            export_result = export_signed(backend.load_trail(), out, signer_key=signer_key)
+        except Exception as exc:
+            return RotateResult(
+                ok=False,
+                exported_records=exported,
+                errors=[f"export failed, purge skipped: {exc}"],
+            )
+        if not export_result.chain_intact:
+            return RotateResult(
+                ok=False,
+                exported_records=exported,
+                archive_path=out,
+                errors=["exported chain did not verify at export time, purge skipped"],
+            )
+
+        verdict = verify_signed(out)
+        if not verdict.ok:
+            return RotateResult(
+                ok=False,
+                exported_records=exported,
+                archive_path=out,
+                errors=["archive failed re-verification, purge skipped"] + verdict.errors,
+            )
+
+        purged = backend.purge_older_than(retention_days * 86400, dry_run=dry_run)
+        logger.info(
+            "rotate: archived %d record(s) to %s, %s %d record(s) older than %d day(s)",
+            exported, out, "would purge" if dry_run else "purged", purged, retention_days,
+        )
+        return RotateResult(
+            ok=True,
+            exported_records=exported,
+            purged_records=purged,
+            archive_path=out,
+        )
+    finally:
+        backend.close()

--- a/src/vaara/audit/shadow_report.py
+++ b/src/vaara/audit/shadow_report.py
@@ -1,0 +1,138 @@
+"""The shadow report: what would have been blocked, from the trail alone.
+
+Shadow mode (``InterceptionPipeline(enforce=False)``, or ``--shadow`` on the
+MCP proxy) records the true decision for every call while allowing all of
+them, so an operator can run Vaara in front of live traffic without breaking
+anything. This module answers the question that run exists to answer: over
+the last N days, what would enforcement have done?
+
+The report reads the audit DB directly and needs nothing beyond the standard
+library. In an enforcing deployment the same numbers describe what actually
+was blocked, since the trail records decisions identically in both modes.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Union
+
+_DECISION_QUERY = """
+SELECT event_type, tool_name, agent_id, data
+FROM audit_records
+WHERE timestamp >= ?
+  AND (event_type = 'action_blocked'
+       OR (event_type = 'decision_made'))
+"""
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def shadow_report(db_path: Union[str, Path], days: int = 7) -> dict[str, Any]:
+    """Summarise decisions over the trailing window, grouped by tool.
+
+    Returns a JSON-serialisable dict. ``would_block`` counts deny decisions
+    (stored as ``action_blocked`` records regardless of enforcement mode),
+    ``would_escalate`` counts escalate decisions.
+    """
+    now = time.time()
+    cutoff = now - days * 86400.0
+    uri = f"file:{Path(db_path)}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    try:
+        rows = conn.execute(_DECISION_QUERY, (cutoff,)).fetchall()
+    finally:
+        conn.close()
+
+    allowed = 0
+    escalated: dict[str, dict[str, Any]] = {}
+    blocked: dict[str, dict[str, Any]] = {}
+
+    for event_type, tool_name, agent_id, data_json in rows:
+        try:
+            data = json.loads(data_json)
+        except (TypeError, ValueError):
+            data = {}
+        decision = data.get("decision", "")
+        risk = data.get("risk_score")
+        reason = data.get("reason", "")
+
+        if event_type == "action_blocked":
+            bucket = blocked
+        elif decision == "escalate":
+            bucket = escalated
+        else:
+            allowed += 1
+            continue
+
+        entry = bucket.setdefault(tool_name, {
+            "tool_name": tool_name,
+            "count": 0,
+            "agents": set(),
+            "max_risk": None,
+            "sample_reason": reason,
+        })
+        entry["count"] += 1
+        entry["agents"].add(agent_id)
+        if isinstance(risk, (int, float)):
+            entry["max_risk"] = risk if entry["max_risk"] is None else max(entry["max_risk"], risk)
+
+    def _finalise(bucket: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+        out = []
+        for entry in sorted(bucket.values(), key=lambda e: (-e["count"], e["tool_name"])):
+            entry["agents"] = sorted(entry["agents"])
+            out.append(entry)
+        return out
+
+    blocked_list = _finalise(blocked)
+    escalated_list = _finalise(escalated)
+    would_block = sum(e["count"] for e in blocked_list)
+    would_escalate = sum(e["count"] for e in escalated_list)
+
+    return {
+        "window_days": days,
+        "since": _iso(cutoff),
+        "until": _iso(now),
+        "total_decisions": allowed + would_block + would_escalate,
+        "allowed": allowed,
+        "would_escalate": would_escalate,
+        "would_block": would_block,
+        "blocked": blocked_list,
+        "escalated": escalated_list,
+    }
+
+
+def render_text(report: dict[str, Any]) -> str:
+    """Plain-text rendering of a shadow report for terminals and emails."""
+    lines = [
+        f"Vaara shadow report, last {report['window_days']} day(s)",
+        f"  window   {report['since']} .. {report['until']}",
+        f"  decisions {report['total_decisions']}: "
+        f"{report['allowed']} allowed, "
+        f"{report['would_escalate']} would have escalated, "
+        f"{report['would_block']} would have been blocked",
+    ]
+    if report["blocked"]:
+        lines.append("")
+        lines.append("Would have been blocked:")
+        for entry in report["blocked"]:
+            risk = f" max_risk={entry['max_risk']:.2f}" if entry["max_risk"] is not None else ""
+            agents = ", ".join(entry["agents"])
+            lines.append(f"  {entry['count']:4d}x {entry['tool_name']}{risk}  agents: {agents}")
+            if entry["sample_reason"]:
+                lines.append(f"        reason: {entry['sample_reason']}")
+    if report["escalated"]:
+        lines.append("")
+        lines.append("Would have escalated to human review:")
+        for entry in report["escalated"]:
+            risk = f" max_risk={entry['max_risk']:.2f}" if entry["max_risk"] is not None else ""
+            lines.append(f"  {entry['count']:4d}x {entry['tool_name']}{risk}")
+    if not report["blocked"] and not report["escalated"]:
+        lines.append("")
+        lines.append("Nothing would have been blocked or escalated in this window.")
+    return "\n".join(lines)

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -370,6 +370,53 @@ def _keygen_attest(out: Path, pub_out: Path) -> int:
     return 0
 
 
+def _cmd_trail_rotate(args: argparse.Namespace) -> int:
+    from vaara.audit.rotate import rotate
+
+    db_path = Path(args.db).expanduser()
+    if not db_path.is_file():
+        print(f"vaara trail rotate: not a file: {db_path}", file=sys.stderr)
+        return 2
+
+    result = rotate(
+        db_path=db_path,
+        out_path=Path(args.out).expanduser(),
+        signer_key=Path(args.key).expanduser(),
+        retention_days=args.retention_days,
+        tenant_id="" if args.all_tenants else args.tenant,
+        dry_run=args.dry_run,
+    )
+    if not result.ok:
+        for err in result.errors:
+            print(f"vaara trail rotate: {err}", file=sys.stderr)
+        return 1
+    print(f"Archived {result.exported_records} record(s) to {result.archive_path} (verified).")
+    if args.dry_run:
+        print(f"Would purge {result.purged_records} record(s) older than {args.retention_days} day(s).")
+        print("Run without --dry-run to apply.")
+    else:
+        print(f"Purged {result.purged_records} record(s) older than {args.retention_days} day(s).")
+        print("Archive the zip externally; the live DB now has a chain seam at the boundary.")
+    return 0
+
+
+def _cmd_trail_shadow_report(args: argparse.Namespace) -> int:
+    import json as _json
+
+    from vaara.audit.shadow_report import render_text, shadow_report
+
+    db_path = Path(args.db).expanduser()
+    if not db_path.is_file():
+        print(f"vaara trail shadow-report: not a file: {db_path}", file=sys.stderr)
+        return 2
+    report = shadow_report(db_path, days=args.days)
+    if args.format == "json":
+        print(_json.dumps(report, indent=2))
+    else:
+        print(render_text(report))
+    return 0
+
+
 def _cmd_trail_export(args: argparse.Namespace) -> int:
     try:
         from vaara.audit.export import export_signed
@@ -3970,6 +4017,44 @@ def build_parser() -> argparse.ArgumentParser:
         help="Purge across all tenants in this DB. Use only on single-tenant deployments or after deliberate review.",
     )
     pp.set_defaults(func=_cmd_trail_purge)
+
+    prot = tsub.add_parser(
+        "rotate",
+        help="Export a signed archive, verify it, then purge old records (fail-closed)",
+    )
+    prot.add_argument("--db", required=True, help="Path to the audit SQLite DB")
+    prot.add_argument("--out", required=True, help="Path to write the signed archive zip")
+    prot.add_argument("--key", required=True, help="Path to Ed25519 signing private key (PEM)")
+    prot.add_argument(
+        "--retention-days", required=True, type=int,
+        help="Records older than this many days are purged after the archive verifies",
+    )
+    prot.add_argument(
+        "--dry-run", action="store_true",
+        help="Export and verify the archive, report the purge count, delete nothing",
+    )
+    rot_scope = prot.add_mutually_exclusive_group(required=True)
+    rot_scope.add_argument("--tenant", help="Restrict rotation to records with this tenant_id")
+    rot_scope.add_argument(
+        "--all-tenants", action="store_true",
+        help="Rotate across all tenants in this DB",
+    )
+    prot.set_defaults(func=_cmd_trail_rotate)
+
+    psr = tsub.add_parser(
+        "shadow-report",
+        help="Summarise what enforcement would have blocked over the trailing window",
+    )
+    psr.add_argument("--db", required=True, help="Path to the audit SQLite DB")
+    psr.add_argument(
+        "--days", type=int, default=7,
+        help="Trailing window in days (default 7)",
+    )
+    psr.add_argument(
+        "--format", choices=["text", "json"], default="text",
+        help="Output format (default text)",
+    )
+    psr.set_defaults(func=_cmd_trail_shadow_report)
 
     pr = sub.add_parser(
         "review",

--- a/src/vaara/integrations/_mcp_overt.py
+++ b/src/vaara/integrations/_mcp_overt.py
@@ -130,6 +130,7 @@ def policy_hash_from_perimeter(
     resource_deny: set[str],
     prompt_allow: Optional[set[str]],
     prompt_deny: set[str],
+    policy_source: Optional[bytes] = None,
 ) -> bytes:
     """SHA-256 over canonical JSON of the operator perimeter configuration.
 
@@ -146,6 +147,11 @@ def policy_hash_from_perimeter(
         "prompt_allow": sorted(prompt_allow) if prompt_allow else None,
         "prompt_deny": sorted(prompt_deny),
     }
+    if policy_source is not None:
+        # A --policy file governs decisions, so it must be covered by the
+        # attested hash. The key is added only when a policy is present, so
+        # perimeter-only deployments keep their historical hash.
+        config["policy_sha256"] = hashlib.sha256(policy_source).hexdigest()
     payload = json.dumps(config, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(payload).digest()
 

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -195,15 +195,23 @@ class VaaraMCPProxy:
         upstream_headers: Optional[dict[str, dict[str, str]]] = None,
         allow_private_upstream_hosts: Optional[bool] = None,
         router: Optional[NotificationRouter] = None,
+        policy: Optional[Any] = None,
+        shadow: bool = False,
     ) -> None:
         if pipeline is not None:
+            # An explicit pipeline carries its own enforce setting; shadow
+            # only applies to the internally-built one.
             self._pipeline = pipeline
             self._backend = None
         else:
             db = db_path or Path(os.environ.get("VAARA_DB", "vaara_audit.db"))
             self._backend = SQLiteAuditBackend(db)
             trail = AuditTrail(on_record=self._backend.write_record)
-            self._pipeline = InterceptionPipeline(trail=trail)
+            self._pipeline = InterceptionPipeline(trail=trail, enforce=not shadow)
+        if policy is not None:
+            # Same rebinding `vaara serve` does: thresholds and sequence
+            # patterns come from the loaded policy, scorer state is kept.
+            self._pipeline.scorer.apply_policy(policy)
         self._agent_id_default = agent_id_default
         # An empty allowlist means "no restriction" (None and empty set are equivalent
         # here); a non-empty allowlist restricts to exactly those names. Denylist
@@ -1603,6 +1611,16 @@ def main(argv: Optional[list[str]] = None) -> None:
     )
     parser.add_argument("--db", type=Path, default=None,
                         help="Audit database path (default: $VAARA_DB or ./vaara_audit.db)")
+    parser.add_argument("--policy", type=Path, default=None,
+                        help="YAML/JSON policy file (thresholds, sequences) applied to the "
+                             "interception pipeline. Same format as `vaara serve --policy`; "
+                             "starter policies for common MCP servers live in "
+                             "examples/policies/mcp-starters/. YAML needs the [yaml] extra.")
+    parser.add_argument("--shadow", action="store_true",
+                        help="Observe-only mode: classify, score, and audit every call but "
+                             "block nothing. The trail records the true decision, so "
+                             "`vaara trail shadow-report` shows what enforcement would have "
+                             "blocked. Flip to enforcing by dropping this flag.")
     parser.add_argument("--agent-id", default="mcp-proxy-client",
                         help="Default agent_id for the audit trail")
     parser.add_argument("--allow-tool", action="append", default=[], dest="allow_tools",
@@ -1667,12 +1685,30 @@ def main(argv: Optional[list[str]] = None) -> None:
     prompt_allow = set(args.allow_prompts) if args.allow_prompts else None
     prompt_deny = set(args.deny_prompts) if args.deny_prompts else set()
 
+    policy_obj = None
+    policy_source: Optional[bytes] = None
+    if args.policy is not None:
+        from vaara.policy.validate import validate_source
+
+        policy_path = args.policy.expanduser()
+        policy_obj, report = validate_source(policy_path)
+        if policy_obj is None:
+            print(
+                f"vaara-mcp-proxy: policy {policy_path} failed validation:",
+                file=sys.stderr,
+            )
+            for issue in report.issues:
+                print(f"  {issue.level.value}: {issue.message}", file=sys.stderr)
+            sys.exit(2)
+        policy_source = policy_path.read_bytes()
+
     overt_emitter = _build_overt_emitter_from_args(
         args,
         policy_hash=policy_hash_from_perimeter(
             tool_allow=tool_allow, tool_deny=tool_deny,
             resource_allow=resource_allow, resource_deny=resource_deny,
             prompt_allow=prompt_allow, prompt_deny=prompt_deny,
+            policy_source=policy_source,
         ),
     )
 
@@ -1712,6 +1748,8 @@ def main(argv: Optional[list[str]] = None) -> None:
             prompt_denylist=prompt_deny if prompt_deny else None,
             overt_emitter=overt_emitter,
             attest_emitter=attest_emitter,
+            policy=policy_obj,
+            shadow=args.shadow,
         )
     except (ValueError, ProxyError) as e:
         # ProxyError here means a --upstream-url target was refused by the SSRF

--- a/src/vaara/scorer/_param_signals.py
+++ b/src/vaara/scorer/_param_signals.py
@@ -1,0 +1,98 @@
+"""Deterministic parameter-content risk signals for the base rule scorer.
+
+Stdlib only, so it runs in a zero-config install with no ML extra and with no
+dependency on the integrations layer. The one signal here is the cloud-metadata
+endpoint: a call parameter pointing at 169.254.169.254 (or its IPv6 / dotless /
+hex encodings) is a known SSRF attack, not a probabilistic risk, so it is
+treated as a hard decision floor rather than one averaged expert among many.
+
+The boundary matches the MCP proxy egress guard
+(vaara.integrations._egress_guard, the canonical network-enforcement point):
+the metadata address has no legitimate reason to be dialed, while private and
+loopback hosts stay reachable and are not floored here. The detection is
+duplicated rather than imported to keep the scorer free of any dependency on
+the integrations package.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from typing import Any, Optional
+from urllib.parse import urlsplit
+
+# The cloud instance-metadata endpoints, refused unconditionally.
+_METADATA_V4 = ipaddress.IPv4Address("169.254.169.254")
+_METADATA_V6 = ipaddress.IPv6Address("fe80::a9fe:a9fe")
+
+# Risk assigned when a metadata endpoint is found. High enough that the
+# scorer's decision floor lands the call in deny/escalate regardless of the
+# benign taxonomy base for a network read.
+_METADATA_RISK = 0.95
+
+# Bare host tokens that look like an IP or a dotless/hex integer, pulled from
+# any string value in the parameters (not only well-formed URLs).
+_HOSTISH = re.compile(r"(?:\[[0-9A-Fa-f:]+\]|[0-9A-Fa-f.x]+)")
+
+
+def _coerce_dotless_host(host: str) -> Optional[ipaddress.IPv4Address]:
+    """Parse a bare decimal or hex integer host (``2852039166``, ``0xa9fea9fe``).
+
+    Browsers and ``inet_aton`` accept these as IPv4; ``ipaddress`` does not, so
+    decode them explicitly. Returns the address when the host is such an
+    integer, else None.
+    """
+    base = 16 if host.lower().startswith("0x") else 10
+    try:
+        value = int(host, base)
+    except ValueError:
+        return None
+    if 0 <= value <= 0xFFFFFFFF:
+        return ipaddress.IPv4Address(value)
+    return None
+
+
+def _is_metadata(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:  # ::ffff:a.b.c.d judged on the embedded v4 address
+        ip = mapped
+    return ip == _METADATA_V4 or ip == _METADATA_V6
+
+
+def _host_is_metadata(host: str) -> bool:
+    host = host.strip().strip("[]")
+    if not host:
+        return False
+    dotless = _coerce_dotless_host(host)
+    if dotless is not None and _is_metadata(dotless):
+        return True
+    try:
+        return _is_metadata(ipaddress.ip_address(host))
+    except ValueError:
+        return False
+
+
+def _string_hits_metadata(value: str) -> bool:
+    # Try the value as a URL first (covers scheme://host:port/path), then
+    # scan any host-shaped tokens so an unschemed or embedded address is
+    # still caught.
+    host = urlsplit(value).hostname
+    if host and _host_is_metadata(host):
+        return True
+    return any(_host_is_metadata(tok) for tok in _HOSTISH.findall(value))
+
+
+def _walk(value: Any) -> bool:
+    if isinstance(value, str):
+        return _string_hits_metadata(value)
+    if isinstance(value, dict):
+        return any(_walk(v) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_walk(v) for v in value)
+    return False
+
+
+def metadata_endpoint_risk(parameters: Any) -> float:
+    """Return ``_METADATA_RISK`` if any parameter targets a cloud-metadata
+    endpoint, else 0.0. Recurses through nested dicts and lists."""
+    return _METADATA_RISK if _walk(parameters) else 0.0

--- a/src/vaara/scorer/adaptive.py
+++ b/src/vaara/scorer/adaptive.py
@@ -662,6 +662,10 @@ class AdaptiveScorer:
         self._threshold_allow = threshold_allow
         self._threshold_deny = threshold_deny
         self._policy_lookup = policy_lookup
+        # The default-slot policy set by apply_policy, kept so per-action-class
+        # threshold overrides resolve at decision time. None until a policy is
+        # applied, in which case the constructor defaults stand.
+        self._default_policy: Any = None
         self._burst_window = burst_window_seconds
         self._burst_threshold = burst_threshold
         self._max_tracked_agents = max_tracked_agents
@@ -739,6 +743,9 @@ class AdaptiveScorer:
             self._threshold_allow = new_allow
             self._threshold_deny = new_deny
             self._sequences = new_sequences
+            # Keep the policy so per-action-class threshold overrides
+            # (policy.threshold_for) resolve by tool name at decision time.
+            self._default_policy = policy
             # Per-(agent, pattern) last-match cache keys may reference
             # removed patterns; clear so the next match transition logs
             # cleanly against the new pattern set.
@@ -779,33 +786,39 @@ class AdaptiveScorer:
         with self._lock:
             self._policy_lookup = policy_lookup
 
-    def _thresholds_for(self, tenant_id: str) -> tuple[float, float]:
+    def _thresholds_for(self, tenant_id: str, tool_name: str = "") -> tuple[float, float]:
         """Resolve (allow, deny) thresholds for this call.
 
-        Empty tenant_id or no policy_lookup configured returns the
-        scorer-bound defaults rebound by the most recent apply_policy
-        on the default ("") slot. A configured lookup that returns
-        None (tenant has no policy of its own) also falls back to the
-        defaults. _thresholds_for is called from _evaluate_locked while
-        the scorer lock is held; the lookup acquires the registry lock
-        on top, so lock ordering is consistently scorer -> registry
-        across this codebase (never the reverse).
+        Resolution order: the tenant policy if a lookup is configured and
+        returns one, else the default-slot policy from the most recent
+        apply_policy, else the scorer-bound constructor defaults. Whichever
+        policy applies, a per-action-class override for ``tool_name``
+        (policy.threshold_for) is composed on top of that policy's defaults,
+        so tightening one class does not restate the others.
+
+        _thresholds_for is called from _evaluate_locked while the scorer lock
+        is held; the lookup acquires the registry lock on top, so lock
+        ordering is consistently scorer -> registry across this codebase
+        (never the reverse).
         """
-        if not tenant_id or self._policy_lookup is None:
-            return (self._threshold_allow, self._threshold_deny)
-        try:
-            tenant_policy = self._policy_lookup(tenant_id)
-        except Exception:
-            return (self._threshold_allow, self._threshold_deny)
-        if tenant_policy is None:
-            return (self._threshold_allow, self._threshold_deny)
         from vaara.policy.schema import Policy  # local import to avoid cycles
-        if not isinstance(tenant_policy, Policy):
+
+        policy: Any = None
+        if tenant_id and self._policy_lookup is not None:
+            try:
+                candidate = self._policy_lookup(tenant_id)
+            except Exception:
+                candidate = None
+            if isinstance(candidate, Policy):
+                policy = candidate
+        if policy is None and isinstance(self._default_policy, Policy):
+            policy = self._default_policy
+
+        if policy is None:
             return (self._threshold_allow, self._threshold_deny)
-        return (
-            tenant_policy.thresholds_default.escalate,
-            tenant_policy.thresholds_default.deny,
-        )
+
+        resolved = policy.threshold_for(tool_name) if tool_name else policy.thresholds_default
+        return (resolved.escalate, resolved.deny)
 
     def _calib_category(self, tool_name: str) -> Optional[str]:
         """Category to route through to the calibrator for this action.
@@ -852,7 +865,7 @@ class AdaptiveScorer:
         # Per-tenant threshold dispatch. Empty tenant_id or no lookup
         # configured returns the scorer-bound defaults bound at apply_policy
         # time on the default ("") slot.
-        threshold_allow, threshold_deny = self._thresholds_for(tenant_id)
+        threshold_allow, threshold_deny = self._thresholds_for(tenant_id, tool_name)
 
         # Build risk signals from each expert
         signals = self._compute_signals(
@@ -879,6 +892,18 @@ class AdaptiveScorer:
         # If the worst-case (within 1-alpha confidence) is safe, allow it.
         # If the best-case is dangerous, deny it.
         decision_score = upper
+
+        # Deterministic content floor: a call parameter pointing at a
+        # cloud-metadata endpoint is a known SSRF attack, not a probabilistic
+        # risk to be averaged away by the experts. Floor the decision score so
+        # the base install (no ML extra) does not silently allow it. Benign
+        # and private hosts return 0.0 and leave the score untouched.
+        from vaara.scorer._param_signals import metadata_endpoint_risk
+        content_floor = metadata_endpoint_risk(context.get("parameters"))
+        if content_floor > decision_score:
+            decision_score = content_floor
+            signals["parameter_content"] = content_floor
+
         if decision_score < threshold_allow:
             decision = Decision.ALLOW
         elif decision_score > threshold_deny:
@@ -953,7 +978,7 @@ class AdaptiveScorer:
         reversibility = context.get("reversibility", "partially_reversible")
         blast_radius = context.get("blast_radius", "local")
 
-        threshold_allow, threshold_deny = self._thresholds_for(tenant_id)
+        threshold_allow, threshold_deny = self._thresholds_for(tenant_id, tool_name)
 
         # _compute_signals is read-only for everything except the
         # sequence detector's warning log — silence that temporarily.

--- a/tests/test_bundle_integrity.py
+++ b/tests/test_bundle_integrity.py
@@ -1,0 +1,71 @@
+"""Integrity pinning for classifier bundles.
+
+joblib.load is pickle: loading a tampered bundle is arbitrary code execution.
+The shipped default bundle is verified against a pinned SHA-256 before it is
+unpickled, and a caller loading their own bundle can pass expected_sha256 to
+get the same fail-closed check.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+
+import pytest
+
+pytest.importorskip("joblib")
+pytest.importorskip("xgboost")
+
+import vaara.adversarial_classifier as ac
+
+
+def _sha256(path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _tampered_copy(tmp_path):
+    dst = tmp_path / "tampered.joblib"
+    shutil.copy(ac._DEFAULT_BUNDLE, dst)
+    raw = bytearray(dst.read_bytes())
+    raw[len(raw) // 2] ^= 0xFF
+    dst.write_bytes(bytes(raw))
+    return dst
+
+
+def test_pinned_hash_matches_shipped_bundle():
+    assert ac._DEFAULT_BUNDLE_SHA256 == _sha256(ac._DEFAULT_BUNDLE)
+
+
+def test_default_bundle_load_verifies_pin(monkeypatch, tmp_path):
+    tampered = _tampered_copy(tmp_path)
+    monkeypatch.setattr(ac, "_DEFAULT_BUNDLE", tampered)
+    with pytest.raises(ValueError, match="integrity"):
+        ac.AdversarialClassifier()
+
+
+def test_explicit_path_with_expected_sha256_rejects_tampered(tmp_path):
+    tampered = _tampered_copy(tmp_path)
+    with pytest.raises(ValueError, match="integrity"):
+        ac.AdversarialClassifier(
+            bundle_path=str(tampered),
+            expected_sha256=ac._DEFAULT_BUNDLE_SHA256,
+        )
+
+
+def test_explicit_path_with_matching_sha256_loads(tmp_path):
+    copy = tmp_path / "copy.joblib"
+    shutil.copy(ac._DEFAULT_BUNDLE, copy)
+    clf = ac.AdversarialClassifier(
+        bundle_path=str(copy),
+        expected_sha256=_sha256(copy),
+    )
+    assert clf.bundle_version
+
+
+def test_explicit_path_without_pin_still_loads(tmp_path):
+    # A caller's own bundle with no declared pin keeps working; the trust
+    # decision is theirs.
+    copy = tmp_path / "copy.joblib"
+    shutil.copy(ac._DEFAULT_BUNDLE, copy)
+    clf = ac.AdversarialClassifier(bundle_path=str(copy))
+    assert clf.bundle_version

--- a/tests/test_mcp_proxy_policy.py
+++ b/tests/test_mcp_proxy_policy.py
@@ -1,0 +1,62 @@
+"""--policy on the MCP proxy: a policy file drives the proxy's pipeline.
+
+Before this, the proxy always ran the default scorer thresholds; the only
+operator controls were the exact-name --allow-tool/--deny-tool perimeter.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vaara.integrations._mcp_overt import policy_hash_from_perimeter
+from vaara.integrations.mcp_proxy import VaaraMCPProxy, main
+from vaara.policy import from_dict
+
+_POLICY_DICT = {
+    "version": "0.1",
+    "domains": ["eu_ai_act"],
+    "action_classes": {},
+    "thresholds": {"default": {"escalate": 0.15, "deny": 0.35}},
+}
+
+
+def test_proxy_applies_policy_to_pipeline_scorer(tmp_path):
+    policy = from_dict(_POLICY_DICT)
+    proxy = VaaraMCPProxy(
+        upstream_command=["true"],
+        db_path=tmp_path / "audit.db",
+        policy=policy,
+    )
+    assert proxy._pipeline.scorer._threshold_allow == 0.15
+    assert proxy._pipeline.scorer._threshold_deny == 0.35
+
+
+def test_main_rejects_malformed_policy(tmp_path, capsys):
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"version": "0.1", "thresholds": {"default": {"escalate": 2.0, "deny": 0.1}}}))
+    with pytest.raises(SystemExit) as exc:
+        main([
+            "--upstream", "up=true",
+            "--db", str(tmp_path / "audit.db"),
+            "--policy", str(bad),
+        ])
+    assert exc.value.code == 2
+    err = capsys.readouterr().err.lower()
+    # Must be a validation failure, not argparse choking on an unknown flag.
+    assert "unrecognized arguments" not in err
+    assert "policy" in err and "failed" in err
+
+
+def test_policy_source_changes_perimeter_hash():
+    base = dict(
+        tool_allow=None, tool_deny=set(),
+        resource_allow=None, resource_deny=set(),
+        prompt_allow=None, prompt_deny=set(),
+    )
+    without = policy_hash_from_perimeter(**base)
+    with_policy = policy_hash_from_perimeter(**base, policy_source=b'{"thresholds": {}}')
+    assert without != with_policy
+    # No policy source keeps the historical hash payload byte-identical.
+    assert without == policy_hash_from_perimeter(**base)

--- a/tests/test_mcp_proxy_shadow.py
+++ b/tests/test_mcp_proxy_shadow.py
@@ -1,0 +1,29 @@
+"""--shadow on the MCP proxy: observe-first onboarding.
+
+Shadow mode classifies, scores, and audits every call but blocks nothing,
+so an operator can put the proxy in front of live traffic on day one and
+read the shadow report before flipping to enforcement.
+"""
+
+from __future__ import annotations
+
+
+def test_proxy_shadow_flag_disables_enforcement(tmp_path):
+    from vaara.integrations.mcp_proxy import VaaraMCPProxy
+
+    proxy = VaaraMCPProxy(
+        upstream_command=["true"],
+        db_path=tmp_path / "audit.db",
+        shadow=True,
+    )
+    assert proxy._pipeline._enforce is False
+
+
+def test_proxy_default_is_enforcing(tmp_path):
+    from vaara.integrations.mcp_proxy import VaaraMCPProxy
+
+    proxy = VaaraMCPProxy(
+        upstream_command=["true"],
+        db_path=tmp_path / "audit.db",
+    )
+    assert proxy._pipeline._enforce is True

--- a/tests/test_scorer_metadata_floor.py
+++ b/tests/test_scorer_metadata_floor.py
@@ -1,0 +1,74 @@
+"""Base rule scorer blocks cloud-metadata SSRF without the ML extra.
+
+A zero-config install previously allowed a network fetch to
+169.254.169.254; only the opt-in ML classifier caught it. The rule scorer
+now applies a deterministic decision floor for cloud-metadata endpoints in
+call parameters, mirroring the egress guard's "no legitimate reason to dial"
+boundary. Legitimate private hosts are unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vaara.scorer._param_signals import metadata_endpoint_risk
+
+
+@pytest.mark.parametrize("url", [
+    "http://169.254.169.254/latest/meta-data/",
+    "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+    "http://[fe80::a9fe:a9fe]/latest/meta-data/",
+    "http://2852039166/latest/meta-data/",          # dotless decimal
+    "http://0xa9fea9fe/latest/meta-data/",           # hex
+])
+def test_metadata_urls_flagged(url):
+    assert metadata_endpoint_risk({"url": url}) >= 0.9
+
+
+@pytest.mark.parametrize("params", [
+    {"url": "https://api.github.com/repos/x/y"},
+    {"url": "http://10.0.0.5/internal"},             # RFC1918: legitimate, not floored
+    {"url": "http://localhost:8080/health"},         # loopback: legitimate
+    {"path": "README.md"},
+    {"command": "ls -la"},
+    {},
+])
+def test_benign_params_not_flagged(params):
+    assert metadata_endpoint_risk(params) == 0.0
+
+
+def test_nested_and_listed_params_scanned():
+    params = {"requests": [{"target": "http://169.254.169.254/"}]}
+    assert metadata_endpoint_risk(params) >= 0.9
+
+
+def test_scorer_blocks_metadata_fetch_zero_config():
+    from vaara.scorer.adaptive import AdaptiveScorer
+    from vaara.taxonomy.actions import ActionRequest, create_default_registry
+
+    registry = create_default_registry()
+    scorer = AdaptiveScorer()
+    req = ActionRequest(
+        agent_id="agent-x",
+        tool_name="http_get",
+        action_type=registry.classify("http_get"),
+        parameters={"url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"},
+    )
+    decision = scorer.evaluate(req.to_policy_context())
+    assert decision["action"] in ("deny", "escalate")
+
+
+def test_scorer_allows_benign_fetch():
+    from vaara.scorer.adaptive import AdaptiveScorer
+    from vaara.taxonomy.actions import ActionRequest, create_default_registry
+
+    registry = create_default_registry()
+    scorer = AdaptiveScorer()
+    req = ActionRequest(
+        agent_id="agent-x",
+        tool_name="http_get",
+        action_type=registry.classify("http_get"),
+        parameters={"url": "https://api.github.com/repos/x/y"},
+    )
+    decision = scorer.evaluate(req.to_policy_context())
+    assert decision["action"] == "allow"

--- a/tests/test_scorer_per_class_thresholds.py
+++ b/tests/test_scorer_per_class_thresholds.py
@@ -1,0 +1,76 @@
+"""Per-action-class policy thresholds are enforced, not just parsed.
+
+A policy can tighten one action class ("tx.sign: {escalate: 0.40}") without
+restating the default. Before, threshold_for existed but nothing called it,
+so per-class overrides were silently ignored. The scorer now resolves the
+override by the call's tool name at decision time.
+"""
+
+from __future__ import annotations
+
+from vaara.policy import from_dict
+from vaara.scorer.adaptive import AdaptiveScorer
+
+_POLICY = {
+    "version": "0.1",
+    "domains": ["eu_ai_act"],
+    "action_classes": {
+        "tx.sign": {
+            "category": "financial",
+            "reversibility": "irreversible",
+            "blast_radius": "shared",
+            "urgency": "irrevocable",
+        },
+    },
+    "thresholds": {
+        "default": {"escalate": 0.55, "deny": 0.85},
+        "tx.sign": {"escalate": 0.10, "deny": 0.20},
+    },
+}
+
+
+def _ctx(tool_name, tenant_id=""):
+    return {
+        "tool_name": tool_name,
+        "agent_id": "agent-x",
+        "base_risk_score": 0.30,
+        "tenant_id": tenant_id,
+        "parameters": {},
+    }
+
+
+def test_per_class_override_tightens_named_class():
+    scorer = AdaptiveScorer()
+    scorer.apply_policy(from_dict(_POLICY))
+    decision = scorer.evaluate(_ctx("tx.sign"))
+    # deny threshold is 0.20 for tx.sign; a mid-risk call must not slip to allow.
+    assert decision["threshold_deny"] == 0.20
+    assert decision["threshold_allow"] == 0.10
+
+
+def test_unnamed_class_keeps_default_thresholds():
+    scorer = AdaptiveScorer()
+    scorer.apply_policy(from_dict(_POLICY))
+    decision = scorer.evaluate(_ctx("read_file"))
+    assert decision["threshold_deny"] == 0.85
+    assert decision["threshold_allow"] == 0.55
+
+
+def test_partial_override_inherits_default_deny():
+    policy = dict(_POLICY)
+    policy["thresholds"] = {
+        "default": {"escalate": 0.55, "deny": 0.85},
+        "tx.sign": {"escalate": 0.10},  # deny omitted
+    }
+    scorer = AdaptiveScorer()
+    scorer.apply_policy(from_dict(policy))
+    decision = scorer.evaluate(_ctx("tx.sign"))
+    assert decision["threshold_allow"] == 0.10
+    assert decision["threshold_deny"] == 0.85  # inherited
+
+
+def test_no_policy_uses_constructor_defaults():
+    scorer = AdaptiveScorer(threshold_allow=0.4, threshold_deny=0.7)
+    decision = scorer.evaluate(_ctx("tx.sign"))
+    assert decision["threshold_allow"] == 0.4
+    assert decision["threshold_deny"] == 0.7

--- a/tests/test_shadow_report.py
+++ b/tests/test_shadow_report.py
@@ -1,0 +1,94 @@
+"""The shadow report: what would have been blocked, from the trail alone.
+
+Shadow mode records true decisions while allowing everything, so the report
+is a read over the audit DB: deny decisions land as action_blocked records,
+escalates as decision_made records with decision=escalate.
+"""
+
+from __future__ import annotations
+
+import json
+
+from vaara.audit.shadow_report import render_text, shadow_report
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.audit.trail import AuditTrail
+
+
+def _seed(db_path):
+    backend = SQLiteAuditBackend(db_path)
+    trail = AuditTrail(on_record=backend.write_record)
+    trail.record_decision("a1", "agent-x", "read_file", "allow", "low risk", 0.05)
+    trail.record_decision("a2", "agent-x", "shell_exec", "escalate", "mid risk", 0.45)
+    trail.record_decision("a3", "agent-x", "shell_exec", "deny", "high risk", 0.92)
+    trail.record_decision("a4", "agent-y", "delete_file", "deny", "high risk", 0.88)
+    backend.close()
+
+
+def test_shadow_report_counts(tmp_path):
+    db = tmp_path / "audit.db"
+    _seed(db)
+    report = shadow_report(db, days=7)
+    assert report["total_decisions"] == 4
+    assert report["allowed"] == 1
+    assert report["would_escalate"] == 1
+    assert report["would_block"] == 2
+
+
+def test_shadow_report_groups_blocked_by_tool(tmp_path):
+    db = tmp_path / "audit.db"
+    _seed(db)
+    report = shadow_report(db, days=7)
+    by_tool = {entry["tool_name"]: entry for entry in report["blocked"]}
+    assert by_tool["shell_exec"]["count"] == 1
+    assert by_tool["delete_file"]["count"] == 1
+    assert by_tool["delete_file"]["max_risk"] == 0.88
+
+
+def test_shadow_report_window_excludes_old_records(tmp_path):
+    db = tmp_path / "audit.db"
+    _seed(db)
+    report = shadow_report(db, days=0)
+    assert report["total_decisions"] == 0
+
+
+def test_render_text_mentions_blocked_tools(tmp_path):
+    db = tmp_path / "audit.db"
+    _seed(db)
+    text = render_text(shadow_report(db, days=7))
+    assert "delete_file" in text
+    assert "would have been blocked" in text.lower()
+
+
+def test_report_is_json_serialisable(tmp_path):
+    db = tmp_path / "audit.db"
+    _seed(db)
+    json.dumps(shadow_report(db, days=7))
+
+
+def test_cli_trail_shadow_report_json(tmp_path, capsys):
+    from vaara.cli import main
+
+    db = tmp_path / "audit.db"
+    _seed(db)
+    rc = main(["trail", "shadow-report", "--db", str(db), "--format", "json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["would_block"] == 2
+
+
+def test_cli_trail_shadow_report_text_default(tmp_path, capsys):
+    from vaara.cli import main
+
+    db = tmp_path / "audit.db"
+    _seed(db)
+    rc = main(["trail", "shadow-report", "--db", str(db)])
+    assert rc == 0
+    assert "would have been blocked" in capsys.readouterr().out.lower()
+
+
+def test_cli_trail_shadow_report_missing_db(tmp_path, capsys):
+    from vaara.cli import main
+
+    rc = main(["trail", "shadow-report", "--db", str(tmp_path / "nope.db")])
+    assert rc == 2
+    assert "not" in capsys.readouterr().err.lower()

--- a/tests/test_trail_rotate.py
+++ b/tests/test_trail_rotate.py
@@ -1,0 +1,142 @@
+"""vaara trail rotate: export a signed archive, verify it, then purge.
+
+The documented retention workflow (export signed zip before purge, archive
+externally) was manual; rotate makes it one fail-closed command. The purge
+must never run unless the exported archive verified.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vaara.audit.rotate import RotateResult, rotate
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.audit.trail import AuditTrail
+from vaara.audit.verify import verify_signed
+
+_TEN_DAYS = 10 * 86400.0
+
+
+def _key_pem(tmp_path):
+    key = Ed25519PrivateKey.generate()
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    path = tmp_path / "signer.pem"
+    path.write_bytes(pem)
+    return path
+
+
+def _seed(db_path, monkeypatch):
+    """Two records 10 days old, two written now, all properly chained."""
+    backend = SQLiteAuditBackend(db_path)
+    trail = AuditTrail(on_record=backend.write_record)
+
+    real_time = time.time
+    monkeypatch.setattr("vaara.audit.trail.time.time", lambda: real_time() - _TEN_DAYS)
+    trail.record_decision("old1", "agent-x", "shell_exec", "deny", "high risk", 0.9)
+    trail.record_decision("old2", "agent-x", "read_file", "allow", "low risk", 0.1)
+    monkeypatch.setattr("vaara.audit.trail.time.time", real_time)
+    trail.record_decision("new1", "agent-x", "read_file", "allow", "low risk", 0.1)
+    trail.record_decision("new2", "agent-x", "read_file", "allow", "low risk", 0.1)
+    backend.close()
+
+
+def test_rotate_exports_verifies_and_purges(tmp_path, monkeypatch):
+    db = tmp_path / "audit.db"
+    _seed(db, monkeypatch)
+    out = tmp_path / "archive.zip"
+
+    result = rotate(
+        db_path=db,
+        out_path=out,
+        signer_key=_key_pem(tmp_path),
+        retention_days=7,
+    )
+
+    assert isinstance(result, RotateResult)
+    assert result.ok
+    assert result.exported_records == 4
+    assert result.purged_records == 2
+    assert out.exists()
+    assert verify_signed(out).ok
+
+    backend = SQLiteAuditBackend(db)
+    try:
+        assert backend.count() == 2
+    finally:
+        backend.close()
+
+
+def test_rotate_dry_run_purges_nothing(tmp_path, monkeypatch):
+    db = tmp_path / "audit.db"
+    _seed(db, monkeypatch)
+    out = tmp_path / "archive.zip"
+
+    result = rotate(
+        db_path=db,
+        out_path=out,
+        signer_key=_key_pem(tmp_path),
+        retention_days=7,
+        dry_run=True,
+    )
+
+    assert result.ok
+    assert result.purged_records == 2  # would purge
+    backend = SQLiteAuditBackend(db)
+    try:
+        assert backend.count() == 4
+    finally:
+        backend.close()
+
+
+def test_rotate_bad_key_fails_closed(tmp_path, monkeypatch):
+    db = tmp_path / "audit.db"
+    _seed(db, monkeypatch)
+    bad_key = tmp_path / "bad.pem"
+    bad_key.write_text("not a key")
+
+    result = rotate(
+        db_path=db,
+        out_path=tmp_path / "archive.zip",
+        signer_key=bad_key,
+        retention_days=7,
+    )
+
+    assert not result.ok
+    assert result.purged_records == 0
+    backend = SQLiteAuditBackend(db)
+    try:
+        assert backend.count() == 4  # nothing purged
+    finally:
+        backend.close()
+
+
+def test_cli_trail_rotate(tmp_path, monkeypatch, capsys):
+    from vaara.cli import main
+
+    db = tmp_path / "audit.db"
+    _seed(db, monkeypatch)
+    out = tmp_path / "archive.zip"
+
+    rc = main([
+        "trail", "rotate",
+        "--db", str(db),
+        "--out", str(out),
+        "--key", str(_key_pem(tmp_path)),
+        "--retention-days", "7",
+        "--all-tenants",
+    ])
+    assert rc == 0
+    stdout = capsys.readouterr().out.lower()
+    assert "purged 2" in stdout
+    assert out.exists()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,40 @@
+"""Release hygiene: the package must report the version being released.
+
+v1.23.0 through v1.25.0 shipped wheels whose ``vaara.__version__`` still said
+"1.22.0" because the string in ``src/vaara/__init__.py`` is bumped by hand and
+the release workflow never checks it. These tests make the drift fail the
+build instead of shipping.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import vaara
+
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _pyproject_version() -> str:
+    # Regex instead of tomllib: tomllib is 3.11+, and this is the one line
+    # we need. Anchored to the [project] table's version key.
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r'^version = "([^"]+)"$', text, flags=re.MULTILINE)
+    assert match, "could not find version in pyproject.toml"
+    return match.group(1)
+
+
+@pytest.mark.skipif(not _PYPROJECT.exists(), reason="pyproject.toml not present (installed wheel)")
+def test_package_version_matches_pyproject():
+    assert vaara.__version__ == _pyproject_version()
+
+
+def test_py_typed_marker_ships_with_package():
+    # The "Typing :: Typed" classifier promises PEP 561 type information.
+    # Without the marker file, type checkers ignore every annotation in the
+    # installed package.
+    marker = Path(vaara.__file__).with_name("py.typed")
+    assert marker.is_file(), "src/vaara/py.typed is missing"

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -111,7 +111,10 @@
       "softwareHelp": "https://github.com/vaaraio/vaara",
       "license": "https://www.gnu.org/licenses/agpl-3.0.html",
       "isAccessibleForFree": true,
-      "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" },
+      "offers": [
+        { "@type": "Offer", "name": "Open source (AGPL-3.0)", "price": "0", "priceCurrency": "EUR" },
+        { "@type": "Offer", "name": "Paid pilot and commercial license", "url": "https://vaara.io/#pilots", "availability": "https://schema.org/InStock" }
+      ],
       "author": { "@type": "Person", "name": "Henri Sirkkavaara" },
       "keywords": "AI agent audit trail, EU AI Act Article 12, tamper-evident logging, TPM 2.0, IMA, RFC 3161, SEP-2828, verifiable AI",
       "sameAs": [
@@ -161,6 +164,11 @@
           "@type": "Question",
           "name": "Is Vaara free and open source?",
           "acceptedAnswer": { "@type": "Answer", "text": "Yes. Vaara is licensed under AGPL-3.0, with no SaaS, no telemetry, and no signup. It ships on PyPI, npm, and the MCP registry, with SLSA Build Level 3 and Sigstore-signed releases." }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Vaara offer paid pilots or a commercial license?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. A structured four-week pilot deploys Vaara in your environment against your own agent traffic and ends with a signed evidence bundle and an auditor-ready compliance report on that traffic. A commercial license is available for building on Vaara without the AGPL's source-disclosure obligations. Contact hello@vaara.io." }
         }
       ]
     }
@@ -202,6 +210,14 @@ conformance: <span class="ok">CONFORMS</span>
   <li>Policy gating on every tool call: allow, block, or escalate each agent action against your own policy before it runs, through a transparent MCP proxy with native hooks for LangChain, CrewAI, and the OpenAI Agents SDK. TypeScript client on npm, Claude Code plugin in the same repo.</li>
   <li>Authored SEP-2828, the Model Context Protocol server-side execution-record proposal, reproduced in full by an independent developer from a clean checkout. Releases are SLSA Build Level 3 and Sigstore-signed, with continuous fuzzing on the decoder, audit, and policy loader.</li>
 </ul>
+<p class="stamp" id="pilots">Paid pilots</p>
+<ul>
+  <li>Four weeks, your environment, your traffic. Week 1: the Vaara MCP proxy goes in front of your agents in shadow mode, observing and recording without blocking anything. Weeks 2 and 3: we read the shadow report together, tune a policy and tool perimeter to your actual traffic, and flip to enforcement. Week 4: you receive a signed evidence bundle and an auditor-ready compliance report generated from your own trail.</li>
+  <li>Everything runs in your infrastructure and stays there. The trail, the policy, the reports, and the archive are yours, and they stay verifiable with the standalone checker even if you never talk to us again. The evidence does not depend on the vendor; that is the point of the design.</li>
+  <li>Building Vaara into a closed-source product, or running a modified version as a hosted service without releasing your changes, needs a commercial license instead of the AGPL, granted directly by the sole copyright holder. See <a href="https://github.com/vaaraio/vaara/blob/main/LICENSING.md">LICENSING.md</a>.</li>
+  <li>Contact: <a href="mailto:hello@vaara.io">hello@vaara.io</a>. A fixed fee agreed up front, with no subscription.</li>
+</ul>
+
 <p class="stamp">Adoption (live)</p>
 <ul>
   <li><span id="installs">-</span> total downloads across PyPI and npm</li>


### PR DESCRIPTION
Minor, additive release. The `vaara.receipt/v1` wire format and every verification surface are unchanged.

## Security
- The base rule scorer now blocks a cloud-metadata SSRF fetch (169.254.169.254 and its IPv6, dotless-decimal, and hex encodings, recursed through nested parameters) in a zero-config install. Before, only the opt-in ML classifier caught it. A deterministic decision floor covers this one unambiguous case, mirroring the egress guard's boundary; private and loopback hosts are unaffected.
- The shipped classifier bundle is verified against a pinned SHA-256 before `joblib.load` unpickles it, and `AdversarialClassifier` accepts `expected_sha256` for caller-supplied bundles.

## New capabilities
- MCP proxy `--policy` (fail-closed validation; the policy bytes feed the attested OVERT policy hash) and `--shadow`.
- `vaara trail shadow-report` summarises what enforcement would have blocked, grouped by tool.
- `vaara trail rotate` runs export, re-verify, then purge as one fail-closed command; the purge never runs unless the signed archive re-verified from its own bytes.
- Per-action-class policy thresholds are now enforced at decision time, on both the single-policy and per-tenant paths.

## Hygiene
- `vaara.__version__` un-drifted (it read 1.22.0 since v1.23.0), `py.typed` shipped, and preflight asserts the wheel and installed versions match.
- MCP starter perimeters for five servers, a multi-replica deployment doc, and a govern-first quickstart.

## Verification
- 2163 passed, 17 skipped. ruff clean, mypy strict set clean, zero high-severity bandit, preflight wheel build self-reports 1.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shadow mode for observing MCP tool calls without blocking.
  * Added policy-file support, starter perimeters for five MCP servers, and attested policy hashes.
  * Added audit-trail rotation with signed archive verification and shadow reports.
  * Added stronger protection against tampered classifier bundles and cloud-metadata requests.

* **Bug Fixes**
  * Enforced action-specific policy thresholds and fail-closed validation behavior.
  * Corrected release version reporting and package typing metadata.

* **Documentation**
  * Expanded deployment guidance, quickstarts, governance notes, and pilot/commercial licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->