### PR TITLE
Release hygiene v1.26.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,12 +15,7 @@
         "email": "hello@vaara.io"
       },
       "category": "security",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/vaaraio/vaara.git",
-        "path": "plugins/claude-code-vaara-governance",
-        "ref": "v0.45.0"
-      },
+      "source": "./plugins/claude-code-vaara-governance",
       "homepage": "https://vaara.io"
     }
   ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,17 @@ jobs:
       - name: Test
         run: node --test test/*.test.mjs
 
+      - name: Sync client version to the released tag
+        # The npm client is versioned in clients/ts/package.json, decoupled from
+        # the Python package. A missed manual bump (as in v1.26.0) desyncs the
+        # npm client from the release. Rewrite the version from the tag here, the
+        # same way the MCP manifests are synced below, so it can no longer drift.
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          node -e "const fs=require('fs');const p=require('./package.json');p.version='${VERSION}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          echo "Set @vaara/client version to ${VERSION}"
+
       - name: Publish to npm with provenance
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.26.1] - 2026-07-12
+
+Release hygiene. No functional change to the Python package.
+
+- The npm client (`@vaara/client`) is now version-synced to the release tag in the publish workflow, so it can no longer lag the Python package the way v1.26.0 did (it stayed at 1.25.0). `clients/ts/package.json` bumped to match.
+- The Claude Code plugin marketplace manifest (`.claude-plugin/marketplace.json`) is corrected: the plugin `source` is a repo-relative path and the stale `ref` pin is dropped, so `/plugin marketplace add vaaraio/vaara` then `/plugin install vaara-governance@vaara` installs the current plugin.
+
 ## [1.26.0] - 2026-07-12
 
 Pilot-readiness release: shadow-first onboarding, fail-closed retention rotation, starter perimeters for common MCP servers, and release hygiene. All additive; wire formats unchanged.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.25.0",
+  "version": "1.26.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.26.0"
+version = "1.26.1"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.26.0"
+__version__ = "1.26.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -93,7 +93,7 @@
   .evidence .prompt { color: var(--tri); }
   .evidence .ok { color: var(--tri-bright); }
   .evidence .dim { color: var(--faint); }
-  #installs, #npm-week { color: var(--tri-bright); font-weight: 600; font-family: var(--mono); }
+  #installs { color: var(--tri-bright); font-weight: 600; font-family: var(--mono); }
 </style>
 <script type="application/ld+json">
 {
@@ -220,8 +220,7 @@ conformance: <span class="ok">CONFORMS</span>
 
 <p class="stamp">Adoption (live)</p>
 <ul>
-  <li><span id="installs">-</span> total downloads across PyPI and npm</li>
-  <li><span id="npm-week">-</span> npm downloads, last 7 days (@vaara/client)</li>
+  <li><span id="installs">-</span> total downloads, all time (PyPI and npm)</li>
 </ul>
 
 <p class="stamp">Acknowledged by</p>
@@ -256,13 +255,6 @@ conformance: <span class="ok">CONFORMS</span>
     .then(function(d){
       if (!d || typeof d.total !== "number") return;
       setText("installs", fmt(d.total));
-    })
-    .catch(function(){});
-  fetch("https://api.npmjs.org/downloads/point/last-week/@vaara/client")
-    .then(function(r){ return r.ok ? r.json() : null; })
-    .then(function(d){
-      if (!d || typeof d.downloads !== "number") return;
-      setText("npm-week", fmt(d.downloads));
     })
     .catch(function(){});
 })();


### PR DESCRIPTION
Release-hygiene patch. No functional change to the Python package.

- **npm version sync:** the `publish-npm` job now rewrites `clients/ts/package.json` to the release tag before publishing, mirroring the MCP manifest sync, so the npm client can no longer lag the Python package the way v1.26.0 did (it stayed at 1.25.0). `clients/ts/package.json` bumped to 1.26.1.
- **Plugin marketplace fix:** `.claude-plugin/marketplace.json` used a stale `ref` pin (`v0.45.0`) and a non-standard source shape, so the plugin was not installable from the `/plugins` menu. The plugin `source` is now a repo-relative path with no ref pin. Install: `/plugin marketplace add vaaraio/vaara` then `/plugin install vaara-governance@vaara`.
- **Webpage adoption stat:** show a single all-time total downloads figure (PyPI and npm), drop the npm-last-7-days line.

Verification: 2163 passed, 17 skipped. ruff clean. Version test enforces `__init__` and pyproject both at 1.26.1.