### PR TITLE
docs: add prove-it-yourself example and logs-vs-evidence page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 </p>
 
 <p align="center">
-  <a href="https://pepy.tech/project/vaara"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/vaaraio/vaara/main/.github/badges/installs.json" alt="Downloads"></a>
-</p>
-
-<p align="center">
   <a href="https://pypi.org/project/vaara/"><img src="https://img.shields.io/pypi/v/vaara.svg" alt="PyPI"></a>
   <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg" alt="License"></a>
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://github.com/vaaraio/vaara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://github.com/vaaraio/vaara/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
+</p>
+
+<p align="center">
+  <a href="https://pepy.tech/project/vaara"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/vaaraio/vaara/main/.github/badges/installs.json" alt="Downloads"></a>
 </p>
 
 Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
@@ -83,6 +83,8 @@ python tests/vectors/external_evidence_v0/_check_independent.py
 ```
 
 It re-derives every verdict from the receipt bytes and the public key alone. The output shows the property the trail is built for: a receipt dropped from inside a declared boundary is a provable gap from the held set, with no issuer access and no external witness.
+
+For the whole loop in one runnable file, produce a signed record, verify it yourself, then watch a single forged byte get caught, see [examples/prove-it-yourself/](examples/prove-it-yourself/). The logs-versus-evidence argument behind it is in [docs/logs-vs-evidence.md](docs/logs-vs-evidence.md).
 
 The aggregate runner grades every suite at once, and grades another implementation's vectors the same way:
 
@@ -192,6 +194,7 @@ The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capabilit
 | Path | Contents |
 |---|---|
 | [docs/verifying-evidence.md](docs/verifying-evidence.md) | Every verifier and its trust model |
+| [docs/logs-vs-evidence.md](docs/logs-vs-evidence.md) | Logs vs evidence: proving what an agent did, and what the AI Act actually requires |
 | [docs/architecture.md](docs/architecture.md) | Scoring, conformal coverage, time anchor, formal properties |
 | [SPEC.md](SPEC.md) | The canonical vaara.receipt/v1 receipt format spec |
 | [docs/standards.md](docs/standards.md) | SEP-2828, SEP-2787, OVERT, the sovereign inference harness |

--- a/docs/logs-vs-evidence.md
+++ b/docs/logs-vs-evidence.md
@@ -1,0 +1,56 @@
+# Logs vs evidence: proving what an AI agent did
+
+A log is what your system says happened. Evidence is what a party who does not trust you can confirm happened. For AI agents acting on their own, the second is the one that settles a dispute, and most tooling only produces the first.
+
+This page explains the distinction, what the EU AI Act does and does not require, and how to produce evidence rather than logs. If you want to see it rather than read about it, [examples/prove-it-yourself/](../examples/prove-it-yourself/) is a working end to end run.
+
+## The distinction
+
+A log records activity for the operator's benefit: what to debug, what to monitor, what to bill. Its trust model assumes the reader trusts the writer. That assumption holds inside your own team and breaks the moment the reader is a regulator, an auditor, or a customer after an incident, because you could have edited the log before showing it.
+
+Evidence is built for a reader who does not extend that trust. It carries its own proof of integrity and origin, so the reader checks the record instead of trusting the recorder. Concretely, an evidence record is:
+
+- **Signed**, so its origin is verifiable against a public key.
+- **Hash-chained**, so each entry commits to the previous one and any edit, insertion, or deletion breaks the chain.
+- **Independently verifiable**, so the reader reproduces every verdict from the bytes alone, ideally with software that is not yours.
+- **Fail-closed on authenticity**, so a missing or altered entry is a provable gap, not a silent one.
+
+## Why observability tooling does not cover this
+
+Datadog, Splunk, the OpenTelemetry stack, and application logs answer "what does the system report." They are excellent at that. They are not built to answer "can an outside party confirm this was not changed," and for AI agents they usually do not capture the load-bearing facts at all: the per-agent decision, the policy it was checked against, the reasoning, and the integrity of the sequence of actions. A screenshot of a Datadog dashboard is a claim. A signed, hash-chained record an auditor re-derives themselves is evidence.
+
+GRC platforms like Vanta and Drata sit at the other end. They collect static control evidence for SOC 2 or ISO 27001, snapshots that a configuration was in place. They do not produce a runtime record of what an autonomous agent actually did on a given day. That runtime record is the gap.
+
+## What the EU AI Act actually requires
+
+Be precise here, because over-claiming the law is its own credibility problem.
+
+Article 12 requires high-risk AI systems to automatically record events (logs) over their lifetime and to retain them for an appropriate period. It mandates that logging happens and that records are kept. It does **not** mandate cryptographic tamper-evidence, hash chains, or independent verifiability. A plain retained log can satisfy the letter of Article 12.
+
+So why produce evidence rather than logs? Because the obligation you are really preparing for is not "did you keep a log" but "prove what the system did" when it is challenged, under Article 12 record-keeping, Article 14 human oversight, an incident investigation, a liability claim, or a procurement review. A plain log answers the first and fails the second. Tamper-evident, independently verifiable evidence answers both. The hash chain is not a compliance checkbox. It is what makes the record hold up in front of someone who has every reason to doubt it.
+
+(Note on timing: the exact enforcement dates for high-risk obligations are in legislative flux and have shifted during 2026. Do not build a plan around a single hardcoded date; check the current text of the regulation.)
+
+## How to produce evidence
+
+The mechanics are not exotic. At the point an agent acts, record the action, the decision, and the outcome into a signed, append-only, hash-chained store, and make the export verifiable with a public key and, ideally, a checker that does not depend on your own code.
+
+With Vaara that is the default behavior rather than an add-on:
+
+```python
+import vaara
+
+@vaara.govern
+def transfer_funds(to: str, amount: float) -> str:
+    ...
+```
+
+Every call is decided against your policy, and the decision, the call, and the outcome land in a signed record anyone can verify offline. The [prove-it-yourself example](../examples/prove-it-yourself/) shows the full loop, produce a record, verify it, then watch a single forged byte get caught. The trust model for each verifier is in [verifying-evidence.md](verifying-evidence.md).
+
+## Questions
+
+**Is a hash-chained audit trail required by the EU AI Act?** No. Article 12 requires automatic logging and retention, not tamper-evidence. Tamper-evidence is what makes the log hold up when challenged, which is a stronger and more useful property than the minimum the law names.
+
+**Can I add this without replacing my logging?** Yes. Evidence and logs answer different questions and coexist. Keep your observability stack; add a verifiable record at the decision point.
+
+**Who verifies the evidence?** Whoever needs to: the regulator, the auditor, the customer, or you. Verification needs the record and a public key, not access to your systems, and Vaara ships a standalone checker so an independent party can reproduce the result without running your software.

--- a/examples/prove-it-yourself/.gitignore
+++ b/examples/prove-it-yourself/.gitignore
@@ -1,0 +1,2 @@
+evidence.zip
+evidence_tampered.zip

--- a/examples/prove-it-yourself/README.md
+++ b/examples/prove-it-yourself/README.md
@@ -1,0 +1,52 @@
+# Prove what your AI agent actually did
+
+The short version: run one Python file and you get a signed, hash-chained record of what an AI agent did, which you then verify yourself, offline, without trusting the machine that produced it. Change a single byte of the record and the check fails. That is the difference between a log and evidence.
+
+```bash
+pip install 'vaara[export]'
+python prove_it.py
+```
+
+## What it shows
+
+An agent proposes four tool calls. Vaara scores and decides each one before it runs:
+
+```
+   run  ALLOW    risk=0.113  read a project file
+   run  ALLOW    risk=0.111  search the support knowledge base
+ BLOCK  ESCALATE risk=0.236  run a destructive shell command
+ BLOCK  DENY     risk=0.173  fetch the cloud instance-metadata endpoint (classic SSRF)
+```
+
+Every decision, the two that ran and the two that were blocked, is written into one hash-chained record. The run then does the part that matters:
+
+```
+ verify_signed(evidence.zip)           ->  ok=True
+ verify_signed(evidence_tampered.zip)  ->  ok=False
+   caught: trail.jsonl SHA-256 does not match manifest.trail_sha256
+```
+
+The first bundle verifies from its own bytes and a public key. The second is the same bundle with one recorded action edited after the fact, and the check catches it. No network, no access to the machine, no taking anyone's word for it.
+
+## Why this is not just logging
+
+A log answers "what does the system say happened." Evidence answers "what can a party who does not trust the producer confirm happened." Datadog and Splunk record activity, but you have to trust that the records were not edited, and they do not capture the per-agent decision, its reasoning, or the integrity of the sequence. Vaara's record is content-addressed and fails closed on authenticity: a dropped or altered entry is a provable gap, not a silent one.
+
+This matters the moment someone who does not trust you asks you to prove what your agent did: a regulator under EU AI Act Article 12 record-keeping, an auditor, or a customer after an incident. Your own logs will not settle it, because you could have edited them. This record settles it.
+
+## Questions people ask
+
+**How do I prove what an AI agent actually did?** Record each action and its decision into a signed, hash-chained trail at the point the action happens, then hand that trail to whoever needs to check it. They verify the signature and re-derive the chain from the bytes. This example is a working end to end instance of that.
+
+**Can the person checking it trust the result without trusting me?** Yes, that is the design goal. Verification needs only the bundle and a public key. Vaara also ships a standalone checker that imports no Vaara code, so an independent party reproduces every verdict. See [docs/verifying-evidence.md](../../docs/verifying-evidence.md).
+
+**What happens if a record is tampered with?** The verification fails and names the reason, as the tampered run above shows. The hash chain links each record to the previous one, so an edit anywhere breaks the chain.
+
+**Does this need special hardware?** No. It recomputes verification from the recorded bytes. When a TPM 2.0 or confidential-VM root is present, Vaara can bind the record to it as an optional upgrade, but nothing here requires it.
+
+## Where next
+
+- The one-line adoption path, `@vaara.govern`, is in [examples/quickstart.py](../quickstart.py).
+- Putting Vaara in front of a real MCP server (GitHub, filesystem, Slack, Postgres, Google Workspace) is in [examples/policies/mcp-starters/](../policies/mcp-starters/README.md).
+- The trust model for every verifier is in [docs/verifying-evidence.md](../../docs/verifying-evidence.md).
+- The full logs-versus-evidence argument is in [docs/logs-vs-evidence.md](../../docs/logs-vs-evidence.md).

--- a/examples/prove-it-yourself/prove_it.py
+++ b/examples/prove-it-yourself/prove_it.py
@@ -1,0 +1,121 @@
+"""Prove what your AI agent actually did, and verify it yourself.
+
+One run, offline, no keys to trust. An AI agent makes a handful of tool calls
+under Vaara governance: a safe one runs, dangerous ones are blocked. Vaara
+writes every decision into a signed, hash-chained record. Then you verify that
+record yourself, and watch a single forged byte get caught.
+
+The point is the last part. Anyone can write a log. The question that matters
+is whether a party who does not trust the producer can check it. Here you are
+that party.
+
+    pip install 'vaara[export]'
+    python prove_it.py
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vaara import InterceptionPipeline
+from vaara.audit.export import export_signed
+from vaara.audit.verify import verify_signed
+
+HERE = Path(__file__).parent
+BUNDLE = HERE / "evidence.zip"
+TAMPERED = HERE / "evidence_tampered.zip"
+
+RULE = "=" * 78
+
+
+def banner(title: str) -> None:
+    print(f"\n{RULE}\n {title}\n{RULE}")
+
+
+def main() -> None:
+    banner("Prove what your AI agent actually did")
+
+    # A signing key you generate here and now. In production this lives in a
+    # KMS/HSM and never touches disk; for the demo it is ephemeral.
+    signer = Ed25519PrivateKey.generate()
+
+    # An agent proposes tool calls. Vaara decides each one before it runs.
+    pipeline = InterceptionPipeline()
+    calls = [
+        ("read a project file", "read_file",
+         {"path": "README.md"}),
+        ("search the support knowledge base", "search_docs",
+         {"query": "how do I reset my password"}),
+        ("run a destructive shell command", "shell_exec",
+         {"command": "rm -rf /"}),
+        ("fetch the cloud instance-metadata endpoint (classic SSRF)", "http_get",
+         {"url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"}),
+    ]
+
+    print("\n An agent (agent_id=support-bot) proposes four tool calls.")
+    print(" Vaara scores and decides each one before it can run:\n")
+    for label, tool, params in calls:
+        result = pipeline.intercept(agent_id="support-bot", tool_name=tool, parameters=params)
+        verdict = "ALLOW" if result.allowed else result.decision.upper()
+        mark = "  run " if result.allowed else "BLOCK "
+        print(f"   {mark} {verdict:8} risk={result.risk_score:.3f}  {label}")
+        if result.allowed:
+            pipeline.report_outcome(result.action_id, 0.0)
+
+    print("\n Every decision above, allow and block alike, is now in a")
+    print(" hash-chained record. Nothing was cherry-picked.")
+
+    # Export the record as a signed, self-contained evidence bundle.
+    export_signed(pipeline.trail, BUNDLE, signer_key=signer)
+    print(f"\n Signed evidence bundle written: {BUNDLE.name}")
+
+    banner("Now you verify it, offline, without trusting us")
+
+    ok = verify_signed(BUNDLE)
+    print(f"\n verify_signed({BUNDLE.name})  ->  ok={ok.ok}")
+    print(" The signature checks out and the hash chain re-derives from the")
+    print(" bundle's own bytes. No network, no access to the machine that made it.")
+
+    # Forge one byte and prove the tampering is caught.
+    _forge_one_record(BUNDLE, TAMPERED)
+    forged = verify_signed(TAMPERED)
+    print("\n Someone edits one recorded action, then re-verifies:")
+    print(f" verify_signed({TAMPERED.name})  ->  ok={forged.ok}")
+    if forged.errors:
+        print(f"   caught: {forged.errors[0]}")
+
+    banner("That is the whole idea")
+    print("""
+ A regulator, an auditor, or a customer after an incident can take this
+ bundle and check exactly what the agent did, without your logs, your
+ software, or your word for it. A single forged byte fails the check.
+
+ This is evidence, not a claim. Logs say "trust me"; this does not need to.
+""")
+
+
+def _forge_one_record(src: Path, dst: Path) -> None:
+    """Copy the bundle, flip a character inside the recorded trail."""
+    with zipfile.ZipFile(src) as zin:
+        names = zin.namelist()
+        data = {n: zin.read(n) for n in names}
+    trail_name = next(n for n in names if n.endswith("trail.jsonl"))
+    raw = data[trail_name]
+    # Change an "allow" outcome to look like something it was not.
+    forged = raw.replace(b"support-bot", b"other-agent", 1)
+    if forged == raw:  # fallback: flip the first digit we find
+        forged = bytes(b ^ 0x01 if 48 <= b <= 57 else b for b in raw[:1]) + raw[1:]
+    data[trail_name] = forged
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
+        for n in names:
+            zout.writestr(n, data[n])
+    dst.write_bytes(buf.getvalue())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

- `examples/prove-it-yourself/`: a single runnable file that scores four agent tool calls (two allowed, two blocked, including the cloud metadata SSRF deny), writes a signed hash-chained trail, verifies it offline, then shows a one-byte forgery failing the check.
- `docs/logs-vs-evidence.md`: why ordinary logs cannot settle "what did the agent do" for someone who does not trust the producer, and what the AI Act record-keeping rules actually require.
- README: moved the downloads badge below the shields row and linked both new pages from the docs table and the verify section.

## Verification

- `.venv/bin/pytest -q`: 2163 passed, 17 skipped
- `uvx ruff@0.15.20 check .`: clean
- `.venv/bin/mypy --no-site-packages src/vaara/policy/`: clean
- `examples/prove-it-yourself/prove_it.py`: runs end to end, exit 0; the tampered bundle fails verification as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a runnable example demonstrating signed, hash-chained evidence for AI agent actions.
  * Added offline verification with tamper detection, including allowed and blocked tool actions.
* **Documentation**
  * Added guidance explaining the difference between operational logs and verifiable evidence.
  * Documented evidence requirements, regulatory context, verification practices, and common questions.
  * Updated the README with links to the new documentation and example.
* **Chores**
  * Updated example ignore rules for generated evidence archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->