### PR TITLE
feat(plugin): desktop notifications, friendly settings, protection presets (0.2.0)

### DIFF
--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaara-governance",
-  "version": "0.1.2",
-  "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. SessionStart validates the install and prints version, mode, and audit DB path. /vaara-stats prints a summary of the audit trail.",
+  "version": "0.2.0",
+  "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",
     "email": "hello@vaara.io"

--- a/plugins/claude-code-vaara-governance/README.md
+++ b/plugins/claude-code-vaara-governance/README.md
@@ -12,11 +12,13 @@ PreToolUse runs a two-layer check before Claude executes a tool:
 
 PostToolUse appends an outcome record to the audit trail for every `mcp__*` call, correlating it back to the PreToolUse decision and feeding the MWU online learner.
 
-SessionStart prints a one-line status (Vaara version, mode, audit DB path).
+Blocks and escalations also pop a native desktop notification (macOS via osascript, Linux via notify-send when present), so a decision is visible even when the terminal is buried. Notifications are fire-and-forget and can never break the hook.
+
+SessionStart prints a one-line status (Vaara version, mode, protection preset, notifications, audit DB path).
 
 | Hook | Matches | Mechanism |
 |---|---|---|
-| `PreToolUse` | `Bash`, `WebFetch`, `WebSearch`, `mcp__*` | Layer 1 regex on shell / web. Layer 2 ML on MCP. |
+| `PreToolUse` | `Bash`, `WebFetch`, `WebSearch`, `mcp__*` | Layer 1 regex on shell / web. Layer 2 ML on MCP. Desktop notification on block/escalate. |
 | `PostToolUse` | `mcp__*` | Audit outcome + MWU feedback. |
 | `SessionStart` | n/a | Validate install, print status. |
 
@@ -30,14 +32,36 @@ Then install the plugin via the Claude Code plugin command for your install path
 
 ## Configuration
 
-All knobs are environment variables. None required for the default behaviour.
+The friendly path: run `/vaara-setup` inside Claude Code. It asks three plain-language questions (protect, watch, or off; how strict; popups or not) and writes `~/.vaara/claude-code/config.json`. Nothing is required for the default behaviour.
+
+The config file, hand-editable:
+
+```json
+{
+  "mode": "protect",
+  "protection": "balanced",
+  "notifications": true
+}
+```
+
+| Key | Values | Effect |
+|---|---|---|
+| `mode` | `protect` (default), `watch`, `off` | `watch` checks and records everything but never blocks; `off` disables the plugin. |
+| `protection` | `eco`, `balanced` (default), `performance`, `strict` | Policy preset applied to MCP scoring; these are the `vaara mode` presets. |
+| `notifications` | `true` (default), `false` | Desktop popups on block/escalate. |
+| `agent_id` | string | Agent id written to the audit chain (default `claude-code`). |
+| `audit_db` | path | Audit DB path (default `~/.vaara/claude-code/audit.db`). |
+
+Environment variables override the file (useful for CI or a single session):
 
 | Variable | Effect |
 |---|---|
 | `VAARA_PLUGIN_DISABLE=1` | Disable the whole plugin. All hooks pass through. |
-| `VAARA_PLUGIN_SHADOW=1` | Record every decision to the audit trail but never block. Useful for soak testing before flipping to enforce. |
-| `VAARA_PLUGIN_AGENT_ID` | Override the agent_id written to the audit chain (default `claude-code`). |
-| `VAARA_PLUGIN_AUDIT_DB` | Override the audit DB path (default `~/.vaara/claude-code/audit.db`). |
+| `VAARA_PLUGIN_SHADOW=1` | Same as `"mode": "watch"`: record every decision, never block. |
+| `VAARA_PLUGIN_PROTECTION` | Same as `"protection"`: preset name. |
+| `VAARA_PLUGIN_NOTIFY=0` | Turn desktop notifications off. |
+| `VAARA_PLUGIN_AGENT_ID` | Override the agent_id written to the audit chain. |
+| `VAARA_PLUGIN_AUDIT_DB` | Override the audit DB path. |
 | `VAARA_PLUGIN_DENY_PATTERNS_FILE` | Replace the bundled `policies/default_deny.json` with your own. |
 
 ## Extending the deny patterns
@@ -75,9 +99,9 @@ For a signed, regulator-handoff bundle, export the trail with `vaara trail expor
 
 ## Latency
 
-PreToolUse on Bash / WebFetch / WebSearch is regex-only and sub-millisecond. PreToolUse on `mcp__*` and PostToolUse load the Vaara pipeline, ~0.5 – 2 seconds cold-start on commodity hardware. For tighter MCP latency, run `vaara serve` as a sidecar and reuse a warm process; that path is on the v0.2.0 roadmap.
+PreToolUse on Bash / WebFetch / WebSearch is regex-only and sub-millisecond. PreToolUse on `mcp__*` and PostToolUse load the Vaara pipeline, roughly 0.5 to 2 seconds cold-start on commodity hardware. For tighter MCP latency, run `vaara serve` as a sidecar and reuse a warm process; that path is on the roadmap.
 
-## Known limitations (v0.1.0)
+## Known limitations
 
 - Cold-start latency per MCP call (see above).
 - PostToolUse correlates to the most recent `ACTION_REQUESTED` for the same agent + tool. Parallel calls to the same MCP tool can race; outcome attribution may swap. The audit chain itself stays intact.

--- a/plugins/claude-code-vaara-governance/commands/vaara-setup.md
+++ b/plugins/claude-code-vaara-governance/commands/vaara-setup.md
@@ -1,0 +1,26 @@
+---
+description: Friendly settings for Vaara governance. Choose protection level, watch vs protect mode, and notifications, in plain language.
+argument-hint: (no arguments)
+---
+
+You are the settings surface for the vaara-governance plugin. Walk the user through their governance settings in plain language, then write the result to `~/.vaara/claude-code/config.json`. Assume the user is smart but not interested in thresholds and env vars; translate.
+
+Steps:
+
+1. Read `~/.vaara/claude-code/config.json` if it exists (missing file means defaults). Also note whether `VAARA_PLUGIN_SHADOW`, `VAARA_PLUGIN_DISABLE`, `VAARA_PLUGIN_NOTIFY`, or `VAARA_PLUGIN_PROTECTION` are set in the environment; environment variables override the file, so if one is set, tell the user their choice here will not take effect until they remove it.
+
+2. Show the current state in one short plain-language paragraph. Example: "Right now Vaara is watching but not blocking: every tool call gets checked and recorded, nothing is stopped. Protection level is balanced. Popup notifications are on. Your records are in ~/.vaara/claude-code/audit.db."
+
+3. Ask, using the AskUserQuestion tool, one question at a time:
+
+   - Mode: "Should Vaara protect or just watch?" Options: "Protect" (risky tool calls are stopped or held for your ok; the rest run normally), "Watch only" (nothing is ever blocked; everything is checked and recorded so you can see what protection would have done), "Off" (no checking, no records).
+   - Protection level (skip if mode is Off): "How strict should it be?" Options mapped to presets: "Relaxed" (performance: only clearly risky calls get flagged), "Balanced (recommended)" (balanced: the default), "Strict" (strict: anything doubtful gets held for your ok), "Paranoid" (eco: tightest blocking, expect interruptions).
+   - Notifications (skip if mode is Off): "Popup on your screen when something is blocked or held?" Options: "Yes (recommended)", "No, terminal only".
+
+4. Write the config file. Keys: `mode` ("protect" | "watch" | "off"), `protection` ("performance" | "balanced" | "strict" | "eco"), `notifications` (true | false). Preserve any other keys already in the file (for example `agent_id` or `audit_db`). Create the directory if needed.
+
+5. Confirm in plain language what is now active, and close with the two things worth knowing:
+   - "See what Vaara has recorded: /vaara-stats"
+   - "Every check, allow and block alike, lands in a tamper-evident record at <audit_db path>. That record is the point: it is proof of what your AI actually did."
+
+Do not mention threshold numbers, env var names (unless one is overriding), or Vaara internals unless the user asks. If the user asks what the records are for, the one-line answer: logs say trust me, this record can be checked by someone who does not trust you.

--- a/plugins/claude-code-vaara-governance/hooks/_config.py
+++ b/plugins/claude-code-vaara-governance/hooks/_config.py
@@ -1,0 +1,63 @@
+"""Plugin settings from ``~/.vaara/claude-code/config.json``.
+
+Written by ``/vaara-setup`` and hand-editable. Environment variables win
+over the file, so existing env-based setups keep working unchanged. A
+missing or malformed file means defaults; a settings file must never be
+able to break the hooks.
+
+Keys:
+  mode           "protect" (default) | "watch" (record, never block) | "off"
+  protection     policy preset: "eco" | "balanced" | "performance" | "strict"
+  notifications  true (default) | false, desktop popups on block/escalate
+  agent_id       agent id written to the audit chain (default "claude-code")
+  audit_db       audit DB path (default ~/.vaara/claude-code/audit.db)
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+CONFIG_PATH = Path.home() / ".vaara" / "claude-code" / "config.json"
+
+
+def load_config() -> dict:
+    try:
+        data = json.loads(CONFIG_PATH.read_text())
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def plugin_disabled(cfg: dict) -> bool:
+    if os.environ.get("VAARA_PLUGIN_DISABLE") == "1":
+        return True
+    return cfg.get("mode") == "off"
+
+
+def shadow_mode(cfg: dict) -> bool:
+    if os.environ.get("VAARA_PLUGIN_SHADOW") == "1":
+        return True
+    return cfg.get("mode") == "watch"
+
+
+def agent_id(cfg: dict) -> str:
+    return os.environ.get("VAARA_PLUGIN_AGENT_ID") or cfg.get("agent_id") or "claude-code"
+
+
+def audit_db_path(cfg: dict) -> Path:
+    override = os.environ.get("VAARA_PLUGIN_AUDIT_DB") or cfg.get("audit_db")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".vaara" / "claude-code" / "audit.db"
+
+
+def notifications_enabled(cfg: dict) -> bool:
+    if os.environ.get("VAARA_PLUGIN_NOTIFY") == "0":
+        return False
+    return cfg.get("notifications", True) is not False
+
+
+def protection_preset(cfg: dict) -> str | None:
+    preset = os.environ.get("VAARA_PLUGIN_PROTECTION") or cfg.get("protection")
+    return preset if isinstance(preset, str) and preset else None

--- a/plugins/claude-code-vaara-governance/hooks/_notify.py
+++ b/plugins/claude-code-vaara-governance/hooks/_notify.py
@@ -1,0 +1,50 @@
+"""Desktop notification for governance decisions. Fire-and-forget.
+
+Sends a native notification when the gate blocks or escalates a tool
+call, so the decision is visible even when the terminal is buried.
+macOS uses osascript; Linux uses notify-send when present. Anything
+missing or failing is silently ignored: a notification must never be
+able to break the hook that sends it.
+
+Env vars:
+  VAARA_PLUGIN_NOTIFY=0   disable notifications (default: enabled)
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+def _clean(text: str, limit: int) -> str:
+    # osascript receives the strings inside AppleScript double quotes;
+    # strip characters that would terminate or escape the literal.
+    text = text.replace('"', "'").replace("\\", "/").replace("\n", " ")
+    return text[:limit]
+
+
+def notify(verdict: str, tool_name: str, detail: str) -> None:
+    """Show '<verdict> <tool>' with the reason underneath. Never raises."""
+    if os.environ.get("VAARA_PLUGIN_NOTIFY") == "0":
+        return
+    try:
+        title = _clean(f"Vaara: {verdict}", 60)
+        subtitle = _clean(tool_name, 80)
+        body = _clean(detail, 180)
+        if sys.platform == "darwin":
+            script = (
+                f'display notification "{body}" '
+                f'with title "{title}" subtitle "{subtitle}" '
+                f'sound name "Funk"'
+            )
+            cmd = ["osascript", "-e", script]
+        elif shutil.which("notify-send"):
+            cmd = ["notify-send", "--app-name=Vaara", f"{title} {subtitle}", body]
+        else:
+            return
+        subprocess.Popen(
+            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+    except Exception:
+        pass

--- a/plugins/claude-code-vaara-governance/hooks/post_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/post_tool_use.py
@@ -19,16 +19,17 @@ Env vars match pre_tool_use.py:
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+import _config  # noqa: E402
+
+CFG = _config.load_config()
+
 
 def _audit_db_path() -> Path:
-    override = os.environ.get("VAARA_PLUGIN_AUDIT_DB")
-    if override:
-        return Path(override).expanduser()
-    return Path.home() / ".vaara" / "claude-code" / "audit.db"
+    return _config.audit_db_path(CFG)
 
 
 def _outcome_severity(tool_response: object) -> float:
@@ -52,7 +53,7 @@ def _outcome_severity(tool_response: object) -> float:
 
 
 def main() -> int:
-    if os.environ.get("VAARA_PLUGIN_DISABLE") == "1":
+    if _config.plugin_disabled(CFG):
         return 0
 
     try:
@@ -69,7 +70,7 @@ def main() -> int:
     except ImportError:
         return 0
 
-    agent_id = os.environ.get("VAARA_PLUGIN_AGENT_ID", "claude-code")
+    agent_id = _config.agent_id(CFG)
     db_path = _audit_db_path()
     if not db_path.exists():
         return 0

--- a/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
@@ -23,12 +23,20 @@ VAARA_PLUGIN_DENY_PATTERNS_FILE.
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+import _config  # noqa: E402
 from _deny_patterns import load_deny_rules, match_deny_rule  # noqa: E402
+from _notify import notify as _raw_notify  # noqa: E402
+
+CFG = _config.load_config()
+
+
+def notify(verdict: str, tool_name: str, detail: str) -> None:
+    if _config.notifications_enabled(CFG):
+        _raw_notify(verdict, tool_name, detail)
 
 
 def _emit(message: str) -> None:
@@ -36,10 +44,7 @@ def _emit(message: str) -> None:
 
 
 def _audit_db_path() -> Path:
-    override = os.environ.get("VAARA_PLUGIN_AUDIT_DB")
-    if override:
-        return Path(override).expanduser()
-    return Path.home() / ".vaara" / "claude-code" / "audit.db"
+    return _config.audit_db_path(CFG)
 
 
 def _append_deny_audit(
@@ -91,6 +96,19 @@ def _classify_mcp(
     trail._on_record = backend.write_record
     pipeline = InterceptionPipeline(trail=trail, enforce=not shadow)
 
+    preset = _config.protection_preset(CFG)
+    if preset:
+        try:
+            from vaara.policy import from_dict
+            from vaara.policy.modes import get_mode, to_policy_dict
+
+            pipeline.scorer.apply_policy(from_dict(to_policy_dict(get_mode(preset))))
+        except Exception as exc:
+            _emit(
+                f"vaara-governance: protection preset {preset!r} not applied "
+                f"({exc}); using default thresholds."
+            )
+
     try:
         result = pipeline.intercept(
             agent_id=agent_id,
@@ -109,6 +127,9 @@ def _classify_mcp(
                 f"(risk {result.risk_score:.2f}, action_id={result.action_id}). "
                 f"Reason: {result.reason}"
             )
+            notify(
+                "ESCALATE", tool_name, f"risk {result.risk_score:.2f}: {result.reason}"
+            )
         return 0
 
     _emit(
@@ -116,11 +137,12 @@ def _classify_mcp(
         f"(risk {result.risk_score:.2f}, action_id={result.action_id}). "
         f"Reason: {result.reason}"
     )
+    notify("BLOCKED", tool_name, f"risk {result.risk_score:.2f}: {result.reason}")
     return 2
 
 
 def main() -> int:
-    if os.environ.get("VAARA_PLUGIN_DISABLE") == "1":
+    if _config.plugin_disabled(CFG):
         return 0
 
     try:
@@ -133,8 +155,8 @@ def main() -> int:
     if not isinstance(tool_input, dict):
         tool_input = {"_raw": tool_input}
     session_id = event.get("session_id", "")
-    agent_id = os.environ.get("VAARA_PLUGIN_AGENT_ID", "claude-code")
-    shadow = os.environ.get("VAARA_PLUGIN_SHADOW") == "1"
+    agent_id = _config.agent_id(CFG)
+    shadow = _config.shadow_mode(CFG)
 
     rules = load_deny_rules()
     match = match_deny_rule(rules, tool_name, tool_input)
@@ -146,8 +168,10 @@ def main() -> int:
                 f"vaara-governance: SHADOW deny on {tool_name} "
                 f"(rule={rule_id}): {message}"
             )
+            notify("SHADOW deny", tool_name, message)
             return 0
         _emit(f"vaara-governance: BLOCKED {tool_name} (rule={rule_id}). {message}")
+        notify("BLOCKED", tool_name, message)
         return 2
 
     if not tool_name.startswith("mcp__"):

--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -9,9 +9,13 @@ VAARA_PLUGIN_AUDIT_DB, VAARA_PLUGIN_SHADOW).
 """
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+import _config  # noqa: E402
+
+CFG = _config.load_config()
 
 
 def _emit(message: str) -> None:
@@ -19,15 +23,12 @@ def _emit(message: str) -> None:
 
 
 def _audit_db_path() -> Path:
-    override = os.environ.get("VAARA_PLUGIN_AUDIT_DB")
-    if override:
-        return Path(override).expanduser()
-    return Path.home() / ".vaara" / "claude-code" / "audit.db"
+    return _config.audit_db_path(CFG)
 
 
 def main() -> int:
-    if os.environ.get("VAARA_PLUGIN_DISABLE") == "1":
-        _emit("vaara-governance: disabled via VAARA_PLUGIN_DISABLE=1.")
+    if _config.plugin_disabled(CFG):
+        _emit("vaara-governance: off (config.json mode or VAARA_PLUGIN_DISABLE=1).")
         return 0
 
     try:
@@ -40,7 +41,9 @@ def main() -> int:
         )
         return 0
 
-    mode = "shadow" if os.environ.get("VAARA_PLUGIN_SHADOW") == "1" else "enforce"
+    mode = "watch (nothing blocked, all recorded)" if _config.shadow_mode(CFG) else "protect"
+    preset = _config.protection_preset(CFG) or "balanced"
+    notif = "on" if _config.notifications_enabled(CFG) else "off"
     db_path = _audit_db_path()
     existed = db_path.exists()
     try:
@@ -53,8 +56,10 @@ def main() -> int:
         db_state = f"unavailable ({exc!r})"
 
     _emit(
-        f"vaara-governance v0.1.2 loaded "
-        f"(vaara {vaara.__version__}, mode={mode}, audit_db={db_path} [{db_state}])."
+        f"vaara-governance v0.2.0 loaded "
+        f"(vaara {vaara.__version__}, mode={mode}, protection={preset}, "
+        f"notifications={notif}, audit_db={db_path} [{db_state}]). "
+        f"Settings: /vaara-setup"
     )
     return 0
 


### PR DESCRIPTION
## What

The vaara-governance Claude Code plugin grows the two things people actually asked for: you can see the gate work without watching the terminal, and you can configure it without reading an env-var table.

- **Desktop notifications.** A block or escalation pops a native notification (macOS osascript, Linux notify-send). Fire-and-forget with a bare except: a notification can never break the hook that sends it.
- **Config file.** `~/.vaara/claude-code/config.json` with plain keys: `mode` (protect / watch / off), `protection` (the `vaara mode` presets), `notifications`, `agent_id`, `audit_db`. Env vars override the file, so every existing setup keeps working unchanged.
- **Protection presets.** The `protection` key applies eco / balanced / performance / strict thresholds to MCP scoring. Unknown preset warns and falls back to defaults.
- **/vaara-setup.** Plain-language settings walk-through (protect or watch, how strict, popups or not) that writes the config file. No thresholds or env vars mentioned unless one is overriding.

## Verification

- Hook matrix run against the real hooks with an isolated HOME: watch mode returns exit 0 with a SHADOW deny line and a notification; off mode passes through; `notifications: false` sends nothing; protect mode blocks with exit 2; bogus preset prints the fallback warning and continues.
- Notification transport tested through PATH shims for both branches: notify-send receives the expected args end to end from a real hook invocation, and the osascript AppleScript renders with quote-safe escaping. Not verified: actual rendering on a real mac, no macOS here; the AppleScript is the documented display notification form.
- `ruff check .` clean, full suite 2163 passed / 17 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive `/vaara-setup` configuration for operating mode, protection level, notifications, and audit settings.
  * Added native desktop notifications for blocked and escalated actions on macOS and Linux.
  * Added support for configurable protection presets and persistent settings.

* **Documentation**
  * Expanded setup guidance, configuration details, environment variable overrides, and audit record information.
  * Updated plugin version and feature description to reflect the new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->