### PR TITLE
docs: list Homebrew and npm install options in the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ def transfer_funds(to: str, amount: float) -> str:
 
 That is the whole thing. Every call to a governed function is risk-scored and decided against your policy before the body runs. A blocked call raises `vaara.Blocked`; an allowed call runs, and the decision, the call, and the outcome land in a signed record anyone can verify offline. Python 3.10+, zero runtime dependencies.
 
+Other ways in: Homebrew installs the CLI (`brew tap vaaraio/tap && brew install vaara`; newer brew asks you to `brew trust vaaraio/tap` first), and [`@vaara/client`](https://www.npmjs.com/package/@vaara/client) on npm is the TypeScript client for the HTTP API. The MCP proxy and server ship with the Python package.
+
 <details>
 <summary><b>Prefer the explicit pipeline?</b></summary>
 


### PR DESCRIPTION
## What

One sentence under the quick start naming the other install paths: Homebrew for the CLI (`brew tap vaaraio/tap && brew install vaara`, with the `brew trust` step newer Homebrew requires for third-party taps) and `@vaara/client` on npm for the TypeScript HTTP client.

## Verification

The Homebrew path was installed end to end on a real macOS machine today (tap, trust, install; `vaara version` prints 1.26.1). Docs only, no code changes.