### PR TITLE
cli: --db export, did-you-mean suggestions, readable help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+CLI usability, driven by first-run friction on the export path. No wire-format change.
+
+- `vaara trail export` and `vaara trail export-article12` accept `--db` to export straight from an audit SQLite DB (for example the Claude Code plugin's `~/.vaara/claude-code/audit.db`); `--trail` JSONL remains and the two are mutually exclusive. Previously the only DB-to-signed-zip route was a `trail rotate --dry-run` workaround.
+- A mistyped command now gets a did-you-mean suggestion (`vaara trail exoprt` suggests `export`) instead of only the choices list.
+- `vaara --help` and error usage lines show `COMMAND` instead of the full brace-wall of 33 subcommand names, at every level.
+- The Claude Code plugin README's export instructions now name a command that can read the plugin's own DB, and mention the `vaara[export]` extra.
+
 ## [1.26.1] - 2026-07-12
 
 Release hygiene. No functional change to the Python package.

--- a/plugins/claude-code-vaara-governance/README.md
+++ b/plugins/claude-code-vaara-governance/README.md
@@ -95,7 +95,7 @@ vaara compliance report --db ~/.vaara/claude-code/audit.db --format md
 vaara compliance dashboard --db ~/.vaara/claude-code/audit.db --out ~/audit-dashboard.html
 ```
 
-For a signed, regulator-handoff bundle, export the trail with `vaara trail export --trail PATH --out PATH --key PATH`, then verify the zip with `vaara trail verify --zip PATH`.
+For a signed, regulator-handoff bundle, export straight from the plugin's DB with `vaara trail export --db ~/.vaara/claude-code/audit.db --out trail.zip --key PATH`, then verify the zip with `vaara trail verify --zip trail.zip`. Signing needs the export extra: `pip install "vaara[export]"`.
 
 ## Latency
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -204,6 +204,7 @@ import calendar
 import hashlib
 import json
 import os
+import re
 import stat
 import sys
 import time
@@ -417,21 +418,31 @@ def _cmd_trail_shadow_report(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_trail_export(args: argparse.Namespace) -> int:
-    try:
-        from vaara.audit.export import export_signed
-        from vaara.audit.trail import AuditTrail
-    except ImportError:
-        print(_INSTALL_HINT, file=sys.stderr)
-        return 2
+def _load_trail_source(args: argparse.Namespace):
+    """Load an AuditTrail from --trail (JSONL) or --db (SQLite).
+
+    Returns (trail, None) on success or (None, exit_code) on failure with
+    the error already printed. The two flags are mutually exclusive and one
+    is required, enforced at the parser level.
+    """
+    from vaara.audit.trail import AuditRecord, AuditTrail
+
+    db_arg = getattr(args, "db", None)
+    if db_arg:
+        db_path = Path(db_arg).expanduser()
+        if not db_path.is_file():
+            print(f"audit DB not found: {db_path}", file=sys.stderr)
+            return None, 2
+        from vaara.audit.sqlite_backend import SQLiteAuditBackend
+
+        return SQLiteAuditBackend(db_path).load_trail(), None
 
     trail_path = Path(args.trail).expanduser()
     if not trail_path.exists():
         print(f"trail JSONL not found: {trail_path}", file=sys.stderr)
-        return 2
+        return None, 2
 
     trail = AuditTrail()
-    from vaara.audit.trail import AuditRecord
     with open(trail_path, "r", encoding="utf-8") as f:
         for line in f:
             line = line.strip()
@@ -442,6 +453,30 @@ def _cmd_trail_export(args: argparse.Namespace) -> int:
             trail._by_action[rec.action_id].append(rec)
             if rec.record_hash:
                 trail._last_hash = rec.record_hash
+    return trail, None
+
+
+def _add_trail_source_args(sub_parser: argparse.ArgumentParser) -> None:
+    """--trail JSONL / --db SQLite input group shared by the trail exports."""
+    src = sub_parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--trail", help="Path to trail JSONL file")
+    src.add_argument(
+        "--db",
+        help="Path to an audit SQLite DB (e.g. the Claude Code plugin's "
+             "~/.vaara/claude-code/audit.db)",
+    )
+
+
+def _cmd_trail_export(args: argparse.Namespace) -> int:
+    try:
+        from vaara.audit.export import export_signed
+    except ImportError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 2
+
+    trail, err = _load_trail_source(args)
+    if trail is None:
+        return err
 
     out = Path(args.out).expanduser()
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -785,14 +820,8 @@ def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
     try:
         from vaara.audit.article12_export import export_article12
         from vaara.audit.timeanchor import TimeAnchorError
-        from vaara.audit.trail import AuditRecord, AuditTrail
     except ImportError:
         print(_INSTALL_HINT, file=sys.stderr)
-        return 2
-
-    trail_path = Path(args.trail).expanduser()
-    if not trail_path.exists():
-        print(f"trail JSONL not found: {trail_path}", file=sys.stderr)
         return 2
 
     system_meta = None
@@ -814,17 +843,9 @@ def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
         print(f"invalid --period: {exc}", file=sys.stderr)
         return 2
 
-    trail = AuditTrail()
-    with open(trail_path, "r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if not line:
-                continue
-            rec = AuditRecord.from_dict(json.loads(line))
-            trail._records.append(rec)
-            trail._by_action[rec.action_id].append(rec)
-            if rec.record_hash:
-                trail._last_hash = rec.record_hash
+    trail, err = _load_trail_source(args)
+    if trail is None:
+        return err
 
     # Folding handoff / enforcement evidence needs the attestation extra (the
     # crypto the record and binding lenses use). Fail fast with the install
@@ -3793,9 +3814,37 @@ def _help_dispatch(parser: argparse.ArgumentParser):
     return _print
 
 
+class _SuggestingParser(argparse.ArgumentParser):
+    """ArgumentParser that adds a did-you-mean hint on unknown commands.
+
+    argparse only grew ``suggest_on_error`` in Python 3.14; this backports
+    the one case that matters for a CLI this wide: a mistyped subcommand.
+    """
+
+    def error(self, message: str):
+        match = re.search(r"invalid choice: '([^']+)' \(choose from (.+)\)", message)
+        if match:
+            import difflib
+
+            attempted = match.group(1)
+            choices = [c.strip().strip("'\"") for c in match.group(2).split(",")]
+            close = difflib.get_close_matches(attempted, choices, n=1)
+            if close:
+                message = (
+                    f"invalid choice: {attempted!r}. Did you mean {close[0]!r}? "
+                    f"Run `{self.prog} --help` for the full command list."
+                )
+            else:
+                message = (
+                    f"invalid choice: {attempted!r}. "
+                    f"Run `{self.prog} --help` for the full command list."
+                )
+        super().error(message)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(prog="vaara", description="Vaara AI Agent Execution Layer")
-    sub = p.add_subparsers(dest="cmd")
+    p = _SuggestingParser(prog="vaara", description="Vaara AI Agent Execution Layer")
+    sub = p.add_subparsers(dest="cmd", metavar="COMMAND")
     p.set_defaults(func=_help_dispatch(p))
 
     sub.add_parser("version", help="Print Vaara version").set_defaults(func=_cmd_version)
@@ -3821,11 +3870,11 @@ def build_parser() -> argparse.ArgumentParser:
     pk.set_defaults(func=_cmd_keygen)
 
     pt = sub.add_parser("trail", help="Audit-trail commands")
-    tsub = pt.add_subparsers(dest="trail_cmd")
+    tsub = pt.add_subparsers(dest="trail_cmd", metavar="COMMAND")
     pt.set_defaults(func=_help_dispatch(pt))
 
     pe = tsub.add_parser("export", help="Export a signed, regulator-handoff trail zip")
-    pe.add_argument("--trail", required=True, help="Path to trail JSONL file")
+    _add_trail_source_args(pe)
     pe.add_argument("--out", required=True, help="Path to write the signed zip")
     pe.add_argument("--key", required=True, help="Path to Ed25519 signing private key (PEM)")
     pe.add_argument("--agent-id", default="", help="Optional agent_id tag for the manifest")
@@ -3910,7 +3959,7 @@ def build_parser() -> argparse.ArgumentParser:
         "export-article12",
         help="Export a signed EU AI Act Article 12 regulator package",
     )
-    pa12.add_argument("--trail", required=True, help="Path to trail JSONL file")
+    _add_trail_source_args(pa12)
     pa12.add_argument(
         "--key", required=True,
         help="Ed25519 private key (PEM) to sign the package",
@@ -4060,7 +4109,7 @@ def build_parser() -> argparse.ArgumentParser:
         "review",
         help="Human-in-the-loop review queue (EU AI Act Article 14)",
     )
-    rsub = pr.add_subparsers(dest="review_cmd")
+    rsub = pr.add_subparsers(dest="review_cmd", metavar="COMMAND")
     pr.set_defaults(func=_help_dispatch(pr))
 
     rl = rsub.add_parser("list", help="List queue items (default: pending)")
@@ -4126,7 +4175,7 @@ def build_parser() -> argparse.ArgumentParser:
         "policy",
         help="Policy artifact commands (validate, test, reload)",
     )
-    psub = pp_policy.add_subparsers(dest="policy_cmd")
+    psub = pp_policy.add_subparsers(dest="policy_cmd", metavar="COMMAND")
     pp_policy.set_defaults(func=_help_dispatch(pp_policy))
 
     pvalid = psub.add_parser(
@@ -4159,7 +4208,7 @@ def build_parser() -> argparse.ArgumentParser:
         "compliance",
         help="Compliance reporting commands",
     )
-    csub = pcr.add_subparsers(dest="compliance_cmd")
+    csub = pcr.add_subparsers(dest="compliance_cmd", metavar="COMMAND")
     pcr.set_defaults(func=_help_dispatch(pcr))
     pcrep = csub.add_parser(
         "report",
@@ -4251,7 +4300,7 @@ def build_parser() -> argparse.ArgumentParser:
         "detect",
         help="Named detectors (injection, pii) over Vaara's scoring surface",
     )
-    dsub = pdetect.add_subparsers(dest="detect_cmd")
+    dsub = pdetect.add_subparsers(dest="detect_cmd", metavar="COMMAND")
     pdetect.set_defaults(func=_help_dispatch(pdetect))
 
     def _add_text_input_args(p_):
@@ -4297,7 +4346,7 @@ def build_parser() -> argparse.ArgumentParser:
             "OVERT 1.0 attestation commands (Protocol Profile 1.0 Annex B.6)"
         ),
     )
-    osub = povert.add_subparsers(dest="overt_cmd")
+    osub = povert.add_subparsers(dest="overt_cmd", metavar="COMMAND")
     povert.set_defaults(func=_help_dispatch(povert))
     pov_verify = osub.add_parser(
         "verify",
@@ -4341,7 +4390,7 @@ def build_parser() -> argparse.ArgumentParser:
         "attest",
         help="SEP-2787 tool-call attestation commands",
     )
-    asub = pattest.add_subparsers(dest="attest_cmd")
+    asub = pattest.add_subparsers(dest="attest_cmd", metavar="COMMAND")
     pattest.set_defaults(func=_help_dispatch(pattest))
     pa_verify = asub.add_parser(
         "verify",
@@ -4364,7 +4413,7 @@ def build_parser() -> argparse.ArgumentParser:
         "receipt",
         help="Execution-receipt commands (post-execution sibling of SEP-2787)",
     )
-    rcsub = preceipt.add_subparsers(dest="receipt_cmd")
+    rcsub = preceipt.add_subparsers(dest="receipt_cmd", metavar="COMMAND")
     preceipt.set_defaults(func=_help_dispatch(preceipt))
     prc_verify = rcsub.add_parser(
         "verify",
@@ -5125,7 +5174,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Hardware TEE attestation commands (experimental, AMD SEV-SNP)"
         ),
     )
-    tsub = ptee.add_subparsers(dest="tee_cmd")
+    tsub = ptee.add_subparsers(dest="tee_cmd", metavar="COMMAND")
     ptee.set_defaults(func=_help_dispatch(ptee))
 
     ptee_parse = tsub.add_parser(
@@ -5213,7 +5262,7 @@ def build_parser() -> argparse.ArgumentParser:
             "(eco / balanced / performance / strict)"
         ),
     )
-    msub = pmode.add_subparsers(dest="mode_cmd")
+    msub = pmode.add_subparsers(dest="mode_cmd", metavar="COMMAND")
     pmode.set_defaults(func=_help_dispatch(pmode))
 
     pml = msub.add_parser(

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -1,0 +1,110 @@
+"""Tests for CLI usability: did-you-mean suggestions and --db trail export."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.cli import build_parser, main
+from vaara.pipeline import InterceptionPipeline
+
+
+def _make_db(tmp_path):
+    db = tmp_path / "audit.db"
+    backend = SQLiteAuditBackend(db)
+    trail = backend.load_trail()
+    trail._on_record = backend.write_record
+    pipeline = InterceptionPipeline(trail=trail, enforce=False)
+    for i in range(3):
+        pipeline.intercept(
+            agent_id="test-agent",
+            tool_name=f"mcp__demo__tool{i}",
+            parameters={"x": i},
+        )
+    return db
+
+
+def _make_key(tmp_path):
+    key = tmp_path / "key"
+    assert main(["keygen", "--dev", "--out", str(key)]) == 0
+    return key
+
+
+def test_mistyped_command_suggests_closest(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["verion"])
+    err = capsys.readouterr().err
+    assert "Did you mean 'version'?" in err
+
+
+def test_mistyped_trail_subcommand_suggests_closest(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["trail", "exoprt"])
+    err = capsys.readouterr().err
+    assert "Did you mean 'export'?" in err
+
+
+def test_mistyped_command_without_close_match_points_at_help(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["zzzzzz"])
+    err = capsys.readouterr().err
+    assert "Did you mean" not in err
+    assert "--help" in err
+
+
+def test_usage_line_shows_metavar_not_command_wall(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["--help"])
+    out = capsys.readouterr().out
+    assert "usage: vaara [-h] COMMAND ..." in out.splitlines()[0]
+
+
+def test_trail_export_from_sqlite_db(tmp_path, capsys):
+    db = _make_db(tmp_path)
+    key = _make_key(tmp_path)
+    out = tmp_path / "trail.zip"
+    assert main([
+        "trail", "export", "--db", str(db), "--out", str(out), "--key", str(key),
+    ]) == 0
+    assert out.is_file()
+    capsys.readouterr()
+    assert main(["trail", "verify", "--zip", str(out)]) == 0
+    assert "Verification: OK" in capsys.readouterr().out
+
+
+def test_trail_export_article12_from_sqlite_db(tmp_path):
+    db = _make_db(tmp_path)
+    key = _make_key(tmp_path)
+    out = tmp_path / "a12.zip"
+    assert main([
+        "trail", "export-article12",
+        "--db", str(db), "--out", str(out), "--key", str(key),
+    ]) == 0
+    assert out.is_file()
+
+
+def test_trail_export_rejects_trail_and_db_together(tmp_path, capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args([
+            "trail", "export", "--trail", "t.jsonl", "--db", "a.db",
+            "--out", "o.zip", "--key", "k",
+        ])
+    assert "not allowed with" in capsys.readouterr().err
+
+
+def test_trail_export_requires_a_source(capsys):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["trail", "export", "--out", "o.zip", "--key", "k"])
+    assert "--trail" in capsys.readouterr().err
+
+
+def test_trail_export_missing_db_file_errors(tmp_path, capsys):
+    key = _make_key(tmp_path)
+    capsys.readouterr()
+    rc = main([
+        "trail", "export", "--db", str(tmp_path / "absent.db"),
+        "--out", str(tmp_path / "o.zip"), "--key", str(key),
+    ])
+    assert rc == 2
+    assert "audit DB not found" in capsys.readouterr().err


### PR DESCRIPTION
Fixes three pieces of first-run friction on the export path, found by dogfooding the plugin's audit trail export tonight.

What was wrong:
- The Claude Code plugin writes a SQLite DB, but every trail export command only accepted --trail JSONL. The sole DB-to-signed-zip route was the `trail rotate --dry-run` workaround, and the plugin README pointed at a command that could not read the plugin's own DB.
- A mistyped command printed the full 33-entry choices wall with no suggestion.
- `vaara --help` and every usage/error line printed that same wall.

Changes:
- `trail export` and `trail export-article12` accept `--db` (audit SQLite DB) or `--trail` (JSONL), mutually exclusive, via a shared loader. Loading goes through `SQLiteAuditBackend.load_trail()`, the same path the plugin hook uses.
- Did-you-mean on invalid subcommands at every level (`vaara trail exoprt` suggests `export`). argparse only grows `suggest_on_error` in Python 3.14, so this backports the one case that matters.
- `COMMAND` metavar on all 11 subparser groups, so usage lines stay one line.
- Plugin README export instructions corrected and the `vaara[export]` extra named.
- CHANGELOG entry under Unreleased.

Verified:
- End to end in a fresh venv: pipeline-written SQLite DB, `trail export --db` produces a signed zip, `trail verify` says OK, `export-article12 --db` produces the package.
- 9 new tests in tests/test_cli_ux.py; full suite 1192 passed, 146 skipped, ruff clean. The one failure (test_v040_per_tenant_threshold) fails identically on unmodified main in this environment and is unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export audit trails directly from SQLite databases using the `--db` option.
  * Added helpful “did you mean” suggestions for mistyped commands.
  * Improved CLI help and error messages with clearer `COMMAND` placeholders.

* **Documentation**
  * Updated plugin guidance for database-based exports, verification, and required export installation options.

* **Bug Fixes**
  * Added validation for missing, conflicting, or invalid audit-trail sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->