### PR TITLE
plugin: custom decision thresholds in config.json (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CLI usability, driven by first-run friction on the export path. No wire-format c
 - A mistyped command now gets a did-you-mean suggestion (`vaara trail exoprt` suggests `export`) instead of only the choices list.
 - `vaara --help` and error usage lines show `COMMAND` instead of the full brace-wall of 33 subcommand names, at every level.
 - The Claude Code plugin README's export instructions now name a command that can read the plugin's own DB, and mention the `vaara[export]` extra.
+- Claude Code plugin 0.3.0: an optional `"thresholds": {"escalate": E, "deny": D}` in `~/.vaara/claude-code/config.json` overrides the protection preset's default decision thresholds (`0 <= E <= D <= 1`; malformed values are ignored, the preset still provides the rest of the policy shape). First test coverage for the plugin's config helpers (`tests/test_plugin_config.py`).
 
 ## [1.26.1] - 2026-07-12
 

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/plugins/claude-code-vaara-governance/README.md
+++ b/plugins/claude-code-vaara-governance/README.md
@@ -48,6 +48,7 @@ The config file, hand-editable:
 |---|---|---|
 | `mode` | `protect` (default), `watch`, `off` | `watch` checks and records everything but never blocks; `off` disables the plugin. |
 | `protection` | `eco`, `balanced` (default), `performance`, `strict` | Policy preset applied to MCP scoring; these are the `vaara mode` presets. |
+| `thresholds` | `{"escalate": E, "deny": D}` with `0 <= E <= D <= 1` | Optional custom decision thresholds, overriding the preset's defaults. The preset still provides the rest of the policy shape. Malformed values are ignored. |
 | `notifications` | `true` (default), `false` | Desktop popups on block/escalate. |
 | `agent_id` | string | Agent id written to the audit chain (default `claude-code`). |
 | `audit_db` | path | Audit DB path (default `~/.vaara/claude-code/audit.db`). |

--- a/plugins/claude-code-vaara-governance/hooks/_config.py
+++ b/plugins/claude-code-vaara-governance/hooks/_config.py
@@ -8,6 +8,8 @@ able to break the hooks.
 Keys:
   mode           "protect" (default) | "watch" (record, never block) | "off"
   protection     policy preset: "eco" | "balanced" | "performance" | "strict"
+  thresholds     optional {"escalate": E, "deny": D} overriding the preset's
+                 default thresholds (0 <= E <= D <= 1)
   notifications  true (default) | false, desktop popups on block/escalate
   agent_id       agent id written to the audit chain (default "claude-code")
   audit_db       audit DB path (default ~/.vaara/claude-code/audit.db)
@@ -61,3 +63,25 @@ def notifications_enabled(cfg: dict) -> bool:
 def protection_preset(cfg: dict) -> str | None:
     preset = os.environ.get("VAARA_PLUGIN_PROTECTION") or cfg.get("protection")
     return preset if isinstance(preset, str) and preset else None
+
+
+def custom_thresholds(cfg: dict) -> tuple[float, float] | None:
+    """Optional custom decision thresholds from config.json.
+
+    Shape: ``"thresholds": {"escalate": 0.5, "deny": 0.8}``. Both keys
+    required, numeric, with 0 <= escalate <= deny <= 1. Anything else is
+    ignored (never break the hook over a bad settings file). When present,
+    these override the preset's default thresholds; the preset still
+    provides the rest of the policy shape.
+    """
+    raw = cfg.get("thresholds")
+    if not isinstance(raw, dict):
+        return None
+    escalate, deny = raw.get("escalate"), raw.get("deny")
+    if not isinstance(escalate, (int, float)) or not isinstance(deny, (int, float)):
+        return None
+    if isinstance(escalate, bool) or isinstance(deny, bool):
+        return None
+    if not (0 <= escalate <= deny <= 1):
+        return None
+    return float(escalate), float(deny)

--- a/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
@@ -97,16 +97,24 @@ def _classify_mcp(
     pipeline = InterceptionPipeline(trail=trail, enforce=not shadow)
 
     preset = _config.protection_preset(CFG)
-    if preset:
+    custom = _config.custom_thresholds(CFG)
+    if preset or custom:
         try:
             from vaara.policy import from_dict
             from vaara.policy.modes import get_mode, to_policy_dict
 
-            pipeline.scorer.apply_policy(from_dict(to_policy_dict(get_mode(preset))))
+            policy = to_policy_dict(get_mode(preset or "balanced"))
+            if custom:
+                escalate, deny = custom
+                policy["thresholds"]["default"] = {
+                    "escalate": escalate, "deny": deny,
+                }
+            pipeline.scorer.apply_policy(from_dict(policy))
         except Exception as exc:
             _emit(
-                f"vaara-governance: protection preset {preset!r} not applied "
-                f"({exc}); using default thresholds."
+                f"vaara-governance: policy (preset={preset!r}, "
+                f"custom_thresholds={custom!r}) not applied ({exc}); "
+                f"using default thresholds."
             )
 
     try:

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -1,0 +1,75 @@
+"""Tests for the Claude Code plugin's config helpers (hooks/_config.py).
+
+The hooks live outside the package, so they are imported by path. This
+is the first test coverage for them; keep it dependency-free.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_HOOKS = Path(__file__).parent.parent / "plugins" / "claude-code-vaara-governance" / "hooks"
+
+
+@pytest.fixture()
+def config_mod(monkeypatch):
+    monkeypatch.syspath_prepend(str(_HOOKS))
+    spec = importlib.util.spec_from_file_location("_config", _HOOKS / "_config.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    # A stray env var must not leak into assertions below.
+    for var in ("VAARA_PLUGIN_PROTECTION", "VAARA_PLUGIN_SHADOW"):
+        monkeypatch.delenv(var, raising=False)
+    yield mod
+    sys.modules.pop("_config", None)
+
+
+def test_custom_thresholds_valid(config_mod):
+    cfg = {"thresholds": {"escalate": 0.5, "deny": 0.8}}
+    assert config_mod.custom_thresholds(cfg) == (0.5, 0.8)
+
+
+def test_custom_thresholds_int_values_accepted(config_mod):
+    cfg = {"thresholds": {"escalate": 0, "deny": 1}}
+    assert config_mod.custom_thresholds(cfg) == (0.0, 1.0)
+
+
+def test_custom_thresholds_absent(config_mod):
+    assert config_mod.custom_thresholds({}) is None
+
+
+@pytest.mark.parametrize("bad", [
+    {"escalate": 0.9, "deny": 0.5},          # escalate above deny
+    {"escalate": -0.1, "deny": 0.5},         # below range
+    {"escalate": 0.5, "deny": 1.5},          # above range
+    {"escalate": "0.5", "deny": 0.8},        # wrong type
+    {"escalate": True, "deny": 0.8},         # bool is not a threshold
+    {"escalate": 0.5},                       # missing key
+    "0.5,0.8",                               # not a dict
+    None,
+])
+def test_custom_thresholds_rejects_malformed(config_mod, bad):
+    assert config_mod.custom_thresholds({"thresholds": bad}) is None
+
+
+def test_preset_still_reads_protection_key(config_mod):
+    assert config_mod.protection_preset({"protection": "strict"}) == "strict"
+    assert config_mod.protection_preset({}) is None
+
+
+def test_custom_thresholds_compose_into_policy(config_mod):
+    """The pre_tool_use composition: custom overrides the preset default."""
+    pytest.importorskip("vaara")
+    from vaara.policy import from_dict
+    from vaara.policy.modes import get_mode, to_policy_dict
+
+    custom = config_mod.custom_thresholds(
+        {"thresholds": {"escalate": 0.33, "deny": 0.66}})
+    policy = to_policy_dict(get_mode("balanced"))
+    escalate, deny = custom
+    policy["thresholds"]["default"] = {"escalate": escalate, "deny": deny}
+    parsed = from_dict(policy)  # must validate
+    assert parsed is not None


### PR DESCRIPTION
Adds the one knob the presets don't give: user-set decision thresholds.

An optional `"thresholds": {"escalate": E, "deny": D}` in `~/.vaara/claude-code/config.json` overrides the protection preset's default thresholds. The preset still provides the rest of the policy shape, so this composes rather than replaces. Validation is strict: both keys numeric, `0 <= E <= D <= 1`, booleans rejected, and anything malformed is ignored — a bad settings file must never break the hook.

Changes:
- `hooks/_config.py`: `custom_thresholds()` reader, documented in the module docstring.
- `hooks/pre_tool_use.py`: policy composition — preset dict via `to_policy_dict(get_mode(...))`, custom values override `thresholds.default`, single `apply_policy` call.
- Plugin README config table + plugin.json bump to 0.3.0.
- `tests/test_plugin_config.py`: first test coverage for the plugin's config helpers (13 tests), including a policy round-trip through `vaara.policy.from_dict`.
- CHANGELOG entry under Unreleased.

Verified end to end in a fresh venv: with `{"escalate": 0.0, "deny": 0.0001}` the hook blocks a real MCP call (exit 2, custom threshold visible in the recorded reason string); with `{"escalate": 0.99, "deny": 1.0}` it allows (exit 0); under `VAARA_PLUGIN_SHADOW=1` the deny is recorded but not enforced, as designed. Full suite: 1205 passed, ruff clean; the one failure (test_v040_per_tenant_threshold) fails identically on unmodified main in this environment and is unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional custom escalation and denial thresholds for the Claude Code governance plugin.
  - Thresholds must be ordered between 0 and 1; invalid values are safely ignored.
  - Plugin version updated to 0.3.0.

- **Documentation**
  - Documented threshold configuration and fallback behavior.

- **Tests**
  - Added coverage for valid, invalid, missing, and policy-compatible threshold settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->