### PR TITLE
docs: settle the AI Act dates per the adopted Omnibus VII

### DIFF
--- a/docs/eu-ai-act-article-12.md
+++ b/docs/eu-ai-act-article-12.md
@@ -11,7 +11,7 @@ This page states precisely what the text requires, what it does not, and what th
 - **Minimum content for remote biometric systems.** For the Annex III point 1(a) systems, Article 12(3) names specifics: period of each use, the reference database checked, the input data matched, and the identity of the persons who verified the results under Article 14(5).
 - **Retention.** Logs are kept "for a period appropriate to the intended purpose", of at least six months, by providers (Article 19(1)) and by deployers to the extent the logs are under their control (Article 26(6)). Union or national law, in particular data-protection law, can change that period.
 
-Timing caveat: the enforcement dates for high-risk obligations have been in legislative flux during 2026. Do not anchor a compliance plan to a hardcoded date from a blog post, this one included. Check the current consolidated text.
+Timing: the dates settled in June 2026. Under the Omnibus VII simplification regulation, given final approval by the Council on 29 June 2026, the high-risk obligations (including Article 12) apply from **2 December 2027** for stand-alone high-risk systems and **2 August 2028** for high-risk systems embedded in products. The Article 50 transparency obligations were not delayed and apply from **2 August 2026**, with a grace period to 2 December 2026 only for marking machine-generated content in systems already on the market. Source: [Council press release, 29 June 2026](https://www.consilium.europa.eu/en/press/press-releases/2026/06/29/artificial-intelligence-council-gives-final-green-light-to-simplify-and-streamline-rules/); confirm details against the consolidated text once published in the Official Journal.
 
 ## What the text does not require
 

--- a/docs/logs-vs-evidence.md
+++ b/docs/logs-vs-evidence.md
@@ -29,7 +29,7 @@ Article 12 requires high-risk AI systems to automatically record events (logs) o
 
 So why produce evidence rather than logs? Because the obligation you are really preparing for is not "did you keep a log" but "prove what the system did" when it is challenged, under Article 12 record-keeping, Article 14 human oversight, an incident investigation, a liability claim, or a procurement review. A plain log answers the first and fails the second. Tamper-evident, independently verifiable evidence answers both. The hash chain is not a compliance checkbox. It is what makes the record hold up in front of someone who has every reason to doubt it.
 
-(Note on timing: the exact enforcement dates for high-risk obligations are in legislative flux and have shifted during 2026. Do not build a plan around a single hardcoded date; check the current text of the regulation.)
+(Note on timing: the dates settled in June 2026 with the Omnibus VII regulation. High-risk obligations apply from 2 December 2027 for stand-alone systems and 2 August 2028 for systems embedded in products; the Article 50 transparency obligations were not delayed and apply from 2 August 2026. Source: [Council press release, 29 June 2026](https://www.consilium.europa.eu/en/press/press-releases/2026/06/29/artificial-intelligence-council-gives-final-green-light-to-simplify-and-streamline-rules/).)
 
 ## How to produce evidence
 


### PR DESCRIPTION
Both GEO docs pages carried a deliberate "dates in legislative flux" caveat instead of a hardcoded deadline. That caution paid off: the Omnibus VII regulation got the Council's final approval on 29 June 2026, so this upgrades the caveat to the settled facts.

- High-risk obligations (including Article 12): apply from 2 December 2027 for stand-alone high-risk systems, 2 August 2028 for those embedded in products.
- Article 50 transparency: NOT delayed, applies from 2 August 2026, with a grace period to 2 December 2026 only for marking machine-generated content in systems already on the market.
- Source cited inline: Council press release of 29 June 2026 (consilium.europa.eu). The consolidated text lands in the Official Journal shortly; the Article 12 page says to confirm against it.

Checked the rest of the public tree (docs/, README, llms.txt) for other date claims: none exist, so these two caveats were the only places to touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated EU AI Act guidance with specific enforcement dates for Article 12 logging obligations:
    - Stand-alone high-risk systems: 2 December 2027
    - Embedded high-risk systems: 2 August 2028
  - Clarified that Article 50 transparency obligations begin on 2 August 2026.
  - Added a limited grace period for certain machine-generated content already on the market until 2 December 2026.
  - Added sourcing for the updated timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->