### PR TITLE
plugin: fail closed when the vaara package is missing (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ CLI usability, driven by first-run friction on the export path. No wire-format c
 - A mistyped command now gets a did-you-mean suggestion (`vaara trail exoprt` suggests `export`) instead of only the choices list.
 - `vaara --help` and error usage lines show `COMMAND` instead of the full brace-wall of 33 subcommand names, at every level.
 - The Claude Code plugin README's export instructions now name a command that can read the plugin's own DB, and mention the `vaara[export]` extra.
+- Claude Code plugin 0.4.0: the gate now FAILS CLOSED. In protect mode, an `mcp__*` call is blocked (with an install hint) when the `vaara` package is not importable, instead of silently passing through unscored. Shadow mode still passes through (it can record nothing it cannot score), and `"fail_open": true` / `VAARA_PLUGIN_FAIL_OPEN=1` is the documented opt-out. Covered by subprocess tests that genuinely block the import.
 - Claude Code plugin 0.3.0: an optional `"thresholds": {"escalate": E, "deny": D}` in `~/.vaara/claude-code/config.json` overrides the protection preset's default decision thresholds (`0 <= E <= D <= 1`; malformed values are ignored, the preset still provides the rest of the policy shape). First test coverage for the plugin's config helpers (`tests/test_plugin_config.py`).
 
 ## [1.26.1] - 2026-07-12

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/plugins/claude-code-vaara-governance/README.md
+++ b/plugins/claude-code-vaara-governance/README.md
@@ -52,6 +52,7 @@ The config file, hand-editable:
 | `notifications` | `true` (default), `false` | Desktop popups on block/escalate. |
 | `agent_id` | string | Agent id written to the audit chain (default `claude-code`). |
 | `audit_db` | path | Audit DB path (default `~/.vaara/claude-code/audit.db`). |
+| `fail_open` | `false` (default), `true` | What happens to `mcp__*` calls in protect mode when the `vaara` package is not importable. Default: fail closed (block with an install hint). `true` passes them through unscored. |
 
 Environment variables override the file (useful for CI or a single session):
 
@@ -64,6 +65,7 @@ Environment variables override the file (useful for CI or a single session):
 | `VAARA_PLUGIN_AGENT_ID` | Override the agent_id written to the audit chain. |
 | `VAARA_PLUGIN_AUDIT_DB` | Override the audit DB path. |
 | `VAARA_PLUGIN_DENY_PATTERNS_FILE` | Replace the bundled `policies/default_deny.json` with your own. |
+| `VAARA_PLUGIN_FAIL_OPEN=1` | Same as `"fail_open": true`. |
 
 ## Extending the deny patterns
 

--- a/plugins/claude-code-vaara-governance/hooks/_config.py
+++ b/plugins/claude-code-vaara-governance/hooks/_config.py
@@ -60,6 +60,18 @@ def notifications_enabled(cfg: dict) -> bool:
     return cfg.get("notifications", True) is not False
 
 
+def fail_open(cfg: dict) -> bool:
+    """Whether a missing vaara package passes MCP calls through unscored.
+
+    Default False: in protect mode the gate fails closed when its engine
+    is not importable. ``"fail_open": true`` in config.json opts back
+    into availability-over-enforcement.
+    """
+    if os.environ.get("VAARA_PLUGIN_FAIL_OPEN") == "1":
+        return True
+    return cfg.get("fail_open") is True
+
+
 def protection_preset(cfg: dict) -> str | None:
     preset = os.environ.get("VAARA_PLUGIN_PROTECTION") or cfg.get("protection")
     return preset if isinstance(preset, str) and preset else None

--- a/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
@@ -83,11 +83,25 @@ def _classify_mcp(
         from vaara.audit.sqlite_backend import SQLiteAuditBackend
         from vaara.pipeline import InterceptionPipeline
     except ImportError:
+        # Fail CLOSED in protect mode: a gate that waves everything through
+        # when its engine is missing is not a gate. Shadow mode records
+        # nothing it can't score, so passing through there is honest; and
+        # `"fail_open": true` in config.json is the documented escape hatch
+        # for operators who prefer availability over enforcement.
+        if shadow or _config.fail_open(CFG):
+            _emit(
+                "vaara-governance: vaara package not importable. "
+                "Run `pip install vaara>=0.40.1`. Passing through this MCP call."
+            )
+            return 0
         _emit(
-            "vaara-governance: vaara package not importable. "
-            "Run `pip install vaara>=0.40.1`. Passing through this MCP call."
+            "vaara-governance: BLOCKED (fail-closed): the vaara package is "
+            "not importable, so this MCP call cannot be scored or recorded. "
+            "Run `pip install vaara>=0.40.1`, or set \"fail_open\": true in "
+            "~/.vaara/claude-code/config.json to pass through unscored."
         )
-        return 0
+        notify("BLOCKED", tool_name, "vaara not installed; failing closed")
+        return 2
 
     db_path = _audit_db_path()
     db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -6,6 +6,9 @@ is the first test coverage for them; keep it dependency-free.
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -73,3 +76,72 @@ def test_custom_thresholds_compose_into_policy(config_mod):
     policy["thresholds"]["default"] = {"escalate": escalate, "deny": deny}
     parsed = from_dict(policy)  # must validate
     assert parsed is not None
+
+
+def test_fail_open_default_false(config_mod, monkeypatch):
+    monkeypatch.delenv("VAARA_PLUGIN_FAIL_OPEN", raising=False)
+    assert config_mod.fail_open({}) is False
+    assert config_mod.fail_open({"fail_open": False}) is False
+    assert config_mod.fail_open({"fail_open": "yes"}) is False  # strict bool
+
+
+def test_fail_open_via_config_and_env(config_mod, monkeypatch):
+    monkeypatch.delenv("VAARA_PLUGIN_FAIL_OPEN", raising=False)
+    assert config_mod.fail_open({"fail_open": True}) is True
+    monkeypatch.setenv("VAARA_PLUGIN_FAIL_OPEN", "1")
+    assert config_mod.fail_open({}) is True
+
+
+# --- fail-closed integration: run the hook with the vaara import blocked ---
+
+
+def _run_hook_without_vaara(tmp_path, config: dict, extra_env: dict):
+    """Run pre_tool_use.py in a subprocess where importing vaara fails."""
+    blocker = tmp_path / "blocker"
+    blocker.mkdir(exist_ok=True)
+    (blocker / "sitecustomize.py").write_text(
+        "import sys\n"
+        "class _Block:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'vaara' or name.startswith('vaara.'):\n"
+        "            raise ImportError('blocked for test: ' + name)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _Block())\n"
+    )
+    home = tmp_path / "home"
+    cfg_dir = home / ".vaara" / "claude-code"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.json").write_text(json.dumps(config))
+    env = {
+        "HOME": str(home),
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONPATH": str(blocker),
+        **extra_env,
+    }
+    event = json.dumps({
+        "tool_name": "mcp__demo__write_file",
+        "tool_input": {"path": "/x"},
+        "session_id": "s1",
+    })
+    return subprocess.run(
+        [sys.executable, str(_HOOKS / "pre_tool_use.py")],
+        input=event, capture_output=True, text=True, env=env, timeout=60,
+    )
+
+
+
+def test_missing_vaara_fails_closed_in_protect_mode(tmp_path):
+    proc = _run_hook_without_vaara(tmp_path, {"mode": "protect"}, {})
+    assert proc.returncode == 2, proc.stderr
+    assert "fail-closed" in proc.stderr
+
+
+def test_missing_vaara_passes_through_with_fail_open(tmp_path):
+    proc = _run_hook_without_vaara(tmp_path, {"mode": "protect", "fail_open": True}, {})
+    assert proc.returncode == 0, proc.stderr
+    assert "Passing through" in proc.stderr
+
+
+def test_missing_vaara_passes_through_in_shadow(tmp_path):
+    proc = _run_hook_without_vaara(tmp_path, {"mode": "watch"}, {})
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
Henri's finding: with the plugin installed but the `vaara` pip package missing, the hook printed a warning and passed every MCP call through ungoverned. For a governance gate that is the wrong default — the operator believes they are protected and nothing is scored, recorded, or blocked.

Behavior now:
- **protect mode + vaara not importable**: the `mcp__*` call is BLOCKED (exit 2) with a clear message naming the fix (`pip install vaara>=0.40.1`) and the opt-out. Desktop notification fires.
- **shadow mode**: still passes through — shadow can record nothing it cannot score, so blocking there would be enforcement the operator explicitly turned off.
- **`"fail_open": true`** in config.json or `VAARA_PLUGIN_FAIL_OPEN=1`: documented opt-out, availability over enforcement.

Tests: three subprocess integration tests that genuinely block the vaara import (sitecustomize meta-path hook honoring the Python 3.12 `find_spec` protocol) plus unit tests for the config reader. Full suite 1210 passed, ruff clean; the one failing test fails identically on unmodified main in this environment and is unrelated.

Plugin bumped to 0.4.0 (behavior change), README config/env tables updated, CHANGELOG entry under Unreleased.