### PR TITLE
feat: EU AI Act Article 50 transparency evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+- EU AI Act Article 50 transparency evidence: `vaara.audit.article50.record_disclosure()` records a disclosure event (50(1) through 50(4), with channel, subject, and an optional notice hash) into the same signed hash-chained trail as the agent's actions, through the existing pipeline — no new event type or wire format. `vaara trail export-article50 --db|--trail --key --out [--system-meta] [--period]` writes the standard signed trail zip with `article50_report.md` and `article50_summary.json` folded in: per-paragraph counts, the events, and 50(1) session coverage with the 50(5) at-or-before-first-action timing check. The report states what it proves and what it does not.
+
 CLI usability, driven by first-run friction on the export path. No wire-format change.
 
 - `vaara trail export` and `vaara trail export-article12` accept `--db` to export straight from an audit SQLite DB (for example the Claude Code plugin's `~/.vaara/claude-code/audit.db`); `--trail` JSONL remains and the two are mutually exclusive. Previously the only DB-to-signed-zip route was a `trail rotate --dry-run` workaround.

--- a/docs/eu-ai-act-august-2026.md
+++ b/docs/eu-ai-act-august-2026.md
@@ -35,6 +35,39 @@ Article 50 obligations are behavioral: inform, mark, disclose, at a defined time
 
 This is the same evidence problem Vaara already solves for tool calls: the [signed, hash-chained trail](tamper-evident-audit-trail.md) records events at the decision point, and an outside party [verifies the export offline](verifying-evidence.md). A disclosure event is one more event type in the same chain. The [logs vs evidence distinction](logs-vs-evidence.md) applies unchanged: a disclosure line in an application log persuades people who already trust you; a verifiable record persuades the ones who do not.
 
+## Recording and exporting Article 50 evidence
+
+Vaara treats a disclosure as one more event in the same signed,
+hash-chained trail as the agent's actions. At the moment the notice is
+shown:
+
+```python
+from vaara.audit.article50 import record_disclosure
+
+record_disclosure(
+    trail,
+    paragraph="50(1)",
+    statement="You are chatting with an AI assistant operated by Demo Oy.",
+    session_id=session_id,
+    channel="chat_ui",
+)
+```
+
+When someone asks, one command produces the package:
+
+```bash
+vaara trail export-article50 --db audit.db --out article50.zip --key signing.pem
+```
+
+The zip is the standard signed trail with `article50_report.md` folded
+in: disclosure counts per paragraph, the events themselves, and 50(1)
+session coverage including whether each disclosure preceded the
+session's first action (the 50(5) timing question). The report states
+plainly what it proves (the record was made then and has not been
+altered) and what it does not (that pixels rendered, or that wording met
+accessibility requirements). Verify offline with
+`vaara trail verify --zip article50.zip --pubkey <key>`.
+
 ## Questions
 
 **Does Article 50 apply to my internal-only agent?** 50(1) turns on interaction with natural persons; an internal tool where every user knows it is AI is typically covered by the "obvious from the context" carve-out. Document that reasoning; the assessment itself is worth recording.

--- a/src/vaara/audit/article50.py
+++ b/src/vaara/audit/article50.py
@@ -1,0 +1,325 @@
+"""EU AI Act Article 50 transparency evidence: record it, then prove it.
+
+Article 50 duties are behavioral: inform the person they are interacting
+with AI (50(1)), mark synthetic content (50(2)), inform about emotion
+recognition / biometric categorisation (50(3)), disclose deepfakes and
+public-interest AI text (50(4)), all at the latest at the first
+interaction and accessibly (50(5)). When challenged, the question is
+retrospective: show that the disclosure happened. A banner screenshot is
+a claim about today; a hash-chained record next to the agent's actions
+is evidence about every session.
+
+This module adds no new wire format and no new event type. A disclosure
+is an ordinary action recorded through the existing interception
+pipeline under the reserved tool name ``vaara.article50.disclosure``,
+so it lands in the same signed, hash-chained trail as everything else.
+``export_article50`` then writes the standard signed trail zip and folds
+in a human-readable report plus a machine summary, mirroring
+``export_article12``.
+
+The report is honest about limits: a disclosure record proves the
+operator's system logged the disclosure event at that moment inside a
+tamper-evident chain. It does not prove pixels appeared on a screen or
+that the wording met accessibility requirements. The report says so.
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Union
+
+DISCLOSURE_TOOL = "vaara.article50.disclosure"
+
+#: The Article 50 paragraphs a disclosure record may claim.
+PARAGRAPHS = ("50(1)", "50(2)", "50(3)", "50(4)")
+
+
+def record_disclosure(
+    trail,
+    *,
+    paragraph: str,
+    statement: str,
+    agent_id: str = "operator",
+    session_id: str = "",
+    channel: str = "",
+    subject: str = "",
+    notice_sha256: str = "",
+) -> str:
+    """Record one Article 50 disclosure event into ``trail``.
+
+    ``paragraph`` names the obligation (one of :data:`PARAGRAPHS`).
+    ``statement`` is what was disclosed, in the operator's words (for
+    50(1) typically the notice text or its identifier). ``channel`` is
+    where it surfaced (``"chat_ui"``, ``"api_response_header"``, ...),
+    ``subject`` identifies what it applies to (a session, a piece of
+    content), and ``notice_sha256`` optionally pins the exact notice
+    bytes shown. Returns the ``action_id`` of the recorded event.
+
+    The record flows through the normal interception pipeline, so it is
+    chained, signable, and exportable like any other action. Call it at
+    the moment the disclosure is made (50(5): at the latest at the first
+    interaction), not retroactively.
+    """
+    if paragraph not in PARAGRAPHS:
+        raise ValueError(
+            f"paragraph must be one of {PARAGRAPHS}, got {paragraph!r}"
+        )
+    if not statement:
+        raise ValueError("statement must not be empty")
+
+    from vaara.pipeline import InterceptionPipeline
+
+    pipeline = InterceptionPipeline(trail=trail, enforce=False)
+    result = pipeline.intercept(
+        agent_id=agent_id,
+        tool_name=DISCLOSURE_TOOL,
+        parameters={
+            "article": paragraph,
+            "statement": statement,
+            "channel": channel,
+            "subject": subject,
+            "notice_sha256": notice_sha256,
+        },
+        session_id=session_id,
+        context={"vaara_article50": True},
+    )
+    return result.action_id
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def find_disclosures(records) -> list[dict]:
+    """Extract disclosure events from trail records, oldest first."""
+    out = []
+    for rec in records:
+        if rec.tool_name != DISCLOSURE_TOOL:
+            continue
+        if rec.event_type.value != "action_requested":
+            continue
+        params = (rec.data or {}).get("parameters", {}) or {}
+        out.append({
+            "action_id": rec.action_id,
+            "record_id": rec.record_id,
+            "timestamp": rec.timestamp,
+            "time_utc": _iso(rec.timestamp),
+            "agent_id": rec.agent_id,
+            "session_id": (rec.data or {}).get("session_id") or "",
+            "article": params.get("article", ""),
+            "statement": params.get("statement", ""),
+            "channel": params.get("channel", ""),
+            "subject": params.get("subject", ""),
+            "notice_sha256": params.get("notice_sha256", ""),
+        })
+    return out
+
+
+def build_article50_report(
+    records,
+    manifest: dict,
+    *,
+    system_meta: Optional[dict] = None,
+    period: Optional[tuple] = None,
+) -> dict:
+    """Build the Article 50 summary as a JSON-serialisable dict.
+
+    ``period`` optionally narrows the *summary counts* to (start_ts,
+    end_ts); the signed trail itself always stays whole, matching the
+    Article 12 report's behavior.
+    """
+    disclosures = find_disclosures(records)
+    if period is not None:
+        start, end = period
+        disclosures = [
+            d for d in disclosures
+            if (start is None or d["timestamp"] >= start)
+            and (end is None or d["timestamp"] <= end)
+        ]
+
+    by_paragraph = Counter(d["article"] for d in disclosures)
+
+    # 50(1)/(5) coverage: of the sessions that saw agent activity, how
+    # many carry a 50(1) disclosure, and did it come before the
+    # session's first non-disclosure action?
+    session_first_action: dict[str, float] = {}
+    for rec in records:
+        if rec.event_type.value != "action_requested":
+            continue
+        if rec.tool_name == DISCLOSURE_TOOL:
+            continue
+        sid = (rec.data or {}).get("session_id") or ""
+        if not sid:
+            continue
+        if sid not in session_first_action or rec.timestamp < session_first_action[sid]:
+            session_first_action[sid] = rec.timestamp
+
+    first_disclosure_501: dict[str, float] = {}
+    for d in disclosures:
+        if d["article"] != "50(1)" or not d["session_id"]:
+            continue
+        sid = d["session_id"]
+        if sid not in first_disclosure_501 or d["timestamp"] < first_disclosure_501[sid]:
+            first_disclosure_501[sid] = d["timestamp"]
+
+    covered, covered_before_first = [], []
+    for sid, first_action in session_first_action.items():
+        if sid in first_disclosure_501:
+            covered.append(sid)
+            if first_disclosure_501[sid] <= first_action:
+                covered_before_first.append(sid)
+
+    return {
+        "standard": "EU AI Act Article 50 transparency evidence",
+        "generated_utc": _iso(records[-1].timestamp) if records else "",
+        "system": system_meta or {},
+        "trail": {
+            "records": manifest.get("record_count", len(records)),
+            "algorithm": manifest.get("signature_algorithm", ""),
+            "signer_pubkey_fingerprint": manifest.get(
+                "signer_pubkey_fingerprint", ""
+            ),
+        },
+        "disclosures": {
+            "total": len(disclosures),
+            "by_paragraph": {p: by_paragraph.get(p, 0) for p in PARAGRAPHS},
+            "events": disclosures,
+        },
+        "session_coverage_50_1": {
+            "sessions_with_agent_activity": len(session_first_action),
+            "sessions_with_50_1_disclosure": len(covered),
+            "disclosed_at_or_before_first_action": len(covered_before_first),
+        },
+        "what_this_proves": (
+            "Each disclosure event above was recorded into a signed, "
+            "hash-chained trail at the stated time, alongside the agent "
+            "actions it accompanies. Editing, inserting, or deleting any "
+            "of these records after the fact breaks the chain and the "
+            "signature, which any party can check offline from this "
+            "package alone."
+        ),
+        "what_this_does_not_prove": (
+            "That the disclosure was rendered on a screen, read, or "
+            "worded accessibly (Article 50(5) manner requirements), nor "
+            "that machine-readable content marking (50(2)) survives "
+            "downstream processing. Those need UI-level and content-level "
+            "evidence respectively; this package proves the operator's "
+            "system made and kept the record."
+        ),
+    }
+
+
+def render_article50_md(report: dict) -> str:
+    """Render the report dict as a regulator-readable Markdown document."""
+    lines = [
+        "# EU AI Act Article 50 transparency evidence",
+        "",
+        f"Signed trail: {report['trail']['records']} records, "
+        f"{report['trail']['algorithm']}, signer fingerprint "
+        f"`{report['trail']['signer_pubkey_fingerprint']}`.",
+        "",
+    ]
+    system = report.get("system") or {}
+    if system:
+        lines += ["## System", ""]
+        for key, value in system.items():
+            lines.append(f"- **{key}**: {value}")
+        lines.append("")
+
+    disc = report["disclosures"]
+    lines += [
+        "## Disclosure events",
+        "",
+        f"Total recorded: {disc['total']}",
+        "",
+    ]
+    for paragraph in PARAGRAPHS:
+        lines.append(f"- Article {paragraph}: {disc['by_paragraph'][paragraph]}")
+    lines.append("")
+
+    if disc["events"]:
+        lines += [
+            "| time (UTC) | article | channel | session | statement |",
+            "|---|---|---|---|---|",
+        ]
+        for event in disc["events"]:
+            statement = event["statement"].replace("|", "\\|")
+            if len(statement) > 80:
+                statement = statement[:77] + "..."
+            lines.append(
+                f"| {event['time_utc']} | {event['article']} | "
+                f"{event['channel']} | {event['session_id']} | {statement} |"
+            )
+        lines.append("")
+
+    cov = report["session_coverage_50_1"]
+    lines += [
+        "## Article 50(1) session coverage",
+        "",
+        f"- Sessions with agent activity: {cov['sessions_with_agent_activity']}",
+        f"- Sessions carrying a 50(1) disclosure: "
+        f"{cov['sessions_with_50_1_disclosure']}",
+        f"- Disclosed at or before the session's first action (50(5) "
+        f"timing): {cov['disclosed_at_or_before_first_action']}",
+        "",
+        "## What this package proves",
+        "",
+        report["what_this_proves"],
+        "",
+        "## What this package does not prove",
+        "",
+        report["what_this_does_not_prove"],
+        "",
+        "## Verify",
+        "",
+        "`vaara trail verify --zip <this file> --pubkey <trusted key>` "
+        "checks the signature and the hash chain offline. The disclosure "
+        "events are ordinary records in `trail.jsonl`; re-derive this "
+        "report from them without trusting the operator.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def export_article50(
+    trail,
+    out_path: Union[str, Path],
+    *,
+    signer_key=None,
+    signer=None,
+    system_meta: Optional[dict] = None,
+    period: Optional[tuple] = None,
+    agent_id: str = "",
+):
+    """Write a signed Article 50 transparency evidence package.
+
+    The zip is the standard signed trail export (same bytes an Article 12
+    package signs) with ``article50_report.md`` and
+    ``article50_summary.json`` folded in afterwards, built from the
+    records that were actually signed.
+    """
+    from vaara.audit.article12_export import _records_from_zip
+    from vaara.audit.export import export_signed
+
+    out_path = Path(out_path)
+    result = export_signed(
+        trail, out_path, signer_key=signer_key, signer=signer,
+        agent_id=agent_id,
+    )
+
+    records, manifest = _records_from_zip(out_path)
+    report = build_article50_report(
+        records, manifest, system_meta=system_meta, period=period,
+    )
+
+    with zipfile.ZipFile(out_path, "a", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("article50_report.md", render_article50_md(report))
+        zf.writestr(
+            "article50_summary.json",
+            json.dumps(report, indent=2, sort_keys=False).encode("utf-8"),
+        )
+
+    return result

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -815,6 +815,55 @@ def _obtain_time_anchor(args: argparse.Namespace, trail):
         raise ValueError(f"time anchoring failed: {exc}") from exc
 
 
+def _cmd_trail_export_article50(args: argparse.Namespace) -> int:
+    """Export a signed EU AI Act Article 50 transparency evidence package."""
+    try:
+        from vaara.audit.article50 import export_article50
+    except ImportError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 2
+
+    system_meta = None
+    if args.system_meta:
+        meta_path = Path(args.system_meta).expanduser()
+        if not meta_path.exists():
+            print(f"system-meta JSON not found: {meta_path}", file=sys.stderr)
+            return 2
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                system_meta = json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"failed to read system-meta: {exc}", file=sys.stderr)
+            return 2
+
+    try:
+        period = _parse_period(args.period)
+    except ValueError as exc:
+        print(f"invalid --period: {exc}", file=sys.stderr)
+        return 2
+
+    trail, err = _load_trail_source(args)
+    if trail is None:
+        return err
+
+    out = Path(args.out).expanduser()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result = export_article50(
+            trail, out, signer_key=Path(args.key).expanduser(),
+            system_meta=system_meta, period=period,
+        )
+    except ImportError:
+        print(_INSTALL_HINT, file=sys.stderr)
+        return 2
+
+    print(f"Exported Article 50 transparency package to {out}")
+    print(f"  records:      {result.manifest['record_count']}")
+    print(f"  chain intact: {result.chain_intact}")
+    print("  report:       article50_report.md")
+    return 0 if result.chain_intact else 1
+
+
 def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
     """Export a signed EU AI Act Article 12 regulator package from a trail."""
     try:
@@ -4026,6 +4075,29 @@ def build_parser() -> argparse.ArgumentParser:
              "enforcement bindings against.",
     )
     pa12.set_defaults(func=_cmd_trail_export_article12)
+
+    pa50 = tsub.add_parser(
+        "export-article50",
+        help="Export a signed EU AI Act Article 50 transparency evidence package",
+    )
+    _add_trail_source_args(pa50)
+    pa50.add_argument(
+        "--key", required=True,
+        help="Ed25519 private key (PEM) to sign the package",
+    )
+    pa50.add_argument("--out", required=True, help="Path to write the package zip")
+    pa50.add_argument(
+        "--system-meta", default=None,
+        help="Optional JSON with system identity (system_name, provider, "
+             "deployer). Absent fields are simply omitted from the report.",
+    )
+    pa50.add_argument(
+        "--period", default=None,
+        help="Optional report lens START:END (YYYY-MM-DD:YYYY-MM-DD); either "
+             "side may be empty. Narrows the summary counts only; the signed "
+             "trail stays whole.",
+    )
+    pa50.set_defaults(func=_cmd_trail_export_article50)
 
     prec = tsub.add_parser(
         "receipt",

--- a/tests/test_article50.py
+++ b/tests/test_article50.py
@@ -1,0 +1,156 @@
+"""Tests for the Article 50 transparency evidence module and CLI."""
+from __future__ import annotations
+
+import json
+import zipfile
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from vaara.audit.article50 import (
+    DISCLOSURE_TOOL,
+    build_article50_report,
+    export_article50,
+    find_disclosures,
+    record_disclosure,
+    render_article50_md,
+)
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.audit.verify import verify_signed
+from vaara.pipeline import InterceptionPipeline
+
+
+def _persistent_trail(tmp_path):
+    backend = SQLiteAuditBackend(tmp_path / "audit.db")
+    trail = backend.load_trail()
+    trail._on_record = backend.write_record
+    return trail
+
+
+def _agent_activity(trail, session_id: str, n: int = 2) -> None:
+    pipeline = InterceptionPipeline(trail=trail, enforce=False)
+    for i in range(n):
+        pipeline.intercept(
+            agent_id="assistant-1",
+            tool_name=f"mcp__demo__tool{i}",
+            parameters={"x": i},
+            session_id=session_id,
+        )
+
+
+def test_record_disclosure_lands_in_trail(tmp_path):
+    trail = _persistent_trail(tmp_path)
+    action_id = record_disclosure(
+        trail,
+        paragraph="50(1)",
+        statement="You are chatting with an AI assistant.",
+        session_id="s1",
+        channel="chat_ui",
+    )
+    assert action_id
+    events = find_disclosures(trail._records)
+    assert len(events) == 1
+    event = events[0]
+    assert event["article"] == "50(1)"
+    assert event["session_id"] == "s1"
+    assert event["channel"] == "chat_ui"
+    assert "AI assistant" in event["statement"]
+
+
+def test_record_disclosure_validates_input(tmp_path):
+    trail = _persistent_trail(tmp_path)
+    with pytest.raises(ValueError):
+        record_disclosure(trail, paragraph="50(9)", statement="x")
+    with pytest.raises(ValueError):
+        record_disclosure(trail, paragraph="50(1)", statement="")
+
+
+def test_report_session_coverage_and_timing(tmp_path):
+    trail = _persistent_trail(tmp_path)
+    # session s1: disclosure BEFORE first action (compliant timing)
+    record_disclosure(
+        trail, paragraph="50(1)", statement="AI notice", session_id="s1",
+    )
+    _agent_activity(trail, "s1")
+    # session s2: activity with no disclosure at all
+    _agent_activity(trail, "s2")
+
+    report = build_article50_report(trail._records, {"record_count": 0})
+    cov = report["session_coverage_50_1"]
+    assert cov["sessions_with_agent_activity"] == 2
+    assert cov["sessions_with_50_1_disclosure"] == 1
+    assert cov["disclosed_at_or_before_first_action"] == 1
+    assert report["disclosures"]["by_paragraph"]["50(1)"] == 1
+    assert report["disclosures"]["by_paragraph"]["50(4)"] == 0
+
+    md = render_article50_md(report)
+    assert "does not prove" in md
+    assert "Sessions with agent activity: 2" in md
+
+
+def test_export_package_verifies_and_carries_report(tmp_path):
+    key = tmp_path / "key"
+    from vaara.cli import main as cli_main
+    assert cli_main(["keygen", "--dev", "--out", str(key)]) == 0
+
+    trail = _persistent_trail(tmp_path)
+    record_disclosure(
+        trail, paragraph="50(1)", statement="AI notice", session_id="s1",
+    )
+    _agent_activity(trail, "s1")
+
+    out = tmp_path / "a50.zip"
+    result = export_article50(trail, out, signer_key=key)
+    assert result.chain_intact
+
+    with zipfile.ZipFile(out) as zf:
+        names = zf.namelist()
+        assert "article50_report.md" in names
+        assert "article50_summary.json" in names
+        summary = json.loads(zf.read("article50_summary.json"))
+        assert summary["disclosures"]["total"] == 1
+        assert DISCLOSURE_TOOL in zf.read("trail.jsonl").decode()
+
+    # The signed core must still verify with the standard verifier.
+    verdict = verify_signed(out)
+    assert verdict.ok, verdict.errors
+
+
+def test_cli_export_article50_from_db(tmp_path, capsys):
+    from vaara.cli import main as cli_main
+
+    key = tmp_path / "key"
+    assert cli_main(["keygen", "--dev", "--out", str(key)]) == 0
+
+    trail = _persistent_trail(tmp_path)
+    record_disclosure(
+        trail, paragraph="50(1)", statement="AI notice", session_id="s1",
+    )
+    _agent_activity(trail, "s1")
+
+    out = tmp_path / "a50.zip"
+    capsys.readouterr()
+    rc = cli_main([
+        "trail", "export-article50",
+        "--db", str(tmp_path / "audit.db"),
+        "--out", str(out), "--key", str(key),
+    ])
+    assert rc == 0
+    assert "Article 50 transparency package" in capsys.readouterr().out
+    assert out.is_file()
+
+
+def test_disclosures_default_allow_and_never_blocked(tmp_path):
+    """A disclosure record must never be blocked by the gate itself."""
+    trail = _persistent_trail(tmp_path)
+    record_disclosure(
+        trail, paragraph="50(4)", statement="This image is AI-generated.",
+        subject="img-123",
+    )
+    blocked = [
+        r for r in trail._records
+        if r.tool_name == DISCLOSURE_TOOL
+        and r.event_type.value == "action_blocked"
+    ]
+    assert blocked == []


### PR DESCRIPTION
The best-in-class move for what is actually law on 2 August 2026. Article 50 duties are behavioral, so when challenged the question is retrospective: show that the disclosure happened. Watermarking vendors answer 50(2) marking only; nobody produces disclosure evidence for 50(1)/(4)/(5). Now we do.

Design (spec freeze respected — no new event type, receipt format, or wire change):
- `vaara.audit.article50.record_disclosure(trail, paragraph="50(1)", statement=..., session_id=..., channel=..., subject=..., notice_sha256=...)` routes an ordinary action through the existing InterceptionPipeline under the reserved tool name `vaara.article50.disclosure`. Same chain, same signing, same verifiers.
- `vaara trail export-article50 --db|--trail --key --out [--system-meta] [--period]` mirrors export-article12: standard signed trail zip, then `article50_report.md` + `article50_summary.json` folded in, built from the records that were actually signed.
- The report gives per-paragraph counts, the disclosure events, and Article 50(1) session coverage including whether each disclosure came at or before the session's first action (the 50(5) timing question). It states plainly what it proves and what it does not (no claim about pixels rendered or accessibility of wording).

Verified end to end in this environment: recorded 50(1) + 50(4) disclosures alongside real pipeline activity across two sessions, exported, `vaara trail verify` says OK, report correctly shows one covered and one uncovered session. Six tests in tests/test_article50.py; full suite 1211 passed, ruff clean (the single failure is the known env-specific one, identical on unmodified main).

Docs: the August 2026 page gains a 'Recording and exporting Article 50 evidence' section. CHANGELOG under Unreleased.