### PR TITLE
plugin: auto-record the Article 50(1) disclosure per session (0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+- Claude Code plugin 0.5.0: set `"article50_statement"` in config.json (or `VAARA_PLUGIN_ARTICLE50_STATEMENT`) and every session start auto-records it as an EU AI Act Article 50(1) disclosure event into the audit trail, bound to the session id and timestamped before the session's first tool call — the 50(5) timing question answered by construction. The SessionStart status line reports it, and its version string now reads from plugin.json instead of a hardcoded constant (it said v0.2.0 since 0.3.0).
+
 - EU AI Act Article 50 transparency evidence: `vaara.audit.article50.record_disclosure()` records a disclosure event (50(1) through 50(4), with channel, subject, and an optional notice hash) into the same signed hash-chained trail as the agent's actions, through the existing pipeline — no new event type or wire format. `vaara trail export-article50 --db|--trail --key --out [--system-meta] [--period]` writes the standard signed trail zip with `article50_report.md` and `article50_summary.json` folded in: per-paragraph counts, the events, and 50(1) session coverage with the 50(5) at-or-before-first-action timing check. The report states what it proves and what it does not.
 
 CLI usability, driven by first-run friction on the export path. No wire-format change.

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/plugins/claude-code-vaara-governance/README.md
+++ b/plugins/claude-code-vaara-governance/README.md
@@ -52,6 +52,7 @@ The config file, hand-editable:
 | `notifications` | `true` (default), `false` | Desktop popups on block/escalate. |
 | `agent_id` | string | Agent id written to the audit chain (default `claude-code`). |
 | `audit_db` | path | Audit DB path (default `~/.vaara/claude-code/audit.db`). |
+| `article50_statement` | string | When set, SessionStart records this as an EU AI Act Article 50(1) disclosure event into the audit trail with the session id, before the session's first tool call. Off when absent. |
 | `fail_open` | `false` (default), `true` | What happens to `mcp__*` calls in protect mode when the `vaara` package is not importable. Default: fail closed (block with an install hint). `true` passes them through unscored. |
 
 Environment variables override the file (useful for CI or a single session):
@@ -65,6 +66,7 @@ Environment variables override the file (useful for CI or a single session):
 | `VAARA_PLUGIN_AGENT_ID` | Override the agent_id written to the audit chain. |
 | `VAARA_PLUGIN_AUDIT_DB` | Override the audit DB path. |
 | `VAARA_PLUGIN_DENY_PATTERNS_FILE` | Replace the bundled `policies/default_deny.json` with your own. |
+| `VAARA_PLUGIN_ARTICLE50_STATEMENT` | Same as `"article50_statement"`. |
 | `VAARA_PLUGIN_FAIL_OPEN=1` | Same as `"fail_open": true`. |
 
 ## Extending the deny patterns

--- a/plugins/claude-code-vaara-governance/hooks/_config.py
+++ b/plugins/claude-code-vaara-governance/hooks/_config.py
@@ -13,6 +13,8 @@ Keys:
   notifications  true (default) | false, desktop popups on block/escalate
   agent_id       agent id written to the audit chain (default "claude-code")
   audit_db       audit DB path (default ~/.vaara/claude-code/audit.db)
+  article50_statement  optional Article 50(1) disclosure text, auto-recorded
+                 into the trail per session by SessionStart
 """
 from __future__ import annotations
 
@@ -75,6 +77,23 @@ def fail_open(cfg: dict) -> bool:
 def protection_preset(cfg: dict) -> str | None:
     preset = os.environ.get("VAARA_PLUGIN_PROTECTION") or cfg.get("protection")
     return preset if isinstance(preset, str) and preset else None
+
+
+def article50_statement(cfg: dict) -> str | None:
+    """Optional Article 50(1) disclosure statement, auto-recorded per session.
+
+    When set (config key ``article50_statement`` or env
+    ``VAARA_PLUGIN_ARTICLE50_STATEMENT``), the SessionStart hook records
+    the statement as a 50(1) disclosure event into the audit trail with
+    the session id, at the moment the session begins — before the
+    session's first tool call, which is what the 50(5) timing question
+    asks. Absent or empty means off.
+    """
+    statement = (
+        os.environ.get("VAARA_PLUGIN_ARTICLE50_STATEMENT")
+        or cfg.get("article50_statement")
+    )
+    return statement if isinstance(statement, str) and statement.strip() else None
 
 
 def custom_thresholds(cfg: dict) -> tuple[float, float] | None:

--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-"""SessionStart hook: validate the Vaara install and print a one-line
-governance summary so the operator sees the plugin loaded.
+"""SessionStart hook: validate the Vaara install, print a one-line
+governance summary, and (when configured) record the EU AI Act
+Article 50(1) disclosure for this session into the audit trail.
 
-Exits 0 in all cases; missing or broken install just prints a warning.
+Exits 0 in all cases; missing or broken install just prints a warning,
+and the disclosure step can never break the hook.
 
 Env vars match the rest of the plugin (VAARA_PLUGIN_DISABLE,
-VAARA_PLUGIN_AUDIT_DB, VAARA_PLUGIN_SHADOW).
+VAARA_PLUGIN_AUDIT_DB, VAARA_PLUGIN_SHADOW,
+VAARA_PLUGIN_ARTICLE50_STATEMENT).
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -26,10 +30,50 @@ def _audit_db_path() -> Path:
     return _config.audit_db_path(CFG)
 
 
+def _plugin_version() -> str:
+    try:
+        manifest = Path(__file__).parent.parent / ".claude-plugin" / "plugin.json"
+        return json.loads(manifest.read_text()).get("version", "?")
+    except Exception:
+        return "?"
+
+
+def _record_session_disclosure(statement: str, session_id: str) -> str:
+    """Record the 50(1) disclosure for this session. Returns a status word."""
+    try:
+        from vaara.audit.article50 import record_disclosure
+        from vaara.audit.sqlite_backend import SQLiteAuditBackend
+    except ImportError:
+        return "skipped (needs vaara>=1.27)"
+    try:
+        db_path = _audit_db_path()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        backend = SQLiteAuditBackend(db_path)
+        trail = backend.load_trail()
+        trail._on_record = backend.write_record
+        record_disclosure(
+            trail,
+            paragraph="50(1)",
+            statement=statement,
+            agent_id=_config.agent_id(CFG),
+            session_id=session_id,
+            channel="claude-code-session",
+        )
+        return "recorded"
+    except Exception as exc:
+        return f"failed ({exc!r})"
+
+
 def main() -> int:
     if _config.plugin_disabled(CFG):
         _emit("vaara-governance: off (config.json mode or VAARA_PLUGIN_DISABLE=1).")
         return 0
+
+    try:
+        event = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        event = {}
+    session_id = event.get("session_id", "") if isinstance(event, dict) else ""
 
     try:
         import vaara
@@ -55,10 +99,16 @@ def main() -> int:
     except Exception as exc:
         db_state = f"unavailable ({exc!r})"
 
+    disclosure = ""
+    statement = _config.article50_statement(CFG)
+    if statement:
+        status = _record_session_disclosure(statement, session_id)
+        disclosure = f", article50_disclosure={status}"
+
     _emit(
-        f"vaara-governance v0.2.0 loaded "
+        f"vaara-governance v{_plugin_version()} loaded "
         f"(vaara {vaara.__version__}, mode={mode}, protection={preset}, "
-        f"notifications={notif}, audit_db={db_path} [{db_state}]). "
+        f"notifications={notif}, audit_db={db_path} [{db_state}]{disclosure}). "
         f"Settings: /vaara-setup"
     )
     return 0

--- a/tests/test_plugin_config.py
+++ b/tests/test_plugin_config.py
@@ -145,3 +145,44 @@ def test_missing_vaara_passes_through_with_fail_open(tmp_path):
 def test_missing_vaara_passes_through_in_shadow(tmp_path):
     proc = _run_hook_without_vaara(tmp_path, {"mode": "watch"}, {})
     assert proc.returncode == 0, proc.stderr
+
+
+def test_article50_statement_reader(config_mod, monkeypatch):
+    monkeypatch.delenv("VAARA_PLUGIN_ARTICLE50_STATEMENT", raising=False)
+    assert config_mod.article50_statement({}) is None
+    assert config_mod.article50_statement({"article50_statement": "  "}) is None
+    assert config_mod.article50_statement(
+        {"article50_statement": "You are talking to AI."}
+    ) == "You are talking to AI."
+    monkeypatch.setenv("VAARA_PLUGIN_ARTICLE50_STATEMENT", "Env notice")
+    assert config_mod.article50_statement({}) == "Env notice"
+
+
+def test_session_start_records_article50_disclosure(tmp_path):
+    """Full subprocess run: hook writes the 50(1) event with the session id."""
+    import sqlite3
+
+    home = tmp_path / "home"
+    cfg_dir = home / ".vaara" / "claude-code"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "config.json").write_text(json.dumps(
+        {"article50_statement": "You are interacting with an AI assistant."}
+    ))
+    proc = subprocess.run(
+        [sys.executable, str(_HOOKS / "session_start.py")],
+        input=json.dumps({"session_id": "sess-42"}),
+        capture_output=True, text=True, timeout=60,
+        env={"HOME": str(home), "PATH": os.environ.get("PATH", "")},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "article50_disclosure=recorded" in proc.stderr
+
+    conn = sqlite3.connect(cfg_dir / "audit.db")
+    rows = conn.execute(
+        "SELECT data FROM audit_records WHERE tool_name = "
+        "'vaara.article50.disclosure' AND event_type = 'action_requested'"
+    ).fetchall()
+    assert len(rows) == 1
+    data = json.loads(rows[0][0])
+    assert data["session_id"] == "sess-42"
+    assert data["parameters"]["article"] == "50(1)"


### PR DESCRIPTION
Builds on #385. One config line and every Claude Code session gets Article 50 disclosure evidence for free:

```json
{ "article50_statement": "You are interacting with an AI assistant operated by X." }
```

SessionStart records the statement as a 50(1) disclosure event into the audit trail, bound to the session id, timestamped at session start — i.e. before the session's first tool call, which is exactly what the Article 50(5) at-the-latest-at-first-interaction timing check in `export-article50` looks for. The whole compliance story becomes: one config key, then `vaara trail export-article50 --db ... ` whenever someone asks.

Details:
- `_config.article50_statement()`: config key or `VAARA_PLUGIN_ARTICLE50_STATEMENT`, empty/absent = off.
- Recording goes through `vaara.audit.article50.record_disclosure` (needs the article50 module from #385; on an older vaara the status line says `skipped (needs vaara>=1.27)` and nothing breaks).
- The SessionStart status line gains `article50_disclosure=recorded|skipped|failed`, and its version string now reads from plugin.json (it was hardcoded `v0.2.0` since 0.3.0).
- Plugin bumped to 0.5.0.

Tested: subprocess integration test runs the real hook with a configured statement and asserts the 50(1) event lands in the DB with the session id; config reader unit tests; plus a live end-to-end run in this environment (status line `article50_disclosure=recorded`, event visible in the trail). Full plugin test file: 20 passed; ruff clean.