### PR TITLE
release: 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.27.0] - 2026-07-13
+
+Dogfood release: everything in it came from one weekend of using Vaara on Vaara. EU AI Act Article 50 transparency evidence (record disclosures, export a signed regulator package), a gate that fails closed, custom thresholds, and the CLI export path that actually works from a plugin's SQLite trail.
+
 
 - Claude Code plugin 0.5.0: set `"article50_statement"` in config.json (or `VAARA_PLUGIN_ARTICLE50_STATEMENT`) and every session start auto-records it as an EU AI Act Article 50(1) disclosure event into the audit trail, bound to the session id and timestamped before the session's first tool call — the 50(5) timing question answered by construction. The SessionStart status line reports it, and its version string now reads from plugin.json instead of a hardcoded constant (it said v0.2.0 since 0.3.0).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.26.1"
+version = "1.27.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.26.1"
+__version__ = "1.27.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Cuts the release for everything merged since 1.26.1 (#380, #381, #382, #383, #384, #385, #386): the Article 50 transparency evidence layer end to end (record_disclosure, trail export-article50, plugin auto-disclosure per session), the fail-closed plugin gate, custom decision thresholds, --db trail export, and the CLI usability round.

- pyproject and __version__ to 1.27.0 (version-pin tests pass).
- CHANGELOG: Unreleased becomes [1.27.0] - 2026-07-13 with a release summary.

After merge, tagging v1.27.0 triggers release.yml (PyPI trusted publishing + attestations, GitHub release with sigstore signatures, npm client, MCP registry) and the tap's bump-formula workflow picks up the new sdist within its next cycle.

Full suite: 1218 passed; the single failure is the known environment-specific one, identical on unmodified main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 1.27.0 is now available.
  * Added release notes for the 1.27.0 dogfood release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->