### PR TITLE
release: 1.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.28.0] - 2026-07-13
+
+- Claude Code plugin 0.6.1: a session whose governance cannot run announces it. When neither the `vaara` binary nor `python3` is on PATH, the SessionStart hook prints the warning to stdout (which Claude Code injects into the session context) instead of only stderr, so a dead install is stated in the session instead of failing silently. Plugin 0.6.0 expected `vaara hook` from an engine release that had not shipped yet; this release ships it.
 - `vaara hook pre-tool-use|post-tool-use|session-start`: the Claude Code hook logic now lives in the package (`vaara.integrations.claude_code_hooks`, default deny patterns bundled) and the plugin's hooks shell out to the `vaara` binary on PATH via a shim, falling back to the bundled `python3` scripts. Any CLI install — pip, pipx, Homebrew — is now a complete engine install; the split-brain where the CLI lived in one Python environment and the hooks ran another (silently ungoverned) is impossible by construction. Plugin 0.6.0.
 
 ## [1.27.0] - 2026-07-13

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/plugins/claude-code-vaara-governance/hooks/run.sh
+++ b/plugins/claude-code-vaara-governance/hooks/run.sh
@@ -12,8 +12,16 @@ if command -v vaara >/dev/null 2>&1 && vaara hook --help >/dev/null 2>&1; then
 fi
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "vaara-governance: neither the vaara binary nor python3 is on PATH;" \
-       "governance is NOT active. Install with: pip install vaara" >&2
+  msg="vaara-governance: neither the vaara binary nor python3 is on PATH; \
+governance is NOT active. Tool calls run unchecked and unrecorded. \
+Install with: pip install vaara"
+  echo "$msg" >&2
+  # SessionStart stdout is injected into the model's context, so the
+  # session itself learns governance is off and can tell the user.
+  # Silence here is the one failure mode this plugin must never have.
+  if [ "$kind" = "session-start" ]; then
+    echo "$msg"
+  fi
   exit 0
 fi
 

--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -78,10 +78,14 @@ def main() -> int:
     try:
         import vaara
     except ImportError:
-        _emit(
+        # stdout on SessionStart is injected into the model's context, so
+        # the session itself learns governance is off and tells the user.
+        # A silent no-op is the one failure mode this plugin must not have.
+        print(
             "vaara-governance: vaara package not importable. "
-            "Run `pip install vaara>=0.40.1` to enable runtime governance. "
-            "Tool calls will pass through unchecked until then."
+            "Governance is NOT active: tool calls run unchecked and "
+            "unrecorded. Run `pip install vaara>=0.40.1` to enable it.",
+            flush=True,
         )
         return 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.27.0"
+version = "1.28.0"
 description = "Runtime evidence layer for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -6,7 +6,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.27.0"
+__version__ = "1.28.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Ships the `vaara hook` engine side that plugin 0.6.0 already expects, plus plugin 0.6.1: when governance cannot run (no vaara binary and no python3 on PATH), the SessionStart hook now says so on stdout instead of failing silently. Hook test suites pass (26/26).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer warnings when governance is unavailable, including guidance to install the required runtime.
  * Session-start notifications now explicitly indicate when tool calls are unchecked and unrecorded.

* **Bug Fixes**
  * Improved handling of missing governance tools and corrected the expected hook behavior.

* **Chores**
  * Updated the package and Claude Code plugin versions to 1.28.0 and 0.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->