### PR TITLE
chore: recolor the downloads badge to the brand green

### DIFF
--- a/.github/badges/installs.json
+++ b/.github/badges/installs.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"downloads","message":"79.3k all-time","total":79317,"color":"1f6feb"}
+{"schemaVersion":1,"label":"downloads","message":"79.3k all-time","total":79317,"color":"78A08A"}

--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
           msg=$(awk -v n="$total" 'BEGIN{ if (n>=1000) printf "%.1fk all-time", n/1000; else printf "%d all-time", n }')
-          printf '{"schemaVersion":1,"label":"downloads","message":"%s","total":%d,"color":"1f6feb"}\n' "$msg" "$total" \
+          printf '{"schemaVersion":1,"label":"downloads","message":"%s","total":%d,"color":"78A08A"}\n' "$msg" "$total" \
             > installs.json
           cat installs.json
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/vaara/"><img src="https://img.shields.io/pypi/v/vaara.svg?color=78A08A" alt="PyPI"></a>
-  <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg?color=78A08A" alt="License"></a>
+  <a href="https://pypi.org/project/vaara/"><img src="https://img.shields.io/pypi/v/vaara.svg" alt="PyPI"></a>
+  <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg" alt="License"></a>
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://github.com/vaaraio/vaara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://github.com/vaaraio/vaara/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
-  <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-78A08A" alt="Hugging Face Space"></a>
+  <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 </p>
 
 <p align="center">
-  <a href="https://pypi.org/project/vaara/"><img src="https://img.shields.io/pypi/v/vaara.svg" alt="PyPI"></a>
-  <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg" alt="License"></a>
+  <a href="https://pypi.org/project/vaara/"><img src="https://img.shields.io/pypi/v/vaara.svg?color=78A08A" alt="PyPI"></a>
+  <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg?color=78A08A" alt="License"></a>
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://github.com/vaaraio/vaara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://github.com/vaaraio/vaara/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
-  <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
+  <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-78A08A" alt="Hugging Face Space"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Recolors only the downloads badge to the Vaara green `#78A08A` (sampled from the wordmark): the `installs.json` colour and the refresh workflow's colour, so weekly refreshes stay green. No other badges touched.

Turns green after the next `downloads-badge` workflow run.