### PR TITLE
chore(badge): hourly live downloads count

### DIFF
--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -4,12 +4,19 @@ name: Downloads badge
 # to the unprotected `badges` branch (installs.json at its root), which the
 # README badge and the website both read. Keyless: PyPI total comes from the
 # public ClickHouse pypi dataset, npm from the registry downloads API. Runs
-# weekly and on demand. It publishes to `badges` rather than `main` because
-# the main ruleset requires a pull request, which a bot push cannot satisfy.
+# hourly and on demand so the "live downloads" count stays fresh. It commits
+# only when the number changes, so quiet hours produce no churn. It publishes
+# to `badges` rather than `main` because the main ruleset requires a pull
+# request, which a bot push cannot satisfy.
+#
+# Hourly is the freshest reliable cadence here: PyPI's all-time source
+# (ClickHouse) sends no CORS header, so a browser cannot read it directly and
+# a true per-visit count would need a standalone proxy. This endpoint JSON is
+# the single source both the shield and the site consume, so they stay in sync.
 
 on:
   schedule:
-    - cron: "0 6 * * 1"   # Mondays 06:00 UTC
+    - cron: "0 * * * *"   # top of every hour, UTC
   workflow_dispatch: {}
 
 permissions:
@@ -50,8 +57,17 @@ jobs:
             echo "total=$total looks wrong, leaving the badge untouched"; exit 0
           fi
 
+          # Only rewrite when the number actually moved. The timestamp is
+          # bumped alongside the total, so "updated N ago" on the site tracks
+          # when the count last changed instead of churning the branch hourly.
+          old=$(jq -r '.total // 0' installs.json 2>/dev/null || echo 0)
+          if [ "$total" = "$old" ]; then
+            echo "total unchanged at $total, leaving the badge untouched"; exit 0
+          fi
+
           msg=$(awk -v n="$total" 'BEGIN{ if (n>=1000) printf "%.1fk all-time", n/1000; else printf "%d all-time", n }')
-          printf '{"schemaVersion":1,"label":"downloads","message":"%s","total":%d,"color":"78A08A"}\n' "$msg" "$total" \
+          gen=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          printf '{"schemaVersion":1,"label":"downloads","message":"%s","total":%d,"color":"78A08A","generated":"%s"}\n' "$msg" "$total" "$gen" \
             > installs.json
           cat installs.json
 

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -94,6 +94,7 @@
   .evidence .ok { color: var(--tri-bright); }
   .evidence .dim { color: var(--faint); }
   #installs { color: var(--tri-bright); font-weight: 600; font-family: var(--mono); }
+  .ago { opacity: .55; font-size: .85em; }
 </style>
 <script type="application/ld+json">
 {
@@ -220,7 +221,7 @@ conformance: <span class="ok">CONFORMS</span>
 
 <p class="stamp">Adoption (live)</p>
 <ul>
-  <li><span id="installs">-</span> total downloads, all time (PyPI and npm)</li>
+  <li><span id="installs">-</span> live downloads, all time (PyPI and npm) <span id="installs-ago" class="ago"></span></li>
 </ul>
 
 <p class="stamp">Acknowledged by</p>
@@ -250,11 +251,21 @@ conformance: <span class="ok">CONFORMS</span>
 (function(){
   function setText(id, value) { var el = document.getElementById(id); if (el) el.textContent = value; }
   function fmt(n) { return n.toLocaleString("en-US"); }
-  fetch("https://raw.githubusercontent.com/vaaraio/vaara/badges/installs.json")
+  function ago(iso) {
+    var t = Date.parse(iso); if (isNaN(t)) return "";
+    var s = Math.max(0, Math.round((Date.now() - t) / 1000));
+    if (s < 90) return "updated just now";
+    var m = Math.round(s / 60); if (m < 90) return "updated " + m + "m ago";
+    var h = Math.round(m / 60); if (h < 36) return "updated " + h + "h ago";
+    return "updated " + Math.round(h / 24) + "d ago";
+  }
+  // Cache-bust so the browser reads the freshest badge JSON, not a CDN copy.
+  fetch("https://raw.githubusercontent.com/vaaraio/vaara/badges/installs.json?_=" + Date.now())
     .then(function(r){ return r.ok ? r.json() : null; })
     .then(function(d){
       if (!d || typeof d.total !== "number") return;
       setText("installs", fmt(d.total));
+      if (d.generated) setText("installs-ago", ago(d.generated));
     })
     .catch(function(){});
 })();


### PR DESCRIPTION
## What

Move the downloads badge from a weekly refresh to hourly, and present the count as a live number on the site.

## Why

The scheduled run had been failing: the earlier version pushed to `main`, which the branch ruleset rejects, so the count only refreshed on manual dispatch. Weekly is also too coarse for a number labeled as a live download total.

## Changes

- `.github/workflows/downloads-badge.yml`: cron from weekly to hourly. Adds a `generated` timestamp to `installs.json`, and rewrites the file only when the total changes, so idle hours produce no commits on the `badges` branch.
- `webpage/index.html`: caption reads "live downloads, all time (PyPI and npm)", shows "updated N ago" from the timestamp, and cache-busts the fetch so the browser reads the freshest JSON.

## Constraint

PyPI's all-time source (the public ClickHouse dataset) sends no CORS header, so a browser cannot read it directly. Hourly refresh of the shared endpoint JSON is the freshest cadence that keeps the README shield and the site showing the same number.

Replaces #417 (that branch was cut from a divergent local release commit).