### PR TITLE
brand: surface Accountable Autonomy on README and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/vaaraio/vaara/badges/installs.json" alt="Downloads">
 </p>
 
+<p align="center"><b>Accountable Autonomy.</b> A verifiable receipt for every action your AI agents take, checkable by anyone.</p>
+
 Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
 
 Vaara checks every agent tool call against your policy and writes the call and its outcome into a signed, hash-chained record an outside party can verify offline, with no access to your system and none of your software. It needs no special hardware, and binds to your machine's TPM 2.0 or confidential-VM root when you have one. It runs entirely in your own environment. No SaaS, no telemetry. It answers "show me what the agent actually did" wherever that question lands: after an incident, in procurement, in a dispute. And when EU AI Act record-keeping obligations reach your systems, the same trail is the Article 12 evidence, already running.

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Vaara — Tamper-evident evidence layer for AI agents | EU AI Act Article 12</title>
+<title>Vaara: Accountable Autonomy for AI agents | Tamper-evident EU AI Act Article 12 evidence</title>
 <meta name="description" content="Vaara is the open-source tamper-evident runtime evidence layer for AI agents. Prove what an agent actually did, let an outside party verify it without trusting you, and bind the record to the machine's own TPM 2.0 + IMA attestation. EU AI Act Article 12 audit trail. No SaaS, no telemetry, AGPL-3.0.">
 <meta name="keywords" content="AI agent audit trail, tamper-evident AI logging, EU AI Act Article 12, EU AI Act compliance, AI governance, signed execution record, verifiable AI, AI accountability, TPM 2.0 attestation, IMA measurement, RFC 3161 timestamp, eIDAS qualified timestamp, SEP-2828, MCP execution record, agent observability, sovereign AI, hash-chained audit log, Ed25519, ML-DSA-65, post-quantum, SLSA, Sigstore, open source AI compliance">
 <meta name="author" content="Henri Sirkkavaara">
@@ -182,6 +182,7 @@
 <div class="wordmark">
   <img src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-dark.png" alt="Vaara">
 </div>
+<p style="text-transform:uppercase;letter-spacing:.14em;font-weight:600;opacity:.65;margin:.1rem 0 .6rem;font-size:.95rem;">Accountable Autonomy</p>
 <h1>Vaara is the tamper-evident runtime evidence layer for AI systems. It turns every action an agent takes into a record an outside party can verify without trusting you, then binds that record to the machine's own TPM 2.0 + IMA attestation. EU AI Act compliance, and any other case where you have to prove what an agent actually did.</h1>
 <p class="stance">Open source. No SaaS. No telemetry. No signup.</p>
 <div class="evidence">


### PR DESCRIPTION
Puts the Accountable Autonomy positioning on the public surfaces (README header line, site title, hero eyebrow), alongside the GitHub About. Copy only, no code or claims changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an “Accountable Autonomy” tagline describing verifiable records for AI agent actions.
  * Updated the README introduction with clearer product messaging.

* **Style**
  * Updated the webpage title to reference Accountable Autonomy and tamper-evident EU AI Act Article 12 evidence.
  * Added an “Accountable Autonomy” label near the top of the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->