### PR TITLE
chore: add SPDX license headers across source tree

### DIFF
--- a/plugins/claude-code-vaara-governance/hooks/_config.py
+++ b/plugins/claude-code-vaara-governance/hooks/_config.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Plugin settings from ``~/.vaara/claude-code/config.json``.
 
 Written by ``/vaara-setup`` and hand-editable. Environment variables win

--- a/plugins/claude-code-vaara-governance/hooks/_deny_patterns.py
+++ b/plugins/claude-code-vaara-governance/hooks/_deny_patterns.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Layer-1 regex deny-pattern matching for the Vaara Claude Code plugin.
 
 Loaded by ``pre_tool_use.py`` BEFORE the Vaara ML classifier. Matches

--- a/plugins/claude-code-vaara-governance/hooks/_notify.py
+++ b/plugins/claude-code-vaara-governance/hooks/_notify.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Desktop notification for governance decisions. Fire-and-forget.
 
 Sends a native notification when the gate blocks or escalates a tool

--- a/plugins/claude-code-vaara-governance/hooks/post_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/post_tool_use.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """PostToolUse hook: close the audit loop for the just-executed tool call.
 
 Appends an outcome record to the persistent SQLite audit trail so the

--- a/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """PreToolUse hook: two-layer governance for the proposed tool call.
 
 Layer 1 — regex deny patterns from ``policies/default_deny.json``. Applied

--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """SessionStart hook: validate the Vaara install, print a one-line
 governance summary, and (when configured) record the EU AI Act
 Article 50(1) disclosure for this session into the audit trail.

--- a/plugins/claude-code-vaara-governance/scripts/vaara_stats.py
+++ b/plugins/claude-code-vaara-governance/scripts/vaara_stats.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Vaara governance stats for the Claude Code audit trail.
 
 Reads ~/.vaara/claude-code/audit.db (or VAARA_PLUGIN_AUDIT_DB) and prints

--- a/scripts/_v036_common.py
+++ b/scripts/_v036_common.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Shared helpers for v0.36 cross-model held-out generation.
 
 The Mixtral leg (generate_targeted_v036.py) and the Claude leg

--- a/scripts/_v037_common.py
+++ b/scripts/_v037_common.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Shared helpers for v0.37 cross-family held-out generation.
 
 The Llama-3.3-70B-Instruct leg (generate_targeted_v037.py) imports from

--- a/scripts/_v039_common.py
+++ b/scripts/_v039_common.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Shared helpers for the v0.39 LLM-agent harness.
 
 v0.32-v0.38 scored adversarial entries already shaped like tool calls.

--- a/scripts/anchor_receipt_demo.py
+++ b/scripts/anchor_receipt_demo.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Mint and verify a self-hosted rfc3161 timestamp anchor over a Vaara receipt.
 
 Fully offline: stands up a local Time-Stamping Authority, anchors the receipt's

--- a/scripts/anchor_release.py
+++ b/scripts/anchor_release.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Anchor a Vaara release to a qualified RFC 3161 TSA — dogfoods vaara.audit.timeanchor.
 
 The release is already anchored by three independent registries (PyPI, npm,

--- a/scripts/audit_bipia_labels.py
+++ b/scripts/audit_bipia_labels.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Audit the BIPIA auto-labeller: how many `reflects_injection=True` rows
 actually have signal carried by parameters, vs how many are example.com
 placeholders the labeller false-positived?

--- a/scripts/build_conformance_corpus.py
+++ b/scripts/build_conformance_corpus.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Assemble the standalone SEP-2828 conformance corpus from the source vectors.
 
 The canonical fixtures live under ``tests/vectors/`` where the test suite and

--- a/scripts/build_conformance_statement_vectors.py
+++ b/scripts/build_conformance_statement_vectors.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Regenerate the conformance-statement golden vectors from the live corpus.
 
 The ``conformance_statement_v0`` vectors pin what ``vaara conformance-statement``

--- a/scripts/build_credential_grant_vectors.py
+++ b/scripts/build_credential_grant_vectors.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Generate the credential_grant_v0 conformance vectors.
 
 Run once with Vaara installed; emits, under

--- a/scripts/build_train_val_test_split.py
+++ b/scripts/build_train_val_test_split.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Deterministic stratified train/val/test split over the adversarial corpus.
 
 Ratio:        70 / 15 / 15

--- a/scripts/build_v037_split.py
+++ b/scripts/build_v037_split.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Build tests/adversarial/v037_split.json.
 
 Composition per the v0.37 scope in STATE.md:

--- a/scripts/build_v039_entries.py
+++ b/scripts/build_v039_entries.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Convert v0.39 BIPIA harness traces into classifier-shaped entries.
 
 Reads tests/adversarial/traces/bipia-s43-*.jsonl, shapes each emitted

--- a/scripts/build_v039_split.py
+++ b/scripts/build_v039_split.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Build tests/adversarial/v039_split.json.
 
 Composition:

--- a/scripts/classifier_vs_heuristic.py
+++ b/scripts/classifier_vs_heuristic.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """classifier_vs_heuristic.py — honest held-out test.
 Train on 200 original seeds + 50 benign. Test on 1945 unseen Qwen variants.
 Force labels from category-origin (not Qwen's `expected` field)."""

--- a/scripts/conformance_runner.py
+++ b/scripts/conformance_runner.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Run every Vaara conformance suite and report a single pass/fail verdict.
 
 Each suite under ``tests/vectors/<name>/`` ships an independent checker

--- a/scripts/consolidate.py
+++ b/scripts/consolidate.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Archive working-tree clutter that maps to shipped work.
 
 Default mode: --dry-run. Use --apply to move files to .shipped/YYYY-MM/.

--- a/scripts/demo_multiagent_attribution.py
+++ b/scripts/demo_multiagent_attribution.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Demo: reconstruct a multi-agent delegation chain and prove it can't be forged.
 
 Runs a three-agent chain through Vaara's governance pipeline:

--- a/scripts/e1_generate.py
+++ b/scripts/e1_generate.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """E1 - generate jailbreak variants via a vLLM OpenAI-compatible endpoint.
 
 Three styles per the v0.5.3 red-team notebook: roleplay (persona bypass),

--- a/scripts/e2_generate.py
+++ b/scripts/e2_generate.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """E2 — generate benign read_file canonical-path entries via a vLLM endpoint.
 
 Produces BENIGN test fixtures: read_file calls on unambiguously safe paths

--- a/scripts/eval_adversarial.py
+++ b/scripts/eval_adversarial.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Evaluate Vaara scorer against the adversarial corpus.
 
 Usage:

--- a/scripts/eval_distribution_shift.py
+++ b/scripts/eval_distribution_shift.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Distribution-shift split — hand-curated vs LLM-generated recall.
 
 v0.5.3's adversarial classifier was trained on a corpus that mixes:

--- a/scripts/eval_pair_attack.py
+++ b/scripts/eval_pair_attack.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """PAIR adaptive attacker — iterate jailbreak prompts against the Vaara stack.
 
 PAIR (Chao et al. 2023) iteratively refines attack prompts via an attacker

--- a/scripts/eval_per_category.py
+++ b/scripts/eval_per_category.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Per-category recall + FPR for a classifier bundle on the v031_split TEST fold.
 
 Calibrates the decision threshold on VAL at target FPR (default 5%), then

--- a/scripts/eval_pipeline_attribution.py
+++ b/scripts/eval_pipeline_attribution.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Per-entry attribution of Pipeline.intercept + AdversarialClassifier.
 
 Runs every corpus entry through a fresh Pipeline (clean state) and the

--- a/scripts/eval_stack_ablation.py
+++ b/scripts/eval_stack_ablation.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Stack ablation — heuristic-only / classifier-only / full-stack comparison.
 
 v0.5.3 ships two stacking layers:

--- a/scripts/eval_v032.py
+++ b/scripts/eval_v032.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Evaluate a classifier bundle on the v031_split VAL and TEST folds.
 
 Calibrates the decision threshold on VAL at target FPR (default 5%), then

--- a/scripts/eval_v036_holdout.py
+++ b/scripts/eval_v036_holdout.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Evaluate a classifier bundle on the v036_holdout fold.
 
 The held-out fold has no benign entries and no VAL; threshold is fixed at the

--- a/scripts/eval_v037_holdout.py
+++ b/scripts/eval_v037_holdout.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Evaluate a classifier bundle on the v037 holdout fold.
 
 Holdout composition (from v037_split.json): v036 Mixtral DE + v036 Claude DE

--- a/scripts/eval_v038_phase1.py
+++ b/scripts/eval_v038_phase1.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Evaluate a classifier bundle on the v0.38 Phase 1 generation (Llama-3.3-70B, seed 43).
 
 Reads tests/adversarial/generated/{TM,PE,DE}-v038-llama33-s43.jsonl directly,

--- a/scripts/eval_v039_bipia.py
+++ b/scripts/eval_v039_bipia.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Evaluate v8 against captured BIPIA agent traces.
 
 Reads a JSONL trace file written by scripts/run_v039_bipia.py, shapes

--- a/scripts/eval_v039_v9.py
+++ b/scripts/eval_v039_v9.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Calibrate + eval v9 across the v0.39 surfaces.
 
 Four surfaces in one pass, v8 + v9 side-by-side:

--- a/scripts/generate_decision_pairing_vectors.py
+++ b/scripts/generate_decision_pairing_vectors.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Generate the SEP-2828 decision/outcome pairing conformance vectors.
 
 Writes signed fixtures under ``tests/vectors/decision_pairing_v0/``. Each

--- a/scripts/generate_evidence_ref_vectors.py
+++ b/scripts/generate_evidence_ref_vectors.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Generate the evidenceRef conformance vectors.
 
 Writes signed fixtures under ``tests/vectors/evidence_ref_v0/``. Each case

--- a/scripts/generate_matched_benign_v035.py
+++ b/scripts/generate_matched_benign_v035.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """v0.35 matched-benign generation via Qwen-2.5-72B / vLLM.
 
 Generates ALLOW-labeled benign tool calls that share surface vocabulary

--- a/scripts/generate_receipt_vectors.py
+++ b/scripts/generate_receipt_vectors.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Generate the v0 execution-receipt conformance vectors.
 
 Writes pinned keys and signed fixtures under

--- a/scripts/generate_sep2787_attestation_vectors.py
+++ b/scripts/generate_sep2787_attestation_vectors.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Generate the v0 SEP-2787 attestation conformance vectors.
 
 Writes pinned keys and signed fixtures under

--- a/scripts/generate_targeted_v034.py
+++ b/scripts/generate_targeted_v034.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """v0.34 targeted adversarial generation via Qwen-2.5-72B / vLLM.
 
 Generalised over e1_generate.py: --category draws few-shot seeds from

--- a/scripts/generate_targeted_v036.py
+++ b/scripts/generate_targeted_v036.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """v0.36 cross-model held-out generation via Mixtral-8x7B-Instruct / vLLM.
 
 Mirrors generate_targeted_v034.py but with v036 IDs, a model-tag suffix on

--- a/scripts/generate_targeted_v036_claude.py
+++ b/scripts/generate_targeted_v036_claude.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """v0.36 cross-model held-out generation via Claude (Anthropic SDK).
 
 Closed-weight RLHF-heavy attacker leg. Same prompt structure as the Mixtral

--- a/scripts/generate_targeted_v037.py
+++ b/scripts/generate_targeted_v037.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """v0.37 cross-family held-out generation via Llama-3.3-70B-Instruct / vLLM.
 
 Mirrors generate_targeted_v036.py with v037 IDs and Llama-family defaults.

--- a/scripts/qualified_anchor_dss_demo.py
+++ b/scripts/qualified_anchor_dss_demo.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Anchor a receipt to a qualified TSA and validate the token in EU DSS.
 
 Reproduces the 1.30.0 claim end to end, against live services: obtains an

--- a/scripts/relabel_v039_traces.py
+++ b/scripts/relabel_v039_traces.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Re-label captured v0.39 BIPIA traces using the fixed labeller.
 
 The 2026-05-27 audit found `looks_like_injection_follow` had a 67%

--- a/scripts/run_v039_bipia.py
+++ b/scripts/run_v039_bipia.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """v0.39 BIPIA harness driver.
 
 Runs an LLM agent against BIPIA injected prompts, captures tool calls,

--- a/scripts/save_classifier_bundle.py
+++ b/scripts/save_classifier_bundle.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Train an XGBoost adversarial classifier and save a deployable joblib bundle.
 
 Loads the corpus via ``train_adversarial_classifier.load_corpus_keyed``,

--- a/scripts/sweep_v032_hparams.py
+++ b/scripts/sweep_v032_hparams.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Grid search XGBoost hparams for v0.32, ranked by TEST recall at calibrated FPR<=5% on VAL.
 
 Trains many XGBoost models on the v031_split TRAIN fold with MiniLM embeddings,

--- a/scripts/three_way_variants.py
+++ b/scripts/three_way_variants.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Three-way variant comparison for v0.31 item 6.
 
 Reads the attribution JSON produced by eval_pipeline_attribution.py and

--- a/scripts/threshold_sweep_cv.py
+++ b/scripts/threshold_sweep_cv.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """5-fold cross-validated threshold sweep on the adversarial corpus.
 
 For each fold, fits XGBoost on the training partition, collects out-of-fold

--- a/scripts/threshold_sweep_val.py
+++ b/scripts/threshold_sweep_val.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Classifier threshold sweep on VAL fold for v0.31 item 7.
 
 Reads the attribution JSON and sweeps classifier thresholds on the VAL

--- a/scripts/tpm/_assemble_bundle.py
+++ b/scripts/tpm/_assemble_bundle.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Assemble a vaara.tpm-evidence-bundle/v0 from tpm2-tools capture outputs.
 
 Called by ``capture-tpm-binding.sh`` after it has driven the TPM. Kept separate

--- a/scripts/tpm/_assemble_chain.py
+++ b/scripts/tpm/_assemble_chain.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Assemble a vaara.tpm-evidence-chain/v0 from tpm2-tools capture outputs.
 
 Called by ``capture-tpm-chain.sh`` after it has driven the TPM once per tick. Kept

--- a/scripts/train_adversarial_classifier.py
+++ b/scripts/train_adversarial_classifier.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Train a classifier on the adversarial corpus v1.
 
 Proof-of-concept: does a trained classifier beat the current heuristic

--- a/scripts/train_and_eval_bge_base.py
+++ b/scripts/train_and_eval_bge_base.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """v0.33 step 2 experiment: train v4 bundle with BAAI/bge-base-en-v1.5 and evaluate.
 
 Standalone A/B against v0.32's MiniLM-backed v3 bundle. Does NOT touch

--- a/scripts/train_v9_upweighted.py
+++ b/scripts/train_v9_upweighted.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Retrain v9 with BIPIA follows upweighted via XGBoost sample_weight.
 
 Reuses build_features/build_labels/load_corpus_keyed from

--- a/scripts/tune_classifier_threshold.py
+++ b/scripts/tune_classifier_threshold.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Sweep classifier thresholds against the full corpus in a single pipeline pass.
 
 Computes (pipe_decision_pre_classifier, classifier_prob, expected, source) for

--- a/scripts/validate_v037.py
+++ b/scripts/validate_v037.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Validate v037 generated jsonl: schema + required-field + per-cat consistency.
 
 Mirrors validate_v036.py with the v037 glob. Fail-loud on any malformed entry

--- a/scripts/verify_vaara_trail.py
+++ b/scripts/verify_vaara_trail.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Standalone verifier for a Vaara signed audit-trail export.
 
 No Vaara install required. Only dependency:

--- a/scripts/wilson_intervals.py
+++ b/scripts/wilson_intervals.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Wilson 95% intervals on v0.31 headline numbers.
 
 The Wilson score interval is the conventional small-sample CI for a

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Vaara. Runtime action governance for AI agents.
 
 Sits between AI agents and their execution environment.

--- a/src/vaara/_sanitize.py
+++ b/src/vaara/_sanitize.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Internal JSON-safe coercion for audit-trail hashing.
 
 Real agent tools routinely pass datetimes, bytes, dataclasses, and

--- a/src/vaara/adversarial_classifier.py
+++ b/src/vaara/adversarial_classifier.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Adversarial tool-call classifier (opt-in ML scorer).
 
 Ships with a pre-trained XGBoost model trained on the v0.31 split's

--- a/src/vaara/approvals.py
+++ b/src/vaara/approvals.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """File-based approval handshake between the gate and a human surface.
 
 The pipeline (or a hook driving it) writes ``<action_id>.request.json``

--- a/src/vaara/attestation/__init__.py
+++ b/src/vaara/attestation/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Runtime attestation envelopes: OVERT 1.0 and SEP-2787 v2.
 
 This package ships two coexisting attestation surfaces:

--- a/src/vaara/attestation/_attest_canonical.py
+++ b/src/vaara/attestation/_attest_canonical.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """RFC 8785 (JCS) canonicalization and args-commitment helpers.
 
 Internal module. Public surface is in ``vaara.attestation.tool_call_attestation``.

--- a/src/vaara/attestation/_attest_emit.py
+++ b/src/vaara/attestation/_attest_emit.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Emit and verify for SEP-2787 envelopes.
 
 Internal module. Public surface is in ``vaara.attestation.tool_call_attestation``.

--- a/src/vaara/attestation/_attest_signing.py
+++ b/src/vaara/attestation/_attest_signing.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Signing-mode helpers for SEP-2787 attestation envelopes.
 
 Three signing modes matching the v1 SEP-2787 draft: HS256 (HMAC-SHA256

--- a/src/vaara/attestation/_attest_types.py
+++ b/src/vaara/attestation/_attest_types.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Dataclasses and serialization helpers for SEP-2787 envelopes.
 
 Internal module. Public surface is in ``vaara.attestation.tool_call_attestation``.

--- a/src/vaara/attestation/_attest_verifier.py
+++ b/src/vaara/attestation/_attest_verifier.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """SEP-2787 verifier step 5: argument commitment verification.
 
 Internal module. Public surface is in ``vaara.attestation.tool_call_attestation``.

--- a/src/vaara/attestation/_attestation_result.py
+++ b/src/vaara/attestation/_attestation_result.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Express a Vaara attestation verdict as an IETF RATS EAR (Phase 2: neutral verify).
 
 Phases 0 and 1 of the hardware-governance layer bind a SEP-2828 record to a TPM

--- a/src/vaara/attestation/_audit_summary.py
+++ b/src/vaara/attestation/_audit_summary.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """The one-page audit summary: the record-set verdict a regulator reads.
 
 ``check_record_set`` answers the machine question and ``verify-records`` prints

--- a/src/vaara/attestation/_bundle.py
+++ b/src/vaara/attestation/_bundle.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """One-call evidence-bundle verification: the 0.6 trust-plane capstone.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_bundle_io.py
+++ b/src/vaara/attestation/_bundle_io.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """On-disk format for an evidence bundle: load a JSON document into a bundle.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_bundle_set.py
+++ b/src/vaara/attestation/_bundle_set.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Full-lens verification over a whole directory of evidence bundles.
 
 ``verify_evidence_bundle`` runs every lens over one bundle. An auditor who

--- a/src/vaara/attestation/_conformance_statement.py
+++ b/src/vaara/attestation/_conformance_statement.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Conformance self-test and statement for the published SEP-2828 corpus.
 
 An emitter that claims SEP-2828 conformance answers "trust us" with "prove it

--- a/src/vaara/attestation/_data_locality.py
+++ b/src/vaara/attestation/_data_locality.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Emit and signature-verify data-locality records (``vaara.data-locality/v0``).
 
 Internal module. Public surface is in ``vaara.attestation.data_locality``.

--- a/src/vaara/attestation/_decision_binding.py
+++ b/src/vaara/attestation/_decision_binding.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Binding and rationale digests for the SEP-2828 decision record.
 
 Pure standard library (with a lazy, optional `rfc8785` for JCS canonicalization),

--- a/src/vaara/attestation/_decision_conformance.py
+++ b/src/vaara/attestation/_decision_conformance.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Producer-agnostic conformance check for SEP-2828 decision records.
 
 The sibling of ``_receipt_conformance``. A decision record is the

--- a/src/vaara/attestation/_decision_emit.py
+++ b/src/vaara/attestation/_decision_emit.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Emit and verify-signature for decision-record envelopes.
 
 Internal module. Public surface is in ``vaara.attestation.decision``.

--- a/src/vaara/attestation/_decision_proof_verify.py
+++ b/src/vaara/attestation/_decision_proof_verify.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Cryptographic verification of a SEP-2828 ``decisionProof`` (behind the extra).
 
 The keyless conformance checker (``_decision_conformance``) validates the proof

--- a/src/vaara/attestation/_decision_types.py
+++ b/src/vaara/attestation/_decision_types.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Dataclasses and serialization for decision-record envelopes.
 
 Internal module. Public surface is in ``vaara.attestation.decision``.

--- a/src/vaara/attestation/_decision_verifier.py
+++ b/src/vaara/attestation/_decision_verifier.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Back-link verification and pairing for decision records.
 
 Internal module. Public surface is in ``vaara.attestation.decision``.

--- a/src/vaara/attestation/_declarative.py
+++ b/src/vaara/attestation/_declarative.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Data-only source profiles: bind a foreign format without writing code.
 
 The built-in profiles in ``_normalize`` are Python because two of them must

--- a/src/vaara/attestation/_enforcement.py
+++ b/src/vaara/attestation/_enforcement.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Attested enforcement: bind an AMD SEV-SNP report to a SEP-2828 record.
 
 The enforcement point that writes execution records can itself run inside an

--- a/src/vaara/attestation/_enforcement_set.py
+++ b/src/vaara/attestation/_enforcement_set.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Enforcement verification over a whole directory of (record, report, VCEK) triples.
 
 ``verify_enforcement`` binds one signed SEP-2828 record to one SEV-SNP report.

--- a/src/vaara/attestation/_handoff.py
+++ b/src/vaara/attestation/_handoff.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Cross-org evidence handoff: hand one signed record to another org's regulator.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_handoff_set.py
+++ b/src/vaara/attestation/_handoff_set.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Handoff verification over a whole directory of cross-org packages.
 
 ``verify_handoff`` checks one self-contained handoff package: one org's record,

--- a/src/vaara/attestation/_ingest_emit.py
+++ b/src/vaara/attestation/_ingest_emit.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Emit and verify-signature for ``vaara.ingest/v0`` envelopes.
 
 Internal module. Public surface is in ``vaara.attestation.receipt``.

--- a/src/vaara/attestation/_key_history.py
+++ b/src/vaara/attestation/_key_history.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Key validity windows: verify a record under a rotated or retired key.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_normalize.py
+++ b/src/vaara/attestation/_normalize.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Normalize adjacent MCP records into the SEP-2828 evidence model.
 
 Vaara is the receiving side for agent execution evidence. A SEP-2828

--- a/src/vaara/attestation/_receipt_cbom.py
+++ b/src/vaara/attestation/_receipt_cbom.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """CycloneDX-CBOM crypto-posture derivation and verification (v0).
 
 Internal module. Public surface re-exports ``crypto_posture_for`` and

--- a/src/vaara/attestation/_receipt_conformance.py
+++ b/src/vaara/attestation/_receipt_conformance.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Producer-agnostic conformance check for SEP-2828 execution records.
 
 Given any JSON that claims to be a SEP-2828 execution receipt, this

--- a/src/vaara/attestation/_receipt_cose.py
+++ b/src/vaara/attestation/_receipt_cose.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """COSE Receipt (SCITT-compatible) emission over Vaara's transparency log.
 
 A SCITT / COSE *Receipt* (draft-ietf-cose-merkle-tree-proofs) is a cryptographic

--- a/src/vaara/attestation/_receipt_emit.py
+++ b/src/vaara/attestation/_receipt_emit.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Emit and verify-signature for execution-receipt envelopes.
 
 Internal module. Public surface is in ``vaara.attestation.receipt``.

--- a/src/vaara/attestation/_receipt_existence.py
+++ b/src/vaara/attestation/_receipt_existence.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Qualified existence-in-time proof over a SEP-2828 execution record.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_receipt_identity.py
+++ b/src/vaara/attestation/_receipt_identity.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Resolvable agent identity (did:web) for execution receipts.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_receipt_identity_live.py
+++ b/src/vaara/attestation/_receipt_identity_live.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Live-resolvable agent identity (did:web) for execution receipts.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_receipt_pq.py
+++ b/src/vaara/attestation/_receipt_pq.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Post-quantum hybrid signing for execution receipts (v0).
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_receipt_retention.py
+++ b/src/vaara/attestation/_receipt_retention.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Verify a retained execution record under a rotated or retired key.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_receipt_types.py
+++ b/src/vaara/attestation/_receipt_types.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Dataclasses and serialization for execution-receipt envelopes.
 
 Internal module. Public surface is in ``vaara.attestation.receipt``.

--- a/src/vaara/attestation/_receipt_vc.py
+++ b/src/vaara/attestation/_receipt_vc.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """W3C Verifiable Credential serialization for execution receipts (opt-in).
 
 Internal module. Public surface re-exports ``receipt_to_vc`` and

--- a/src/vaara/attestation/_receipt_verifier.py
+++ b/src/vaara/attestation/_receipt_verifier.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Back-link verification between a receipt and its request attestation.
 
 Internal module. Public surface is in ``vaara.attestation.receipt``.

--- a/src/vaara/attestation/_record_set_conformance.py
+++ b/src/vaara/attestation/_record_set_conformance.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Set-level conformance for a pile of SEP-2828 records.
 
 ``check_record_conformance`` answers a question about one record. An

--- a/src/vaara/attestation/_record_set_findings.py
+++ b/src/vaara/attestation/_record_set_findings.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Cross-record findings for a set of SEP-2828 records.
 
 The properties that only show up across records, factored out of

--- a/src/vaara/attestation/_revocation.py
+++ b/src/vaara/attestation/_revocation.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Cross-stack revocation: one revocation-in-time rule for every lens.
 
 Internal module. Public surface is re-exported from

--- a/src/vaara/attestation/_tpm.py
+++ b/src/vaara/attestation/_tpm.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """TPM 2.0 quote structures, IMA log replay, and a mock quoter.
 
 The vendor-neutral, commodity-hardware twin of :mod:`vaara.attestation.tee`.

--- a/src/vaara/attestation/_tpm_binding.py
+++ b/src/vaara/attestation/_tpm_binding.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """TPM binding: bind a TPM 2.0 quote + IMA log to a SEP-2828 record.
 
 The vendor-neutral, commodity-hardware twin of

--- a/src/vaara/attestation/_tpm_bundle.py
+++ b/src/vaara/attestation/_tpm_bundle.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """The TPM evidence bundle: one self-contained file the verifier consumes.
 
 Phase-0 binds three things a regulator must check together: the signed SEP-2828

--- a/src/vaara/attestation/_tpm_chain.py
+++ b/src/vaara/attestation/_tpm_chain.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """TPM evidence chain: a continuous-attestation loop bound to a SEP-2828 record.
 
 Phase 1 of the hardware-governance binding, the continuous-attestation twin of the

--- a/src/vaara/attestation/_tpm_chain_bundle.py
+++ b/src/vaara/attestation/_tpm_chain_bundle.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """The TPM evidence-chain bundle: one file carrying a whole attestation loop.
 
 The continuous-attestation counterpart of :mod:`vaara.attestation._tpm_bundle`.

--- a/src/vaara/attestation/cose_receipt.py
+++ b/src/vaara/attestation/cose_receipt.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Public surface: SCITT-compatible COSE Receipts over Vaara's transparency log.
 
 Keyless first. A Vaara COSE Receipt is an RFC 6962 inclusion proof serialised in

--- a/src/vaara/attestation/data_locality.py
+++ b/src/vaara/attestation/data_locality.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Data-locality records: signed evidence of where an agent action's data went.
 
 When personal data leaves for a model endpoint, the accountability question is

--- a/src/vaara/attestation/decision.py
+++ b/src/vaara/attestation/decision.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Decision records: the pre-execution sibling of SEP-2787.
 
 SEP-2787 attests a ``tools/call`` *request* before it runs. The

--- a/src/vaara/attestation/iap.py
+++ b/src/vaara/attestation/iap.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """OVERT Phase 3 Independent Attestation Provider (IAP) reference.
 
 A Vaara AAL-3 ``BaseEnvelope`` is a Provisional Receipt signed by the

--- a/src/vaara/attestation/overt.py
+++ b/src/vaara/attestation/overt.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """OVERT 1.0 Protocol Profile 1.0 Base Envelope (Annex B.6).
 
 The Base Envelope is a 9-field closed-schema structure emitted for every

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Execution receipts: the post-execution sibling of SEP-2787.
 
 SEP-2787 attests a ``tools/call`` *request* before it runs: issuer,

--- a/src/vaara/attestation/s3p.py
+++ b/src/vaara/attestation/s3p.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """OVERT 1.0 MEA-2 Statistical Safety Signal Protocol (S3P) emitter.
 
 S3P (OVERT Section 9, control MEA-2) is the normative auditor-reproducible

--- a/src/vaara/attestation/sep2787.py
+++ b/src/vaara/attestation/sep2787.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Deprecated alias for :mod:`vaara.attestation.tool_call_attestation`.
 
 Vaara's tool-call attestation was formerly exposed here under the SEP-2787

--- a/src/vaara/attestation/tee.py
+++ b/src/vaara/attestation/tee.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Hardware TEE attestation hook for OVERT 1.0 Base Envelopes.
 
 Status: experimental. Adds an optional hardware-rooted attestation layer

--- a/src/vaara/attestation/tool_call_attestation.py
+++ b/src/vaara/attestation/tool_call_attestation.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Vaara tool-call attestation envelope (v2 shape).
 
 Vaara's own per-tool-call attestation: a signed JSON envelope carried in

--- a/src/vaara/attestation/transparency_log.py
+++ b/src/vaara/attestation/transparency_log.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """In-process Merkle transparency log for OVERT Phase 3 inclusion proofs.
 
 Reference log compatible with RFC 6962-style binary Merkle trees. The IAP

--- a/src/vaara/attestation/zk/__init__.py
+++ b/src/vaara/attestation/zk/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Zero-knowledge decisionProof engine (behind the attestation extra).
 
 Transparent commit-and-prove over P-256 (secp256r1). Proves that a SEP-2828

--- a/src/vaara/attestation/zk/_circuit.py
+++ b/src/vaara/attestation/zk/_circuit.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """The constrained decision predicate, compiled to a set of range statements.
 
 The runtime verdict is a threshold branch over a risk score. Proving membership

--- a/src/vaara/attestation/zk/_commit.py
+++ b/src/vaara/attestation/zk/_commit.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Pedersen commitments and generator vectors over P-256.
 
 A Pedersen commitment `commit(value, blind) = value*G + blind*H` is perfectly

--- a/src/vaara/attestation/zk/_group.py
+++ b/src/vaara/attestation/zk/_group.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """P-256 (secp256r1) group and scalar field, implemented from the public NIST
 parameters using only the standard library.
 

--- a/src/vaara/attestation/zk/_params.py
+++ b/src/vaara/attestation/zk/_params.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Public parameters for the decisionProof engine and their digest.
 
 The setup is transparent: the only public parameters are the curve, the second

--- a/src/vaara/attestation/zk/_prove.py
+++ b/src/vaara/attestation/zk/_prove.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Prover for the decisionProof.
 
 The statement: the committed score and thresholds (published as Pedersen

--- a/src/vaara/attestation/zk/_verify.py
+++ b/src/vaara/attestation/zk/_verify.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Verifier for the decisionProof.
 
 Rebuilds the published commitments and the verdict's homomorphic difference

--- a/src/vaara/audit/__init__.py
+++ b/src/vaara/audit/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Audit trail — structured, immutable, regulation-mapped action logging."""

--- a/src/vaara/audit/article12_export.py
+++ b/src/vaara/audit/article12_export.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """EU AI Act Article 12 one-command regulator export.
 
 Composes the existing signed-export path with a generated Article 12

--- a/src/vaara/audit/article12_report.py
+++ b/src/vaara/audit/article12_report.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """EU AI Act Article 12 record-keeping report — pure builders and renderers.
 
 Turns an audit trail into a regulator-facing mapping against the Article 12

--- a/src/vaara/audit/article50.py
+++ b/src/vaara/audit/article50.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """EU AI Act Article 50 transparency evidence: record it, then prove it.
 
 Article 50 duties are behavioral: inform the person they are interacting

--- a/src/vaara/audit/delegation.py
+++ b/src/vaara/audit/delegation.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Reconstruct multi-agent delegation chains from the audit trail.
 
 Read-side only. The delegation edge — ``parent_action_id`` — is captured at

--- a/src/vaara/audit/export.py
+++ b/src/vaara/audit/export.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Signed, regulator-handoff export of the audit trail.
 
 Produces a single zip containing:

--- a/src/vaara/audit/incident_export.py
+++ b/src/vaara/audit/incident_export.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Article 73 EU AI Act serious-incident report export.
 
 INTERIM format pending publication of the Commission template promised by

--- a/src/vaara/audit/ots_anchor.py
+++ b/src/vaara/audit/ots_anchor.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """OpenTimestamps witness anchors for Vaara receipts (SPEC.md Section 4).
 
 The ``opentimestamps`` timestampAnchors method commits a receipt's

--- a/src/vaara/audit/prov_export.py
+++ b/src/vaara/audit/prov_export.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """W3C PROV-DM export for the Vaara audit trail.
 
 Produces PROV-JSON (W3C Submission, 2013) so any PROV-aware consumer can

--- a/src/vaara/audit/receipt_anchor.py
+++ b/src/vaara/audit/receipt_anchor.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Self-hosted RFC 3161 timestamp anchors for Vaara receipts (SPEC.md Section 4).
 
 A receipt's signature proves who decided and what it bound to, not *when*. A

--- a/src/vaara/audit/receipt_page.py
+++ b/src/vaara/audit/receipt_page.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Render a Vaara receipt as a self-contained static HTML evidence page.
 
 One receipt in, one HTML document out: the decision, the signed-payload

--- a/src/vaara/audit/receipts.py
+++ b/src/vaara/audit/receipts.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Article 12 commit-prove receipt pair.
 
 A receipt binds a gate-time commitment to its post-execution outcome

--- a/src/vaara/audit/review_queue.py
+++ b/src/vaara/audit/review_queue.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Human-in-the-loop review queue.
 
 EU AI Act Article 14 requires high-risk AI systems to be designed for

--- a/src/vaara/audit/rotate.py
+++ b/src/vaara/audit/rotate.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Retention rotation: export a signed archive, verify it, then purge.
 
 ``purge_older_than`` leaves a documented hash-chain seam at the retention

--- a/src/vaara/audit/shadow_report.py
+++ b/src/vaara/audit/shadow_report.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """The shadow report: what would have been blocked, from the trail alone.
 
 Shadow mode (``InterceptionPipeline(enforce=False)``, or ``--shadow`` on the

--- a/src/vaara/audit/signer.py
+++ b/src/vaara/audit/signer.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Pluggable signers for the audit-trail export envelope.
 
 Vaara's default signer is Ed25519 via ``cryptography``. v0.14.0 adds an

--- a/src/vaara/audit/sqlite_backend.py
+++ b/src/vaara/audit/sqlite_backend.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """SQLite persistence backend for the audit trail.
 
 The in-memory trail is fast but volatile.  This backend writes every record

--- a/src/vaara/audit/timeanchor.py
+++ b/src/vaara/audit/timeanchor.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """External time anchoring for the audit hash chain (v0.48).
 
 The hash chain proves order and integrity, but not *when* it existed: every

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Immutable audit trail with regulatory article mapping.
 
 Every action that passes through the Vaara execution layer gets an audit

--- a/src/vaara/audit/verify.py
+++ b/src/vaara/audit/verify.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Verifier for signed audit-trail exports produced by :mod:`vaara.audit.export`.
 
 This module is intentionally self-contained — it imports only the standard

--- a/src/vaara/audit_cli.py
+++ b/src/vaara/audit_cli.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """``vaara-audit`` command-line interface.
 
 Subcommands:

--- a/src/vaara/auth.py
+++ b/src/vaara/auth.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """API key authentication and role-based access control for Vaara.
 
 Enterprise deployments expose the MCP server and pipeline to untrusted

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Vaara command-line interface.
 
 Subcommands:

--- a/src/vaara/compliance/__init__.py
+++ b/src/vaara/compliance/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Compliance engine — maps audit evidence to regulatory articles, generates reports."""

--- a/src/vaara/compliance/dashboard.py
+++ b/src/vaara/compliance/dashboard.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Static HTML article-coverage dashboard renderer.
 
 Produces a single self-contained HTML page from a ``ConformityReport``.

--- a/src/vaara/compliance/engine.py
+++ b/src/vaara/compliance/engine.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Compliance engine — collects article-by-article evidence from the audit trail.
 
 This module takes the audit trail as input and produces:

--- a/src/vaara/compliance/render.py
+++ b/src/vaara/compliance/render.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Auditor-facing renderers for ConformityReport.
 
 Each rendering produces a deployer-shippable artefact:

--- a/src/vaara/credential/__init__.py
+++ b/src/vaara/credential/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Receipt-bound, scoped, short-lived credential broker (OAuth-for-agents).
 
 Vaara's authority layer: the proxy mints a signed, short-lived credential

--- a/src/vaara/credential/_authorization_receipt.py
+++ b/src/vaara/credential/_authorization_receipt.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Mint a signed, recomputable authorization receipt from a gateway verdict.
 
 Internal module. Public surface is in ``vaara.credential``.

--- a/src/vaara/credential/_contiguity.py
+++ b/src/vaara/credential/_contiguity.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Gap-evident completeness over a stream of authorization receipts.
 
 The per-boundary sequence assigned at issuance is contiguous by construction

--- a/src/vaara/credential/_grant_attenuation.py
+++ b/src/vaara/credential/_grant_attenuation.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Delegated-privilege attenuation over capability grants.
 
 Internal module. Public surface is re-exported from ``vaara.credential``.

--- a/src/vaara/credential/_grant_capability.py
+++ b/src/vaara/credential/_grant_capability.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Typed capability constraints for capability-mode grants (Phase C).
 
 Internal module. Public surface is in ``vaara.credential``.

--- a/src/vaara/credential/_grant_emit.py
+++ b/src/vaara/credential/_grant_emit.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Emit and verify-signature for brokered-credential (grant) envelopes.
 
 Internal module. Public surface is in ``vaara.credential``.

--- a/src/vaara/credential/_grant_parse.py
+++ b/src/vaara/credential/_grant_parse.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Closed-schema parsers for brokered-credential wire objects.
 
 Internal module. Public surface is in ``vaara.credential``.

--- a/src/vaara/credential/_grant_types.py
+++ b/src/vaara/credential/_grant_types.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Dataclasses and serialization for brokered-credential (grant) envelopes.
 
 Internal module. Public surface is in ``vaara.credential``.

--- a/src/vaara/credential/_grant_verify.py
+++ b/src/vaara/credential/_grant_verify.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Verify a brokered credential against the runtime call it claims to authorize.
 
 Internal module. Public surface is in ``vaara.credential``.

--- a/src/vaara/credential/gateway.py
+++ b/src/vaara/credential/gateway.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Reference gateway shim: refuse a tool call lacking a valid grant.
 
 Public surface for ``vaara.credential``.

--- a/src/vaara/detect/__init__.py
+++ b/src/vaara/detect/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Named detector aliases over Vaara's existing scoring surface.
 
 Three buyer-visible categories that the EU AI Act and the agentic-AI

--- a/src/vaara/detect/injection.py
+++ b/src/vaara/detect/injection.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Prompt-injection detection over Vaara's adversarial classifier.
 
 Wraps the model that produced vaara-bench-v1's headline numbers

--- a/src/vaara/detect/pii.py
+++ b/src/vaara/detect/pii.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Regex-based PII extractor.
 
 Six categories cover the buyer-visible "PII detection" feature without

--- a/src/vaara/embeddings.py
+++ b/src/vaara/embeddings.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Sentence-transformer embeddings for the adversarial classifier (v0.32+).
 
 Loads ``sentence-transformers/all-MiniLM-L6-v2`` lazily on first call and

--- a/src/vaara/govern.py
+++ b/src/vaara/govern.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """The one-liner.
 
 A whole governance engine behind a single embeddable call: one decorator turns

--- a/src/vaara/integrations/__init__.py
+++ b/src/vaara/integrations/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Framework integrations: drop-in middleware for LangChain, CrewAI, OpenAI Agents SDK, and MCP."""

--- a/src/vaara/integrations/_content_safety_articles.py
+++ b/src/vaara/integrations/_content_safety_articles.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Canonical mapping from guardrail findings to EU AI Act articles.
 
 This module is the value, not the SDK glue around it. Each provider

--- a/src/vaara/integrations/_content_safety_base.py
+++ b/src/vaara/integrations/_content_safety_base.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Shared shape for cloud-guardrail content-safety adapters.
 
 Three adapters live alongside this module — Bedrock, Azure, GCP — and

--- a/src/vaara/integrations/_egress_guard.py
+++ b/src/vaara/integrations/_egress_guard.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """SSRF egress guard for the remote MCP HTTP connector.
 
 The ``--upstream-url`` connector hands a user-supplied URL to ``urllib`` and

--- a/src/vaara/integrations/_mcp_attest.py
+++ b/src/vaara/integrations/_mcp_attest.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """SEP-2787 attestation + execution-receipt pairing for the Vaara MCP proxy.
 
 Internal helper. Off unless the operator wires the proxy with a signing key

--- a/src/vaara/integrations/_mcp_notify.py
+++ b/src/vaara/integrations/_mcp_notify.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Transport-aware notification routing for the Vaara MCP proxy.
 
 Upstream MCP servers can push notifications back to the client mid-call

--- a/src/vaara/integrations/_mcp_overt.py
+++ b/src/vaara/integrations/_mcp_overt.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """OVERT 1.0 Base Envelope emission for the Vaara MCP proxy.
 
 Internal helper that turns each governed MCP interaction (``tools/call``,

--- a/src/vaara/integrations/_mcp_upstream.py
+++ b/src/vaara/integrations/_mcp_upstream.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Upstream MCP subprocess client for the proxy.
 
 Owns the subprocess lifecycle of an upstream MCP server, demuxes responses

--- a/src/vaara/integrations/_mcp_upstream_http.py
+++ b/src/vaara/integrations/_mcp_upstream_http.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Remote HTTP/SSE upstream MCP client for the proxy.
 
 Speaks the MCP Streamable HTTP transport (spec revisions 2025-03-26 and

--- a/src/vaara/integrations/azure_content_safety.py
+++ b/src/vaara/integrations/azure_content_safety.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Azure AI Content Safety adapter — upstream content-safety signal.
 
 Wraps Azure's ContentSafetyClient. The Azure surface is broader than

--- a/src/vaara/integrations/bedrock_guardrails.py
+++ b/src/vaara/integrations/bedrock_guardrails.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """AWS Bedrock Guardrails adapter — upstream content-safety signal.
 
 Wraps the Bedrock Runtime ``ApplyGuardrail`` API. Caller supplies a

--- a/src/vaara/integrations/claude_code_hooks.py
+++ b/src/vaara/integrations/claude_code_hooks.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Claude Code hook runner: the plugin's governance logic, in the package.
 
 ``vaara hook pre-tool-use|post-tool-use|session-start`` reads the hook

--- a/src/vaara/integrations/crewai.py
+++ b/src/vaara/integrations/crewai.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """CrewAI integration — Vaara as task-level and tool-level governance.
 
 CrewAI orchestrates multi-agent crews where agents have roles, goals, and

--- a/src/vaara/integrations/gcp_model_armor.py
+++ b/src/vaara/integrations/gcp_model_armor.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """GCP Model Armor adapter — upstream content-safety signal.
 
 Wraps google-cloud-modelarmor's ``sanitize_user_prompt`` /

--- a/src/vaara/integrations/guardrails_ai.py
+++ b/src/vaara/integrations/guardrails_ai.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Guardrails AI adapter. Upstream output-validation signal.
 
 Wraps a pre-configured ``guardrails.Guard``. Each validator on the

--- a/src/vaara/integrations/init_governance.py
+++ b/src/vaara/integrations/init_governance.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """One-command local governance setup: ``vaara init`` / ``vaara ungovern``.
 
 Turns "install + N manual steps" into a single self-healing command. Between

--- a/src/vaara/integrations/langchain.py
+++ b/src/vaara/integrations/langchain.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """LangChain integration — Vaara as a tool-calling callback handler.
 
 LangChain's callback system fires events for every tool invocation.

--- a/src/vaara/integrations/llm_guard.py
+++ b/src/vaara/integrations/llm_guard.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """LLM Guard adapter. Upstream scanner-library signal.
 
 Wraps the ``llm_guard`` scanner pipeline. The deployer assembles a

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """MCP proxy: Vaara as a transparent runtime governance layer for MCP.
 
 Sits between an MCP client (Claude Code, Cursor, any MCP-capable host) and an

--- a/src/vaara/integrations/mcp_server.py
+++ b/src/vaara/integrations/mcp_server.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Model Context Protocol (MCP) server for agent governance.
 
 Exposes Vaara's interception pipeline as an MCP server so that AI agents

--- a/src/vaara/integrations/nemo_guardrails.py
+++ b/src/vaara/integrations/nemo_guardrails.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """NVIDIA NeMo Guardrails adapter. Upstream rails signal.
 
 Wraps a pre-configured ``LLMRails`` instance. NeMo Guardrails runs

--- a/src/vaara/integrations/openai_agents.py
+++ b/src/vaara/integrations/openai_agents.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """OpenAI Agents SDK integration — Vaara as a guardrail.
 
 OpenAI's Agents SDK (March 2025) uses a guardrails pattern where

--- a/src/vaara/integrations/rebuff.py
+++ b/src/vaara/integrations/rebuff.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Rebuff adapter. Upstream prompt-injection signal.
 
 Rebuff layers four checks: heuristic, LLM-based, vector-DB

--- a/src/vaara/pipeline.py
+++ b/src/vaara/pipeline.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Interception pipeline — the main entry point for the Vaara execution layer.
 
 Wires the components together:

--- a/src/vaara/policy/__init__.py
+++ b/src/vaara/policy/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Vaara policy schema — JSON-native, YAML via the optional `vaara[yaml]` extra.
 
 The policy expresses, in declarative form, the deployer's choices for:

--- a/src/vaara/policy/controller.py
+++ b/src/vaara/policy/controller.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Hot policy reload.
 
 The controller owns the live ``Policy`` and the listeners that need to

--- a/src/vaara/policy/loader.py
+++ b/src/vaara/policy/loader.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Policy loaders. JSON is core (stdlib). YAML requires the `vaara[yaml]` extra."""
 
 from __future__ import annotations

--- a/src/vaara/policy/modes.py
+++ b/src/vaara/policy/modes.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Vaara policy modes — preset threshold bundles.
 
 Each mode is a preset operating point for the risk thresholds Vaara uses to

--- a/src/vaara/policy/registry.py
+++ b/src/vaara/policy/registry.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Per-tenant policy registry.
 
 A ``PolicyRegistry`` owns one ``PolicyController`` per tenant_id, with the

--- a/src/vaara/policy/schema.py
+++ b/src/vaara/policy/schema.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Vaara policy dataclasses.
 
 All types are frozen so a loaded Policy is a value object — passing it

--- a/src/vaara/policy/test_cases.py
+++ b/src/vaara/policy/test_cases.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Policy test framework — Conftest analog for Vaara YAML/JSON policies.
 
 A test case is a synthetic action context plus an expected verdict.

--- a/src/vaara/policy/test_cases_io.py
+++ b/src/vaara/policy/test_cases_io.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """YAML / JSON loaders for policy test-case files.
 
 Cases document shape::

--- a/src/vaara/policy/validate.py
+++ b/src/vaara/policy/validate.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Structured policy validation.
 
 `from_dict` / `from_json` / `from_yaml` raise PolicyError on the first

--- a/src/vaara/sandbox/__init__.py
+++ b/src/vaara/sandbox/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 # Sandbox module — synthetic trace generation for cold-start training.

--- a/src/vaara/sandbox/trace_gen.py
+++ b/src/vaara/sandbox/trace_gen.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Synthetic trace generation for cold-start training data.
 
 The MWU scorer (§4) starts cold — uniform expert weights, no calibration

--- a/src/vaara/scorer/__init__.py
+++ b/src/vaara/scorer/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Adaptive risk scorer — ML-based action risk scoring with conformal guarantees."""
 
 from vaara.scorer.adaptive import (

--- a/src/vaara/scorer/_param_signals.py
+++ b/src/vaara/scorer/_param_signals.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Deterministic parameter-content risk signals for the base rule scorer.
 
 Stdlib only, so it runs in a zero-config install with no ML extra and with no

--- a/src/vaara/scorer/action_gate.py
+++ b/src/vaara/scorer/action_gate.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """
 Runtime action gate — inference wrapper around the per-step scorer.
 

--- a/src/vaara/scorer/adaptive.py
+++ b/src/vaara/scorer/adaptive.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Adaptive risk scorer with conformal prediction and MWU learning.
 
 Complements declarative policy engines (rule-based / YAML / Rego) by

--- a/src/vaara/scorer/composite.py
+++ b/src/vaara/scorer/composite.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """CompositeScorer — run Vaara alongside external scorers, combine results.
 
 The composite implements the same ``evaluate(context) -> dict`` shape

--- a/src/vaara/scorer/composition.py
+++ b/src/vaara/scorer/composition.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """ExternalScorer — call a remote /v1/score endpoint as a scorer backend.
 
 The v0.10.0 HTTP API defines a stable wire contract for scorers; this

--- a/src/vaara/scorer/mc_dropout_gate.py
+++ b/src/vaara/scorer/mc_dropout_gate.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """MC dropout NN per-action-step gate.
 
 Alternative to TrainedGateScorer (GBM bootstrap). The MC dropout network

--- a/src/vaara/scorer/stacked_gate.py
+++ b/src/vaara/scorer/stacked_gate.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Stacked GBM + MC dropout gate — composes both backends via a trained LR.
 
 The stacked ensemble evaluates both `TrainedGateScorer` (GBM bootstrap) and

--- a/src/vaara/scorer/trained_gate.py
+++ b/src/vaara/scorer/trained_gate.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Trained per-action-step gate backend.
 
 Wraps a frozen action-gate bundle (bootstrap ensemble + conformal q_hat)

--- a/src/vaara/server/__init__.py
+++ b/src/vaara/server/__init__.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Vaara HTTP API reference server.
 
 Exposes the Vaara scorer and audit trail as a network service following the

--- a/src/vaara/server/app.py
+++ b/src/vaara/server/app.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """FastAPI application factory for the Vaara HTTP API reference server.
 
 The server holds a single in-process `AdaptiveScorer` and `AuditTrail` for

--- a/src/vaara/server/routes.py
+++ b/src/vaara/server/routes.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Route handlers for the Vaara HTTP API reference server."""
 
 from __future__ import annotations

--- a/src/vaara/server/schemas.py
+++ b/src/vaara/server/schemas.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Pydantic models matching docs/openapi.yaml v1 contract.
 
 These models are the wire format. The internal `AdaptiveScorer.evaluate(ctx)`

--- a/src/vaara/server/state.py
+++ b/src/vaara/server/state.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Server state container — scorer + audit trail + policy registry singletons."""
 
 from __future__ import annotations

--- a/src/vaara/taxonomy/__init__.py
+++ b/src/vaara/taxonomy/__init__.py
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Action taxonomy — classifies agent actions by type, reversibility, and blast radius."""

--- a/src/vaara/taxonomy/actions.py
+++ b/src/vaara/taxonomy/actions.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
 """Action taxonomy for AI agent execution layer.
 
 Classifies every action an AI agent can take by:


### PR DESCRIPTION
Adds SPDX headers to 226 source files so the tree is REUSE-compliant and every file declares its license inline.

Each file gets two lines at the top:

    # SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
    # SPDX-License-Identifier: AGPL-3.0-or-later

No functional changes. Headers only.