### PR TITLE
Release v1.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.39.0] - 2026-07-21
+
+- `POST /v1/anchor` on the reference server turns a receipt into an `rfc3161-eidas-qualified` anchor behind an inbound x402 payment gate. The gate is configured entirely from the environment and off by default: with `VAARA_X402_ENABLED` unset every request is admitted, so tests and self-hosters get the full pipeline for free. When enabled it answers `HTTP 402` with x402 payment requirements and admits a request only once a valid `X-PAYMENT` header settles through the configured facilitator (`VAARA_X402_FACILITATOR`); with no facilitator a presented payment cannot be settled and is refused rather than trusted, so an enabled gate never admits an unverified payment. Receiving wallet, network, asset, and price are set by the `VAARA_X402_*` variables.
+- The anchor endpoint ships no default timestamp provider. The operator names their own QTSP through `VAARA_ANCHOR_TSA_URL`; with none set, anchoring raises and the endpoint returns `503 anchor_not_configured` rather than routing traffic to a provider the operator did not choose. The anchorer does no network I/O at construction and the receipt-anchor stack is imported lazily, so core `ServerState` imports and runs without the anchor extra installed.
+
 ## [1.38.0] - 2026-07-20
 
 - `vaara ingest` and `vaara normalize` recognize two agent-payment settlement formats and file them onto the SEP-2828 evidence model as declarative source profiles, with no new code on the ingest path. `x402-settlement` maps an x402 settlement response, lifting the payer, the atomic amount, and the on-chain transaction hash and CAIP-2 network that anchor it into advisory context on the outcome plane. The settlement response is an unsigned server assertion, so `signature`, `backLink`, and `outcomeDerived` are reported missing rather than asserted: the transaction and network let a relying party confirm the payment on-chain, but the object carries no signature over its own bytes.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.38.0"
+version = "1.39.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.38.0",
+  "version": "1.39.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.38.0",
+  "version": "1.39.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-      "version": "1.38.0",
+      "version": "1.39.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.38.0"
+__version__ = "1.39.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## Release v1.39.0

Version bump across all planes (PyPI, npm client, MCP registry manifests, Claude Code plugin) plus the changelog entry.

### What ships

- `POST /v1/anchor` on the reference server: turns a receipt into an `rfc3161-eidas-qualified` anchor behind an inbound x402 payment gate. Off by default (`VAARA_X402_ENABLED` unset admits every request); when enabled it answers `HTTP 402` with x402 requirements and admits only a payment settled through the configured facilitator, refusing an unverifiable one rather than trusting it.
- No default timestamp provider is baked in. The operator names their own QTSP via `VAARA_ANCHOR_TSA_URL`; with none set the endpoint returns `503 anchor_not_configured` rather than routing traffic to a provider nobody chose. The anchorer does no network I/O at construction, so core `ServerState` runs without the anchor extra.

Full detail in CHANGELOG.md. Tag is applied after squash-merge at the merged SHA, which fires the publish workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release 1.39.0 adds optional payment-gated anchoring for `POST /v1/anchor`.
  * Anchoring now requires a configured timestamp service; otherwise requests return `503 anchor_not_configured`.
  * Payment verification fails closed when enabled but cannot be completed.

* **Documentation**
  * Updated release notes with the new anchoring and timestamp-service configuration requirements.

* **Chores**
  * Updated package, plugin, and server metadata to version 1.39.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->