### PR TITLE
site: lead the hero with the promise and the pain

### DIFF
--- a/webpage/index.html
+++ b/webpage/index.html
@@ -183,7 +183,8 @@
   <img src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-dark.png" alt="Vaara">
 </div>
 <p style="text-align:center;text-transform:uppercase;letter-spacing:.14em;font-weight:600;opacity:.65;margin:.1rem 0 .6rem;font-size:.95rem;">Accountable Autonomy</p>
-<h1>Vaara is the tamper-evident runtime evidence layer for AI systems. It turns every action an agent takes into a record an outside party can verify without trusting you, then binds that record to the machine's own TPM 2.0 + IMA attestation. EU AI Act compliance, and any other case where you have to prove what an agent actually did.</h1>
+<h1>A verifiable receipt for every action your AI agents take, checkable by anyone.</h1>
+<p style="text-align:center;max-width:60ch;margin:0 auto 1rem;opacity:.82;line-height:1.5;">Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.</p>
 <p class="stance">Open source. No SaaS. No telemetry. No signup.</p>
 <div class="evidence">
   <div class="evidence-head">


### PR DESCRIPTION
The hero h1 opened with "the tamper-evident runtime evidence layer for AI systems... binds that record to the machine's own TPM 2.0 + IMA attestation." That is jargon before the reader knows why they should care, and it buries the demo.

Lead instead with the same opening the README uses: the one-line promise, then the concrete problem in plain language, then straight into the existing verify-record proof. Order is now tagline (kicker) then promise then problem then proof.

The keyword-dense meta description, Open Graph, and JSON-LD blocks are left unchanged: those keywords carry the search value and are read by machines, not by the visitor landing on the page.