### PR TITLE
anchor: any EU-qualified provider, operator-configured

### DIFF
--- a/scripts/qualified_anchor_dss_demo.py
+++ b/scripts/qualified_anchor_dss_demo.py
@@ -4,20 +4,24 @@
 """Anchor a receipt to a qualified TSA and validate the token in EU DSS.
 
 Reproduces the 1.30.0 claim end to end, against live services: obtains an
-RFC 3161 token from an eIDAS-qualified TSA (default: Sectigo's qualified
-endpoint, listed as TSA/QTST with status granted on the Spanish trusted
-list), pins the signer's issuing CA out of the first reply, records the
+RFC 3161 token from an eIDAS-qualified TSA of YOUR choosing, pins the
+signer's issuing CA out of the first reply, records the
 ``rfc3161-eidas-qualified`` anchor, then submits the token plus the
 receipt's JCS signed payload to the European Commission's DSS demo
 validator and prints its verdict. Expected output ends with::
 
     DSS verdict: PASSED QTSA (Qualified timestamp)
 
-Needs the network (the TSA and the DSS demo webapp) and the 'timeanchor'
-extra. The TSA is a free public endpoint with no SLA; a refusal or
-timeout is a service condition, not a Vaara failure.
+No TSA is baked in; Vaara does not choose a trust service provider for
+you. Set ``VAARA_DEMO_TSA_URL`` to the RFC 3161 endpoint of a qualified
+timestamping authority you have selected from the EU trusted lists
+(https://eidas.ec.europa.eu/efda/tl-browser/), under that provider's own
+terms of use. Needs the network (the TSA and the DSS demo webapp) and
+the 'timeanchor' extra. A refusal or timeout is a service condition,
+not a Vaara failure.
 
-    python scripts/qualified_anchor_dss_demo.py [path/to/receipt.json]
+    VAARA_DEMO_TSA_URL=https://... \\
+        python scripts/qualified_anchor_dss_demo.py [path/to/receipt.json]
 """
 from __future__ import annotations
 
@@ -43,7 +47,9 @@ from vaara.audit.timeanchor import (
 
 DEFAULT = (Path(__file__).resolve().parents[1]
            / "tests/vectors/x402_settlement_v0/generic/step1/receipt.json")
-TSA_URL = "http://timestamp.sectigo.com/qualified"
+import os
+
+TSA_URL = os.environ.get("VAARA_DEMO_TSA_URL", "")
 DSS_URL = ("https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo"
            "/services/rest/validation/validateSignature")
 
@@ -95,6 +101,13 @@ def dss_validate(token_der: bytes, payload: bytes) -> tuple[str, str, str]:
 
 
 def main() -> int:
+    if not TSA_URL:
+        raise SystemExit(
+            "Set VAARA_DEMO_TSA_URL to the RFC 3161 endpoint of a "
+            "qualified TSA you have chosen from the EU trusted lists "
+            "(https://eidas.ec.europa.eu/efda/tl-browser/). Vaara ships "
+            "no default provider."
+        )
     receipt_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT
     receipt = json.loads(receipt_path.read_text())
 

--- a/scripts/qualified_anchor_dss_demo.py
+++ b/scripts/qualified_anchor_dss_demo.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import sys
 import urllib.request
 from pathlib import Path
@@ -47,8 +48,6 @@ from vaara.audit.timeanchor import (
 
 DEFAULT = (Path(__file__).resolve().parents[1]
            / "tests/vectors/x402_settlement_v0/generic/step1/receipt.json")
-import os
-
 TSA_URL = os.environ.get("VAARA_DEMO_TSA_URL", "")
 DSS_URL = ("https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo"
            "/services/rest/validation/validateSignature")

--- a/tests/test_anchor_endpoint.py
+++ b/tests/test_anchor_endpoint.py
@@ -30,8 +30,8 @@ _ANCHOR = {
     "method": "rfc3161-eidas-qualified",
     "anchoredDigest": "sha256:" + "ab" * 32,
     "token": "Zm9v",
-    "authority": "Sectigo Qualified Time Stamping CA",
-    "tsaUrl": "http://timestamp.sectigo.com/qualified",
+    "authority": "Example Qualified Time Stamping CA",
+    "tsaUrl": "https://qtsa.example.eu/qualified",
 }
 
 
@@ -73,7 +73,7 @@ def test_free_mode_anchors_the_receipt():
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["anchor"]["method"] == "rfc3161-eidas-qualified"
-    assert body["anchor"]["authority"].startswith("Sectigo")
+    assert body["anchor"]["authority"].startswith("Example")
     assert body["attested"] == "2026-07-21T12:00:00+00:00"
     assert "DSS" in body["dss_hint"] or "dss" in body["dss_hint"]
 

--- a/tests/test_timeanchor.py
+++ b/tests/test_timeanchor.py
@@ -263,7 +263,6 @@ def test_verify_anchor_over_records_rejects_rewritten_chain():
 # do not control.
 _LIVE_TSAS = [
     "http://timestamp.digicert.com",
-    "http://timestamp.sectigo.com",
     "https://freetsa.org/tsr",
 ]
 


### PR DESCRIPTION
Vaara's qualified timestamp anchoring works with any EU-qualified timestamping provider chosen from the EU trusted lists. The provider endpoint is operator configuration everywhere: VAARA_ANCHOR_TSA_URL on the server (since 1.39.0) and VAARA_DEMO_TSA_URL for the end-to-end DSS validation script.

Test fixtures use example values.

Tests: 20 pass, 1 skipped (the opt-in live round trip).