### PR TITLE
readme: clickable video poster (raw <video> renders blank on github)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,15 @@
 Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
 
 <p align="center">
-  <video src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-v150-launch.mp4" width="720" controls muted playsinline></video>
+  <a href="https://github.com/vaaraio/vaara/releases/tag/v1.50.0">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-dark.png">
+      <img src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-light.png" width="640" alt="Watch the Vaara for macOS launch video">
+    </picture>
+  </a>
 </p>
 
-<p align="center"><a href="https://github.com/vaaraio/vaara/releases/tag/v1.50.0">Watch the launch video</a> &middot; Vaara for macOS is in public beta</p>
+<p align="center"><a href="https://github.com/vaaraio/vaara/releases/tag/v1.50.0">&#9654;&nbsp; Watch the launch video (24s)</a> &middot; Vaara for macOS is in public beta</p>
 
 ## Quick start
 


### PR DESCRIPTION
The committed <video src=raw.githubusercontent...> does not render an inline player on github.com. Swap it for a clickable wordmark poster (light/dark aware) linking to the release, so the hero is never a blank box. True inline player can be added later by dragging the mp4 into the README on the web.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the launch section with a link to the v1.50.0 GitHub Release.
  * Added a launch image and clarified that Vaara for macOS is in public beta.
  * Updated the launch video call-to-action text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->