### PR TITLE
readme: autoplaying gif hero from the launch video

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,7 @@
 Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
 
 <p align="center">
-  <a href="https://github.com/vaaraio/vaara/releases/tag/v1.50.0">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-dark.png">
-      <img src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-light.png" width="640" alt="Watch the Vaara for macOS launch video">
-    </picture>
-  </a>
+  <a href="https://github.com/vaaraio/vaara/releases/tag/v1.50.0"><img src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-v150-launch.gif" width="720" alt="Vaara for macOS launch demo"></a>
 </p>
 
 <p align="center"><a href="https://github.com/vaaraio/vaara/releases/tag/v1.50.0">&#9654;&nbsp; Watch the launch video (24s)</a> &middot; Vaara for macOS is in public beta</p>


### PR DESCRIPTION
Swaps the static wordmark poster for a real inline GIF built from the launch mp4.

GitHub sanitizes <video> tags that point at raw.githubusercontent and does not render release-hosted or committed mp4 files as a player, but it does render committed GIFs inline and autoplays them. So this shows actual motion from the demo in the README itself, with the click-through still going to the release for the full video with sound.

- docs/vaara-v150-launch.gif: 720w, 12fps, 4.1MB (under the 10MB inline cap)
- generated from the 24s launch master with a two-pass palette for quality