### PR TITLE
cli: bare vaara drops an interactive user into the menu (TTY-guarded)

### DIFF
--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -4370,10 +4370,29 @@ def _cmd_menu(args: argparse.Namespace) -> int:
         return 0
 
 
+def _is_interactive() -> bool:
+    """True when a human is at the terminal (stdin and stdout are both TTYs)."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _default_entry(parser: argparse.ArgumentParser):
+    """Bare ``vaara`` with no subcommand: an interactive user is dropped into
+    the menu, while a non-interactive caller (pipe, script, CI) gets the usage
+    listing as before, so no automated caller changes behaviour."""
+    help_fn = _help_dispatch(parser)
+
+    def _run(args: argparse.Namespace) -> int:
+        if _is_interactive():
+            return _cmd_menu(args)
+        return help_fn(args)
+
+    return _run
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = _SuggestingParser(prog="vaara", description="Vaara AI Agent Execution Layer")
     sub = p.add_subparsers(dest="cmd", metavar="COMMAND")
-    p.set_defaults(func=_help_dispatch(p))
+    p.set_defaults(func=_default_entry(p))
 
     sub.add_parser("version", help="Print Vaara version").set_defaults(func=_cmd_version)
 

--- a/tests/test_cli_default_menu.py
+++ b/tests/test_cli_default_menu.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Bare ``vaara`` with no subcommand drops an interactive user into the menu,
+while non-interactive callers (scripts, pipes, CI) keep the usage listing so
+no automated caller changes behaviour.
+"""
+import vaara.cli as cli
+import vaara.menu as menu
+
+
+def test_bare_vaara_interactive_launches_menu(monkeypatch):
+    monkeypatch.setattr(cli, "_is_interactive", lambda: True, raising=False)
+    calls = {"menu": 0}
+
+    def fake_menu(*a, **k):
+        calls["menu"] += 1
+        return 7
+
+    monkeypatch.setattr(menu, "run_menu", fake_menu)
+
+    rc = cli.main([])
+
+    assert calls["menu"] == 1
+    assert rc == 7
+
+
+def test_bare_vaara_noninteractive_prints_usage(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_is_interactive", lambda: False, raising=False)
+    calls = {"menu": 0}
+
+    def fake_menu(*a, **k):
+        calls["menu"] += 1
+        return 0
+
+    monkeypatch.setattr(menu, "run_menu", fake_menu)
+
+    rc = cli.main([])
+
+    captured = capsys.readouterr()
+    text = captured.out + captured.err
+    assert calls["menu"] == 0
+    assert rc == 0
+    assert "COMMAND" in text or "usage" in text.lower()


### PR DESCRIPTION
Bare `vaara` with no subcommand now opens the tiered menu (basic / professional / enterprise) for an interactive user, instead of printing the full command wall. Non-interactive callers (pipes, scripts, CI) keep the usage listing unchanged, so nothing automated changes.

Adds `_is_interactive()` (stdin and stdout both TTYs) and routes the top-level parser default through it. Tested both paths.