### PR TITLE
feat: EU qualified-TSA provider picker (vaara anchor-providers)

### DIFF
--- a/src/vaara/audit/eu_trusted_list.py
+++ b/src/vaara/audit/eu_trusted_list.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Parse the EU List of Trusted Lists (LOTL) and national trusted lists.
+
+The LOTL (ETSI TS 119 612, EU Commission Implementing Decision 2015/1505) is a
+top-level XML that points to each member state's national trusted list. Each
+national list enumerates trust service providers and their services, of which
+the qualified timestamping services (``ServiceTypeIdentifier`` ending in
+``TSA/QTST``) are the ones a Vaara operator can pick as a qualified RFC 3161
+anchor provider.
+
+This module only parses bytes into plain records. Fetching them over the
+network, caching, and presenting a picker live in their own layers, so this
+part stays pure and testable from committed fixtures. It endorses no provider:
+it surfaces the official public list for the operator to choose from.
+"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from collections.abc import Callable
+from dataclasses import dataclass
+
+# The official EU List of Trusted Lists, published by the European Commission.
+LOTL_URL = "https://ec.europa.eu/tools/lotl/eu-lotl.xml"
+
+# ETSI service type and status URIs (TS 119 612).
+_QTST = "http://uri.etsi.org/TrstSvc/Svctype/TSA/QTST"
+_GRANTED = "http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted"
+_XML_TL_MIME = "application/vnd.etsi.tsl+xml"
+_XML_LANG = "{http://www.w3.org/XML/1998/namespace}lang"
+
+
+@dataclass(frozen=True)
+class TSLPointer:
+    """A pointer from the LOTL to one member state's national trusted list."""
+
+    territory: str
+    location: str
+
+
+@dataclass(frozen=True)
+class QualifiedTSA:
+    """A qualified timestamping service an operator can anchor against."""
+
+    territory: str
+    provider: str
+    service_name: str
+    endpoint: str
+
+
+def _ln(elem: ET.Element) -> str:
+    """Local name of a tag, dropping any ``{namespace}`` prefix."""
+    return elem.tag.rsplit("}", 1)[-1]
+
+
+def _iter(root: ET.Element, name: str) -> list[ET.Element]:
+    return [e for e in root.iter() if _ln(e) == name]
+
+
+def _first(root: ET.Element, name: str) -> ET.Element | None:
+    for e in root.iter():
+        if _ln(e) == name:
+            return e
+    return None
+
+
+def _text(elem: ET.Element | None) -> str:
+    return (elem.text or "").strip() if elem is not None else ""
+
+
+def _name_text(container: ET.Element | None) -> str:
+    """First ``Name`` under a container, preferring the English variant."""
+    if container is None:
+        return ""
+    names = _iter(container, "Name")
+    for n in names:
+        if n.get(_XML_LANG) == "en":
+            return _text(n)
+    return _text(names[0]) if names else ""
+
+
+def parse_lotl(data: bytes) -> list[TSLPointer]:
+    """Return the pointers to member-state XML trusted lists in a LOTL.
+
+    Pointers to human-readable renderings (PDF) or other MIME types are
+    skipped, so only machine-readable national lists remain.
+    """
+    root = ET.fromstring(data)
+    pointers: list[TSLPointer] = []
+    for ptr in _iter(root, "OtherTSLPointer"):
+        location = _text(_first(ptr, "TSLLocation"))
+        territory = _text(_first(ptr, "SchemeTerritory"))
+        mime = ""
+        for m in _iter(ptr, "MimeType"):
+            mime = _text(m)
+            if mime:
+                break
+        if not location or mime != _XML_TL_MIME:
+            continue
+        pointers.append(TSLPointer(territory=territory, location=location))
+    return pointers
+
+
+def parse_trusted_list(data: bytes, territory: str = "") -> list[QualifiedTSA]:
+    """Return the granted qualified timestamping services in a national list."""
+    root = ET.fromstring(data)
+    out: list[QualifiedTSA] = []
+    for tsp in _iter(root, "TrustServiceProvider"):
+        provider = _name_text(_first(tsp, "TSPName"))
+        for svc in _iter(tsp, "TSPService"):
+            if _text(_first(svc, "ServiceTypeIdentifier")) != _QTST:
+                continue
+            status = _text(_first(svc, "ServiceStatus"))
+            if status and status != _GRANTED:
+                continue
+            supply = _first(svc, "ServiceSupplyPoint")
+            out.append(
+                QualifiedTSA(
+                    territory=territory,
+                    provider=provider,
+                    service_name=_name_text(_first(svc, "ServiceName")),
+                    endpoint=_text(supply),
+                )
+            )
+    return out
+
+
+def providers_for_country(
+    country: str, fetch: Callable[[str], bytes]
+) -> list[QualifiedTSA]:
+    """Fetch the LOTL, find the national list for ``country``, and return its
+    granted qualified timestamping services.
+
+    ``fetch`` maps a URL to bytes; it is injected so this stays testable and
+    the network transport (and any caching) lives in the caller.
+    """
+    for ptr in parse_lotl(fetch(LOTL_URL)):
+        if ptr.territory == country:
+            return parse_trusted_list(fetch(ptr.location), territory=country)
+    return []

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -4389,6 +4389,45 @@ def _default_entry(parser: argparse.ArgumentParser):
     return _run
 
 
+def _http_fetch(url: str) -> bytes:
+    """Fetch a trusted-list URL over HTTP(S). Refuses other schemes."""
+    import urllib.request
+
+    if not url.startswith(("https://", "http://")):
+        raise ValueError(f"refusing non-http url: {url!r}")
+    with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310
+        return resp.read()
+
+
+def _cmd_anchor_providers(args: argparse.Namespace) -> int:
+    """List a country's EU qualified timestamping providers from the official
+    trusted list, so the operator can pick one for eIDAS-qualified anchoring.
+
+    It surfaces the public list and endorses no provider and sets no default:
+    the operator chooses, then passes the endpoint as the qualified TSA.
+    """
+    import json as _json
+    from dataclasses import asdict
+
+    from vaara.audit import eu_trusted_list
+
+    try:
+        tsas = eu_trusted_list.providers_for_country(args.country, fetch=_http_fetch)
+    except Exception as exc:  # noqa: BLE001 - network or parse, reported plainly
+        print(f"could not load the EU trusted list: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(_json.dumps([asdict(t) for t in tsas], indent=2))
+        return 0
+    if not tsas:
+        print(f"no qualified timestamping providers found for {args.country!r}")
+        return 0
+    for t in tsas:
+        print(f"{t.provider}  |  {t.service_name}  |  {t.endpoint}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = _SuggestingParser(prog="vaara", description="Vaara AI Agent Execution Layer")
     sub = p.add_subparsers(dest="cmd", metavar="COMMAND")
@@ -4401,6 +4440,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Interactive menu over the common commands, gated by settings "
              "depth (basic / professional / enterprise)",
     ).set_defaults(func=_cmd_menu)
+
+    pap = sub.add_parser(
+        "anchor-providers",
+        help="List EU qualified timestamping providers (QTSA) from the official "
+             "trusted list, to pick an eIDAS-qualified anchor",
+    )
+    pap.add_argument("--country", required=True, metavar="CC",
+                     help="ISO country code, e.g. AT, FI, DE")
+    pap.add_argument("--json", action="store_true", help="Emit JSON")
+    pap.set_defaults(func=_cmd_anchor_providers)
 
     pk = sub.add_parser(
         "keygen",

--- a/tests/test_cli_anchor_providers.py
+++ b/tests/test_cli_anchor_providers.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""`vaara anchor-providers --country CC` lists the EU qualified timestamping
+providers from the official trusted list so an operator can pick one. It
+endorses none and sets no default.
+"""
+import json
+
+import vaara.audit.eu_trusted_list as etl
+from vaara.audit.eu_trusted_list import QualifiedTSA
+from vaara.cli import main
+
+_SAMPLE = [
+    QualifiedTSA(
+        territory="AT",
+        provider="ACME QTSP",
+        service_name="ACME Qualified Timestamping",
+        endpoint="https://tsa.example.at/tsa",
+    )
+]
+
+
+def test_anchor_providers_lists_qualified_tsas(monkeypatch, capsys):
+    seen = {}
+
+    def fake(country, fetch):
+        seen["country"] = country
+        return _SAMPLE
+
+    monkeypatch.setattr(etl, "providers_for_country", fake)
+
+    rc = main(["anchor-providers", "--country", "AT"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert seen["country"] == "AT"
+    assert "ACME QTSP" in out
+    assert "https://tsa.example.at/tsa" in out
+
+
+def test_anchor_providers_json_is_machine_readable(monkeypatch, capsys):
+    monkeypatch.setattr(etl, "providers_for_country", lambda country, fetch: _SAMPLE)
+
+    rc = main(["anchor-providers", "--country", "AT", "--json"])
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    data = json.loads(out)
+    assert data[0]["endpoint"] == "https://tsa.example.at/tsa"
+    assert data[0]["provider"] == "ACME QTSP"

--- a/tests/test_eu_trusted_list.py
+++ b/tests/test_eu_trusted_list.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Parse the EU LOTL and national trusted lists (ETSI TS 119 612) down to the
+qualified timestamping services a user can pick as an anchor provider.
+"""
+from vaara.audit.eu_trusted_list import (
+    LOTL_URL,
+    QualifiedTSA,
+    TSLPointer,
+    parse_lotl,
+    parse_trusted_list,
+    providers_for_country,
+)
+
+# Minimal LOTL: one pointer to an XML national list (AT), one to a PDF (human
+# readable) that must be ignored.
+LOTL_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<TrustServiceStatusList xmlns="http://uri.etsi.org/02231/v2#">
+  <SchemeInformation>
+    <PointersToOtherTSL>
+      <OtherTSLPointer>
+        <TSLLocation>https://tl.example.at/tl.xml</TSLLocation>
+        <AdditionalInformation>
+          <OtherInformation><SchemeTerritory>AT</SchemeTerritory></OtherInformation>
+          <OtherInformation><MimeType xmlns="http://uri.etsi.org/02231/v2/additionaltypes#">application/vnd.etsi.tsl+xml</MimeType></OtherInformation>
+        </AdditionalInformation>
+      </OtherTSLPointer>
+      <OtherTSLPointer>
+        <TSLLocation>https://tl.example.at/tl.pdf</TSLLocation>
+        <AdditionalInformation>
+          <OtherInformation><SchemeTerritory>AT</SchemeTerritory></OtherInformation>
+          <OtherInformation><MimeType xmlns="http://uri.etsi.org/02231/v2/additionaltypes#">application/pdf</MimeType></OtherInformation>
+        </AdditionalInformation>
+      </OtherTSLPointer>
+    </PointersToOtherTSL>
+  </SchemeInformation>
+</TrustServiceStatusList>
+"""
+
+# Minimal national list: one provider, one qualified timestamp service (granted,
+# with an endpoint) and one non-timestamp service that must be excluded.
+AT_TL_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<TrustServiceStatusList xmlns="http://uri.etsi.org/02231/v2#">
+  <TrustServiceProviderList>
+    <TrustServiceProvider>
+      <TSPInformation>
+        <TSPName><Name xml:lang="en">ACME QTSP</Name></TSPName>
+      </TSPInformation>
+      <TSPServices>
+        <TSPService><ServiceInformation>
+          <ServiceTypeIdentifier>http://uri.etsi.org/TrstSvc/Svctype/TSA/QTST</ServiceTypeIdentifier>
+          <ServiceName><Name xml:lang="en">ACME Qualified Timestamping</Name></ServiceName>
+          <ServiceStatus>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted</ServiceStatus>
+          <ServiceSupplyPoints>
+            <ServiceSupplyPoint>https://tsa.example.at/tsa</ServiceSupplyPoint>
+          </ServiceSupplyPoints>
+        </ServiceInformation></TSPService>
+        <TSPService><ServiceInformation>
+          <ServiceTypeIdentifier>http://uri.etsi.org/TrstSvc/Svctype/CA/QC</ServiceTypeIdentifier>
+          <ServiceName><Name xml:lang="en">ACME Qualified Certificates</Name></ServiceName>
+          <ServiceStatus>http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/granted</ServiceStatus>
+        </ServiceInformation></TSPService>
+      </TSPServices>
+    </TrustServiceProvider>
+  </TrustServiceProviderList>
+</TrustServiceStatusList>
+"""
+
+
+def test_parse_lotl_returns_only_xml_national_list_pointers():
+    pointers = parse_lotl(LOTL_XML)
+    assert pointers == [TSLPointer(territory="AT", location="https://tl.example.at/tl.xml")]
+
+
+def test_parse_trusted_list_returns_only_qualified_timestamp_services():
+    tsas = parse_trusted_list(AT_TL_XML, territory="AT")
+    assert tsas == [
+        QualifiedTSA(
+            territory="AT",
+            provider="ACME QTSP",
+            service_name="ACME Qualified Timestamping",
+            endpoint="https://tsa.example.at/tsa",
+        )
+    ]
+
+
+def test_parse_trusted_list_skips_non_granted_services():
+    revoked = AT_TL_XML.replace(b"Svcstatus/granted", b"Svcstatus/withdrawn")
+    assert parse_trusted_list(revoked, territory="AT") == []
+
+
+def _fake_fetch(url: str) -> bytes:
+    return {
+        LOTL_URL: LOTL_XML,
+        "https://tl.example.at/tl.xml": AT_TL_XML,
+    }[url]
+
+
+def test_providers_for_country_walks_lotl_to_national_list():
+    tsas = providers_for_country("AT", fetch=_fake_fetch)
+    assert tsas == [
+        QualifiedTSA(
+            territory="AT",
+            provider="ACME QTSP",
+            service_name="ACME Qualified Timestamping",
+            endpoint="https://tsa.example.at/tsa",
+        )
+    ]
+
+
+def test_providers_for_country_unknown_country_is_empty():
+    assert providers_for_country("ZZ", fetch=_fake_fetch) == []


### PR DESCRIPTION
Adds `vaara anchor-providers --country CC`, which surfaces the official EU List of Trusted Lists (ETSI TS 119 612, Commission Decision 2015/1505) so an operator can pick a qualified timestamping provider for eIDAS-qualified anchoring instead of hand-typing a TSA URL.

- Parses the LOTL and a member state's national list down to granted qualified timestamping services (`ServiceTypeIdentifier .../TSA/QTST`) and their endpoints.
- Fetched live over HTTPS (scheme-guarded); parser and orchestration are pure and tested from committed ETSI fixtures.
- **No hardcoded default provider and no endorsement**: it presents the public official list and the operator chooses. This restores the qualified-provider convenience without re-introducing a bundled default.

Foundation for the interactive pick-and-set flow and the app-side picker; those follow.