### PR TITLE
Settle step of the x402 gate requires settlement flags

### DIFF
--- a/src/vaara/server/x402.py
+++ b/src/vaara/server/x402.py
@@ -152,7 +152,10 @@ class X402Gate:
             }
         ).encode("ascii")
         base = self.config.facilitator.rstrip("/")
-        for path in ("/verify", "/settle"):
+        # Each step must confirm with ITS OWN flags: a verify-shaped answer
+        # ("isValid") on /settle is not settlement and must not admit the call.
+        checks = (("/verify", ("isValid", "success")), ("/settle", ("settled", "success")))
+        for path, flags in checks:
             try:
                 req = urllib.request.Request(
                     base + path,
@@ -164,10 +167,6 @@ class X402Gate:
                     report = json.load(resp)
             except Exception:
                 return False
-            if not (
-                report.get("isValid")
-                or report.get("success")
-                or report.get("settled")
-            ):
+            if not any(report.get(flag) for flag in flags):
                 return False
         return True

--- a/tests/test_x402_gate_settle.py
+++ b/tests/test_x402_gate_settle.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The x402 gate's settlement handshake: each facilitator step must confirm
+with its own flags. A verify-shaped answer on /settle is not settlement."""
+import io
+import json
+from unittest import mock
+
+from vaara.server.x402 import X402Config, X402Gate
+
+
+def _gate() -> X402Gate:
+    return X402Gate(
+        X402Config(
+            enabled=True,
+            pay_to="0xabc",
+            network="base",
+            asset="usdc",
+            price="10",
+            facilitator="https://facilitator.test",
+        )
+    )
+
+
+def _urlopen_returning(responses):
+    """urlopen stub yielding one canned JSON body per called path, in order."""
+    bodies = iter(responses)
+
+    def fake_urlopen(req, timeout=None):  # noqa: ARG001
+        body = json.dumps(next(bodies)).encode()
+        resp = io.BytesIO(body)
+        resp.__enter__ = lambda *a: resp
+        resp.__exit__ = lambda *a: False
+        return resp
+
+    return fake_urlopen
+
+
+def _settle_with(responses) -> bool:
+    with mock.patch(
+        "vaara.server.x402.urllib.request.urlopen",
+        _urlopen_returning(responses),
+    ):
+        return _gate()._settle("hdr", "/resource", "10")
+
+
+def test_settled_when_both_steps_confirm():
+    assert _settle_with([{"isValid": True}, {"settled": True}]) is True
+
+
+def test_settle_success_flag_accepted():
+    assert _settle_with([{"isValid": True}, {"success": True}]) is True
+
+
+def test_verify_shaped_settle_answer_is_refused():
+    # the audited leniency: isValid alone on /settle must NOT admit the call
+    assert _settle_with([{"isValid": True}, {"isValid": True}]) is False
+
+
+def test_failed_verify_refused():
+    assert _settle_with([{"isValid": False}, {"settled": True}]) is False
+
+
+def test_no_facilitator_refuses():
+    gate = X402Gate(
+        X402Config(
+            enabled=True, pay_to="0xabc", network="base",
+            asset="usdc", price="10", facilitator=None,
+        )
+    )
+    assert gate._settle("hdr", "/resource", "10") is False


### PR DESCRIPTION
The facilitator handshake accepted isValid, success or settled from both /verify and /settle. That let a verify-shaped answer on /settle (isValid alone) count as settled payment.

Each step now checks its own flags:

- /verify: isValid or success
- /settle: settled or success

Adds direct unit tests for the gate handshake (5 cases, including the refused verify-shaped /settle answer and the no-facilitator refusal). Existing settlement vector and declarative profile tests pass unchanged (31 passed, 1 skipped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment settlement validation by requiring each verification step to return the appropriate confirmation.
  * Prevented mismatched or incomplete facilitator responses from being accepted as successful settlements.
  * Continued to support valid generic success confirmations where applicable.

* **Tests**
  * Added coverage for successful settlements, rejected verification responses, failed verification, and missing facilitator configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->