### PR TITLE
Harden trusted-list parsing against DTDs and non-https pointers

### DIFF
--- a/src/vaara/audit/eu_trusted_list.py
+++ b/src/vaara/audit/eu_trusted_list.py
@@ -30,6 +30,19 @@ _XML_TL_MIME = "application/vnd.etsi.tsl+xml"
 _XML_LANG = "{http://www.w3.org/XML/1998/namespace}lang"
 
 
+def _parse_xml(data: bytes) -> ET.Element:
+    """Parse trusted-list XML with DTDs refused outright.
+
+    Genuine ETSI TS 119 612 lists carry no document type declaration, so any
+    DOCTYPE here is malformed or hostile (XXE, entity-expansion). Refusing it
+    up front keeps the stdlib parser safe without a new dependency.
+    """
+    head = data[:4096]
+    if b"<!DOCTYPE" in head or b"<!ENTITY" in head:
+        raise ValueError("trusted-list XML with a DTD is refused")
+    return ET.fromstring(data)
+
+
 @dataclass(frozen=True)
 class TSLPointer:
     """A pointer from the LOTL to one member state's national trusted list."""
@@ -85,7 +98,7 @@ def parse_lotl(data: bytes) -> list[TSLPointer]:
     Pointers to human-readable renderings (PDF) or other MIME types are
     skipped, so only machine-readable national lists remain.
     """
-    root = ET.fromstring(data)
+    root = _parse_xml(data)
     pointers: list[TSLPointer] = []
     for ptr in _iter(root, "OtherTSLPointer"):
         location = _text(_first(ptr, "TSLLocation"))
@@ -97,13 +110,17 @@ def parse_lotl(data: bytes) -> list[TSLPointer]:
                 break
         if not location or mime != _XML_TL_MIME:
             continue
+        # only https pointers are followed: a compromised or tampered LOTL must
+        # not be able to steer the fetcher at plain-http or non-web schemes
+        if not location.startswith("https://"):
+            continue
         pointers.append(TSLPointer(territory=territory, location=location))
     return pointers
 
 
 def parse_trusted_list(data: bytes, territory: str = "") -> list[QualifiedTSA]:
     """Return the granted qualified timestamping services in a national list."""
-    root = ET.fromstring(data)
+    root = _parse_xml(data)
     out: list[QualifiedTSA] = []
     for tsp in _iter(root, "TrustServiceProvider"):
         provider = _name_text(_first(tsp, "TSPName"))

--- a/tests/test_eu_trusted_list.py
+++ b/tests/test_eu_trusted_list.py
@@ -110,3 +110,20 @@ def test_providers_for_country_walks_lotl_to_national_list():
 
 def test_providers_for_country_unknown_country_is_empty():
     assert providers_for_country("ZZ", fetch=_fake_fetch) == []
+
+
+def test_parse_lotl_skips_non_https_pointers():
+    lotl = LOTL_XML.replace(
+        b"https://tl.example.at/tl.xml", b"http://tl.example.at/tl.xml"
+    )
+    assert parse_lotl(lotl) == []
+
+
+def test_xml_with_doctype_is_refused():
+    import pytest
+
+    hostile = b'<?xml version="1.0"?><!DOCTYPE x [<!ENTITY a "b">]>' + LOTL_XML.split(b"?>", 1)[1]
+    with pytest.raises(ValueError):
+        parse_lotl(hostile)
+    with pytest.raises(ValueError):
+        parse_trusted_list(hostile)


### PR DESCRIPTION
Two hardening changes in the EU trusted-list layer, no new dependencies:

- XML carrying a DOCTYPE or entity declaration is refused before parsing. Genuine ETSI TS 119 612 lists carry none, so any DTD is malformed or hostile (XXE, entity expansion).
- LOTL pointers to national lists are followed only over https, so a tampered LOTL cannot steer the fetcher at plain-http or non-web schemes.

Adds tests for both (hostile DTD refused in both parsers, non-https pointer skipped). Full trusted-list suite passes (7 tests).