### PR TITLE
fix: use Bundle.main for resource loading instead of Bundle.module

### DIFF
--- a/clients/macos/Sources/VaaraMenuBar/VaaraApp.swift
+++ b/clients/macos/Sources/VaaraMenuBar/VaaraApp.swift
@@ -33,9 +33,10 @@ struct VaaraApp: App {
     }
 
     private func markImage(for state: GateState) -> NSImage {
-        if let url = Bundle.module.url(
-            forResource: "icons/vaara-\(state.rawValue)", withExtension: "png"),
-           let img = NSImage(contentsOf: url) {
+        let bundle = Bundle.main
+        let resourcePath = bundle.resourcePath ?? ""
+        let iconPath = "\(resourcePath)/icons/vaara-\(state.rawValue).png"
+        if let img = NSImage(contentsOfFile: iconPath) {
             return img
         }
         let color = stateColor(state)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.51.0"
+version = "1.51.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Bundle.module is a SwiftPM feature. When compiling directly with swiftc (as Homebrew does to avoid the SwiftPM/Homebrew double-sandbox issue), Bundle.module does not exist. Switch to Bundle.main + resourcePath, which works with both swiftc and SwiftPM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of macOS menu bar status icons.
  * Preserved the fallback placeholder when a status icon cannot be loaded.

* **Chores**
  * Updated the application version to 1.51.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->