### PR TITLE
docs: clarify brew install includes macOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Your AI agent transferred the funds, wrote the file, called the tool. Later, som
 
 ```bash
 pip install vaara                            # Python: CLI, MCP proxy, server
-brew tap vaaraio/tap && brew install vaara   # CLI via Homebrew
+brew tap vaaraio/tap && brew install vaara   # macOS: CLI + menu-bar app (built from source)
 npm install @vaara/client                    # TypeScript client for the HTTP API
 ```
 

--- a/clients/macos/Sources/VaaraMenuBar/VaaraApp.swift
+++ b/clients/macos/Sources/VaaraMenuBar/VaaraApp.swift
@@ -33,9 +33,10 @@ struct VaaraApp: App {
     }
 
     private func markImage(for state: GateState) -> NSImage {
-        if let url = Bundle.module.url(
-            forResource: "icons/vaara-\(state.rawValue)", withExtension: "png"),
-           let img = NSImage(contentsOf: url) {
+        let bundle = Bundle.main
+        let resourcePath = bundle.resourcePath ?? ""
+        let iconPath = "\(resourcePath)/icons/vaara-\(state.rawValue).png"
+        if let img = NSImage(contentsOfFile: iconPath) {
             return img
         }
         let color = stateColor(state)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.51.0"
+version = "1.51.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
Update README to clarify that `brew install vaara` installs both the CLI and the macOS menu-bar app (built from source). This matches what users see when they run the command.