### PR TITLE
Positioning: Accountable Autonomy across all outward surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <p align="center"><b>Accountable Autonomy.</b></p>
 
-<p align="center">A verifiable receipt for every action your AI agents take, checkable by anyone.</p>
+<p align="center">A verifiable receipt for every autonomous action, checkable by anyone.</p>
 
 Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.
 

--- a/clients/macos/README.md
+++ b/clients/macos/README.md
@@ -6,7 +6,7 @@ your AI tools through Vaara's policy gate; from then on every agent
 move is decided by the rules you set and recorded in the signed audit
 trail, and the menu bar shows the verdicts as they happen.
 
-The Vaara mark sits in the menu bar tinted by your AI agents' latest
+The Vaara mark sits in the menu bar tinted by your latest
 verdict, with a small activity sparkline beside it:
 
 - green: moves are passing policy

--- a/clients/ts/README.md
+++ b/clients/ts/README.md
@@ -2,7 +2,7 @@
 
 Typed JavaScript / TypeScript HTTP client for the [Vaara](https://github.com/vaaraio/vaara) v1 API.
 
-Vaara is a runtime AI agent governance kernel: conformal risk scoring, hash-chained audit trail, EU AI Act article-evidence model, OVERT 1.0 attestation. This package is the JS/TS surface; the Python implementation runs the server.
+Vaara is the accountable autonomy layer: conformal risk scoring, hash-chained audit trail, and independently verifiable receipts for every autonomous action. This package is the JS/TS surface; the Python implementation runs the server.
 
 ## Install
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -2,7 +2,7 @@
   "name": "@vaara/client",
   "version": "1.52.0",
   "mcpName": "io.github.vaaraio/vaara",
-  "description": "TypeScript client for the Vaara HTTP API: EU AI Act runtime evidence for MCP tool calls. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
+  "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 info:
   title: Vaara HTTP API
   version: "1.0.0"
-  summary: Conformal-scoring risk evaluation and hash-chained audit emission for AI agent actions.
+  summary: Conformal-scoring risk evaluation and hash-chained audit emission for autonomous actions.
   description: |
     The Vaara HTTP API exposes the Vaara runtime kernel as a network surface.
     Any agent runtime, control plane, or evaluation framework can call the

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Vaara
 
-> Tamper-evident runtime evidence layer for AI agents. Covers EU AI Act compliance and any case where you need to prove what an agent actually did. Open source, no SaaS, no telemetry.
+> Accountable autonomy: a verifiable receipt for every autonomous action. Covers AI agents, agentic payments, supply chain, and any case where you need to prove what a system actually did. Open source, no SaaS, no telemetry.
 
 Vaara intercepts agent tool calls, scores each one with a conformal risk interval, and writes a hash-chained audit record. Online learning across five expert signals via Multiplicative Weight Update. Distribution-free conformal coverage on the score. An external auditor can verify these properties without trusting your stack.
 

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaara-governance",
   "version": "1.52.0",
-  "description": "Runtime tool-call governance for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
+  "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",
     "email": "hello@vaara.io"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vaaraio/vaara-server",
   "title": "Vaara MCP Server",
-  "description": "EU AI Act runtime evidence as a standalone MCP server: gating, tamper-evident audit",
+  "description": "Accountable autonomy as a standalone MCP server: gating, tamper-evident audit for every autonomous action",
   "websiteUrl": "https://vaara.io",
   "repository": {
     "url": "https://github.com/vaaraio/vaara",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vaaraio/vaara",
   "title": "Vaara",
-  "description": "EU AI Act runtime evidence proxy for MCP servers: gating, tamper-evident audit, time anchor",
+  "description": "Accountable autonomy proxy for MCP servers: gating, tamper-evident audit, time anchor for every autonomous action",
   "websiteUrl": "https://vaara.io",
   "repository": {
     "url": "https://github.com/vaaraio/vaara",

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Vaara: Accountable Autonomy for AI agents | Tamper-evident EU AI Act Article 12 evidence</title>
-<meta name="description" content="Vaara is the open-source tamper-evident runtime evidence layer for AI agents. Prove what an agent actually did, let an outside party verify it without trusting you, and bind the record to the machine's own TPM 2.0 + IMA attestation. EU AI Act Article 12 audit trail. No SaaS, no telemetry, AGPL-3.0.">
-<meta name="keywords" content="AI agent audit trail, tamper-evident AI logging, EU AI Act Article 12, EU AI Act compliance, AI governance, signed execution record, verifiable AI, AI accountability, TPM 2.0 attestation, IMA measurement, RFC 3161 timestamp, eIDAS qualified timestamp, SEP-2828, MCP execution record, agent observability, sovereign AI, hash-chained audit log, Ed25519, ML-DSA-65, post-quantum, SLSA, Sigstore, open source AI compliance">
+<title>Vaara: Accountable Autonomy | Tamper-evident evidence for every autonomous action</title>
+<meta name="description" content="Vaara is the open-source accountable autonomy layer: a verifiable receipt for every autonomous action — AI agents, agentic payments, supply chain, any system that acts on its own. Tamper-evident, independently verifiable, no SaaS, no telemetry, AGPL-3.0.">
+<meta name="keywords" content="accountable autonomy, AI agent audit trail, agentic payments, autonomous actions, tamper-evident evidence, EU AI Act Article 12, signed execution record, verifiable AI, TPM 2.0 attestation, RFC 3161 timestamp, eIDAS qualified timestamp, SEP-2828, MCP execution record, sovereign AI, hash-chained audit log, Ed25519, ML-DSA-65, post-quantum, SLSA, Sigstore, open source compliance">
 <meta name="author" content="Henri Sirkkavaara">
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
 <meta name="googlebot" content="index, follow">
@@ -27,8 +27,8 @@
 <!-- Open Graph -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Vaara">
-<meta property="og:title" content="Vaara — Tamper-evident evidence layer for AI agents">
-<meta property="og:description" content="Prove what an AI agent actually did. An outside party verifies it without trusting you, bound to the machine's own TPM 2.0 + IMA attestation. EU AI Act Article 12. Open source, AGPL-3.0.">
+<meta property="og:title" content="Vaara — Accountable Autonomy">
+<meta property="og:description" content="A verifiable receipt for every autonomous action. AI agents, agentic payments, supply chain — any system that acts on its own. Independently verifiable, open source, AGPL-3.0.">
 <meta property="og:url" content="https://vaara.io/">
 <meta property="og:image" content="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-light.png">
 <meta property="og:image:width" content="1200">
@@ -42,8 +42,8 @@
 
 <!-- Twitter / X -->
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Vaara — Tamper-evident evidence layer for AI agents">
-<meta name="twitter:description" content="Prove what an AI agent actually did, verifiable by an outside party without trusting you. EU AI Act Article 12. Open source, AGPL-3.0.">
+<meta name="twitter:title" content="Vaara — Accountable Autonomy">
+<meta name="twitter:description" content="A verifiable receipt for every autonomous action. AI agents, agentic payments, supply chain — any system that acts on its own. Independently verifiable, open source, AGPL-3.0.">
 <meta name="twitter:image" content="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-light.png">
 <meta name="twitter:image:alt" content="Vaara">
 <style>
@@ -146,9 +146,9 @@
       "@type": "SoftwareApplication",
       "name": "Vaara",
       "applicationCategory": "DeveloperApplication",
-      "applicationSubCategory": "AI governance and audit",
+      "applicationSubCategory": "Security and Audit",
       "operatingSystem": "Linux, macOS, Windows",
-      "description": "Open-source tamper-evident runtime evidence layer for AI agents. Produces signed, hash-chained, independently verifiable execution records bound to TPM 2.0 and IMA attestation, for EU AI Act Article 12 audit trails.",
+      "description": "Open-source accountable autonomy layer. Produces signed, hash-chained, independently verifiable execution records for every autonomous action — AI agents, agentic payments, supply chain, any system that acts on its own.",
       "url": "https://vaara.io/",
       "downloadUrl": "https://pypi.org/project/vaara/",
       "softwareHelp": "https://github.com/vaaraio/vaara",
@@ -159,7 +159,7 @@
         { "@type": "Offer", "name": "Paid pilot and commercial license", "url": "https://vaara.io/#pilots", "availability": "https://schema.org/InStock" }
       ],
       "author": { "@type": "Person", "name": "Henri Sirkkavaara" },
-      "keywords": "AI agent audit trail, EU AI Act Article 12, tamper-evident logging, TPM 2.0, IMA, RFC 3161, SEP-2828, verifiable AI",
+      "keywords": "accountable autonomy, AI agent audit trail, agentic payments, autonomous actions, tamper-evident evidence, EU AI Act Article 12, TPM 2.0, RFC 3161, SEP-2828, verifiable AI",
       "sameAs": [
         "https://github.com/vaaraio/vaara",
         "https://pypi.org/project/vaara/",


### PR DESCRIPTION
## Summary

Update 15 outward-facing descriptions to lead with 'Accountable Autonomy' instead of 'AI governance' or 'AI agents only'.

## Changes

AI agents remain a primary wedge, but the category is broader: agentic payments, supply chain, any system that acts on its own and needs independently verifiable receipts.

### Updated surfaces

- **webpage/index.html**: title, meta description, keywords, og:title, og:description, twitter:title, twitter:description, JSON-LD description and keywords
- **llms.txt**: opening description
- **README.md**: tagline
- **clients/ts/README.md**: description
- **clients/ts/package.json**: description
- **clients/macos/README.md**: description
- **docs/openapi.yaml**: summary
- **server.json**: description
- **server-vaara-server.json**: description
- **plugin.json**: description

### Unchanged (intentionally)

Internal docs (AGENTS.md, wedge docs like prove-what-an-ai-agent-did.md, EU AI Act docs) remain unchanged — they are entry points for specific audiences, not the outward identity.

## Testing

- All CI checks will run on this PR
- No code changes, only documentation and metadata updates
- Webpage will deploy to vaara.io on merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product and package descriptions to emphasize accountable autonomy and verifiable receipts for autonomous actions.
  * Refreshed server, plugin, API, and macOS documentation wording to align with the updated positioning.
  * Updated website titles, metadata, social previews, and structured data to reflect expanded coverage of autonomous actions, agentic payments, and supply chain systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->