### PR TITLE
Fix: match evidence box background to buttons

### DIFF
--- a/webpage/index.html
+++ b/webpage/index.html
@@ -114,7 +114,7 @@
   .links a:hover .target { color: var(--tri-bright); }
   @media (max-width: 520px) { .links { grid-template-columns: 1fr; } }
   footer { margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--line); font-family: var(--mono); font-size: 12px; color: var(--faint); letter-spacing: 0.04em; text-align: center; }
-  .evidence { background: var(--panel-2); color: var(--ink); border: 1px solid var(--line); border-radius: 12px; margin: 0 0 48px; font-family: var(--mono); font-size: 14px; line-height: 1.65; overflow-x: auto; }
+  .evidence { background: var(--panel); color: var(--ink); border: 1px solid var(--line); border-radius: 12px; margin: 0 0 48px; font-family: var(--mono); font-size: 14px; line-height: 1.65; overflow-x: auto; }
   .evidence-head { display: flex; justify-content: space-between; padding: 10px 18px; border-bottom: 1px solid var(--line); font-size: 12px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--faint); }
   .evidence-head .live { color: var(--tri); display: inline-flex; gap: 6px; align-items: center; }
   .evidence-head .live::before { content: ""; width: 6px; height: 6px; background: var(--tri); border-radius: 50%; display: inline-block; }


### PR DESCRIPTION
Aligns the evidence box background with the button panels in light mode. The evidence box now uses the same white background as the ten buttons at the bottom when not hovered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the evidence panel’s background color for improved visual consistency with the surrounding interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->