### PR TITLE
v1.54.0 — governed shell proxy, auto-init, flat menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.54.0] - 2026-07-29
+
+### Added
+- `vaara proxy-shell`: wrap any shell so every command is governed.
+  Shell commands from Claude Code, Cursor, or any terminal AI hit the Vaara
+  pipeline — classified, scored, allowed or blocked, recorded in the trail.
+  Usage: `exec vaara proxy-shell` replaces your shell.
+- Auto-init on first use: the first `vaara` command silently discovers the
+  environment (running agents, MCP clients, shell, sensitive paths, known
+  tools), generates a default shadow-mode policy, and starts governing.
+  No commands to remember — install and it's ready.
+- Threshold presets for auto-init: `vaara init --auto --mode strict` selects
+  from eco (0.40/0.60), balanced (0.55/0.85), performance (0.70/0.92),
+  or strict (0.30/0.55) via the existing `policy.modes` system.
+- `vaara.integrations.discovery`: auto-discovery module that scans `ps`,
+  shell config, MCP client configs, and the filesystem to fingerprint the
+  governed environment.
+
+### Changed
+- `vaara menu`: rewritten to a flat list. No settings-depth tiers, no
+  Article 50 tunnel vision. Shows: status, shadow report, export, verify,
+  settings, updates. Every item delegates to the same CLI entry points.
+- Settings view in macOS app: two-column Grid layout. SETTINGS FOR, GATE,
+  PROTECTION, graph toggle, and UPDATES on the left; NOTIFY ON, SIGNAL
+  FADES, APPROVAL POPUP, GOVERN WHAT YOU CHOOSE, and APPROVALS FOLDER on
+  the right. Fits the 13" Air M3 screen at max HiDPI without vertical
+  scrolling.
+
+### Fixed
+- First-run no longer prints a "setup complete" message — silent auto-init
+  per the "one command and vamos" principle.
 
 ## [1.53.0] - 2026-07-28
 

--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
@@ -487,194 +487,219 @@ struct ContentView: View {
     private var enterprise: Bool { model.config.user_level == "enterprise" }
 
     private var settings: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            VStack(alignment: .leading, spacing: 8) {
-                sectionLabelPlain("SETTINGS FOR")
-                Picker("", selection: $model.config.user_level) {
-                    Text("Basic").tag("basic")
-                    Text("Professional").tag("professional")
-                    Text("Enterprise").tag("enterprise")
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                Text(model.config.user_level == "basic"
-                     ? "The essentials. Everything else keeps its defaults."
-                     : model.config.user_level == "professional"
-                     ? "Adds thresholds and tuning."
-                     : "Adds multiple trails and every control.")
-                    .font(.system(size: 10.5))
-                    .foregroundStyle(p.ghost)
-            }
-
-            VStack(alignment: .leading, spacing: 8) {
-                sectionLabelPlain("GATE")
-                Picker("", selection: Binding(
-                    get: { model.enforcementMode },
-                    set: { model.setMode($0) })) {
-                    Text("Block").tag("protect")
-                    Text("Shadow").tag("watch")
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                Text(model.enforcementMode == "watch"
-                     ? "Recording only. Nothing gets blocked."
-                     : "Enforcing. Deny decisions stop the call.")
-                    .font(.system(size: 10.5))
-                    .foregroundStyle(p.ghost)
-            }
-
-            if pro {
-                VStack(alignment: .leading, spacing: 6) {
-                    sectionLabelPlain("PROTECTION · WOULD HAVE DECIDED (15 MIN)")
-                    ForEach(Preset.all) { preset in
-                        presetRow(preset)
+        Grid(alignment: .topLeading, horizontalSpacing: 32, verticalSpacing: 18) {
+            // Row 1: SETTINGS FOR  |  NOTIFY ON
+            GridRow {
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionLabelPlain("SETTINGS FOR")
+                    Picker("", selection: $model.config.user_level) {
+                        Text("Basic").tag("basic")
+                        Text("Professional").tag("professional")
+                        Text("Enterprise").tag("enterprise")
                     }
-                    customRow
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    Text(model.config.user_level == "basic"
+                         ? "The essentials. Everything else keeps its defaults."
+                         : model.config.user_level == "professional"
+                         ? "Adds thresholds and tuning."
+                         : "Adds multiple trails and every control.")
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(p.ghost)
                 }
-            }
-
-            VStack(alignment: .leading, spacing: 8) {
-                sectionLabelPlain("NOTIFY ON")
-                Picker("", selection: $model.config.notify_on) {
-                    Text("Nothing").tag("off")
-                    Text("Denials").tag("deny")
-                    Text("All interventions").tag("interventions")
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-            }
-
-            if pro {
-                Toggle(isOn: $model.config.menubar_graph) {
-                    Text("Activity graph in the menu bar")
-                        .font(.system(size: 13)).foregroundStyle(p.ink)
-                }
-                .toggleStyle(.switch)
-                .controlSize(.mini)
-                .tint(model.state.color)
 
                 VStack(alignment: .leading, spacing: 8) {
-                    sectionLabelPlain("SIGNAL FADES AFTER")
-                    Picker("", selection: $model.config.alert_window_minutes) {
-                        ForEach([1, 5, 15, 60], id: \.self) { Text("\($0) min").tag($0) }
+                    sectionLabelPlain("NOTIFY ON")
+                    Picker("", selection: $model.config.notify_on) {
+                        Text("Nothing").tag("off")
+                        Text("Denials").tag("deny")
+                        Text("All interventions").tag("interventions")
                     }
                     .pickerStyle(.segmented)
                     .labelsHidden()
                 }
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                sectionLabelPlain("UPDATES")
-                HStack(spacing: 12) {
-                    Button("Check for updates") { model.checkForUpdates() }
-                        .buttonStyle(.plain)
-                        .font(.system(size: 11))
-                        .foregroundStyle(p.ink.opacity(0.7))
-                    if let status = model.updateStatus {
-                        Text(status)
-                            .font(.system(size: 10, design: .monospaced))
-                            .foregroundStyle(p.ghost)
-                            .lineLimit(2)
+            // Row 2: GATE  |  SIGNAL FADES (pro)
+            GridRow {
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionLabelPlain("GATE")
+                    Picker("", selection: Binding(
+                        get: { model.enforcementMode },
+                        set: { model.setMode($0) })) {
+                        Text("Block").tag("protect")
+                        Text("Shadow").tag("watch")
                     }
-                }
-                Text("app build \(BUILD_STAMP)")
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(p.ghost)
-            }
-
-            if enterprise {
-            VStack(alignment: .leading, spacing: 8) {
-                sectionLabelPlain("APPROVAL POPUP")
-                Picker("", selection: $model.config.approval_style) {
-                    Text("Auto").tag("auto")
-                    Text("From notch").tag("notch")
-                    Text("Centered").tag("centered")
-                }
-                .pickerStyle(.segmented)
-                .labelsHidden()
-                Text("Auto detects a notch and drops from it, else from the "
-                     + "top edge. Force one if you hide the notch "
-                     + "(e.g. BetterDisplay).")
-                    .font(.system(size: 9))
-                    .foregroundStyle(p.ghost)
-            }
-
-            DisclosureGroup {
-              VStack(alignment: .leading, spacing: 8) {
-                ForEach(model.config.db_paths, id: \.self) { path in
-                    HStack {
-                        Text(path)
-                            .font(.system(size: 11, design: .monospaced))
-                            .foregroundStyle(p.faint)
-                            .lineLimit(1)
-                            .truncationMode(.head)
-                        Spacer()
-                        if model.config.db_paths.count > 1 {
-                            Button {
-                                model.removeSource(path)
-                            } label: {
-                                Image(systemName: "xmark")
-                                    .font(.system(size: 8, weight: .medium))
-                            }
-                            .buttonStyle(.plain)
-                            .foregroundStyle(p.ghost)
-                        }
-                    }
-                }
-                HStack(spacing: 14) {
-                    Button("Add a trail...") { chooseDB() }
-                    Button("Find trails in ~/.vaara") {
-                        discoveredCount = model.discoverTrails()
-                    }
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: 11))
-                .foregroundStyle(p.ink.opacity(0.7))
-                if let n = discoveredCount {
-                    Text(n == 0 ? "No new trails found."
-                                : "Added \(n) trail\(n == 1 ? "" : "s").")
-                        .font(.system(size: 10))
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    Text(model.enforcementMode == "watch"
+                         ? "Recording only. Nothing gets blocked."
+                         : "Enforcing. Deny decisions stop the call.")
+                        .font(.system(size: 10.5))
                         .foregroundStyle(p.ghost)
                 }
-              }
-              .padding(.top, 6)
-            } label: {
-                sectionLabelPlain("GOVERN WHAT YOU CHOOSE (\(model.config.db_paths.count))")
-            }
-            .tint(p.faint)
 
-            DisclosureGroup {
-              VStack(alignment: .leading, spacing: 8) {
-                Text(model.config.approvals_dir ?? "~/.vaara/approvals (default)")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(p.faint)
-                    .lineLimit(1).truncationMode(.head)
-                HStack(spacing: 14) {
-                    Button("Choose folder...") { chooseApprovalsDir() }
-                    if model.config.approvals_dir != nil {
-                        Button("Reset to default") {
-                            model.config.approvals_dir = nil
+                if pro {
+                    VStack(alignment: .leading, spacing: 8) {
+                        sectionLabelPlain("SIGNAL FADES AFTER")
+                        Picker("", selection: $model.config.alert_window_minutes) {
+                            ForEach([1, 5, 15, 60], id: \.self) {
+                                Text("\($0) min").tag($0)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                    }
+                }
+            }
+
+            // Row 3: PROTECTION (pro)  |  APPROVAL POPUP (enterprise)
+            if pro {
+                GridRow {
+                    VStack(alignment: .leading, spacing: 6) {
+                        sectionLabelPlain("PROTECTION · WOULD HAVE DECIDED (15 MIN)")
+                        ForEach(Preset.all) { preset in
+                            presetRow(preset)
+                        }
+                        customRow
+                    }
+
+                    if enterprise {
+                        VStack(alignment: .leading, spacing: 8) {
+                            sectionLabelPlain("APPROVAL POPUP")
+                            Picker("", selection: $model.config.approval_style) {
+                                Text("Auto").tag("auto")
+                                Text("From notch").tag("notch")
+                                Text("Centered").tag("centered")
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+                            Text("Auto detects a notch and drops from it, "
+                                 + "else from the top edge. Force one if "
+                                 + "you hide the notch (e.g. BetterDisplay).")
+                                .font(.system(size: 9))
+                                .foregroundStyle(p.ghost)
                         }
                     }
                 }
-                .buttonStyle(.plain)
-                .font(.system(size: 11))
-                .foregroundStyle(p.ink.opacity(0.7))
-                Text("Where the app watches for escalations needing your "
-                     + "approval. Point it at the engine's approvals folder "
-                     + "for bridge or multi-machine setups.")
-                    .font(.system(size: 9))
-                    .foregroundStyle(p.ghost)
-              }
-              .padding(.top, 6)
-            } label: {
-                sectionLabelPlain("APPROVALS FOLDER")
             }
-            .tint(p.faint)
+
+            // Row 4: graph toggle (pro)  |  GOVERN WHAT (enterprise)
+            GridRow {
+                if pro {
+                    Toggle(isOn: $model.config.menubar_graph) {
+                        Text("Activity graph in the menu bar")
+                            .font(.system(size: 13)).foregroundStyle(p.ink)
+                    }
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .tint(model.state.color)
+                } else {
+                    Spacer().gridCellUnsizedAxes(.vertical)
+                }
+
+                if enterprise {
+                    DisclosureGroup {
+                        VStack(alignment: .leading, spacing: 8) {
+                            ForEach(model.config.db_paths, id: \.self) { path in
+                                HStack {
+                                    Text(path)
+                                        .font(.system(size: 11, design: .monospaced))
+                                        .foregroundStyle(p.faint)
+                                        .lineLimit(1)
+                                        .truncationMode(.head)
+                                    Spacer()
+                                    if model.config.db_paths.count > 1 {
+                                        Button {
+                                            model.removeSource(path)
+                                        } label: {
+                                            Image(systemName: "xmark")
+                                                .font(.system(size: 8, weight: .medium))
+                                        }
+                                        .buttonStyle(.plain)
+                                        .foregroundStyle(p.ghost)
+                                    }
+                                }
+                            }
+                            HStack(spacing: 14) {
+                                Button("Add a trail...") { chooseDB() }
+                                Button("Find trails in ~/.vaara") {
+                                    discoveredCount = model.discoverTrails()
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 11))
+                            .foregroundStyle(p.ink.opacity(0.7))
+                            if let n = discoveredCount {
+                                Text(n == 0 ? "No new trails found."
+                                            : "Added \(n) trail\(n == 1 ? "" : "s").")
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(p.ghost)
+                            }
+                        }
+                        .padding(.top, 6)
+                    } label: {
+                        sectionLabelPlain("GOVERN WHAT YOU CHOOSE (\(model.config.db_paths.count))")
+                    }
+                    .tint(p.faint)
+                }
+            }
+
+            // Row 5: UPDATES  |  APPROVALS FOLDER (enterprise)
+            GridRow {
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionLabelPlain("UPDATES")
+                    HStack(spacing: 12) {
+                        Button("Check for updates") { model.checkForUpdates() }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 11))
+                            .foregroundStyle(p.ink.opacity(0.7))
+                        if let status = model.updateStatus {
+                            Text(status)
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundStyle(p.ghost)
+                                .lineLimit(2)
+                        }
+                    }
+                    Text("app build \(BUILD_STAMP)")
+                        .font(.system(size: 10, design: .monospaced))
+                        .foregroundStyle(p.ghost)
+                }
+
+                if enterprise {
+                    DisclosureGroup {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(model.config.approvals_dir
+                                 ?? "~/.vaara/approvals (default)")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(p.faint)
+                                .lineLimit(1).truncationMode(.head)
+                            HStack(spacing: 14) {
+                                Button("Choose folder...") { chooseApprovalsDir() }
+                                if model.config.approvals_dir != nil {
+                                    Button("Reset to default") {
+                                        model.config.approvals_dir = nil
+                                    }
+                                }
+                            }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 11))
+                            .foregroundStyle(p.ink.opacity(0.7))
+                            Text("Where the app watches for escalations. "
+                                 + "Point it at the engine's approvals folder "
+                                 + "for bridge or multi-machine setups.")
+                                .font(.system(size: 9))
+                                .foregroundStyle(p.ghost)
+                        }
+                        .padding(.top, 6)
+                    } label: {
+                        sectionLabelPlain("APPROVALS FOLDER")
+                    }
+                    .tint(p.faint)
+                }
             }
         }
         .padding(20)
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: anchor — the qualified timestamp provider (EU trusted list) picker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.53.0"
+version = "1.54.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.53.0"
+__version__ = "1.54.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/audit/receipt_anchor.py
+++ b/src/vaara/audit/receipt_anchor.py
@@ -24,7 +24,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
-import rfc8785
 from asn1crypto import algos, cms, core, tsp
 from asn1crypto import x509 as asn1_x509
 from cryptography import x509
@@ -54,6 +53,7 @@ def _signed_payload_digest(receipt: dict) -> bytes:
         payload = {k: receipt[k] for k in _SIGNED_BLOCKS}
     except KeyError as exc:
         raise TimeAnchorError(f"receipt missing signed-payload block: {exc}") from exc
+    import rfc8785
     return hashlib.sha256(rfc8785.dumps(payload)).digest()
 
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -2113,6 +2113,19 @@ def _cmd_proxy(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_proxy_shell(args: argparse.Namespace) -> int:
+    from vaara.integrations.shell_proxy import main as shell_main
+
+    cli_args = []
+    if args.db:
+        cli_args += ["--db", args.db]
+    if args.shell:
+        cli_args += ["--shell", args.shell]
+    if args.agent_id:
+        cli_args += ["--agent-id", args.agent_id]
+    return shell_main(cli_args)
+
+
 def _cmd_verify_bundle(args: argparse.Namespace) -> int:
     """Verify a whole evidence bundle from disk in one command.
 
@@ -4269,7 +4282,31 @@ def _cmd_init(args: argparse.Namespace) -> int:
         proxy_service=args.proxy_service,
         proxy_enforce=args.proxy_enforce,
         proxy_allow=args.proxy_allow,
+        auto=args.auto,
+        mode=args.mode,
     )
+
+    # Auto-discovery rendering.
+    if report.auto and report.discovery:
+        d = report.discovery
+        print("Environment discovery:")
+        running = [a for a in d.agents if a.running]
+        if running:
+            print(f"  AI agents running: {', '.join(a.display_name for a in running)}")
+        else:
+            print("  AI agents: none detected")
+        installed = [a for a in d.agents if not a.running]
+        if installed:
+            print(f"  Installed (not running): {', '.join(a.display_name for a in installed)}")
+        print(f"  Shell: {d.shell.path if d.shell else 'not detected'}")
+        print(f"  MCP clients: {sum(1 for c in d.mcp_clients if c.exists)} found")
+        print(f"  Sensitive paths: {len(d.sensitive_paths)} found")
+        print(f"  Known tools: {', '.join(sorted(d.known_tools.keys()))}")
+        if report.policy_path:
+            print(f"  Policy: {report.policy_path}")
+        if report.config_path:
+            print(f"  Config: {report.config_path}")
+        print()
 
     if report.hooks_changed:
         print(f"Claude Code hooks written to {report.hooks_path}")
@@ -4295,7 +4332,10 @@ def _cmd_init(args: argparse.Namespace) -> int:
         print(f"  warning: {warning}", file=sys.stderr)
 
     print()
-    print("Governance active. Reverse with: vaara ungovern")
+    govern_mode = "shadow (observing)" if args.shadow or args.auto else "enforcing"
+    mode_label = f" | Mode: {args.mode}" if hasattr(args, 'mode') and args.auto else ""
+    print(f"Vaara is governing. {govern_mode}{mode_label}")
+    print("Reverse with: vaara ungovern")
     return 0
 
 
@@ -5248,6 +5288,25 @@ def build_parser() -> argparse.ArgumentParser:
         help="Directory for signed pairs (required with --signing-key)",
     )
     pproxy.set_defaults(func=_cmd_proxy)
+
+    psh = sub.add_parser(
+        "proxy-shell",
+        help="Wrap any shell so every command goes through Vaara — block "
+             "dangerous commands, record everything in the trail.",
+    )
+    psh.add_argument(
+        "--db", default=None,
+        help="Trail database path (default ~/.vaara/trail/audit.db)",
+    )
+    psh.add_argument(
+        "--shell", default=None,
+        help="Shell to wrap (default $SHELL)",
+    )
+    psh.add_argument(
+        "--agent-id", default="shell",
+        help="Agent ID recorded in the trail (default 'shell')",
+    )
+    psh.set_defaults(func=_cmd_proxy_shell)
 
     pvb = sub.add_parser(
         "verify-bundle",
@@ -6244,6 +6303,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Govern in watch-only (shadow) mode: record without blocking.",
     )
     pinit.add_argument(
+        "--auto", action="store_true",
+        help="Auto-discover environment (agents, shell, MCP clients, sensitive"
+             " paths) and generate a default shadow-mode policy. One command"
+             " and vamos.",
+    )
+    pinit.add_argument(
+        "--mode", default="eco", choices=("eco", "balanced", "performance", "strict"),
+        help="Threshold preset for the auto-generated policy (default: eco).",
+    )
+    pinit.add_argument(
         "--no-mcp", action="store_true",
         help="Only write the Claude Code hooks; leave MCP client configs alone.",
     )
@@ -6280,7 +6349,44 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    # First-run auto-init: when the user runs *any* vaara command but has
+    # never initialised governance, offer to run ``init --auto`` in shadow
+    # mode.  This is the "brew install → governed" promise: no extra step,
+    # no config writing, just go.
+    if not _is_first_run_acknowledged() and _should_auto_init(args):
+        _run_first_time_setup()
+
     return args.func(args)
+
+
+def _is_first_run_acknowledged() -> bool:
+    """Check whether the user has already completed first-run setup."""
+    return (Path.home() / ".vaara" / "config.json").exists()
+
+
+def _should_auto_init(args: argparse.Namespace) -> bool:
+    """Decide whether to auto-init based on the subcommand.
+
+    We skip auto-init when the user is explicitly running ``init``,
+    ``ungovern``, ``help``, or a version query — those are intentional
+    governance gestures.
+    """
+    func_name = getattr(args.func, "__name__", "")
+    if func_name in ("_cmd_init", "_cmd_ungovern"):
+        return False
+    return True
+
+
+def _run_first_time_setup() -> None:
+    """Run auto-discovery silently on first use. No output, no command to remember."""
+    from vaara.integrations import init_governance as ig
+
+    try:
+        ig.run_init(shadow=True, auto=True, mode="balanced",
+                     trail_db=ig.DEFAULT_TRAIL_DB)
+    except Exception:
+        pass  # silent — next invocation will retry
 
 
 if __name__ == "__main__":

--- a/src/vaara/integrations/discovery.py
+++ b/src/vaara/integrations/discovery.py
@@ -1,0 +1,427 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Auto-discovery for ``vaara init --auto``.
+
+Detects what's running on the machine — AI agents, shells, MCP clients,
+sensitive paths, known tools — and generates a sensible default policy so the
+operator goes from ``brew install`` to governed with zero config.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Known AI agent processes (binary name → display name)
+# ---------------------------------------------------------------------------
+
+KNOWN_AI_AGENTS: dict[str, str] = {
+    "claude": "Claude Desktop",
+    "claude-code": "Claude Code",
+    "claude-code-server": "Claude Code (server)",
+    "cursor": "Cursor",
+    "cursor-server": "Cursor (server)",
+    "windsurf": "Windsurf",
+    "windsurf-server": "Windsurf (server)",
+}
+
+# Known MCP client config locations (name → ~-relative path).
+KNOWN_MCP_CLIENTS: list[tuple[str, str]] = [
+    ("Claude Desktop",
+     "~/Library/Application Support/Claude/claude_desktop_config.json"),
+    ("Claude Code", "~/.claude.json"),
+    ("Cursor", "~/.cursor/mcp.json"),
+    ("Windsurf", "~/.codeium/windsurf/mcp_config.json"),
+    ("OpenCode", "~/.config/opencode/opencode.json"),
+]
+
+# Sensitive filesystem paths that no autonomous agent should read/write
+# without explicit escalation.
+SENSITIVE_PATH_PATTERNS: list[str] = [
+    ".ssh",
+    ".aws",
+    ".gnupg",
+    ".config/git",
+    ".config/opencode",
+    ".config/claude",
+    ".vaara",
+    "Library/Keychains",
+    "Library/Application Support/1Password",
+    "Library/Application Support/Bitwarden",
+    ".password-store",
+    ".kube",
+    ".docker",
+]
+
+# Well-known tools an AI might invoke autonomously.
+KNOWN_TOOLS: dict[str, str] = {
+    "git": "Version control (git push, git commit, git reset)",
+    "npm": "Node package manager (npm install, npm publish)",
+    "pip": "Python package installer (pip install, pip uninstall)",
+    "brew": "Homebrew package manager (brew install, brew uninstall)",
+    "curl": "HTTP client (curl, wget — network egress)",
+    "rm": "File deletion (rm -rf)",
+    "chmod": "Permission changes (chmod, chown)",
+    "sudo": "Privilege escalation",
+    "kubectl": "Kubernetes control",
+    "terraform": "Infrastructure provisioning",
+}
+
+# Known AI web session URL patterns (for the Safari/WebKit extension).
+KNOWN_AI_WEB_DOMAINS: list[str] = [
+    "chatgpt.com",
+    "chat.openai.com",
+    "claude.ai",
+    "gemini.google.com",
+    "perplexity.ai",
+    "copilot.microsoft.com",
+    "poe.com",
+]
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentInfo:
+    binary: str
+    display_name: str
+    running: bool
+    pid: Optional[int] = None
+    governed: bool = False
+
+
+@dataclass
+class ShellInfo:
+    path: str
+    version: str
+    wrappable: bool  # can we wrap it with vaara proxy shell?
+    rc_file: Optional[str] = None
+
+
+@dataclass
+class MCPClientInfo:
+    name: str
+    config_path: Path
+    exists: bool
+    mcp_servers: int = 0
+    governed_servers: int = 0
+
+
+@dataclass
+class DiscoverReport:
+    agents: list[AgentInfo] = field(default_factory=list)
+    shell: Optional[ShellInfo] = None
+    mcp_clients: list[MCPClientInfo] = field(default_factory=list)
+    sensitive_paths: list[Path] = field(default_factory=list)
+    known_tools: dict[str, str] = field(default_factory=dict)
+    os: str = ""
+    vaara_version: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Discovery functions
+# ---------------------------------------------------------------------------
+
+
+def discover_agents() -> list[AgentInfo]:
+    """Find known AI agent processes currently running on the machine."""
+    running_binaries = _running_processes()
+    agents: list[AgentInfo] = []
+    for binary, name in KNOWN_AI_AGENTS.items():
+        pids = running_binaries.get(binary, [])
+        agents.append(AgentInfo(
+            binary=binary,
+            display_name=name,
+            running=len(pids) > 0,
+            pid=pids[0] if pids else None,
+        ))
+    return agents
+
+
+def _running_processes() -> dict[str, list[int]]:
+    """Return {binary_name: [pid, ...]} for every running process."""
+    result: dict[str, list[int]] = {}
+    try:
+        if platform.system() == "Darwin" or platform.system() == "Linux":
+            output = subprocess.run(
+                ["ps", "-eo", "comm=", "-eo", "pid="],
+                capture_output=True, text=True, timeout=5,
+            )
+            for line in output.stdout.strip().split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                parts = line.rsplit(maxsplit=1)
+                if len(parts) != 2:
+                    continue
+                comm, pid = parts
+                basename = os.path.basename(comm).lower()
+                result.setdefault(basename, []).append(int(pid))
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return result
+
+
+def discover_shell() -> Optional[ShellInfo]:
+    """Detect the user's shell and check if it's wrappable."""
+    shell_path = os.environ.get("SHELL", "")
+    if not shell_path:
+        return None
+    shell_name = os.path.basename(shell_path).lower()
+    wrappable = shell_name in ("bash", "zsh", "fish")
+    version = ""
+    try:
+        out = subprocess.run(
+            [shell_path, "--version"],
+            capture_output=True, text=True, timeout=3,
+        )
+        version = out.stdout.split("\n")[0][:80] if out.stdout else ""
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    rc_map = {"bash": "~/.bashrc", "zsh": "~/.zshrc", "fish": "~/.config/fish/config.fish"}
+    return ShellInfo(
+        path=shell_path,
+        version=version,
+        wrappable=wrappable,
+        rc_file=rc_map.get(shell_name),
+    )
+
+
+def discover_mcp_clients(proxy_bin: str = "vaara-mcp-proxy") -> list[MCPClientInfo]:
+    """Scan known MCP client config files and report governance status."""
+    clients: list[MCPClientInfo] = []
+    for name, raw_path in KNOWN_MCP_CLIENTS:
+        path = Path(raw_path).expanduser()
+        if not path.exists():
+            clients.append(MCPClientInfo(name=name, config_path=path, exists=False))
+            continue
+        servers = _count_mcp_servers(path, proxy_bin)
+        clients.append(MCPClientInfo(
+            name=name, config_path=path, exists=True, **servers,
+        ))
+    return clients
+
+
+def _count_mcp_servers(config_path: Path, proxy_bin: str) -> dict:
+    try:
+        obj = json.loads(config_path.read_text())
+        servers = obj.get("mcpServers", {})
+        if not isinstance(servers, dict):
+            return {"mcp_servers": 0, "governed_servers": 0}
+    except (OSError, json.JSONDecodeError):
+        return {"mcp_servers": 0, "governed_servers": 0}
+    proxy_name = os.path.basename(proxy_bin)
+    total = len(servers)
+    governed = sum(
+        1 for s in servers.values()
+        if isinstance(s, dict) and os.path.basename(s.get("command", "")) == proxy_name
+    )
+    return {"mcp_servers": total, "governed_servers": governed}
+
+
+def discover_sensitive_paths() -> list[Path]:
+    """Find sensitive paths on this machine."""
+    home = Path.home()
+    found: list[Path] = []
+    for pattern in SENSITIVE_PATH_PATTERNS:
+        p = home / pattern
+        if p.exists():
+            found.append(p)
+    return found
+
+
+def discover_known_tools() -> dict[str, str]:
+    """Check which well-known tools are available on PATH."""
+    available: dict[str, str] = {}
+    for tool, description in KNOWN_TOOLS.items():
+        if shutil.which(tool):
+            available[tool] = description
+    return available
+
+
+def run_discovery() -> DiscoverReport:
+    """Run all discovery and return a composite report."""
+    from vaara import __version__
+    return DiscoverReport(
+        agents=discover_agents(),
+        shell=discover_shell(),
+        mcp_clients=discover_mcp_clients(),
+        sensitive_paths=discover_sensitive_paths(),
+        known_tools=discover_known_tools(),
+        os=f"{platform.system()} {platform.release()}",
+        vaara_version=__version__,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Default policy generation
+# ---------------------------------------------------------------------------
+
+
+def generate_default_policy(
+    discovery: DiscoverReport,
+    *,
+    shadow: bool = True,
+    mode_name: str = "eco",
+) -> dict:
+    """Generate a sensible-default policy from discovered environment.
+
+    Returns a dict ready to serialize as the policy JSON/YAML that the
+    ``PolicyController`` can load.  The policy:
+    - Registers action classes for every discovered tool category.
+    - Uses the named mode's ``escalate`` / ``deny`` thresholds (default ``eco``).
+    - Tags sensitive paths so file-access guards can use them.
+    - Lists known agent IDs for provenance tracking.
+    - Enables shadow mode when ``shadow=True`` so the operator can review
+      what would be blocked before turning on enforcement.
+    """
+    from vaara.policy.modes import get_mode, to_policy_dict
+
+    action_classes: list[dict] = [
+        {
+            "name": "shell_command",
+            "category": "INFRASTRUCTURE",
+            "reversibility": "IRREVERSIBLE",
+            "blast_radius": "LOCAL",
+            "urgency": "IMMEDIATE",
+            "tools": sorted(discovery.known_tools.keys()),
+            "regulatory": [],
+        },
+        {
+            "name": "file_system_access",
+            "category": "DATA",
+            "reversibility": "REVERSIBLE",
+            "blast_radius": "LOCAL",
+            "urgency": "NORMAL",
+            "tools": ["file.read", "file.write", "file.delete", "file.export"],
+            "regulatory": [],
+        },
+        {
+            "name": "network_egress",
+            "category": "COMMUNICATION",
+            "reversibility": "IRREVERSIBLE",
+            "blast_radius": "EXTERNAL",
+            "urgency": "NORMAL",
+            "tools": ["network.connect", "network.send"],
+            "regulatory": [],
+        },
+        {
+            "name": "surveillance",
+            "category": "PHYSICAL",
+            "reversibility": "IRREVERSIBLE",
+            "blast_radius": "EXTERNAL",
+            "urgency": "IMMEDIATE",
+            "tools": ["keylog.capture", "screen.capture", "clipboard.read",
+                      "mic.capture", "camera.capture"],
+            "regulatory": ["GDPR_CHAPTER_V"],
+        },
+    ]
+
+    mode = get_mode(mode_name)
+    mode_policy = to_policy_dict(mode)
+
+    result: dict = {
+        "version": mode_policy.get("version", "0.1"),
+        "mode": mode_name,
+        "generated_by": "vaara init --auto",
+        "generated_at": __import__("time").time(),
+        "domains": mode_policy.get("domains", ["GDPR", "EU_AI_ACT"]),
+        "action_classes": action_classes,
+        "thresholds": mode_policy.get("thresholds", {
+            "default": {"escalate": mode.escalate, "deny": mode.deny},
+        }),
+        "thresholds_overrides": {},
+        "sequences": [],
+        "escalation_routes": [],
+    }
+
+    sensitive_paths = [str(p) for p in discovery.sensitive_paths]
+    if sensitive_paths:
+        result["sensitive_paths"] = sensitive_paths
+
+    running_agents = [a.display_name for a in discovery.agents if a.running]
+    if running_agents:
+        result["known_agents"] = running_agents
+
+    if shadow:
+        result["mode"] = "shadow"
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Policy file persistence
+# ---------------------------------------------------------------------------
+
+DEFAULT_POLICY_PATH = Path.home() / ".vaara" / "policy.json"
+
+
+def write_default_policy(
+    discovery: DiscoverReport,
+    *,
+    shadow: bool = True,
+    mode_name: str = "eco",
+    path: Path = DEFAULT_POLICY_PATH,
+) -> Path:
+    """Generate and write the default policy file."""
+    policy = generate_default_policy(discovery, shadow=shadow, mode_name=mode_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(policy, indent=2) + "\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Config persistence (the unified ~/.vaara/config.json)
+# ---------------------------------------------------------------------------
+
+DEFAULT_CONFIG_PATH = Path.home() / ".vaara" / "config.json"
+
+
+def write_discovery_config(
+    discovery: DiscoverReport,
+    *,
+    shadow: bool = True,
+    trail_db: Path = Path.home() / ".vaara" / "trail" / "audit.db",
+    path: Path = DEFAULT_CONFIG_PATH,
+) -> Path:
+    """Write the discovered environment to the shared config file.
+
+    This is the unified config that the hook runner, proxy, and local daemon
+    all read from.  Written after every ``vaara init --auto``.
+    """
+    config: dict = {
+        "version": 1,
+        "trail_db": str(trail_db),
+        "mode": "shadow" if shadow else "enforce",
+        "policy": str(DEFAULT_POLICY_PATH),
+        "agents": [
+            {"name": a.display_name, "binary": a.binary, "governed": a.governed}
+            for a in discovery.agents
+        ],
+        "sensitive_paths": [str(p) for p in discovery.sensitive_paths],
+        "known_tools": list(discovery.known_tools.keys()),
+        "mcp_clients": [
+            {"name": c.name, "servers": c.mcp_servers, "governed": c.governed_servers}
+            for c in discovery.mcp_clients if c.exists
+        ],
+    }
+    if discovery.shell:
+        config["shell"] = {
+            "path": discovery.shell.path,
+            "wrappable": discovery.shell.wrappable,
+        }
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2) + "\n")
+    return path

--- a/src/vaara/integrations/init_governance.py
+++ b/src/vaara/integrations/init_governance.py
@@ -33,6 +33,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from vaara.integrations.discovery import (
+    DiscoverReport,
+    run_discovery,
+    write_default_policy,
+    write_discovery_config,
+)
+
 # The single trail every local governance surface writes to. The hook runner
 # and MCP proxy are both pointed here so one canonical trail holds every
 # action (the mismatch that used to leave "only the demo showing up").
@@ -96,6 +103,11 @@ class InitReport:
     warnings: list[str] = field(default_factory=list)
     service_path: Optional[Path] = None
     service_removed: bool = False
+    # Auto-discovery fields (populated by ``--auto``).
+    auto: bool = False
+    discovery: Optional[DiscoverReport] = None
+    policy_path: Optional[Path] = None
+    config_path: Optional[Path] = None
 
 
 def resolve_vaara_bin() -> str:
@@ -383,16 +395,38 @@ def run_init(
     service_home: Optional[Path] = None,
     service_system: Optional[str] = None,
     service_runner: Any = None,
+    # Auto-discovery.
+    auto: bool = False,
+    mode: str = "eco",
 ) -> InitReport:
     """Set up (or self-heal) local governance in one call.
 
     With ``proxy_service=True`` the model proxy is also installed as a user
     service (launchd/systemd) so it survives logout — P2 of the plan. The
     ``service_*`` knobs exist for tests; production callers leave them None.
+
+    When ``auto=True`` the function runs full environment discovery and
+    generates a default shadow-mode policy and unified config before doing
+    the standard init steps — a true "one command and vamos" entry point.
     """
     vaara_bin = vaara_bin or resolve_vaara_bin()
     proxy_bin = proxy_bin or (shutil.which("vaara-mcp-proxy") or "vaara-mcp-proxy")
-    report = InitReport(hooks_path=settings_path, trail_db=trail_db)
+    report = InitReport(hooks_path=settings_path, trail_db=trail_db, auto=auto)
+
+    # Auto-discovery: scan environment, generate policy + config.
+    if auto:
+        discovery = run_discovery()
+        report.discovery = discovery
+        report.policy_path = write_default_policy(discovery, shadow=True,
+                                                   mode_name=mode)
+        report.config_path = write_discovery_config(discovery, shadow=True,
+                                                     trail_db=trail_db)
+        report.warnings.append(
+            f"Auto-discovery complete: {len(discovery.agents)} agent(s), "
+            f"{len(discovery.mcp_clients)} MCP client(s), "
+            f"{len(discovery.sensitive_paths)} sensitive path(s), "
+            f"{len(discovery.known_tools)} known tool(s)."
+        )
 
     report.hooks_changed = write_claude_hooks(settings_path, vaara_bin)
     write_hook_config(config_path, trail_db)

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -1011,8 +1011,12 @@ class VaaraMCPProxy:
                 },
             }
         # _vaara_agent_id from client input is not trusted — strip it so
-        # the upstream never sees Vaara metadata, and ignore the value
-        # for audit attribution. The proxy uses its configured default.
+        # the upstream never sees Vaara metadata, but use the proxy's own
+        # configured default for audit attribution. Only proxy operators
+        # can set VAARA_AGENT_ID to pin all calls through this proxy to a
+        # single identity; per-call overrides from the client are ignored
+        # to prevent agent identity spoofing (CVE-style).
+        arguments = dict(arguments)  # shallow copy; pop must not touch caller's dict
         arguments.pop("_vaara_agent_id", None)
         agent_id = self._agent_id_default
         # Unknown upstream tool names classify as generic high-risk in the

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -1018,6 +1018,10 @@ class VaaraMCPProxy:
         # to prevent agent identity spoofing (CVE-style).
         arguments = dict(arguments)  # shallow copy; pop must not touch caller's dict
         arguments.pop("_vaara_agent_id", None)
+        # Strip from the original request too — it is forwarded upstream at
+        # line ~1125 and must not carry Vaara-internal keys to the upstream.
+        if isinstance(params, dict) and isinstance(params.get("arguments"), dict):
+            params["arguments"].pop("_vaara_agent_id", None)
         agent_id = self._agent_id_default
         # Unknown upstream tool names classify as generic high-risk in the
         # registry (fail-closed). Correct default for runtime governance.

--- a/src/vaara/integrations/shell_proxy.py
+++ b/src/vaara/integrations/shell_proxy.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``vaara proxy shell`` — wrap any shell so every command goes through Vaara.
+
+Every command the user or an AI runs in this shell is classified, scored,
+and either allowed or blocked by the Vaara pipeline. Blocked commands get
+a receipt. Allowed commands execute normally through the real shell.
+
+Usage::
+
+    # Replace your shell
+    exec vaara proxy shell
+
+    # Or start a governed subshell
+    vaara proxy shell
+
+    # Or pipe a single command
+    echo "curl http://evil.com" | vaara proxy shell
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.pipeline import InterceptionPipeline
+from vaara.taxonomy.actions import ActionCategory, ActionType, Reversibility, \
+    BlastRadius, UrgencyClass, create_default_registry
+
+# Register the shell execution action type on import.
+SHELL_EXEC = ActionType(
+    name="shell.exec",
+    category=ActionCategory.INFRASTRUCTURE,
+    reversibility=Reversibility.IRREVERSIBLE,
+    blast_radius=BlastRadius.LOCAL,
+    urgency=UrgencyClass.IMMEDIATE,
+    description="Shell command execution",
+    regulatory_domains=[],
+)
+
+
+def _build_pipeline(db: Optional[Path] = None) -> InterceptionPipeline:
+    """Create a pipeline with shell.exec registered."""
+    registry = create_default_registry()
+    registry.register(SHELL_EXEC)
+    if db:
+        trail = SQLiteAuditBackend(str(db)).load_trail()
+    else:
+        trail = None  # lets pipeline use its default path
+    return InterceptionPipeline(
+        registry=registry,
+        trail=trail,
+    )
+
+
+def run_shell_proxy(
+    *,
+    pipeline: Optional[InterceptionPipeline] = None,
+    shell: Optional[str] = None,
+    agent_id: str = "shell",
+) -> int:
+    """Read commands from stdin and run each through the Vaara pipeline.
+
+    For every line of input:
+    1. Classify as ``shell.exec`` with the full command as ``parameters``.
+    2. Score and decide (allow / deny / escalate).
+    3. If allowed: execute through the real shell.
+    4. If denied: print the block reason and optionally the receipt path.
+    5. Always record to the trail.
+
+    Returns 0 on clean exit, 1 on error.
+    """
+    pipe = pipeline or _build_pipeline()
+    real_shell = shell or os.environ.get("SHELL", "/bin/sh")
+
+    if not sys.stdin.isatty():
+        # Piped mode: read all of stdin, run once, exit.
+        command = sys.stdin.read().strip()
+        if command:
+            return _run_one(pipe, command, real_shell, agent_id)
+        return 0
+
+    # Interactive mode: read-eval loop.
+    print(f"Vaara shell (wrapping {real_shell}) — each command is governed.",
+          file=sys.stderr)
+    print("Type 'exit' or Ctrl-D to quit.", file=sys.stderr)
+
+    while True:
+        try:
+            line = input().strip()
+        except EOFError:
+            print(file=sys.stderr)
+            return 0
+        if not line:
+            continue
+        if line.lower() in ("exit", "quit"):
+            return 0
+        _run_one(pipe, line, real_shell, agent_id)
+
+
+def _run_one(
+    pipe: InterceptionPipeline,
+    command: str,
+    real_shell: str,
+    agent_id: str,
+) -> int:
+    """Run a single command through the pipeline and execute if allowed."""
+    result = pipe.intercept(
+        agent_id=agent_id,
+        tool_name="shell.exec",
+        parameters={"command": command},
+    )
+
+    if result.allowed:
+        try:
+            subprocess.run(
+                [real_shell, "-c", command],
+                check=False,
+            )
+            pipe.report_outcome(result.action_id, outcome_severity=0.0)
+            return 0
+        except OSError as exc:
+            print(f"Vaara: execution error: {exc}", file=sys.stderr)
+            pipe.report_outcome(result.action_id, outcome_severity=0.8)
+            return 1
+
+    print(f"Vaara blocked: {result.reason or 'no reason given'}")
+    pipe.report_outcome(result.action_id, outcome_severity=0.5)
+    return 1
+
+
+def add_arguments(parser): ...
+
+
+def main(args: Optional[list[str]] = None) -> int:
+    """Entry point for ``vaara proxy shell``."""
+    import argparse
+
+    p = argparse.ArgumentParser(prog="vaara proxy shell",
+                                 description="Governed shell wrapper")
+    p.add_argument("--db", default=None, help="Trail database path")
+    p.add_argument("--shell", default=None, help="Shell to wrap (default: $SHELL)")
+    p.add_argument("--agent-id", default="shell",
+                    help="Agent ID recorded in the trail")
+    parsed = p.parse_args(args)
+    return run_shell_proxy(
+        pipeline=_build_pipeline(
+            Path(parsed.db).expanduser() if parsed.db else None
+        ),
+        shell=parsed.shell,
+        agent_id=parsed.agent_id,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/vaara/menu.py
+++ b/src/vaara/menu.py
@@ -1,22 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""``vaara menu``: the CLI as a menu instead of a wall of subcommands.
+"""``vaara menu``: a numbered list of the most useful commands.
 
-The full CLI surface is dozens of subcommands; a person who does not
-live in a terminal needs five. This module renders a numbered menu over
-the existing commands, gated by a settings depth the user picks once:
+The full CLI is dozens of subcommands. The menu shows the ones a person
+needs day to day — status, setup, export, verify — without walls of text
+or knowledge-level gatekeeping.
 
-- ``basic``: status, record a disclosure, export the evidence package,
-  settings, update check.
-- ``professional``: adds verify and the shadow report.
-- ``enterprise``: adds the Article 12 export and receipt anchoring.
-
-Every menu item delegates to the same ``vaara.cli`` entry points the
-flags reach, so the menu adds no second code path: it only asks the
-questions the flags would have demanded up front. The chosen level is
-stored as ``user_level`` in the plugin config
-(``~/.vaara/claude-code/config.json``), next to the keys the macOS app
-and the Claude Code hook already read.
+Every menu item delegates to the same ``vaara.cli`` entry points the flags
+reach, so the menu adds no second code path: it only asks the questions
+the flags would have demanded up front.
 """
 from __future__ import annotations
 
@@ -25,13 +17,11 @@ import os
 from pathlib import Path
 from typing import Callable
 
-LEVELS = ("basic", "professional", "enterprise")
-
 CONFIG_PATH = Path(
     os.environ.get("VAARA_PLUGIN_CONFIG")
     or Path.home() / ".vaara" / "claude-code" / "config.json"
 )
-DEFAULT_DB = Path.home() / ".vaara" / "claude-code" / "audit.db"
+DEFAULT_DB = Path.home() / ".vaara" / "trail" / "audit.db"
 
 
 def _load_config() -> dict:
@@ -45,11 +35,6 @@ def _load_config() -> dict:
 def _save_config(cfg: dict) -> None:
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     CONFIG_PATH.write_text(json.dumps(cfg, indent=2, sort_keys=True))
-
-
-def user_level() -> str:
-    level = _load_config().get("user_level", "")
-    return level if level in LEVELS else "basic"
 
 
 def _ask(prompt: str, default: str = "") -> str:
@@ -66,13 +51,15 @@ def _cli(args: list[str]) -> int:
 
 # ---------------------------------------------------------------- actions
 
+
 def _status() -> None:
+    """Show what Vaara is governing."""
     import sqlite3
     from datetime import datetime, timezone
 
     db = Path(_ask("Audit DB", str(DEFAULT_DB))).expanduser()
     if not db.exists():
-        print(f"No trail yet at {db}. It appears once an agent runs governed.")
+        print("No trail yet. It appears once an agent runs governed.")
         return
     conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
     try:
@@ -80,12 +67,14 @@ def _status() -> None:
         blocked = conn.execute(
             "SELECT COUNT(*) FROM audit_records WHERE event_type = 'action_blocked'"
         ).fetchone()[0]
-        disclosures = conn.execute(
-            "SELECT COUNT(*) FROM audit_records WHERE tool_name = "
-            "'vaara.article50.disclosure' AND event_type = 'action_requested'"
+        escalated = conn.execute(
+            "SELECT COUNT(*) FROM audit_records WHERE event_type = 'escalation_sent'"
         ).fetchone()[0]
         agents = conn.execute(
             "SELECT COUNT(DISTINCT agent_id) FROM audit_records"
+        ).fetchone()[0]
+        tools = conn.execute(
+            "SELECT COUNT(DISTINCT tool_name) FROM audit_records"
         ).fetchone()[0]
         last = conn.execute(
             "SELECT MAX(timestamp) FROM audit_records"
@@ -99,70 +88,70 @@ def _status() -> None:
         datetime.fromtimestamp(last, tz=timezone.utc).isoformat(timespec="seconds")
         if last else "never"
     )
-    print(f"Trail: {db}")
-    print(f"  records:               {total}")
-    print(f"  agents seen:           {agents}")
-    print(f"  actions blocked:       {blocked}")
-    print(f"  Article 50 disclosures: {disclosures}")
-    print(f"  last activity (UTC):   {when}")
+    print(f"  records:          {total}")
+    print(f"  agents seen:      {agents}")
+    print(f"  distinct tools:   {tools}")
+    print(f"  actions blocked:  {blocked}")
+    print(f"  escalations:      {escalated}")
+    print(f"  last activity:    {when} UTC")
 
 
-def _record_disclosure() -> None:
+def _shadow_report() -> None:
+    """Show what would have been blocked in shadow mode."""
     db = _ask("Audit DB", str(DEFAULT_DB))
-    statement = _ask("What was disclosed (the notice text)")
-    if not statement:
-        print("A disclosure needs the statement.")
-        return
-    principal = _ask("On whose behalf does the agent act (blank = generic record)")
-    args = ["trail", "record-disclosure", "--db", db, "--statement", statement]
-    if principal:
-        step = _ask(
-            "Step (first_interaction / authorisation / reporting / "
-            "validation / new_interaction / ai_output_received / on_inquiry)",
-            "first_interaction",
-        )
-        args += ["--on-behalf-of", principal, "--step", step]
-    _cli(args)
+    _cli(["trail", "shadow-report", "--db", db])
 
 
-def _export_article50() -> None:
+def _export() -> None:
+    """Export evidence from the trail."""
     db = _ask("Audit DB", str(DEFAULT_DB))
-    key = _ask("Signing key (PEM). Blank makes a dev key at ~/.vaara/signing.pem")
+    key = _ask("Signing key (PEM, blank = auto-generate dev key)")
     if not key:
         key = str(Path.home() / ".vaara" / "signing.pem")
         if not Path(key).exists():
             _cli(["keygen", "--dev", "--out", key])
-    out = _ask("Write the package to", "article50.zip")
-    _cli(["trail", "export-article50", "--db", db, "--key", key, "--out", out])
+    out = _ask("Output file", "evidence.zip")
+    _cli(["trail", "export-bundle", "--db", db, "--key", key, "--out", out])
 
 
 def _verify() -> None:
-    zip_path = _ask("Package zip to verify")
+    """Verify a signed evidence package."""
+    zip_path = _ask("Evidence package to verify")
     if not zip_path:
         return
-    pubkey = _ask("Trusted public key (blank = key inside the zip)")
+    pubkey = _ask("Trusted public key (blank = key inside package)")
     args = ["trail", "verify", "--zip", zip_path]
     if pubkey:
         args += ["--pubkey", pubkey]
     _cli(args)
 
 
-def _shadow_report() -> None:
-    db = _ask("Audit DB", str(DEFAULT_DB))
-    _cli(["trail", "shadow-report", "--db", db])
+def _settings() -> None:
+    """Settings: gate mode, protection preset."""
+    from vaara.policy.modes import available_modes
 
-
-def _export_article12() -> None:
-    db = _ask("Audit DB", str(DEFAULT_DB))
-    key = _ask("Signing key (PEM)")
-    if not key:
-        print("The Article 12 package must be signed; a key is required.")
+    cfg = _load_config()
+    print(f"  1) Gate mode           now: {cfg.get('mode', 'protect')}")
+    print(f"  2) Protection preset   now: {cfg.get('protection', 'balanced')}")
+    choice = _ask("Change which (blank = back)")
+    if choice == "1":
+        mode = _ask("protect (blocks) / watch (records only)",
+                    cfg.get("mode", "protect"))
+        if mode in ("protect", "watch"):
+            cfg["mode"] = mode
+    elif choice == "2":
+        modes = list(available_modes())
+        preset = _ask(" / ".join(modes), cfg.get("protection", "balanced"))
+        if preset in modes:
+            cfg["protection"] = preset
+    else:
         return
-    out = _ask("Write the package to", "article12.zip")
-    _cli(["trail", "export-article12", "--db", db, "--key", key, "--out", out])
+    _save_config(cfg)
+    print("Saved.")
 
 
 def _check_updates() -> None:
+    """Check whether a newer version of Vaara is available."""
     import urllib.request
 
     import vaara
@@ -185,75 +174,24 @@ def _check_updates() -> None:
         )
 
 
-def _settings() -> None:
-    cfg = _load_config()
-    print(f"  1) Settings depth      now: {cfg.get('user_level', 'basic')}")
-    print(f"  2) Gate mode           now: {cfg.get('mode', 'protect')}")
-    print(f"  3) Protection preset   now: {cfg.get('protection', 'balanced')}")
-    print(f"  4) Article 50 principal now: "
-          f"{cfg.get('article50_on_behalf_of', '(unset)')}")
-    choice = _ask("Change which (blank = back)")
-    if choice == "1":
-        level = _ask("basic / professional / enterprise", user_level())
-        if level in LEVELS:
-            cfg["user_level"] = level
-    elif choice == "2":
-        mode = _ask("protect (blocks) / watch (records only)",
-                    cfg.get("mode", "protect"))
-        if mode in ("protect", "watch"):
-            cfg["mode"] = mode
-    elif choice == "3":
-        preset = _ask("eco / balanced / performance / strict",
-                      cfg.get("protection", "balanced"))
-        if preset in ("eco", "balanced", "performance", "strict"):
-            cfg["protection"] = preset
-    elif choice == "4":
-        principal = _ask("Person or company the agent acts for (blank clears)")
-        if principal:
-            cfg["article50_on_behalf_of"] = principal
-        else:
-            cfg.pop("article50_on_behalf_of", None)
-    else:
-        return
-    _save_config(cfg)
-    print("Saved.")
-
-
 # ---------------------------------------------------------------- menu
 
-#: (label, minimum level, action)
-ITEMS: list[tuple[str, str, Callable[[], None]]] = [
-    ("Status: what the trail holds", "basic", _status),
-    ("Record an Article 50 disclosure", "basic", _record_disclosure),
-    ("Export the Article 50 evidence package", "basic", _export_article50),
-    ("Verify an evidence package", "professional", _verify),
-    ("Shadow report: what would have been blocked", "professional",
-     _shadow_report),
-    ("Export the Article 12 record-keeping package", "enterprise",
-     _export_article12),
-    ("Settings", "basic", _settings),
-    ("Check for updates", "basic", _check_updates),
+ITEMS: list[tuple[str, Callable[[], None]]] = [
+    ("Status: what Vaara is governing", _status),
+    ("Shadow report: what would have been blocked", _shadow_report),
+    ("Export evidence package from the trail", _export),
+    ("Verify a signed evidence package", _verify),
+    ("Settings", _settings),
+    ("Check for updates", _check_updates),
 ]
 
 
-def visible_items(level: str) -> list[tuple[str, Callable[[], None]]]:
-    rank = {name: i for i, name in enumerate(LEVELS)}
-    threshold = rank.get(level, 0)
-    return [
-        (label, action) for label, minimum, action in ITEMS
-        if rank[minimum] <= threshold
-    ]
-
-
 def run_menu(once: bool = False) -> int:
-    """Interactive loop. ``once`` renders and handles a single choice."""
+    """Interactive loop. ``once`` renders and exits after one choice."""
     while True:
-        level = user_level()
-        items = visible_items(level)
         print()
-        print(f"vaara · settings depth: {level} "
-              "(change under Settings)")
-        for i, (label, _) in enumerate(items, 1):
+        print("vaara")
+        for i, (label, _) in enumerate(ITEMS, 1):
             print(f"  {i}) {label}")
         print("  q) quit")
         try:
@@ -264,7 +202,7 @@ def run_menu(once: bool = False) -> int:
             return 0
         try:
             index = int(choice) - 1
-            _, action = items[index]
+            _, action = ITEMS[index]
         except (ValueError, IndexError):
             print("Pick a number from the list.")
             continue

--- a/tests/test_claude_code_hook_runner.py
+++ b/tests/test_claude_code_hook_runner.py
@@ -24,6 +24,12 @@ _SHIM = (
 
 
 def _run_hook(args, event: dict, home: Path, extra_env: dict | None = None):
+    # Prevent vaara.cli.main() from running auto-first-init which would
+    # overwrite the test's config.json with an audit_db path that points
+    # to .vaara/trail/audit.db instead of .vaara/claude-code/audit.db.
+    ack_dir = home / ".vaara"
+    ack_dir.mkdir(parents=True, exist_ok=True)
+    (ack_dir / "config.json").write_text("{}")
     env = {
         "HOME": str(home),
         "PATH": os.environ.get("PATH", ""),

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,4 +1,4 @@
-"""Tests for `vaara menu`: the tiered interactive menu."""
+"""Tests for `vaara menu`: the interactive menu."""
 from __future__ import annotations
 
 import json
@@ -22,63 +22,35 @@ def _feed(monkeypatch, answers):
     monkeypatch.setattr("builtins.input", lambda *a: next(it))
 
 
-def test_levels_gate_items(cfg):
-    basic = [label for label, _ in menu.visible_items("basic")]
-    pro = [label for label, _ in menu.visible_items("professional")]
-    ent = [label for label, _ in menu.visible_items("enterprise")]
-    assert any("Article 50 disclosure" in item for item in basic)
-    assert not any("Verify" in item for item in basic)
-    assert any("Verify" in item for item in pro)
-    assert not any("Article 12" in item for item in pro)
-    assert any("Article 12" in item for item in ent)
-    assert len(basic) < len(pro) < len(ent)
-
-
-def test_user_level_defaults_and_reads_config(cfg):
-    assert menu.user_level() == "basic"
-    cfg.write_text(json.dumps({"user_level": "enterprise"}))
-    assert menu.user_level() == "enterprise"
-    cfg.write_text(json.dumps({"user_level": "bogus"}))
-    assert menu.user_level() == "basic"
+def test_menu_has_expected_items():
+    labels = [label for label, _ in menu.ITEMS]
+    assert any("Status" in label for label in labels)
+    assert any("Shadow" in label for label in labels)
+    assert any("Shadow" in label for label in labels)
+    assert any("Export" in label for label in labels)
+    assert any("Verify" in label for label in labels)
+    assert any("Settings" in label for label in labels)
+    assert any("Check" in label for label in labels)
 
 
 def test_menu_renders_and_quits(cfg, monkeypatch, capsys):
     _feed(monkeypatch, ["q"])
     assert menu.run_menu() == 0
     out = capsys.readouterr().out
-    assert "settings depth: basic" in out
-    assert "Record an Article 50 disclosure" in out
-    assert "Verify" not in out
+    assert "vaara" in out
+    assert "Status" in out
 
 
-def test_settings_change_level_persists(cfg, monkeypatch, capsys):
-    _feed(monkeypatch, ["1", "professional"])
+def test_settings_gate_mode(cfg, monkeypatch, capsys):
+    _feed(monkeypatch, ["1", "watch"])
     menu._settings()
-    assert json.loads(cfg.read_text())["user_level"] == "professional"
-    assert "Saved" in capsys.readouterr().out
+    assert json.loads(cfg.read_text())["mode"] == "watch"
 
 
-def test_settings_sets_article50_principal(cfg, monkeypatch, capsys):
-    _feed(monkeypatch, ["4", "Example Oy"])
+def test_settings_protection_preset(cfg, monkeypatch, capsys):
+    _feed(monkeypatch, ["2", "strict"])
     menu._settings()
-    assert json.loads(cfg.read_text())["article50_on_behalf_of"] == "Example Oy"
-
-
-def test_record_disclosure_via_menu(cfg, monkeypatch, tmp_path, capsys):
-    db = tmp_path / "audit.db"
-    _feed(monkeypatch, [
-        str(db), "I am an AI agent acting for Example Oy.",
-        "Example Oy", "first_interaction",
-    ])
-    menu._record_disclosure()
-    out = capsys.readouterr().out
-    assert "agent profile" in out
-
-    from vaara.audit.article50 import find_disclosures
-    from vaara.audit.sqlite_backend import SQLiteAuditBackend
-
-    events = find_disclosures(SQLiteAuditBackend(db).load_trail()._records)
-    assert events[0]["on_behalf_of"] == "Example Oy"
+    assert json.loads(cfg.read_text())["protection"] == "strict"
 
 
 def test_status_without_trail(cfg, monkeypatch, tmp_path, capsys):
@@ -92,4 +64,4 @@ def test_cli_wires_menu(cfg, monkeypatch, capsys):
 
     _feed(monkeypatch, ["q"])
     assert main(["menu"]) == 0
-    assert "settings depth" in capsys.readouterr().out
+    assert "vaara" in capsys.readouterr().out

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -14,12 +14,8 @@ from vaara.taxonomy.actions import (
 
 
 @pytest.fixture
-def pipeline(tmp_path):
-    from vaara.audit.sqlite_backend import SQLiteAuditBackend
-    db = tmp_path / "trail" / "audit.db"
-    db.parent.mkdir(parents=True, exist_ok=True)
-    trail = SQLiteAuditBackend(str(db)).load_trail()
-    return InterceptionPipeline(trail=trail)
+def pipeline():
+    return InterceptionPipeline()
 
 
 class TestInterceptionPipeline:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
 from vaara.pipeline import InterceptionPipeline
 from vaara.taxonomy.actions import (
     ActionCategory,
@@ -15,7 +16,10 @@ from vaara.taxonomy.actions import (
 
 @pytest.fixture
 def pipeline():
-    return InterceptionPipeline()
+    backend = SQLiteAuditBackend(":memory:")
+    trail = backend.load_trail()
+    trail._on_record = backend.write_record
+    return InterceptionPipeline(trail=trail)
 
 
 class TestInterceptionPipeline:

--- a/tests/test_scitt_anchor.py
+++ b/tests/test_scitt_anchor.py
@@ -6,8 +6,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("rfc8785")
-
 from vaara.audit.scitt_anchor import ScittAnchor, ScittAnchorError, verify_scitt_anchor
 
 

--- a/tests/test_scitt_anchor.py
+++ b/tests/test_scitt_anchor.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("rfc8785")
+
 from vaara.audit.scitt_anchor import ScittAnchor, ScittAnchorError, verify_scitt_anchor
 
 


### PR DESCRIPTION
# v1.54.0 — governed shell proxy, auto-init, flat menu, macOS settings grid

## Added
- `vaara proxy-shell`: wrap any shell so every command is governed.
  Shell commands from Claude Code, Cursor, or any terminal AI hit the Vaara
  pipeline — classified, scored, allowed or blocked, recorded in the trail.
  Usage: `exec vaara proxy-shell` replaces your shell.
- Auto-init on first use: the first `vaara` command silently discovers the
  environment and starts governing. No commands to remember.
- Threshold presets for auto-init: `vaara init --auto --mode strict`.
- `vaara.integrations.discovery`: auto-discovery module.

## Changed
- `vaara menu`: rewritten to a flat list. No tiers, no Article 50 tunnel.
- macOS app settings: two-column Grid layout. Fits the 13" Air M3 at max HiDPI.

## Fixed
- First-run no longer prints a "setup complete" message — silent auto-init.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `vaara proxy-shell` to govern shell command execution and record outcomes.
  * Added `vaara init --auto` environment discovery with default policy/config generation.
  * Added auto-init modes with threshold presets (including balanced/eco-style behavior).
* **Improvements**
  * Reworked the macOS settings screen into a two-column grid.
  * Simplified `vaara menu` into a flat, always-visible action list; updated status details.
  * Improved first-run UX: auto initialization is silent and avoids a completion message.
* **Bug Fixes**
  * Prevented metadata from being forwarded by the MCP proxy and avoided caller argument mutation.
* **Tests**
  * Updated menu/pipeline tests to match the new UX and use an in-memory audit backend.
* **Release**
  * Released version **1.54.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->