### PR TITLE
fix: shorten MCP Registry descriptions to ≤100 chars

### DIFF
--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vaaraio/vaara-server",
   "title": "Vaara MCP Server",
-  "description": "Accountable autonomy as a standalone MCP server: gating, tamper-evident audit for every autonomous action",
+  "description": "Accountable autonomy MCP server: gating, tamper-evident audit for every action",
   "websiteUrl": "https://vaara.io",
   "repository": {
     "url": "https://github.com/vaaraio/vaara",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vaaraio/vaara",
   "title": "Vaara",
-  "description": "Accountable autonomy proxy for MCP servers: gating, tamper-evident audit, time anchor for every autonomous action",
+  "description": "Accountable autonomy proxy: gating, tamper-evident audit, time anchor for every action",
   "websiteUrl": "https://vaara.io",
   "repository": {
     "url": "https://github.com/vaaraio/vaara",


### PR DESCRIPTION
MCP Registry rejected v1.54.0 publish because descriptions exceeded 100 characters. Trims both manifests:

- server.json: 113 → 86 chars
- server-vaara-server.json: 105 → 78 chars