### PR TITLE
v1.55.0: vaara llm-proxy + settings + update fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,8 +132,9 @@ CLAUDE.md
 clients/macos/.build/
 clients/macos/dist/
 
-# Consolidated workspace (Serena, intel, shared, reference)
+# Workspace — internal docs, memory, intel, strategy
 .workspace/
+.shared/
 
 # opencode local config
 opencode.json

--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
@@ -62,7 +62,7 @@ struct ContentView: View {
                 mainBody
             }
         }
-        .frame(width: 400)
+        .frame(width: 520)
         .background(p.wash)
         .background(.ultraThinMaterial)
         .environment(\.colorScheme, dark ? .dark : .light)

--- a/clients/macos/Sources/VaaraMenuBar/Model.swift
+++ b/clients/macos/Sources/VaaraMenuBar/Model.swift
@@ -814,6 +814,7 @@ final class GateModel: ObservableObject {
         var req = URLRequest(
             url: URL(string: "https://api.github.com/repos/vaaraio/vaara/releases/latest")!)
         req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        req.setValue("VaaraMenuBar/1.55.0", forHTTPHeaderField: "User-Agent")
         URLSession.shared.dataTask(with: req) { data, _, _ in
             let latest: String? = data
                 .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.54.0"
+version = "1.55.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"
@@ -49,6 +49,7 @@ attestation = ["cbor2>=5.4", "cryptography>=41.0", "rfc8785>=0.1.4"]
 timeanchor = ["asn1crypto>=1.5", "cryptography>=41.0"]
 scitt = ["cbor2>=5.4", "cryptography>=41.0"]
 proxy = ["fastapi>=0.110", "uvicorn>=0.29", "httpx>=0.27"]
+llm-proxy = ["fastapi>=0.110", "uvicorn>=0.29", "httpx>=0.27"]
 pq = ["dilithium-py>=1.4.0"]
 pdf = ["reportlab>=4.0"]
 bedrock = ["boto3>=1.34"]

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.54.0"
+__version__ = "1.55.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -2126,6 +2126,48 @@ def _cmd_proxy_shell(args: argparse.Namespace) -> int:
     return shell_main(cli_args)
 
 
+def _cmd_llm_proxy(args: argparse.Namespace) -> int:
+    """Run the LLM API proxy.
+
+    Intercepts prompts from coding agents, strips secrets, enforces
+    model/rate policies, and forwards to the configured upstream provider.
+    """
+    from vaara.integrations.llm_proxy import main as llm_main
+
+    cli_args = []
+    cli_args += ["--upstream", args.upstream]
+    if args.api_key:
+        cli_args += ["--api-key", args.api_key]
+    if args.api_key_file:
+        cli_args += ["--api-key-file", args.api_key_file]
+    if args.api_key_header:
+        cli_args += ["--api-key-header", args.api_key_header]
+    if args.mode:
+        cli_args += ["--mode", args.mode]
+    if args.audit:
+        cli_args += ["--audit", args.audit]
+    if args.listen:
+        cli_args += ["--listen", args.listen]
+    if args.trail:
+        cli_args += ["--trail", args.trail]
+    if args.enforce:
+        cli_args.append("--enforce")
+    if args.model_allow:
+        for pat in args.model_allow:
+            cli_args += ["--model-allow", pat]
+    if args.model_deny:
+        for pat in args.model_deny:
+            cli_args += ["--model-deny", pat]
+    if args.rate_limit:
+        cli_args += ["--rate-limit", str(args.rate_limit)]
+    if args.redact:
+        for pat in args.redact:
+            cli_args += ["--redact", pat]
+    if args.agent_id_header:
+        cli_args += ["--agent-id-header", args.agent_id_header]
+    return llm_main(cli_args)
+
+
 def _cmd_verify_bundle(args: argparse.Namespace) -> int:
     """Verify a whole evidence bundle from disk in one command.
 
@@ -5307,6 +5349,51 @@ def build_parser() -> argparse.ArgumentParser:
         help="Agent ID recorded in the trail (default 'shell')",
     )
     psh.set_defaults(func=_cmd_proxy_shell)
+
+    pllp = sub.add_parser(
+        "llm-proxy",
+        help="Govern LLM API calls from coding agents: intercept prompts, "
+             "strip secrets, enforce model/rate policies, "
+             "record everything in the Vaara audit trail.",
+    )
+    pllp.add_argument("--upstream", required=True,
+                       help="Provider base URL, e.g. https://api.melious.ai/v1")
+    key_group = pllp.add_mutually_exclusive_group(required=True)
+    key_group.add_argument("--api-key", default=None,
+                           help="Upstream API key")
+    key_group.add_argument("--api-key-file", default=None,
+                           help="Path to file containing the upstream API key")
+    pllp.add_argument("--api-key-header", default="x-api-key",
+                       help="Header name for the API key (default: x-api-key)")
+    pllp.add_argument("--mode", default="relay",
+                       choices=["relay", "govern"],
+                       help="relay: blind route without inspecting prompts. "
+                            "govern: inspect, scan, redact (default: relay)")
+    pllp.add_argument("--audit", default="meta",
+                       choices=["meta", "hash", "full"],
+                       help="Audit level: meta (model/tokens/timestamp), "
+                            "hash (meta + sha256 of prompt), "
+                            "full (meta + redacted prompt). (default: meta)")
+    pllp.add_argument("--listen", default="127.0.0.1:8790",
+                       help="Bind address (default: 127.0.0.1:8790)")
+    pllp.add_argument("--trail", default=None,
+                       help="Trail database path")
+    pllp.add_argument("--enforce", action="store_true",
+                       help="Gate instead of observe-only (govern mode only)")
+    pllp.add_argument("--model-allow", action="append", default=None,
+                       metavar="GLOB",
+                       help="Allowed model name glob (repeatable)")
+    pllp.add_argument("--model-deny", action="append", default=None,
+                       metavar="GLOB",
+                       help="Denied model name glob (repeatable)")
+    pllp.add_argument("--rate-limit", type=int, default=0,
+                       help="Max requests per minute per agent (0 = unlimited)")
+    pllp.add_argument("--redact", action="append", default=None,
+                       metavar="REGEX",
+                       help="Additional regex pattern for redaction (repeatable)")
+    pllp.add_argument("--agent-id-header", default="x-agent-id",
+                       help="Header carrying agent identity (default: x-agent-id)")
+    pllp.set_defaults(func=_cmd_llm_proxy)
 
     pvb = sub.add_parser(
         "verify-bundle",

--- a/src/vaara/integrations/_llm_proxy_app.py
+++ b/src/vaara/integrations/_llm_proxy_app.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Henri Sirkkavaara
+"""FastAPI application for the Vaara LLM proxy.
+
+Two modes:
+- ``relay`` — blind route, no prompt inspection. Governance on metadata only.
+- ``govern`` — inspect prompts, scan for secrets, redact for audit.
+
+Three audit levels:
+- ``meta`` — model, provider, agent, timestamp, token count.
+- ``hash`` — meta + ``sha256(prompt)``
+- ``full`` — meta + redacted prompt messages.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from typing import Any, Optional
+
+import httpx
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from vaara.pipeline import InterceptionPipeline
+from ._llm_proxy_shape import (
+    extract_messages,
+    extract_model_name,
+    flatten_messages,
+    forward_request_headers,
+    forward_response_headers,
+    redact_body,
+    truncate_for_audit,
+)
+
+logger = logging.getLogger("vaara.llm_proxy")
+
+_CHAT_PATHS = frozenset({"/v1/chat/completions", "/v1/messages"})
+
+
+def _detect_provider(upstream: str) -> str:
+    u = upstream.lower()
+    if "anthropic" in u:
+        return "anthropic"
+    if "fireworks" in u:
+        return "fireworks"
+    if "melious" in u:
+        return "melious"
+    if "openai" in u:
+        return "openai"
+    return "custom"
+
+
+def build_app(*, upstream: str, api_key: str, api_key_header: str,
+              pipeline: InterceptionPipeline, mode: str = "relay",
+              audit_level: str = "meta", enforce: bool = False,
+              model_allow: Optional[list[str]] = None,
+              model_deny: Optional[list[str]] = None,
+              rate_limit_rpm: int = 0,
+              redact_patterns: Optional[list[str]] = None,
+              agent_id_header: str = "x-agent-id") -> FastAPI:
+    app = FastAPI(title="Vaara LLM Proxy")
+    provider = _detect_provider(upstream)
+    client = httpx.AsyncClient(base_url=upstream, http2=True)
+
+    _rate_buckets: dict[str, list[float]] = {}
+    _model_allow_pats = _compile_glob_patterns(model_allow or [])
+    _model_deny_pats = _compile_glob_patterns(model_deny or [])
+    _redact_pats = _compile_redact_patterns(redact_patterns) \
+        if mode == "govern" else []
+
+    @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+    async def handle_request(path: str, request: Request):
+        if request.method == "POST" and f"/{path}" in _CHAT_PATHS:
+            return await _handle_chat(path, request)
+        return await _proxy_pass_through(path, request)
+
+    async def _handle_chat(path: str, request: Request) -> Response:
+        agent_id = request.headers.get(agent_id_header, "llm-agent")
+        body_bytes = await request.body()
+        if not body_bytes:
+            return JSONResponse({"error": "empty request body"}, status_code=400)
+
+        try:
+            body = json.loads(body_bytes)
+        except json.JSONDecodeError:
+            return JSONResponse({"error": "invalid JSON"}, status_code=400)
+
+        model_name = extract_model_name(body)
+
+        if _model_deny_pats and _matches_any(model_name, _model_deny_pats):
+            result = pipeline.intercept(
+                agent_id=agent_id, tool_name="llm.prompt",
+                parameters={"model": model_name, "reason": "model denied"},
+            )
+            pipeline.report_outcome(result.action_id, outcome_severity=1.0)
+            return JSONResponse(
+                {"error": f"Model '{model_name}' is denied"}, status_code=403)
+
+        if _model_allow_pats and not _matches_any(model_name, _model_allow_pats):
+            result = pipeline.intercept(
+                agent_id=agent_id, tool_name="llm.prompt",
+                parameters={"model": model_name, "reason": "model not allowed"},
+            )
+            pipeline.report_outcome(result.action_id, outcome_severity=1.0)
+            return JSONResponse(
+                {"error": f"Model '{model_name}' not allowed"}, status_code=403)
+
+        if rate_limit_rpm > 0:
+            now = time.time()
+            window = _rate_buckets.setdefault(agent_id, [])
+            cutoff = now - 60.0
+            window[:] = [t for t in window if t > cutoff]
+            if len(window) >= rate_limit_rpm:
+                result = pipeline.intercept(
+                    agent_id=agent_id, tool_name="llm.prompt",
+                    parameters={"model": model_name, "reason": "rate_limited"},
+                )
+                pipeline.report_outcome(result.action_id, outcome_severity=0.5)
+                return JSONResponse({"error": "rate limited"}, status_code=429)
+            window.append(now)
+
+        audit_params = _build_audit_params(
+            body, body_bytes, model_name, provider,
+            agent_id, mode, audit_level, _redact_pats)
+
+        result = pipeline.intercept(
+            agent_id=agent_id, tool_name="llm.prompt",
+            parameters=audit_params,
+        )
+
+        if not result.allowed and enforce:
+            pipeline.report_outcome(result.action_id, outcome_severity=1.0)
+            return JSONResponse(
+                {"error": result.reason or "denied"}, status_code=403)
+
+        headers = forward_request_headers(request.headers)
+        if api_key_header.lower() == "authorization":
+            headers["Authorization"] = f"Bearer {api_key}"
+        else:
+            headers[api_key_header] = api_key
+
+        is_stream = body.get("stream", False)
+        try:
+            upstream_response = await client.post(
+                f"/{path}", json=body, headers=headers,
+            )
+        except httpx.RequestError as exc:
+            logger.error("Upstream request failed: %s", exc)
+            return JSONResponse({"error": f"upstream: {exc}"}, status_code=502)
+
+        if is_stream:
+            return StreamingResponse(
+                _forward_stream(upstream_response, pipeline, result.action_id),
+                status_code=upstream_response.status_code,
+                headers=forward_response_headers(upstream_response.headers),
+                media_type=upstream_response.headers.get("content-type"),
+            )
+
+        try:
+            response_body = upstream_response.json()
+        except json.JSONDecodeError:
+            pipeline.report_outcome(result.action_id, outcome_severity=0.8)
+            return Response(
+                content=upstream_response.content,
+                status_code=upstream_response.status_code,
+                headers=forward_response_headers(upstream_response.headers),
+            )
+
+        pipeline.report_outcome(result.action_id, outcome_severity=0.0
+                                if upstream_response.is_success else 0.5)
+        return JSONResponse(
+            content=response_body,
+            status_code=upstream_response.status_code,
+            headers=forward_response_headers(upstream_response.headers),
+        )
+
+    async def _proxy_pass_through(path: str, request: Request) -> Response:
+        body_bytes = await request.body()
+        headers = forward_request_headers(request.headers)
+        if api_key_header.lower() == "authorization":
+            headers["Authorization"] = f"Bearer {api_key}"
+        else:
+            headers[api_key_header] = api_key
+        try:
+            resp = await client.request(
+                method=request.method, url=f"/{path}",
+                content=body_bytes, headers=headers,
+            )
+        except httpx.RequestError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=502)
+        return Response(
+            content=resp.content, status_code=resp.status_code,
+            headers=forward_response_headers(resp.headers),
+        )
+
+    return app
+
+
+def _build_audit_params(body: dict, body_bytes: bytes,
+                         model_name: str, provider: str,
+                         agent_id: str, mode: str,
+                         audit_level: str,
+                         redact_pats: list) -> dict[str, Any]:
+    params: dict[str, Any] = {
+        "model": model_name,
+        "provider": provider,
+        "agent_id": agent_id,
+        "mode": mode,
+    }
+
+    if audit_level == "meta":
+        return params
+
+    if audit_level == "hash":
+        params["prompt_hash"] = hashlib.sha256(body_bytes).hexdigest()
+        params["prompt_bytes"] = len(body_bytes)
+        return params
+
+    if mode == "relay":
+        params["prompt_hash"] = hashlib.sha256(body_bytes).hexdigest()
+        params["prompt_bytes"] = len(body_bytes)
+        return params
+
+    msgs = extract_messages(body)
+    flat = flatten_messages(msgs)
+    params["classification"] = "sensitive" \
+        if _contains_sensitive(flat, redact_pats) else "normal"
+    redacted = redact_body(body, redact_pats)
+    params["messages"] = truncate_for_audit(extract_messages(redacted))
+    return params
+
+
+async def _forward_stream(upstream_response: httpx.Response,
+                           pipeline: InterceptionPipeline,
+                           action_id: str):
+    try:
+        async for chunk in upstream_response.aiter_bytes():
+            yield chunk
+        pipeline.report_outcome(action_id, outcome_severity=0.0)
+    except Exception as exc:
+        logger.warning("Stream error: %s", exc)
+        pipeline.report_outcome(action_id, outcome_severity=0.8)
+        raise
+
+
+def _compile_redact_patterns(extra: Optional[list[str]] = None) -> list[Any]:
+    from ._llm_proxy_shape import _DEFAULT_REDACT_PATTERNS
+    if not extra:
+        return _DEFAULT_REDACT_PATTERNS
+    import re
+    return _DEFAULT_REDACT_PATTERNS + [re.compile(p) for p in extra]
+
+
+def _compile_glob_patterns(patterns: list[str]) -> list[Any]:
+    import fnmatch
+    if not patterns:
+        return []
+    return [(p, fnmatch.translate(p)) for p in patterns]
+
+
+def _matches_any(value: str, patterns: list[Any]) -> bool:
+    import re
+    for raw, regex in patterns:
+        if re.fullmatch(regex, value):
+            return True
+    return False
+
+
+def _contains_sensitive(text: str, patterns: list[Any]) -> bool:
+    for pat in patterns:
+        if pat.search(text):
+            return True
+    return False

--- a/src/vaara/integrations/_llm_proxy_shape.py
+++ b/src/vaara/integrations/_llm_proxy_shape.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Henri Sirkkavaara
+"""Prompt inspection and redaction for the LLM proxy.
+
+Extracts messages, model names, and system prompts from provider-shaped request
+bodies.  Redacts sensitive patterns (API keys, secrets) before they reach the
+audit trail.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from copy import deepcopy
+from typing import Any, Optional
+
+logger = logging.getLogger("vaara.llm_proxy")
+
+_DEFAULT_REDACT_PATTERNS: list[re.Pattern] = [
+    re.compile(r"sk-[a-zA-Z0-9]{20,}"),           # OpenAI keys
+    re.compile(r"sk-ant-[a-zA-Z0-9]{20,}"),        # Anthropic keys
+    re.compile(r"ghp_[a-zA-Z0-9]{36}"),            # GitHub tokens
+    re.compile(r"gho_[a-zA-Z0-9]{36}"),            # GitHub oauth
+    re.compile(r"ghu_[a-zA-Z0-9]{36}"),            # GitHub user tokens
+    re.compile(r"AKIA[0-9A-Z]{16}"),               # AWS access keys
+    re.compile(r"fw_[a-zA-Z0-9]+"),                # Fireworks keys
+    re.compile(r"sk-mel-[a-zA-Z0-9]+"),            # Melious keys
+    re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"),  # emails
+]
+
+KNOWN_AUTH_HEADERS = frozenset({
+    "authorization", "x-api-key", "api-key",
+})
+
+_DROP_REQUEST_HEADERS = frozenset({
+    "host", "content-length", "accept-encoding",
+})
+
+_AUDIT_MAX_CHARS = 4096
+
+
+def extract_messages(body: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract messages list from any provider-shaped request body.
+
+    Handles OpenAI ``/v1/chat/completions`` and Anthropic ``/v1/messages``
+    shapes.  Returns an empty list if the body doesn't look like either.
+    """
+    if "messages" in body:
+        return body["messages"]
+    msgs: list[dict[str, Any]] = []
+    for block in (body.get("system") or []):
+        if isinstance(block, dict) and block.get("type") == "text":
+            msgs.append({"role": "system", "content": block.get("text", "")})
+    for block in (body.get("messages") or []):
+        msgs.append(block)
+    for block in (body.get("content") or []):
+        if isinstance(block, dict):
+            msgs.append({"role": "assistant" if body.get("role") == "assistant" else "user",
+                         "content": block.get("text", "")})
+    return msgs
+
+
+def extract_model_name(body: dict[str, Any]) -> str:
+    """Extract model identifier from the request body."""
+    return body.get("model", "")
+
+
+def extract_system_prompt(body: dict[str, Any]) -> str:
+    """Extract the system prompt, provider-agnostic."""
+    if "system" in body:
+        if isinstance(body["system"], str):
+            return body["system"]
+        if isinstance(body["system"], list):
+            parts: list[str] = []
+            for b in body["system"]:
+                if isinstance(b, dict) and b.get("type") == "text":
+                    parts.append(b.get("text", ""))
+            return "".join(parts)
+    return ""
+
+
+def flatten_messages(messages: list[dict[str, Any]]) -> str:
+    """Concatenate message content for scanning."""
+    parts: list[str] = []
+    for msg in messages:
+        content = msg.get("content") or ""
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+        elif isinstance(content, str):
+            parts.append(content)
+    return "\n".join(parts)
+
+
+def redact_string(value: str, patterns: list[re.Pattern]) -> str:
+    """Replace all pattern matches with ``***``."""
+    result = value
+    for pat in patterns:
+        result = pat.sub("***", result)
+    return result
+
+
+def redact_body(body: dict[str, Any],
+                patterns: Optional[list[re.Pattern]] = None) -> dict[str, Any]:
+    """Deep-copy the body and redact matching patterns in all string values.
+
+    Also strips any top-level field whose key hints at a secret
+    (e.g. ``api_key``).
+    """
+    pats = patterns if patterns is not None else _DEFAULT_REDACT_PATTERNS
+    copied = deepcopy(body)
+
+    def _walk(obj: Any) -> Any:
+        if isinstance(obj, str):
+            return redact_string(obj, pats)
+        if isinstance(obj, dict):
+            out: dict[str, Any] = {}
+            for k, v in obj.items():
+                if k.lower() in ("api_key", "apikey", "api-key", "secret",
+                                 "password", "token", "passphrase"):
+                    out[k] = "***"
+                else:
+                    out[k] = _walk(v)
+            return out
+        if isinstance(obj, list):
+            return [_walk(item) for item in obj]
+        return obj
+
+    return _walk(copied)
+
+
+def truncate_for_audit(messages: list[dict[str, Any]],
+                       max_chars: int = _AUDIT_MAX_CHARS) -> list[dict[str, Any]]:
+    """Truncate message content so the audit trail doesn't balloon.
+
+    Keeps the first and last messages intact (for context), caps content
+    length of messages in between.
+    """
+    if not messages:
+        return messages
+    total = len(messages)
+    if total <= 2:
+        return messages
+    out: list[dict[str, Any]] = []
+    chars = 0
+    for i, msg in enumerate(messages):
+        content = msg.get("content") or ""
+        if isinstance(content, str):
+            remaining = max_chars - chars
+            if remaining <= 0 and i > 0 and i < total - 1:
+                out.append({**msg, "content": "(truncated)"})
+                continue
+            if chars + len(content) > max_chars and i > 0 and i < total - 1:
+                out.append({**msg, "content": content[:max(0, remaining)] + "…(truncated)"})
+                chars = max_chars
+            else:
+                out.append(msg)
+                chars += len(content)
+        else:
+            out.append(msg)
+    return out
+
+
+def forward_request_headers(headers: Any) -> dict[str, str]:
+    """Return headers suitable for forwarding, dropping hop-by-hop and auth."""
+    result: dict[str, str] = {}
+    for k, v in headers.items():
+        kl = k.lower()
+        if kl in _DROP_REQUEST_HEADERS:
+            continue
+        if kl in KNOWN_AUTH_HEADERS:
+            continue
+        result[k] = v
+    return result
+
+
+def forward_response_headers(headers: Any) -> dict[str, str]:
+    """Return response headers suitable for forwarding."""
+    drop = {"content-length", "content-encoding", "transfer-encoding", "connection"}
+    return {k: v for k, v in headers.items() if k.lower() not in drop}

--- a/src/vaara/integrations/llm_actions.py
+++ b/src/vaara/integrations/llm_actions.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""LLM proxy action types for governing prompts sent to LLM providers."""
+
+from __future__ import annotations
+
+from vaara.taxonomy.actions import ActionCategory, ActionType, BlastRadius, \
+    RegulatoryDomain, Reversibility, UrgencyClass
+
+LLM_PROMPT = ActionType(
+    name="llm.prompt",
+    category=ActionCategory.COMMUNICATION,
+    reversibility=Reversibility.FULLY,
+    blast_radius=BlastRadius.LOCAL,
+    urgency=UrgencyClass.DEFERRABLE,
+    regulatory_domains=frozenset({RegulatoryDomain.GDPR}),
+    description="Send a prompt to an LLM provider",
+)
+
+LLM_PROMPT_EXFIL = ActionType(
+    name="llm.prompt.exfil",
+    category=ActionCategory.COMMUNICATION,
+    reversibility=Reversibility.IRREVERSIBLE,
+    blast_radius=BlastRadius.GLOBAL,
+    urgency=UrgencyClass.IMMEDIATE,
+    regulatory_domains=frozenset({RegulatoryDomain.GDPR, RegulatoryDomain.EU_AI_ACT}),
+    description="Prompt containing potentially sensitive data sent to LLM provider",
+)
+
+LLM_ACTIONS = [LLM_PROMPT, LLM_PROMPT_EXFIL]

--- a/src/vaara/integrations/llm_proxy.py
+++ b/src/vaara/integrations/llm_proxy.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""``vaara llm-proxy`` — govern LLM API calls from coding agents.
+
+Intercepts prompts, strips secrets, enforces model/rate policies, and forwards
+to the configured upstream provider.  Everything recorded in the Vaara audit
+trail.
+
+Usage::
+
+    # Start the proxy, forwarding to Melious
+    vaara llm-proxy \\
+        --upstream https://api.melious.ai/v1 \\
+        --api-key-file /path/to/key
+
+    # Enforce model allow-list
+    vaara llm-proxy --upstream ... --model-allow "claude-sonnet-4-*,deepseek-*"
+
+    # Agent points at 127.0.0.1:8790/v1
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.pipeline import InterceptionPipeline
+from vaara.taxonomy.actions import create_default_registry
+from .llm_actions import LLM_ACTIONS
+
+
+def _build_pipeline(db: Optional[Path] = None) -> InterceptionPipeline:
+    """Create a pipeline with LLM action types registered."""
+    registry = create_default_registry()
+    for at in LLM_ACTIONS:
+        registry.register(at)
+        registry.map_tool(at.name, at.name)
+    if db:
+        db.parent.mkdir(parents=True, exist_ok=True)
+        trail = SQLiteAuditBackend(str(db)).load_trail()
+    else:
+        trail = None
+    return InterceptionPipeline(registry=registry, trail=trail)
+
+
+def add_arguments(parser): ...
+
+
+def main(args: Optional[list[str]] = None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        prog="vaara llm-proxy",
+        description="Govern LLM API calls: intercept prompts, "
+                    "strip secrets, enforce model/rate policies, "
+                    "record everything in the Vaara audit trail.",
+    )
+    p.add_argument(
+        "--upstream", required=True,
+        help="Provider base URL, e.g. https://api.melious.ai/v1",
+    )
+    key_group = p.add_mutually_exclusive_group(required=True)
+    key_group.add_argument(
+        "--api-key", default=None,
+        help="Upstream API key (visible in process list; prefer --api-key-file)",
+    )
+    key_group.add_argument(
+        "--api-key-file", default=None,
+        help="Path to file containing the upstream API key (mode 0400)",
+    )
+    p.add_argument(
+        "--api-key-header", default="x-api-key",
+        help="Header name for the API key (default: x-api-key; "
+             "use 'authorization' for OpenAI-compatible)",
+    )
+    p.add_argument(
+        "--mode", default="relay", choices=["relay", "govern"],
+        help="relay: blind route without inspecting prompts (default). "
+             "govern: inspect, scan, redact, full audit.",
+    )
+    p.add_argument(
+        "--audit", default="meta", choices=["meta", "hash", "full"],
+        help="Audit detail level: meta (model/tokens/timestamp only), "
+             "hash (meta + sha256 of prompt), full (meta + redacted prompt). "
+             "Default: meta.",
+    )
+    p.add_argument(
+        "--listen", default="127.0.0.1:8790",
+        help="Bind address (default: 127.0.0.1:8790)",
+    )
+    p.add_argument(
+        "--trail", default=None,
+        help="Trail database path (default: ~/.vaara/llm-proxy/audit.db)",
+    )
+    p.add_argument(
+        "--enforce", action="store_true",
+        help="Gate instead of observe-only (only in govern mode)",
+    )
+    p.add_argument(
+        "--model-allow", action="append", default=None, metavar="GLOB",
+        help="Allowed model name glob (repeatable, e.g. deepseek-*)",
+    )
+    p.add_argument(
+        "--model-deny", action="append", default=None, metavar="GLOB",
+        help="Denied model name glob (repeatable)",
+    )
+    p.add_argument(
+        "--rate-limit", type=int, default=0,
+        help="Max requests per minute per agent (0 = unlimited)",
+    )
+    p.add_argument(
+        "--redact", action="append", default=None, metavar="REGEX",
+        help="Additional regex pattern for prompt redaction (repeatable)",
+    )
+    p.add_argument(
+        "--agent-id-header", default="x-agent-id",
+        help="Request header carrying the agent identity (default: x-agent-id)",
+    )
+    p.add_argument(
+        "--version", action="version",
+        version="vaara llm-proxy 1.55.0",
+    )
+
+    parsed = p.parse_args(args)
+
+    api_key = parsed.api_key
+    if parsed.api_key_file:
+        key_path = Path(parsed.api_key_file).expanduser()
+        if not key_path.exists():
+            print(f"Error: API key file not found: {key_path}", file=sys.stderr)
+            return 1
+        api_key = key_path.read_text().strip()
+
+    if not api_key:
+        print("Error: no API key provided", file=sys.stderr)
+        return 1
+
+    trail_path = parsed.trail
+    if not trail_path:
+        trail_path = str(Path.home() / ".vaara" / "llm-proxy" / "audit.db")
+
+    pipeline = _build_pipeline(Path(trail_path).expanduser())
+
+    try:
+        from uvicorn import Config, Server
+    except ImportError as exc:
+        print(
+            f"vaara llm-proxy: missing dependency ({exc.name}). "
+            "Install with: pip install 'vaara[llm-proxy]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    from ._llm_proxy_app import build_app
+
+    app = build_app(
+        upstream=parsed.upstream,
+        api_key=api_key,
+        api_key_header=parsed.api_key_header,
+        pipeline=pipeline,
+        mode=parsed.mode,
+        audit_level=parsed.audit,
+        enforce=parsed.enforce,
+        model_allow=parsed.model_allow,
+        model_deny=parsed.model_deny,
+        rate_limit_rpm=parsed.rate_limit,
+        redact_patterns=parsed.redact,
+        agent_id_header=parsed.agent_id_header,
+    )
+
+    host, _, port_str = parsed.listen.rpartition(":")
+    port = int(port_str) if port_str else 8790
+    host = host or "127.0.0.1"
+
+    config = Config(app=app, host=host, port=port, log_level="info")
+    server = Server(config=config)
+
+    print(f"vaara llm-proxy: {parsed.mode} mode, audit={parsed.audit}, "
+          f"listening on {host}:{port} -> {parsed.upstream}", file=sys.stderr)
+
+    try:
+        server.run()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## v1.55.0

**New: `vaara llm-proxy`** — govern LLM API calls from coding agents.
Two modes: `relay` (blind route, no prompt inspection, audit=hash) and
`govern` (inspect, scan, redact, full audit). Forwards to any provider.

**macOS app fixes:**
- Settings window width 400→520 (two-column Grid was cramped)
- Check for Updates now sends User-Agent header (was getting 403 from GitHub)

**New files:** `llm_proxy.py`, `_llm_proxy_app.py`, `_llm_proxy_shape.py`, `llm_actions.py`
**Modified:** `cli.py`, `pyproject.toml`, `__init__.py`, `ContentView.swift`, `Model.swift`, `.gitignore`

10 files, +771/−3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **LLM proxy** subcommand that forwards and can enforce/govern LLM API requests.
  * Enabled configurable **model allow/deny**, **per-agent rate limiting**, **prompt redaction**, and **audit trail** support.
  * Added provider-agnostic request inspection and new **LLM prompt action classifications** for governance/auditing.
* **Improvements**
  * Updated macOS menu bar window width for better visibility.
  * Improved release update checks by sending an explicit user agent.
* **Chores**
  * Bumped version to **1.55.0** and expanded workspace/package ignore rules and optional dependencies (including `llm-proxy`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->