### PR TITLE
v1.56.0: WebKit Governance + vaara check/outcome CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.55.0] - 2026-07-30
+
+### Added
+- `vaara llm-proxy`: govern LLM API calls from coding agents. Two modes:
+  `--mode relay` (blind route, no prompt inspection, audit=hash) and
+  `--mode govern` (inspect, scan, redact, full audit). Forwards to any
+  upstream provider — swap by changing `--upstream`. New optional extra:
+  `pip install 'vaara[llm-proxy]'`.
+
+### Fixed
+- Settings window width 400 → 520 (two-column Grid layout was cramped).
+- Check for Updates now sends `User-Agent` header (GitHub API was returning
+  403 without it).
+
 ## [1.54.0] - 2026-07-29
 
 ### Added


### PR DESCRIPTION
## v1.56.0

**WebKit Governance** — intercepts AI traffic from Safari, Mail, Orion, and all WKWebView apps at the system level. No browser extension required. macOS Network Extension + Accessibility API observer + app UI toggle.

**New CLI:** `vaara check` and `vaara outcome` for programmatic pipeline access.

**llm-proxy:** `--mode relay|govern` and `--audit meta|hash|full` flags.

**Fixes:** Settings window width, Check for Updates User-Agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `vaara llm-proxy` command with relay and governance modes.
  - Added support for configurable upstream providers, auditing, and optional installation extras.

- **Bug Fixes**
  - Improved the macOS settings window layout.
  - Fixed update checks that could fail because requests lacked identifying header information.

- **Documentation**
  - Added the 1.55.0 changelog entry dated July 30, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->