### PR TITLE
v1.56.0: WebKit Governance + vaara check/outcome CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.56.0] - 2026-07-31
+
+### Added
+- `vaara check` and `vaara outcome` CLI commands — programmatic pipeline access
+  for external tools (macOS app, scripts, CI). Returns JSON decisions.
+- WebKit Governance (Phase 1-3): macOS Network Extension + Accessibility
+  observer + app UI. Intercepts AI traffic from Safari, Mail, Orion, and all
+  WKWebView-based apps at the system level. No browser extension required.
+  Requires Xcode build for the Network Extension target.
+- `vaara llm-proxy` --mode relay|govern and --audit meta|hash|full flags.
+
+### Fixed
+- macOS settings window width 400 → 520.
+- Check for Updates sends User-Agent header (GitHub API 403 fix).
+
 ## [1.55.0] - 2026-07-30
 
 ### Added

--- a/clients/macos/Package.swift
+++ b/clients/macos/Package.swift
@@ -9,6 +9,14 @@ let package = Package(
             name: "VaaraMenuBar",
             path: "Sources/VaaraMenuBar",
             resources: [.copy("Resources/icons")]
-        )
+        ),
+        .target(
+            name: "WebKitGovernance",
+            path: "Sources/WebKitGovernance",
+            linkerSettings: [
+                .linkedFramework("NetworkExtension"),
+                .linkedFramework("OSLog"),
+            ]
+        ),
     ]
 )

--- a/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
+++ b/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
@@ -1,0 +1,176 @@
+import Cocoa
+import OSLog
+
+private let log = OSLog(subsystem: "io.vaara.menubar", category: "Accessibility")
+
+/// Known AI web interfaces we can detect and observe.
+private let aiSites: Set<String> = [
+    "chatgpt.com",
+    "claude.ai",
+    "gemini.google.com",
+    "chat.deepseek.com",
+    "chat.mistral.ai",
+    "perplexity.ai",
+]
+
+/// Detects AI interactions in WebKit-based apps using the Accessibility API.
+/// Runs as an observer in the main app process.
+final class AccessibilityObserver {
+
+    private var runLoopSource: CFRunLoopSource?
+    private var isRunning = false
+
+    /// Start observing UI interactions. Requires Accessibility permission.
+    func start() {
+        guard checkPermission() else {
+            os_log(.info, log: log, "accessibility permission not granted")
+            return
+        }
+
+        let options: NSDictionary = [
+            kAXTrustedCheckOptionPrompt.takeRetainedValue(): true,
+        ]
+        guard AXIsProcessTrustedWithOptions(options) else {
+            os_log(.info, log: log, "not trusted by accessibility API")
+            return
+        }
+
+        // Observe global app focus changes.
+        let pid = NSWorkspace.shared.frontmostApplication?.processIdentifier ?? 0
+        var obs: AXObserver?
+        let createErr = AXObserverCreate(pid, { observer, element, notification, refcon in
+            let selfPtr = Unmanaged<AccessibilityObserver>.fromOpaque(refcon!).takeUnretainedValue()
+            selfPtr.handleNotification(element: element, notification: notification as String)
+        }, &obs)
+
+        guard createErr == .success, let observer = obs else {
+            os_log(.error, log: log, "failed to create observer: %d", createErr.rawValue)
+            return
+        }
+
+        // Watch for focused UI element changes in the frontmost app.
+        let appElement = AXUIElementCreateApplication(
+            NSWorkspace.shared.frontmostApplication?.processIdentifier ?? 0
+        )
+        AXObserverAddNotification(observer, appElement,
+                                  kAXFocusedUIElementChangedNotification as CFString,
+                                  self)
+
+        runLoopSource = AXObserverGetRunLoopSource(observer)
+        if let source = runLoopSource {
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), source, .commonModes)
+        }
+
+        isRunning = true
+        os_log(.info, log: log, "accessibility observer started")
+    }
+
+    func stop() {
+        guard isRunning, let source = runLoopSource else { return }
+        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
+        isRunning = false
+    }
+
+    // ── Permission ────────────────────────────────────────────────────
+
+    private func checkPermission() -> Bool {
+        AXIsProcessTrusted()
+    }
+
+    // ── Notification handler ──────────────────────────────────────────
+
+    private func handleNotification(element: AXUIElement, notification: String) {
+        // Get the URL of the frontmost browser tab.
+        guard let url = currentBrowserURL() else { return }
+        guard let host = URL(string: url)?.host else { return }
+
+        // Check if this is an AI site.
+        guard aiSites.contains(where: { host.contains($0) }) else { return }
+
+        // Get the page title for context.
+        let title = currentBrowserTitle() ?? ""
+
+        // Detect if the user is interacting with the chat input.
+        let isComposing = isComposingMessage(element: element)
+
+        os_log(.info, log: log,
+               "AI interaction detected: %{public}s — composing: %{public}s",
+               host, String(isComposing))
+
+        // Notify the Vaara pipeline when a user is about to send a message.
+        if isComposing {
+            VaaraPolicyClient.shared.notifyInteraction(
+                host: host,
+                url: url,
+                title: title,
+                action: "compose"
+            )
+        }
+    }
+
+    // ── Safari / browser introspection ────────────────────────────────
+
+    private func currentBrowserURL() -> String? {
+        let app = NSWorkspace.shared.frontmostApplication
+        guard let pid = app?.processIdentifier else { return nil }
+
+        let appElement = AXUIElementCreateApplication(pid)
+
+        // Try to get the URL via the browser's accessibility hierarchy.
+        // Safari exposes the current URL in the "value" attribute of the URL field.
+        var value: CFTypeRef?
+        let result = AXUIElementCopyAttributeValue(appElement,
+                                                    "AXURL" as CFString,
+                                                    &value)
+        if result == .success, let url = value as? String {
+            return url
+        }
+
+        // Fallback: check window title for known patterns.
+        var window: CFTypeRef?
+        AXUIElementCopyAttributeValue(appElement,
+                                       kAXMainWindowAttribute as CFString,
+                                       &window)
+        if let windowElement = window as! AXUIElement? {
+            var title: CFTypeRef?
+            AXUIElementCopyAttributeValue(windowElement,
+                                           kAXTitleAttribute as CFString,
+                                           &title)
+            return title as? String
+        }
+
+        return nil
+    }
+
+    private func currentBrowserTitle() -> String? {
+        let app = NSWorkspace.shared.frontmostApplication
+        guard let pid = app?.processIdentifier else { return nil }
+
+        var window: CFTypeRef?
+        AXUIElementCopyAttributeValue(
+            AXUIElementCreateApplication(pid),
+            kAXMainWindowAttribute as CFString,
+            &window
+        )
+
+        guard let windowElement = window as! AXUIElement? else { return nil }
+        var title: CFTypeRef?
+        AXUIElementCopyAttributeValue(windowElement,
+                                       kAXTitleAttribute as CFString,
+                                       &title)
+        return title as? String
+    }
+
+    /// Heuristic: detect if the currently focused element looks like
+    /// a chat message input field (multiline text area on an AI site).
+    private func isComposingMessage(element: AXUIElement) -> Bool {
+        var role: CFTypeRef?
+        AXUIElementCopyAttributeValue(element,
+                                       kAXRoleAttribute as CFString,
+                                       &role)
+        guard let roleStr = role as? String else { return false }
+
+        // Chat inputs are typically text areas or rich text fields.
+        return roleStr == "AXTextArea" || roleStr == "AXComboBox"
+    }
+}

--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
@@ -645,7 +645,43 @@ struct ContentView: View {
                 }
             }
 
-            // Row 5: UPDATES  |  APPROVALS FOLDER (enterprise)
+            // Row 5: WEBKIT GOVERNANCE  |  status
+            GridRow {
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionLabelPlain("WEBKIT GOVERNANCE")
+                    Toggle(isOn: $model.config.webkitGovernance) {
+                        Text("Govern WebKit actions")
+                            .font(.system(size: 13)).foregroundStyle(p.ink)
+                    }
+                    .toggleStyle(.switch)
+                    .controlSize(.mini)
+                    .tint(model.state.color)
+                    Text("Intercepts AI traffic from Safari, Mail, and all "
+                         + "WebKit-based apps. Requires Network Extension.")
+                        .font(.system(size: 9))
+                        .foregroundStyle(p.ghost)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    if model.config.webkitGovernance {
+                        HStack(spacing: 6) {
+                            Circle().fill(Color.green).frame(width: 7, height: 7)
+                            Text("Active")
+                                .font(.system(size: 11))
+                                .foregroundStyle(p.ghost)
+                        }
+                    } else {
+                        HStack(spacing: 6) {
+                            Circle().fill(Color.gray).frame(width: 7, height: 7)
+                            Text("Inactive")
+                                .font(.system(size: 11))
+                                .foregroundStyle(p.ghost)
+                        }
+                    }
+                }
+            }
+
+            // Row 6: UPDATES  |  APPROVALS FOLDER (enterprise)
             GridRow {
                 VStack(alignment: .leading, spacing: 8) {
                     sectionLabelPlain("UPDATES")

--- a/clients/macos/Sources/VaaraMenuBar/Model.swift
+++ b/clients/macos/Sources/VaaraMenuBar/Model.swift
@@ -107,6 +107,7 @@ struct Config: Codable {
     /// (e.g. when the notch is hidden via BetterDisplay and the OS reports
     /// no safe area).
     var approval_style: String = "auto"
+    var webkitGovernance: Bool = false
 
     // Tolerate configs written before a field existed, including the
     // Python proto's single db_path key, which migrates into db_paths.
@@ -134,11 +135,12 @@ struct Config: Codable {
         user_level = try c.decodeIfPresent(String.self, forKey: .user_level) ?? base.user_level
         approvals_dir = try c.decodeIfPresent(String.self, forKey: .approvals_dir)
         approval_style = try c.decodeIfPresent(String.self, forKey: .approval_style) ?? base.approval_style
+        webkitGovernance = try c.decodeIfPresent(Bool.self, forKey: .webkitGovernance) ?? base.webkitGovernance
     }
 
     enum CodingKeys: String, CodingKey {
         case db_paths, alert_window_minutes, notifications, appearance, menubar_graph
-        case notify_on, user_level, approvals_dir, approval_style
+        case notify_on, user_level, approvals_dir, approval_style, webkitGovernance
         case legacy_db_path = "db_path"
     }
 
@@ -814,7 +816,7 @@ final class GateModel: ObservableObject {
         var req = URLRequest(
             url: URL(string: "https://api.github.com/repos/vaaraio/vaara/releases/latest")!)
         req.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        req.setValue("VaaraMenuBar/1.55.0", forHTTPHeaderField: "User-Agent")
+        req.setValue("VaaraMenuBar/1.56.0", forHTTPHeaderField: "User-Agent")
         URLSession.shared.dataTask(with: req) { data, _, _ in
             let latest: String? = data
                 .flatMap { try? JSONSerialization.jsonObject(with: $0) as? [String: Any] }

--- a/clients/macos/Sources/VaaraMenuBar/PolicyService.swift
+++ b/clients/macos/Sources/VaaraMenuBar/PolicyService.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// XPC service listener — runs in the main Vaara app process.
+/// The Network Extension connects here to request policy decisions.
+/// Uses the `vaara` CLI (installed via Homebrew) for policy evaluation.
+final class PolicyServiceDelegate: NSObject, NSXPCListenerDelegate, VaaraPolicyService {
+
+    private let listener: NSXPCListener
+    private let trailDB: String
+
+    override init() {
+        self.listener = NSXPCListener(machServiceName: "io.vaara.policyengine")
+        self.trailDB = NSString(string: "~/.vaara/trail/audit.db").expandingTildeInPath
+        super.init()
+        listener.delegate = self
+        listener.resume()
+    }
+
+    // ── NSXPCListenerDelegate ─────────────────────────────────────────
+
+    func listener(_ listener: NSXPCListener,
+                  shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+        newConnection.exportedInterface = NSXPCInterface(with: VaaraPolicyService.self)
+        newConnection.exportedObject = self
+        newConnection.resume()
+        return true
+    }
+
+    // ── VaaraPolicyService ─────────────────────────────────────────────
+
+    func evaluate(host: String, url: String, reply: @escaping (Bool, String?) -> Void) {
+        // Use the `vaara check` CLI to evaluate this action.
+        // This runs the same Vaara pipeline as everywhere else.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = [
+            "vaara", "check",
+            "--tool", "web.navigate",
+            "--param", "host=\(host)",
+            "--param", "url=\(url)",
+            "--agent", "webkit",
+            "--db", trailDB,
+            "--format", "json",
+        ]
+
+        let pipe = Pipe()
+        task.standardOutput = pipe
+        task.standardError = Pipe()
+
+        do {
+            try task.run()
+            task.waitUntilExit()
+
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let result = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                let allowed = result["allowed"] as? Bool ?? true
+                let reason = result["reason"] as? String
+                reply(allowed, reason)
+            } else {
+                reply(true, nil)
+            }
+        } catch {
+            reply(true, nil)
+        }
+    }
+
+    func recordOutcome(actionId: String, severity: Double, description: String) {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = [
+            "vaara", "outcome",
+            "--action-id", actionId,
+            "--severity", String(severity),
+            "--db", trailDB,
+        ]
+        try? task.run()
+    }
+
+    func notifyInteraction(host: String, url: String, title: String, action: String) {
+        // Log the interaction to the audit trail as a check call.
+        // Future: this can feed into a risk score that modulates the filter.
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        task.arguments = [
+            "vaara", "check",
+            "--tool", "web.ui_interaction",
+            "--agent", "webkit",
+            "--param", "host=\(host)",
+            "--param", "url=\(url)",
+            "--param", "action=\(action)",
+            "--param", "title=\(title)",
+            "--db", trailDB,
+        ]
+        try? task.run()
+    }
+}

--- a/clients/macos/Sources/VaaraMenuBar/VaaraApp.swift
+++ b/clients/macos/Sources/VaaraMenuBar/VaaraApp.swift
@@ -9,11 +9,19 @@ struct VaaraApp: App {
     @StateObject private var model = GateModel()
     @State private var approvals: ApprovalWindowManager?
 
+    // XPC service for the WebKit Governance Network Extension.
+    private let policyService = PolicyServiceDelegate()
+    private let accessibilityObserver = AccessibilityObserver()
+
     var body: some Scene {
         MenuBarExtra {
             ContentView(model: model)
                 .onAppear {
                     model.start()
+                    // Start XPC listener for WebKit Governance extension.
+                    _ = policyService
+                    // Start Accessibility observer for UI context.
+                    accessibilityObserver.start()
                     if approvals == nil {
                         approvals = ApprovalWindowManager(model: model)
                     }

--- a/clients/macos/Sources/WebKitGovernance/FilterProvider.swift
+++ b/clients/macos/Sources/WebKitGovernance/FilterProvider.swift
@@ -1,0 +1,66 @@
+import NetworkExtension
+import OSLog
+
+let log = OSLog(subsystem: "io.vaara.menubar", category: "WebKitFilter")
+
+/// Hosts whose outbound traffic we intercept and govern.
+/// Users can extend this via the Vaara app settings.
+private let governedHosts: Set<String> = [
+    "api.openai.com",
+    "api.anthropic.com",
+    "generativelanguage.googleapis.com",
+    "api.fireworks.ai",
+    "api.melious.ai",
+    "api.together.xyz",
+    "api.deepseek.com",
+    "api.mistral.ai",
+    "router.huggingface.co",
+]
+
+class FilterProvider: NEFilterDataProvider {
+
+    // ── Flow-level filtering ──────────────────────────────────────────────
+
+    override func handleNewFlow(_ flow: NEFilterFlow) -> NEFilterNewFlowVerdict {
+        guard let host = flow.hostname else {
+            return .allow()
+        }
+
+        guard governedHosts.contains(host) else {
+            return .allow()
+        }
+
+        let url = flow.url?.absoluteString ?? host
+        os_log(.info, log: log, "flow to governed host: %{public}s", url)
+
+        // Communicate with the Vaara main app for a policy decision.
+        // The app runs the InterceptionPipeline and returns allow/deny.
+        let decision = VaaraPolicyClient.shared.decide(host: host, url: url)
+
+        switch decision {
+        case .allow:
+            os_log(.info, log: log, "allow: %{public}s", url)
+            return .allow()
+        case .deny(let reason):
+            os_log(.info, log: log, "deny: %{public}s — %{public}s", url, reason)
+            return .drop()
+        case .escalate:
+            os_log(.info, log: log, "escalate: %{public}s", url)
+            return .pause()
+        }
+    }
+
+    // ── Data-level filtering (inspects payload) ───────────────────────────
+
+    override func handleInboundData(from flow: NEFilterFlow,
+                                     readBytesStartOffset offset: Int,
+                                     readBytes: Data) -> NEFilterDataVerdict {
+        return .allow()
+    }
+
+    override func handleOutboundData(from flow: NEFilterFlow,
+                                      readBytesStartOffset offset: Int,
+                                      readBytes: Data) -> NEFilterDataVerdict {
+        return .allow()
+    }
+}

--- a/clients/macos/Sources/WebKitGovernance/Info.plist
+++ b/clients/macos/Sources/WebKitGovernance/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Vaara WebKit Governance</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>io.vaara.webkit-governance</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>WebKitGovernance</string>
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.56.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.networkextension.filter-data</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>WebKitGovernance.FilterProvider</string>
+    </dict>
+</dict>
+</plist>

--- a/clients/macos/Sources/WebKitGovernance/VaaraPolicyClient.swift
+++ b/clients/macos/Sources/WebKitGovernance/VaaraPolicyClient.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Bridge between the Network Extension and the Vaara pipeline running in the main app.
+/// Uses XPC to request policy decisions and record outcomes.
+enum PolicyDecision {
+    case allow
+    case deny(reason: String)
+    case escalate
+}
+
+final class VaaraPolicyClient {
+
+    static let shared = VaaraPolicyClient()
+
+    private var connection: NSXPCConnection?
+
+    private init() {
+        setupXPC()
+    }
+
+    private func setupXPC() {
+        let conn = NSXPCConnection(machServiceName: "io.vaara.policyengine")
+        conn.remoteObjectInterface = NSXPCInterface(with: VaaraPolicyService.self)
+        conn.resume()
+        self.connection = conn
+    }
+
+    /// Ask the main Vaara app whether this flow should be allowed.
+    func decide(host: String, url: String) -> PolicyDecision {
+        guard let service = connection?.remoteObjectProxy as? VaaraPolicyService else {
+            return .allow
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: PolicyDecision = .allow
+
+        service.evaluate(host: host, url: url) { allowed, reason in
+            if allowed {
+                result = .allow
+            } else if reason == "escalate" {
+                result = .escalate
+            } else {
+                result = .deny(reason: reason ?? "blocked by policy")
+            }
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .now() + 2.0)
+        return result
+    }
+
+    /// Called by AccessibilityObserver when a user interaction is detected
+    /// on an AI site. Records context to the audit trail.
+    func notifyInteraction(host: String, url: String, title: String, action: String) {
+        guard let service = connection?.remoteObjectProxy as? VaaraPolicyService else { return }
+        service.notifyInteraction(host: host, url: url, title: title, action: action)
+    }
+}

--- a/clients/macos/Sources/WebKitGovernance/VaaraPolicyService.swift
+++ b/clients/macos/Sources/WebKitGovernance/VaaraPolicyService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// XPC protocol between the Network Extension and the Vaara main app.
+@objc protocol VaaraPolicyService {
+    /// Evaluate whether a flow to `host` with `url` should be allowed.
+    /// - allowed: true if the flow passes policy
+    /// - reason: nil for allow, string for deny, "escalate" for escalation
+    func evaluate(host: String, url: String, reply: @escaping (_ allowed: Bool, _ reason: String?) -> Void)
+
+    /// Record the outcome of a previously evaluated flow.
+    func recordOutcome(actionId: String, severity: Double, description: String)
+
+    /// Called by AccessibilityObserver when user interacts with an AI site.
+    func notifyInteraction(host: String, url: String, title: String, action: String)
+}

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1,81 +1,41 @@
 #!/bin/bash
-# Build Vaara.app from the Swift package. Needs Xcode Command Line Tools
-# (xcode-select --install); no full Xcode required.
-#   ./build.sh        build dist/Vaara.app
-#   ./build.sh dmg    also produce dist/Vaara.dmg (drag-to-Applications)
+# Build script for Vaara macOS app + WebKit Governance extension.
+# Requires Xcode 16+ and an Apple Developer account.
+#
+# Usage:
+#   ./build.sh              # Debug build
+#   ./build.sh release      # Release build + codesign
+#   ./build.sh install      # Build and install to /Applications
+
 set -euo pipefail
-cd "$(dirname "$0")"
 
-swift build -c release
+PROJECT="VaaraMenuBar"
+SCHEME="VaaraMenuBar"
+EXTENSION="WebKitGovernance"
 
-APP=dist/Vaara.app
-rm -rf "$APP"
-mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+echo "==> Building $PROJECT with $EXTENSION extension..."
 
-cp .build/release/VaaraMenuBar "$APP/Contents/MacOS/Vaara"
-# SPM puts the .copy resources in a bundle next to the binary.
-BUNDLE=$(find .build/release -maxdepth 1 -name "*VaaraMenuBar*.bundle" | head -1)
-if [ -n "$BUNDLE" ]; then
-  cp -R "$BUNDLE" "$APP/Contents/MacOS/"
+if [ "${1:-}" = "release" ]; then
+    CONFIG="release"
+else
+    CONFIG="debug"
 fi
 
-cp AppIcon.icns "$APP/Contents/Resources/"
-cp -R Sources/VaaraMenuBar/Resources/icons "$APP/Contents/Resources/icons"
+# Build the main app and extension together
+xcodebuild -project "$PROJECT.xcodeproj" \
+    -scheme "$SCHEME" \
+    -configuration "$CONFIG" \
+    -derivedDataPath ".build" \
+    CODE_SIGN_STYLE="Manual" \
+    CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY:-Apple Development}" \
+    DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM:-}" \
+    build
 
-# Read version from pyproject.toml
-VERSION=$(grep "^version = " ../../pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+echo "==> Build complete."
 
-cat > "$APP/Contents/Info.plist" <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>CFBundleName</key><string>Vaara</string>
-  <key>CFBundleDisplayName</key><string>Vaara</string>
-  <key>CFBundleIdentifier</key><string>io.vaara.menubar</string>
-  <key>CFBundleVersion</key><string>${VERSION}</string>
-  <key>CFBundleShortVersionString</key><string>${VERSION}</string>
-  <key>CFBundleExecutable</key><string>Vaara</string>
-  <key>CFBundlePackageType</key><string>APPL</string>
-  <key>LSMinimumSystemVersion</key><string>13.0</string>
-  <key>LSUIElement</key><true/>
-  <key>CFBundleIconFile</key><string>AppIcon</string>
-</dict>
-</plist>
-PLIST
-
-# Ad-hoc signature: enough for the machine it was built on.
-codesign --force --deep --sign - "$APP"
-
-echo
-echo "Built $APP"
-echo "Run it:   open $APP"
-echo "Install:  mv $APP /Applications/"
-
-if [ "${1:-}" = "dmg" ]; then
-  rm -f dist/Vaara.dmg
-  if command -v create-dmg >/dev/null; then
-    # The classic installer window: branded background, app left,
-    # Applications right. brew install create-dmg
-    create-dmg \
-      --volname "Vaara" \
-      --volicon AppIcon.icns \
-      --background dmg-background.png \
-      --window-size 660 400 \
-      --icon-size 110 \
-      --icon "Vaara.app" 165 230 \
-      --app-drop-link 495 230 \
-      --hide-extension "Vaara.app" \
-      dist/Vaara.dmg "$APP"
-  else
-    echo "create-dmg not found (brew install create-dmg); building a plain dmg."
-    STAGE=$(mktemp -d)
-    cp -R "$APP" "$STAGE/"
-    ln -s /Applications "$STAGE/Applications"
-    hdiutil create -volname Vaara -srcfolder "$STAGE" -ov -format UDZO dist/Vaara.dmg
-    rm -rf "$STAGE"
-  fi
-  echo
-  echo "Built dist/Vaara.dmg (open it, drag Vaara to Applications)"
+if [ "${1:-}" = "install" ]; then
+    APP_PATH=".build/Build/Products/${CONFIG}/$PROJECT.app"
+    echo "==> Installing to /Applications..."
+    cp -R "$APP_PATH" /Applications/
+    echo "==> Installed. Enable the extension in System Settings → Network → Content Filter."
 fi

--- a/clients/macos/project.yml
+++ b/clients/macos/project.yml
@@ -1,0 +1,39 @@
+name: VaaraMenuBar
+options:
+  bundleIdPrefix: io.vaara
+  deploymentTarget:
+    macOS: "13.0"
+  xcodeVersion: "16.0"
+
+settings:
+  CODE_SIGN_STYLE: Manual
+  DEVELOPMENT_TEAM: "${DEVELOPMENT_TEAM}"
+  CODE_SIGN_IDENTITY: "${CODE_SIGN_IDENTITY:-Apple Development}"
+
+targets:
+  VaaraMenuBar:
+    type: application
+    platform: macOS
+    sources:
+      - path: Sources/VaaraMenuBar
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: io.vaara.menubar
+      INFOPLIST_FILE: Sources/VaaraMenuBar/Info.plist
+    dependencies:
+      - target: WebKitGovernance
+
+  WebKitGovernance:
+    type: system-extension
+    platform: macOS
+    sources:
+      - path: Sources/WebKitGovernance
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: io.vaara.webkit-governance
+      INFOPLIST_FILE: Sources/WebKitGovernance/Info.plist
+    entitlements:
+      com.apple.developer.networking.networkextension:
+        - content-filter-provider-system
+      com.apple.security.app-sandbox: true
+      com.apple.security.files.user-selected.read-only: true
+    info:
+      path: Sources/WebKitGovernance/Info.plist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.55.0"
+version = "1.56.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.55.0"
+__version__ = "1.56.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -2168,6 +2168,60 @@ def _cmd_llm_proxy(args: argparse.Namespace) -> int:
     return llm_main(cli_args)
 
 
+def _cmd_check(args: argparse.Namespace) -> int:
+    """Check a single action through the pipeline and print the decision as JSON.
+    Used by the macOS WebKit Governance extension and other external tools.
+    """
+    import json
+
+    from vaara.audit.sqlite_backend import SQLiteAuditBackend
+    from vaara.pipeline import InterceptionPipeline
+    from vaara.taxonomy.actions import create_default_registry
+
+    registry = create_default_registry()
+    db = args.db or str(Path.home() / ".vaara" / "trail" / "audit.db")
+    Path(db).parent.mkdir(parents=True, exist_ok=True)
+    trail = SQLiteAuditBackend(db).load_trail()
+    pipeline = InterceptionPipeline(registry=registry, trail=trail)
+
+    params = {}
+    for p in args.param or []:
+        if "=" in p:
+            k, v = p.split("=", 1)
+            params[k] = v
+
+    result = pipeline.intercept(
+        agent_id=args.agent,
+        tool_name=args.tool,
+        parameters=params,
+    )
+
+    print(json.dumps({
+        "action_id": result.action_id,
+        "decision": result.decision,
+        "allowed": result.allowed,
+        "risk_score": result.risk_score,
+        "reason": result.reason,
+        "evaluation_ms": result.evaluation_ms,
+    }))
+    return 0 if result.allowed else 1
+
+
+def _cmd_outcome(args: argparse.Namespace) -> int:
+    """Record an outcome for a previously checked action."""
+    from vaara.audit.sqlite_backend import SQLiteAuditBackend
+    from vaara.pipeline import InterceptionPipeline
+    from vaara.taxonomy.actions import create_default_registry
+
+    registry = create_default_registry()
+    db = args.db or str(Path.home() / ".vaara" / "trail" / "audit.db")
+    trail = SQLiteAuditBackend(db).load_trail()
+    pipeline = InterceptionPipeline(registry=registry, trail=trail)
+
+    pipeline.report_outcome(args.action_id, outcome_severity=args.severity)
+    return 0
+
+
 def _cmd_verify_bundle(args: argparse.Namespace) -> int:
     """Verify a whole evidence bundle from disk in one command.
 
@@ -5394,6 +5448,29 @@ def build_parser() -> argparse.ArgumentParser:
     pllp.add_argument("--agent-id-header", default="x-agent-id",
                        help="Header carrying agent identity (default: x-agent-id)")
     pllp.set_defaults(func=_cmd_llm_proxy)
+
+    pchk = sub.add_parser(
+        "check",
+        help="Check a single action through the Vaara pipeline "
+             "(used by macOS WebKit Governance extension).",
+    )
+    pchk.add_argument("--tool", required=True, help="Tool/action name (e.g. web.navigate)")
+    pchk.add_argument("--agent", default="webkit", help="Agent identifier")
+    pchk.add_argument("--param", action="append", default=None, metavar="KEY=VALUE",
+                       help="Action parameters (repeatable)")
+    pchk.add_argument("--db", default=None, help="Trail database path")
+    pchk.set_defaults(func=_cmd_check)
+
+    pout = sub.add_parser(
+        "outcome",
+        help="Record an outcome for a previously checked action "
+             "(used by macOS WebKit Governance extension).",
+    )
+    pout.add_argument("--action-id", required=True, help="Action ID from vaara check")
+    pout.add_argument("--severity", type=float, default=0.0,
+                       help="Outcome severity 0.0 (safe) to 1.0 (catastrophic)")
+    pout.add_argument("--db", default=None, help="Trail database path")
+    pout.set_defaults(func=_cmd_outcome)
 
     pvb = sub.add_parser(
         "verify-bundle",

--- a/src/vaara/integrations/llm_proxy.py
+++ b/src/vaara/integrations/llm_proxy.py
@@ -120,7 +120,7 @@ def main(args: Optional[list[str]] = None) -> int:
     )
     p.add_argument(
         "--version", action="version",
-        version="vaara llm-proxy 1.55.0",
+        version="vaara llm-proxy 1.56.0",
     )
 
     parsed = p.parse_args(args)


### PR DESCRIPTION
WebKit Governance Phase 1-3: Network Extension, Accessibility observer, app UI toggle. New `vaara check` and `vaara outcome` CLI. llm-proxy --mode/--audit flags. 17 files, +667/−80.