### PR TITLE
fix: update build stamp to b56 (webkit-governance)

### DIFF
--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
@@ -37,7 +37,7 @@ struct Palette {
 
 /// Bump on every source change; shown in the footer so a stale build is
 /// visible at a glance instead of masquerading as a bug.
-let BUILD_STAMP = "b47 (anchor click-to-choose) · 2026-07-24"
+let BUILD_STAMP = "b56 (webkit-governance) · 2026-07-31"
 
 struct ContentView: View {
     @ObservedObject var model: GateModel


### PR DESCRIPTION
Build stamp was still at b47 from July 24. Updated to b56 for v1.56.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS app build identifier to reflect the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->