### PR TITLE
v1.56.1 — security audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.56.1] - 2026-08-02
+
+### Security
+- **x402 settlement binding**: `X402Gate._settle()` now captures the facilitator
+  settlement response and exposes it via `last_settlement_evidence`. The
+  `/v1/anchor` endpoint returns `settlement_evidence_digest` so callers can bind
+  the paid settlement artifact into a receipt's `evidenceRef.digest`.
+- **JCS canonicalization parity**: `_decision_binding.py` no longer silently
+  produces non-JCS digests via stdlib fallback. Now delegates to the canonical
+  `rfc8785.dumps()` first, then warns on divergence. Fixes a forgery/rejection
+  seam in the keyless decision-proof path.
+- **eIDAS TOFU guard**: `server/anchor.py` trust-on-first-use CA probing now
+  requires explicit `VAARA_ANCHOR_ALLOW_TOFU=1`. Previously ungated — production
+  operators could silently trust an endpoint's first response.
+
 ## [1.56.0] - 2026-07-31
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.52.0",
+  "version": "1.56.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.52.0",
+  "version": "1.56.1",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.56.0"
+version = "1.56.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.52.0",
+  "version": "1.56.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.52.0",
+"version": "1.56.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.52.0",
+  "version": "1.56.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.52.0",
+"version": "1.56.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.56.0"
+__version__ = "1.56.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Patch release for three security findings from independent researcher review. See CHANGELOG.md for details.

- x402 settlement evidence capture
- JCS canonicalization fallback fix
- eIDAS TOFU production guard