### PR TITLE
v1.57.1 — fix macOS app build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.57.1] - 2026-08-02
+
+### Fixed
+- macOS app build: fix `AccessibilityObserver` type error
+  (`UnsafeMutableRawPointer` conversion for `AXObserverAddNotification`).
+- Move `VaaraPolicyClient` and `VaaraPolicyService` into the `VaaraMenuBar`
+  module so the Homebrew formula's `swiftc` invocation can resolve them.
+
 ## [1.57.0] - 2026-08-02
 
 ### Added (EU AI Act general application date — 2 Aug 2026)

--- a/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
+++ b/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
@@ -54,7 +54,7 @@ final class AccessibilityObserver {
         )
         AXObserverAddNotification(observer, appElement,
                                   kAXFocusedUIElementChangedNotification as CFString,
-                                  self)
+                                  Unmanaged.passUnretained(self).toOpaque())
 
         runLoopSource = AXObserverGetRunLoopSource(observer)
         if let source = runLoopSource {

--- a/clients/macos/Sources/VaaraMenuBar/VaaraPolicyClient.swift
+++ b/clients/macos/Sources/VaaraMenuBar/VaaraPolicyClient.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Bridge between the Network Extension and the Vaara pipeline running in the main app.
+/// Uses XPC to request policy decisions and record outcomes.
+enum PolicyDecision {
+    case allow
+    case deny(reason: String)
+    case escalate
+}
+
+final class VaaraPolicyClient {
+
+    static let shared = VaaraPolicyClient()
+
+    private var connection: NSXPCConnection?
+
+    private init() {
+        setupXPC()
+    }
+
+    private func setupXPC() {
+        let conn = NSXPCConnection(machServiceName: "io.vaara.policyengine")
+        conn.remoteObjectInterface = NSXPCInterface(with: VaaraPolicyService.self)
+        conn.resume()
+        self.connection = conn
+    }
+
+    /// Ask the main Vaara app whether this flow should be allowed.
+    func decide(host: String, url: String) -> PolicyDecision {
+        guard let service = connection?.remoteObjectProxy as? VaaraPolicyService else {
+            return .allow
+        }
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: PolicyDecision = .allow
+
+        service.evaluate(host: host, url: url) { allowed, reason in
+            if allowed {
+                result = .allow
+            } else if reason == "escalate" {
+                result = .escalate
+            } else {
+                result = .deny(reason: reason ?? "blocked by policy")
+            }
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .now() + 2.0)
+        return result
+    }
+
+    /// Called by AccessibilityObserver when a user interaction is detected
+    /// on an AI site. Records context to the audit trail.
+    func notifyInteraction(host: String, url: String, title: String, action: String) {
+        guard let service = connection?.remoteObjectProxy as? VaaraPolicyService else { return }
+        service.notifyInteraction(host: host, url: url, title: title, action: action)
+    }
+}

--- a/clients/macos/Sources/VaaraMenuBar/VaaraPolicyService.swift
+++ b/clients/macos/Sources/VaaraMenuBar/VaaraPolicyService.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// XPC protocol between the Network Extension and the Vaara main app.
+@objc protocol VaaraPolicyService {
+    /// Evaluate whether a flow to `host` with `url` should be allowed.
+    /// - allowed: true if the flow passes policy
+    /// - reason: nil for allow, string for deny, "escalate" for escalation
+    func evaluate(host: String, url: String, reply: @escaping (_ allowed: Bool, _ reason: String?) -> Void)
+
+    /// Record the outcome of a previously evaluated flow.
+    func recordOutcome(actionId: String, severity: Double, description: String)
+
+    /// Called by AccessibilityObserver when user interacts with an AI site.
+    func notifyInteraction(host: String, url: String, title: String, action: String)
+}

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.57.0",
+  "version": "1.57.1",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.57.0"
+version = "1.57.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.57.0",
+  "version": "1.57.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.57.0",
+"version": "1.57.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.57.0",
+  "version": "1.57.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.57.0",
+"version": "1.57.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.57.0"
+__version__ = "1.57.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## v1.57.1 — macOS app build fix

Fixes Swift compilation errors preventing Homebrew app installation:

- `AccessibilityObserver.swift:57` — convert `self` to `UnsafeMutableRawPointer`
- Move `VaaraPolicyClient.swift` and `VaaraPolicyService.swift` from WebKitGovernance into VaaraMenuBar module
- Resolves cross-module reference errors

### Changes
- `clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift` — fix type conversion
- `clients/macos/Sources/VaaraMenuBar/VaaraPolicyClient.swift` — moved from WebKitGovernance
- `clients/macos/Sources/VaaraMenuBar/VaaraPolicyService.swift` — moved from WebKitGovernance

### Verification
- `swiftc` compile succeeds for VaaraMenuBar target
- Homebrew formula `brew upgrade vaaraio/tap/vaara` completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS policy evaluation and interaction reporting for network requests.
  * Added support for allow, deny, and escalation decisions, with safe fallback behavior when unavailable.

* **Bug Fixes**
  * Fixed a macOS accessibility observer notification registration type error.

* **Chores**
  * Released version 1.57.1 across packages and integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->