### PR TITLE
v1.57.4: fix Swift pid_t type annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.57.4] - 2026-08-02
+
+### Fixed
+- macOS `AccessibilityObserver`: fix `pid_t` type annotation in `attachTo` and
+  `detachObserver` that broke Swift compilation.
+
 ## [1.57.3] - 2026-08-02
 
 ### Fixed

--- a/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
+++ b/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
@@ -88,7 +88,7 @@ final class AccessibilityObserver {
 
     // ── AXObserver lifecycle ───────────────────────────────────────
 
-    private func attachTo(pid: pid) {
+    private func attachTo(pid: pid_t) {
         var obs: AXObserver?
         let err = AXObserverCreate(pid, { observer, element, notification, refcon in
             guard let refcon = refcon else { return }

--- a/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
+++ b/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
@@ -116,7 +116,7 @@ final class AccessibilityObserver {
         os_log(.info, log: log, "attached AXObserver pid=%d", pid)
     }
 
-    private func detachObserver(_ observer: AXObserver, pid: pid) {
+    private func detachObserver(_ observer: AXObserver, pid: pid_t) {
         let appEl = AXUIElementCreateApplication(pid)
         AXObserverRemoveNotification(observer, appEl,
             kAXFocusedUIElementChangedNotification as CFString)


### PR DESCRIPTION
Fix `pid` → `pid_t` type annotations in AccessibilityObserver that broke Homebrew Swift compilation. Also bumps version to 1.57.4.