### PR TITLE
v1.58.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.58.2] - 2026-08-03
+
+Fixes the macOS version probe: the menu-bar footer ran `vaara --version`,
+which the CLI does not accept (the flag is `vaara version`), so the version
+display silently failed on every install. The footer now calls `vaara version`
+and correctly shows the installed engine version.
+
+### Fixed
+- macOS footer version probe: `vaara --version` -> `vaara version`.
+
 ## [1.58.1] - 2026-08-03
 
 Small macOS app release: the menu-bar footer no longer shows a stale,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.58.3] - 2026-08-03
+
+macOS footer spacing: the footer hugged the window's bottom edge at 12pt
+vertical padding while every other element uses 16-22pt. It now uses 14pt
+plus a subtle wash so it reads as a footer with breathing room, matching the
+"unhurried spacing" of the rest of the popover.
+
+### Fixed
+- macOS footer vertical padding 12pt -> 14pt, with a hairline background wash.
+
 ## [1.58.2] - 2026-08-03
 
 Fixes the macOS version probe: the menu-bar footer ran `vaara --version`,

--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
@@ -1027,7 +1027,9 @@ struct ContentView: View {
         .font(.system(size: 12))
         .foregroundStyle(p.faint)
         .padding(.horizontal, 20)
-        .padding(.vertical, 12)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity)
+        .background(p.wash.opacity(0.5))
     }
 
     private func footerTab(_ label: String, _ target: Screen) -> some View {

--- a/clients/macos/Sources/VaaraMenuBar/Model.swift
+++ b/clients/macos/Sources/VaaraMenuBar/Model.swift
@@ -878,7 +878,7 @@ final class GateModel: ObservableObject {
         guard let vaara = SetupScanner.engineStatus().vaaraPath else { return nil }
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: vaara)
-        proc.arguments = ["--version"]
+        proc.arguments = ["version"]
         let pipe = Pipe()
         proc.standardOutput = pipe
         proc.standardError = Pipe()

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.58.1",
+  "version": "1.58.2",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.58.2",
+  "version": "1.58.3",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.58.2",
+  "version": "1.58.3",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.58.1",
+  "version": "1.58.2",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.58.2"
+version = "1.58.3"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.58.1"
+version = "1.58.2"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.58.2",
+  "version": "1.58.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.58.2",
+"version": "1.58.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.58.1",
+  "version": "1.58.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.58.1",
+"version": "1.58.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,19 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-<<<<<<< HEAD
   "version": "1.58.3",
-=======
->>>>>>> origin/main
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-<<<<<<< HEAD
 "version": "1.58.3",
-=======
->>>>>>> origin/main
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.58.2",
+  "version": "1.58.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.58.2",
+"version": "1.58.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.58.1",
+  "version": "1.58.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.58.1",
+"version": "1.58.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.58.2"
+__version__ = "1.58.3"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.58.1"
+__version__ = "1.58.2"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## What's changed

macOS footer spacing only. The footer sat 12pt from the window's bottom edge
while the rest of the popover uses 16-22pt of padding, so it looked cramped
at the bottom. Now 14pt vertical with a subtle wash so the footer reads as a
distinct bar with breathing room.

- `ContentView.swift` footer: `.padding(.vertical, 14)` + `maxWidth: .infinity`
  + hairline wash.

No engine changes in this release.