### PR TITLE
v1.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.59.0] - 2026-08-03
+
+macOS app consolidation release. Pulls the 1.58.x macOS fixes into one
+coherent release and corrects the settings layout regression.
+
+### Added
+- `clients/macos/Package.swift` declares the `VaaraMenuBar` executable
+  product, so `swift build` actually links a runnable binary.
+
+### Fixed
+- The menu-bar footer reads the installed engine version via `vaara version`
+  (the CLI rejects `--version`), so the on-screen version matches the binary
+  no matter how the app was installed.
+- The update-check User-Agent is derived from the installed version instead
+  of a hardcoded value.
+- Footer bottom padding is 20pt, matching the app-wide standard, so the
+  footer no longer hugs the window edge.
+- Settings screen is a plain `Grid` with 20pt padding — the bounded
+  ScrollView introduced in 1.58.4 (which added an unwanted scrollbar) is
+  removed; tall enterprise content no longer clips to the window edge.
+- Bumped `BUILD_STAMP` to `b57 · 2026-08-03`.
+
 ## [1.58.4] - 2026-08-03
 
 macOS Settings screen: the Grid was the one screen without the bounded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.58.4] - 2026-08-03
+
+macOS Settings screen: the Grid was the one screen without the bounded
+ScrollView every other tab uses, so tall content (enterprise rows) clipped
+against the popover's bottom edge and text hugged the border. It now scrolls
+inside a `maxHeight: 560` container like Overview and History, and the footer
+keeps the app-wide 20pt bottom padding instead of 14pt.
+
+Also fixes the SPM manifest: `VaaraMenuBar` was declared as an executable
+target but never listed under `products:`, so `swift build` compiled the code
+but never linked a runnable binary.
+
+### Fixed
+- macOS Settings screen: bounded ScrollView (maxHeight 560) + 20pt footer bottom padding.
+- `clients/macos/Package.swift`: added the `VaaraMenuBar` executable product.
+
 ## [1.58.3] - 2026-08-03
 
 macOS footer spacing: the footer hugged the window's bottom edge at 12pt

--- a/clients/macos/Package.swift
+++ b/clients/macos/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 let package = Package(
     name: "VaaraMenuBar",
     platforms: [.macOS(.v13)],
+    products: [
+        .executable(name: "VaaraMenuBar", targets: ["VaaraMenuBar"]),
+    ],
     targets: [
         .executableTarget(
             name: "VaaraMenuBar",

--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
@@ -490,8 +490,7 @@ struct ContentView: View {
     private var enterprise: Bool { model.config.user_level == "enterprise" }
 
     private var settings: some View {
-        ScrollView {
-            Grid(alignment: .topLeading, horizontalSpacing: 32, verticalSpacing: 18) {
+        Grid(alignment: .topLeading, horizontalSpacing: 32, verticalSpacing: 18) {
             // Row 1: SETTINGS FOR  |  NOTIFY ON
             GridRow {
                 VStack(alignment: .leading, spacing: 8) {
@@ -739,10 +738,8 @@ struct ContentView: View {
                     .tint(p.faint)
                 }
             }
-            }
-            .padding(20)
         }
-        .frame(maxHeight: 560)
+        .padding(20)
     }
 
     // MARK: anchor — the qualified timestamp provider (EU trusted list) picker

--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
@@ -490,7 +490,8 @@ struct ContentView: View {
     private var enterprise: Bool { model.config.user_level == "enterprise" }
 
     private var settings: some View {
-        Grid(alignment: .topLeading, horizontalSpacing: 32, verticalSpacing: 18) {
+        ScrollView {
+            Grid(alignment: .topLeading, horizontalSpacing: 32, verticalSpacing: 18) {
             // Row 1: SETTINGS FOR  |  NOTIFY ON
             GridRow {
                 VStack(alignment: .leading, spacing: 8) {
@@ -738,8 +739,10 @@ struct ContentView: View {
                     .tint(p.faint)
                 }
             }
+            }
+            .padding(20)
         }
-        .padding(20)
+        .frame(maxHeight: 560)
     }
 
     // MARK: anchor — the qualified timestamp provider (EU trusted list) picker
@@ -1027,7 +1030,8 @@ struct ContentView: View {
         .font(.system(size: 12))
         .foregroundStyle(p.faint)
         .padding(.horizontal, 20)
-        .padding(.vertical, 14)
+        .padding(.top, 14)
+        .padding(.bottom, 20)
         .frame(maxWidth: .infinity)
         .background(p.wash.opacity(0.5))
     }

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.58.3",
+  "version": "1.58.4",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.58.4",
+  "version": "1.59.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.58.3",
+  "version": "1.58.4",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.58.4",
+  "version": "1.59.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.58.4"
+version = "1.59.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.58.3"
+version = "1.58.4"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.58.4",
+  "version": "1.59.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.58.4",
+"version": "1.59.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.58.3",
+  "version": "1.58.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.58.3",
+"version": "1.58.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.58.4",
+  "version": "1.59.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.58.4",
+"version": "1.59.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.58.3",
+  "version": "1.58.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.58.3",
+"version": "1.58.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.58.3"
+__version__ = "1.58.4"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.58.4"
+__version__ = "1.59.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## What's changed

macOS app consolidation release — pulls the 1.58.x macOS fixes into one
coherent 1.59.0 and corrects the settings layout regression.

- **Version probe fix**: the menu-bar footer ran `vaara --version`, which the
  CLI rejects (the flag is `vaara version`), so the version display silently
  failed. Now calls `vaara version` and shows the live installed engine
  version. The update-check User-Agent is derived from that same version.
- **Footer spacing**: bottom padding is 20pt, matching the app-wide standard;
  the footer no longer hugs the window edge.
- **Settings layout**: returned to a plain `Grid` with 20pt padding. The
  bounded ScrollView introduced in 1.58.4 (which added a scrollbar the
  design never asked for) is removed. Tall enterprise content no longer
  clips to the window edge.
- **Build fix**: `Package.swift` declares the `VaaraMenuBar` executable
  product so `swift build` links a runnable binary instead of compiling
  without emitting one.
- Bumped `BUILD_STAMP` to `b57 · 2026-08-03`.

No engine changes in this release.