### PR TITLE
v1.60.0: MCP proxy HTTP auth and gateway-denial trail pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.60.0] - 2026-08-04
+
+Boundary hardening for the MCP proxy. Closes the two gaps between what the
+proxy does and what its audit trail says, both found by review rather than by
+tests.
+
+### Added
+- The Streamable HTTP transport takes an API key (`--api-key`, or
+  `VAARA_PROXY_API_KEY`). When set, every `/mcp` request must carry
+  `Authorization: Bearer <key>` or it is rejected with 401. The check runs
+  before any route handler, so `X-Vaara-Tenant` and `X-Vaara-Upstream` are
+  never read from an unauthenticated caller. Keys are compared in constant
+  time. `GET /health` stays open so load balancers keep working.
+- `--allow-unauthenticated` for operators whose bind is protected by other
+  means, such as mTLS or a private network segment.
+
+### Fixed
+- `vaara-mcp-proxy --transport http` now refuses to bind a non-loopback host
+  when no API key is configured. `X-Vaara-Tenant` selects the tenant a call is
+  attributed to and `X-Vaara-Upstream` selects the upstream, and therefore the
+  policy, that governs it. Read from an unauthenticated caller on a reachable
+  bind, those headers allow tenant spoofing and weakest-policy shopping. This
+  mirrors the guard `vaara serve` already applies. Loopback binds are
+  unaffected and still need no key.
+- A credential-gateway denial is now recorded as a blocked outcome against the
+  same `action_id` as the policy decision. For a constrained tool the policy
+  decision can be `allow` while the gateway then refuses, most often because
+  runtime arguments no longer match the digest the grant was minted for. The
+  trail previously kept the `allow` and carried nothing showing the call never
+  executed, so the record and the behaviour disagreed. A failure to write the
+  outcome is logged and never masks the denial.
+
+### Upgrading
+Operators running `vaara-mcp-proxy --transport http` on a non-loopback host
+without an API key will see the process refuse to start. Set `--api-key` or
+`VAARA_PROXY_API_KEY`, or pass `--allow-unauthenticated` if the port is
+protected another way.
+
 ## [1.59.0] - 2026-08-03
 
 macOS app consolidation release. Pulls the 1.58.x macOS fixes into one

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.59.0"
+version = "1.60.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.59.0",
+  "version": "1.60.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.59.0",
+"version": "1.60.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.59.0",
+  "version": "1.60.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.59.0",
+"version": "1.60.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.59.0"
+__version__ = "1.60.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import contextvars
+import hmac
 import json
 import logging
 import os
@@ -199,7 +200,17 @@ class VaaraMCPProxy:
         router: Optional[NotificationRouter] = None,
         policy: Optional[Any] = None,
         shadow: bool = False,
+        api_key: Optional[str] = None,
     ) -> None:
+        # Bearer key for the Streamable HTTP transport. The stdio transport
+        # is not affected: it has no network surface. When set, EVERY /mcp
+        # request must carry it, and it is checked BEFORE X-Vaara-Tenant and
+        # X-Vaara-Upstream are read — those headers pick the audit tenant
+        # and the upstream, so trusting them from an unauthenticated caller
+        # is tenant spoofing plus weakest-policy shopping.
+        self._api_key = (
+            api_key or os.environ.get("VAARA_PROXY_API_KEY") or None
+        )
         if pipeline is not None:
             # An explicit pipeline carries its own enforce setting; shadow
             # only applies to the internally-built one.
@@ -465,6 +476,34 @@ class VaaraMCPProxy:
                 "tools/call."
             ),
         )
+
+        # Bearer gate. Runs before any route handler, so X-Vaara-Tenant and
+        # X-Vaara-Upstream are never read from an unauthenticated caller.
+        # /health stays open: it exposes no tenant data and load balancers
+        # need it. Constant-time compare — a timing oracle on the key is
+        # cheap to avoid.
+        @app.middleware("http")
+        async def _proxy_api_key_gate(request: _StarletteRequest, call_next):
+            expected = proxy._api_key
+            if expected and request.url.path != "/health":
+                supplied = request.headers.get("authorization", "")
+                scheme, _, token = supplied.partition(" ")
+                if scheme.lower() != "bearer" or not hmac.compare_digest(
+                    token.strip(), expected
+                ):
+                    return JSONResponse(
+                        status_code=401,
+                        content={"error": {
+                            "code": "unauthorized",
+                            "message": (
+                                "This proxy requires a bearer key. Send "
+                                "`Authorization: Bearer <key>`. Without it "
+                                "the X-Vaara-Tenant and X-Vaara-Upstream "
+                                "headers are not honoured."
+                            ),
+                        }},
+                    )
+            return await call_next(request)
 
         @app.get("/health")
         async def health() -> dict:
@@ -816,7 +855,10 @@ class VaaraMCPProxy:
 
         return app
 
-    def run_http(self, host: str, port: int, log_level: str = "info") -> None:
+    def run_http(
+        self, host: str, port: int, log_level: str = "info",
+        allow_unauthenticated: bool = False,
+    ) -> None:
         """Run the proxy on Streamable HTTP (MCP 2026 transport).
 
         POST /mcp accepts one JSON-RPC message and returns one JSON response.
@@ -836,10 +878,37 @@ class VaaraMCPProxy:
                 "vaara-mcp-proxy --transport http requires the 'server' "
                 "extra. Install with: pip install 'vaara[server]'"
             ) from exc
+        # Bind guard, same shape as `vaara serve`. X-Vaara-Tenant picks the
+        # audit tenant and X-Vaara-Upstream picks which upstream (and so
+        # which policy) a call is governed by. Unauthenticated on a
+        # network-reachable bind, that is tenant spoofing plus
+        # weakest-policy shopping by anyone who can reach the port.
+        _host = (host or "").strip()
+        _is_loopback = _host in ("127.0.0.1", "localhost", "::1")
+        if not _is_loopback and self._api_key is None:
+            if not allow_unauthenticated:
+                raise RuntimeError(
+                    f"vaara-mcp-proxy: refusing to bind {_host!r} without an "
+                    "API key.\nThe HTTP transport reads X-Vaara-Tenant and "
+                    "X-Vaara-Upstream from the caller, so an unauthenticated\n"
+                    "network-reachable proxy lets any client\n"
+                    "  - attribute its calls to another tenant's audit trail\n"
+                    "  - pick whichever upstream has the weakest policy\n"
+                    "Set --api-key (or VAARA_PROXY_API_KEY), or pass\n"
+                    "--allow-unauthenticated if this bind is protected another "
+                    "way (e.g. mTLS or a private network segment)."
+                )
+            logger.warning(
+                "binding %r UNAUTHENTICATED — any client that can reach this "
+                "port can spoof X-Vaara-Tenant and choose its upstream via "
+                "X-Vaara-Upstream. Set an API key as soon as possible.",
+                _host,
+            )
         app = self._build_http_app()
         logger.info(
-            "Vaara MCP proxy starting on http://%s:%d (%s, upstreams=%s)",
+            "Vaara MCP proxy starting on http://%s:%d (%s, upstreams=%s, auth=%s)",
             host, port, self.PROXY_NAME, sorted(self._upstreams.keys()),
+            "on" if self._api_key else "off",
         )
         uvicorn.run(app, host=host, port=port, log_level=log_level)
 
@@ -1104,6 +1173,45 @@ class VaaraMCPProxy:
                 arguments=arguments,
             )
             if not verdict.ok:
+                # The policy decision at step 1 already went into the chain,
+                # and for a constrained tool it can be `allow` while the
+                # gateway refuses here — runtime arguments that no longer
+                # match the digest the grant was minted for are the common
+                # case. Without this the trail would say the call was
+                # allowed and carry no record that it never executed:
+                # record and behaviour would disagree, which is exactly the
+                # failure the prior-approval path is written to avoid.
+                # Report the blocked outcome against the same action_id so
+                # the decision and its non-execution stay paired.
+                _denied_action_id = str(getattr(result, "action_id", "") or "")
+                if _denied_action_id:
+                    try:
+                        self._pipeline.report_outcome(
+                            action_id=_denied_action_id,
+                            outcome_severity=1.0,
+                            description=(
+                                f"blocked by credential gateway before "
+                                f"execution: {verdict.reason}"
+                            ),
+                        )
+                    except Exception:  # pragma: no cover - never mask the denial
+                        logger.exception(
+                            "failed to record blocked outcome for gateway "
+                            "denial (action_id=%s, tool=%s)",
+                            _denied_action_id, tool_name,
+                        )
+                self._overt_emit(
+                    surface="mcp.tool.call",
+                    identifier=tool_name,
+                    identifier_field="tool_name",
+                    request_obj={"tool": tool_name, "arguments": arguments},
+                    decision="DENY",
+                    reason=f"grant invalid: {verdict.reason}",
+                    extra={
+                        "agent_id": agent_id,
+                        "action_id": getattr(result, "action_id", None) or "",
+                    },
+                )
                 return self._error_response(
                     request_id,
                     -32603,
@@ -1620,6 +1728,23 @@ def main(argv: Optional[list[str]] = None) -> None:
         default="info",
         choices=["critical", "error", "warning", "info", "debug", "trace"],
     )
+    parser.add_argument(
+        "--api-key", default=None,
+        help=(
+            "Bearer key required on every /mcp request when --transport http. "
+            "Falls back to VAARA_PROXY_API_KEY. Without it the proxy refuses a "
+            "non-loopback bind, because X-Vaara-Tenant and X-Vaara-Upstream "
+            "would be honoured from any caller."
+        ),
+    )
+    parser.add_argument(
+        "--allow-unauthenticated",
+        action="store_true",
+        help=(
+            "Permit a non-loopback --transport http bind with no API key. Only "
+            "when the port is protected another way (mTLS, private segment)."
+        ),
+    )
     parser.add_argument("--db", type=Path, default=None,
                         help="Audit database path (default: $VAARA_DB or ./vaara_audit.db)")
     parser.add_argument("--policy", type=Path, default=None,
@@ -1761,6 +1886,7 @@ def main(argv: Optional[list[str]] = None) -> None:
             attest_emitter=attest_emitter,
             policy=policy_obj,
             shadow=args.shadow,
+            api_key=args.api_key,
         )
     except (ValueError, ProxyError) as e:
         # ProxyError here means a --upstream-url target was refused by the SSRF
@@ -1772,6 +1898,7 @@ def main(argv: Optional[list[str]] = None) -> None:
                 host=args.http_host,
                 port=args.http_port,
                 log_level=args.http_log_level,
+                allow_unauthenticated=args.allow_unauthenticated,
             )
         else:
             proxy.run()

--- a/tests/test_mcp_proxy_gateway_denial_recorded.py
+++ b/tests/test_mcp_proxy_gateway_denial_recorded.py
@@ -1,0 +1,114 @@
+"""A credential-gateway denial must land in the trail, not just on the wire.
+
+Regression cover for the boundary an external reviewer (VATE) flagged: the
+MCP proxy takes its local policy decision (``InterceptionPipeline.intercept``)
+and writes it to the hash chain BEFORE the constrained-grant
+``CredentialGateway.authorize`` check runs. For a constrained tool the policy
+decision can be ``allow`` while the gateway then refuses — runtime arguments
+that no longer match the digest the grant was minted for are the common case.
+
+Without an outcome record for that refusal the trail claims the call was
+allowed and carries nothing saying it never executed. Record and behaviour
+would disagree, which is the same failure mode the prior-approval path is
+written to avoid.
+"""
+
+from unittest.mock import MagicMock
+
+
+def _proxy_with_denying_gateway(monkeypatch, *, reason="args digest mismatch"):
+    from vaara.integrations import mcp_proxy
+    from vaara.pipeline import InterceptionPipeline
+    from vaara.audit.trail import AuditTrail
+
+    trail = AuditTrail(on_record=lambda _r: None)
+    pipeline = InterceptionPipeline(trail=trail)
+    monkeypatch.setattr(
+        "vaara.integrations._mcp_upstream.UpstreamMCPClient.__init__",
+        lambda self, command, **kw: None,
+    )
+    p = mcp_proxy.VaaraMCPProxy(upstream_command=["echo"], pipeline=pipeline)
+
+    upstream = MagicMock()
+    upstream.request.return_value = {
+        "jsonrpc": "2.0", "id": 1,
+        "result": {"content": [{"type": "text", "text": "ok"}]},
+    }
+    p._upstream = upstream
+
+    # Constrained tool whose gateway refuses.
+    verdict = MagicMock()
+    verdict.ok = False
+    verdict.reason = reason
+
+    attest = MagicMock()
+    attest.gateway = MagicMock()
+    attest.gateway.authorize.return_value = verdict
+    attest.is_constrained.return_value = True
+    # emit_attestation returns an (attestation, counter) pair; emit_grant
+    # returns None here so the request carries no credential and the
+    # gateway is the thing that refuses.
+    attest.emit_attestation.return_value = (MagicMock(), 1)
+    attest.emit_grant.return_value = None
+    p._attest = attest
+    p._mint_credentials = True
+    p._emit_authorization_receipts = False
+
+    return p, pipeline, trail, upstream
+
+
+def _call(p, tool="read_file", args=None):
+    return p._handle_request({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": args or {"path": "/tmp/x"}},
+    })
+
+
+def test_gateway_denial_is_reported_as_a_blocked_outcome(monkeypatch):
+    p, pipeline, trail, upstream = _proxy_with_denying_gateway(monkeypatch)
+
+    reported = []
+    real = pipeline.report_outcome
+
+    def spy(action_id, outcome_severity, description=""):
+        reported.append((action_id, outcome_severity, description))
+        return real(action_id, outcome_severity, description)
+
+    monkeypatch.setattr(pipeline, "report_outcome", spy)
+
+    resp = _call(p)
+
+    # The caller still gets the denial.
+    assert "error" in resp, resp
+    assert "grant required but not valid" in resp["error"]["message"]
+
+    # ...and the refusal is on the record, at full severity, tied to the
+    # same action_id the policy decision used.
+    assert reported, "gateway denial was not reported as an outcome"
+    action_id, severity, description = reported[0]
+    assert action_id, "outcome reported without an action_id"
+    assert severity == 1.0
+    assert "gateway" in description.lower()
+    assert "args digest mismatch" in description
+
+
+def test_gateway_denial_does_not_reach_upstream(monkeypatch):
+    p, pipeline, trail, upstream = _proxy_with_denying_gateway(monkeypatch)
+    _call(p)
+    upstream.request.assert_not_called()
+
+
+def test_outcome_failure_never_masks_the_denial(monkeypatch):
+    """If recording the outcome blows up, the call is still refused."""
+    p, pipeline, trail, upstream = _proxy_with_denying_gateway(monkeypatch)
+
+    def boom(*a, **kw):
+        raise RuntimeError("trail unavailable")
+
+    monkeypatch.setattr(pipeline, "report_outcome", boom)
+
+    resp = _call(p)
+    assert "error" in resp
+    assert "grant required but not valid" in resp["error"]["message"]
+    upstream.request.assert_not_called()

--- a/tests/test_mcp_proxy_http_auth.py
+++ b/tests/test_mcp_proxy_http_auth.py
@@ -1,0 +1,127 @@
+"""The HTTP transport must authenticate before it trusts scope headers.
+
+``X-Vaara-Tenant`` picks which tenant's audit trail a call is attributed to
+and ``X-Vaara-Upstream`` picks which upstream — and so which policy — governs
+it. Read from an unauthenticated caller on a network-reachable bind, that is
+tenant spoofing plus weakest-policy shopping by anyone who can reach the port.
+
+Mirrors the guard `vaara serve` already has: a bearer gate on the app, and a
+refusal to bind a non-loopback host without a key.
+"""
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+def _proxy(monkeypatch, **kw):
+    from vaara.integrations import mcp_proxy
+    from vaara.pipeline import InterceptionPipeline
+    from vaara.audit.trail import AuditTrail
+
+    monkeypatch.setattr(
+        "vaara.integrations._mcp_upstream.UpstreamMCPClient.__init__",
+        lambda self, command, **k: None,
+    )
+    trail = AuditTrail(on_record=lambda _r: None)
+    pipeline = InterceptionPipeline(trail=trail)
+    return mcp_proxy.VaaraMCPProxy(
+        upstream_command=["echo"], pipeline=pipeline, **kw
+    )
+
+
+_MCP_HEADERS = {
+    "accept": "application/json, text/event-stream",
+    "content-type": "application/json",
+}
+_BODY = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+
+
+def test_no_key_configured_means_open(monkeypatch):
+    """Default (loopback dev) behaviour is unchanged."""
+    monkeypatch.delenv("VAARA_PROXY_API_KEY", raising=False)
+    p = _proxy(monkeypatch)
+    assert p._api_key is None
+    c = TestClient(p._build_http_app())
+    assert c.get("/health").status_code == 200
+
+
+def test_missing_key_is_401_and_scope_headers_are_not_honoured(monkeypatch):
+    p = _proxy(monkeypatch, api_key="s3cret")
+    c = TestClient(p._build_http_app())
+    r = c.post(
+        "/mcp",
+        json=_BODY,
+        headers={**_MCP_HEADERS, "X-Vaara-Tenant": "victim-tenant"},
+    )
+    assert r.status_code == 401, r.text
+    assert r.json()["error"]["code"] == "unauthorized"
+
+
+def test_wrong_key_is_401(monkeypatch):
+    p = _proxy(monkeypatch, api_key="s3cret")
+    c = TestClient(p._build_http_app())
+    r = c.post(
+        "/mcp",
+        json=_BODY,
+        headers={**_MCP_HEADERS, "Authorization": "Bearer wrong"},
+    )
+    assert r.status_code == 401
+
+
+def test_health_stays_open_for_load_balancers(monkeypatch):
+    p = _proxy(monkeypatch, api_key="s3cret")
+    c = TestClient(p._build_http_app())
+    assert c.get("/health").status_code == 200
+
+
+def test_correct_key_passes_the_gate(monkeypatch):
+    from unittest.mock import MagicMock
+
+    p = _proxy(monkeypatch, api_key="s3cret")
+    upstream = MagicMock()
+    upstream.request.return_value = {
+        "jsonrpc": "2.0", "id": 1, "result": {"tools": []},
+    }
+    p._upstream = upstream
+    for name in list(p._upstreams):
+        p._upstreams[name] = upstream
+
+    c = TestClient(p._build_http_app())
+    r = c.post(
+        "/mcp",
+        json=_BODY,
+        headers={**_MCP_HEADERS, "Authorization": "Bearer s3cret"},
+    )
+    # Past the gate: whatever the handler does, it is not a 401.
+    assert r.status_code != 401
+
+
+def test_env_var_supplies_the_key(monkeypatch):
+    monkeypatch.setenv("VAARA_PROXY_API_KEY", "from-env")
+    p = _proxy(monkeypatch)
+    assert p._api_key == "from-env"
+
+
+def test_refuses_non_loopback_bind_without_a_key(monkeypatch):
+    monkeypatch.delenv("VAARA_PROXY_API_KEY", raising=False)
+    p = _proxy(monkeypatch)
+    with pytest.raises(RuntimeError, match="refusing to bind"):
+        p.run_http(host="0.0.0.0", port=59997)
+
+
+def test_loopback_without_a_key_is_allowed(monkeypatch):
+    """Local dev must not need a key. Guard the check, not uvicorn."""
+    monkeypatch.delenv("VAARA_PROXY_API_KEY", raising=False)
+    p = _proxy(monkeypatch)
+    started = {}
+
+    def fake_run(app, host, port, log_level):
+        started["host"] = host
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+    p.run_http(host="127.0.0.1", port=59996)
+    assert started["host"] == "127.0.0.1"


### PR DESCRIPTION
Boundary hardening for the MCP proxy. Two gaps between what the proxy does and
what its audit trail says, both found by review rather than by tests.

## HTTP transport authentication

`X-Vaara-Tenant` selects which tenant a call is attributed to. `X-Vaara-Upstream`
selects the upstream, and therefore the policy, that governs it. The Streamable
HTTP transport read both straight from the caller with no authentication
anywhere in the path, so any client that could reach the port could attribute
its calls to another tenant's audit trail and pick whichever upstream had the
weakest policy.

The transport now accepts an API key via `--api-key` or `VAARA_PROXY_API_KEY`.
When one is set, every `/mcp` request must carry `Authorization: Bearer <key>`.
The check lives in a middleware that runs before any route handler, so the
scope headers are never read from an unauthenticated caller. Keys are compared
with `hmac.compare_digest`. `GET /health` stays open for load balancers.

`run_http` also refuses to bind a non-loopback host when no key is configured,
listing the two concrete attacks in the error. `--allow-unauthenticated` is the
explicit opt-out for operators whose port is protected by mTLS or a private
segment. This mirrors the guard `vaara serve` already applies, so there is one
pattern to reason about rather than two.

Loopback binds are unaffected and still need no key.

## Gateway denials now reach the trail

The proxy takes its policy decision and writes it to the hash chain before the
constrained-grant `CredentialGateway.authorize` check runs. For a constrained
tool the policy decision can be `allow` while the gateway then refuses, most
often because runtime arguments no longer match the digest the grant was minted
for.

Previously the trail kept the `allow` and carried nothing showing the call never
executed. Record and behaviour disagreed, which is the failure mode the
prior-approval path is written to avoid.

The denial is now reported as a blocked outcome against the same `action_id`,
with the gateway's reason in the description, plus an OVERT deny emit. A failure
to write the outcome is logged and never masks the denial itself.

## Tests

Eleven new tests across two files.

`tests/test_mcp_proxy_http_auth.py` covers the missing key returning 401 with a
spoofed tenant header present, a wrong key, the env-var path, `/health` staying
open, a correct key passing the gate, the non-loopback refusal, and loopback
still working without a key.

`tests/test_mcp_proxy_gateway_denial_recorded.py` covers the denial being
reported at full severity against the right `action_id`, the upstream never
being called, and the denial surviving a trail write failure.

## Verification

Full suite in a CI-equivalent environment: 2398 passed, 31 skipped. `ruff check`
clean on `src/` and `tests/`. The 30 failures and 28 errors present in that run
are pre-existing, confirmed by running the same files with this change stashed,
and surface only when the full optional extras are installed.

## Upgrading

Operators running `vaara-mcp-proxy --transport http` on a non-loopback host
without an API key will see the process refuse to start. Set `--api-key` or
`VAARA_PROXY_API_KEY`, or pass `--allow-unauthenticated` if the port is
protected another way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional bearer-key authentication for MCP HTTP requests, configurable through the command line or environment.
  * Health checks remain available without authentication.
  * Added an explicit opt-in for unauthenticated access on non-loopback network bindings.

* **Security**
  * Unauthenticated requests can no longer spoof tenant or upstream context.
  * Credential-gateway denials are recorded with the correct action and reason.

* **Release**
  * Updated the project and package version to 1.60.0.
  * Added upgrade guidance and release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->