### PR TITLE
conformance: accept all three JCS canonicalization aliases

### DIFF
--- a/src/vaara/credential/_contiguity.py
+++ b/src/vaara/credential/_contiguity.py
@@ -24,6 +24,10 @@ from typing import Any, Optional
 
 from vaara.attestation._attest_canonical import canonical_json
 
+# SPEC.md section 1: "jcs-rfc8785", "JCS" and "jcs-json-v1" are accepted
+# aliases for the same algorithm; consumers MUST accept all three.
+_JCS_ALIASES = ("jcs-rfc8785", "JCS", "jcs-json-v1")
+
 
 def evidence_binding_ok(receipt: dict[str, Any]) -> bool:
     """The receipt's ``evidence`` block binds to its signed ``evidenceRef.digest``.
@@ -52,7 +56,7 @@ def evidence_binding_ok(receipt: dict[str, Any]) -> bool:
         return False
     derived = record.get("decisionDerived")
     ref = derived.get("evidenceRef") if isinstance(derived, dict) else None
-    if not isinstance(ref, dict) or ref.get("canonicalization") != "JCS":
+    if not isinstance(ref, dict) or ref.get("canonicalization") not in _JCS_ALIASES:
         return False
     signed = ref.get("digest")
     if not isinstance(signed, str):

--- a/tests/vectors/ap2_v0/_check_independent.py
+++ b/tests/vectors/ap2_v0/_check_independent.py
@@ -46,6 +46,10 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
+# SPEC.md section 1: "jcs-rfc8785", "JCS" and "jcs-json-v1" are accepted
+# aliases for the same algorithm; consumers MUST accept all three.
+_JCS_ALIASES = ("jcs-rfc8785", "JCS", "jcs-json-v1")
+
 HERE = Path(__file__).resolve().parent
 _CASES = ("complete", "dropped")
 _SIGNED_KEYS = ("version", "alg", "backLink", "decisionDerived", "issuerAsserted")
@@ -91,7 +95,7 @@ def _names_checkout(authz, checkout_ref) -> bool:
 def _evidence_binding_resolves(authz) -> bool:
     receipt = authz.get("record", {})
     ref = receipt.get("decisionDerived", {}).get("evidenceRef")
-    if not isinstance(ref, dict) or ref.get("canonicalization") != "JCS":
+    if not isinstance(ref, dict) or ref.get("canonicalization") not in _JCS_ALIASES:
         return False
     return _sha256_hex(_jcs(authz.get("evidence", {}))) == ref.get("digest")
 

--- a/tests/vectors/authorization_v0/_check_independent.py
+++ b/tests/vectors/authorization_v0/_check_independent.py
@@ -46,6 +46,10 @@ from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from cryptography.hazmat.primitives import hashes
 
+# SPEC.md section 1: "jcs-rfc8785", "JCS" and "jcs-json-v1" are accepted
+# aliases for the same algorithm; consumers MUST accept all three.
+_JCS_ALIASES = ("jcs-rfc8785", "JCS", "jcs-json-v1")
+
 HERE = Path(__file__).resolve().parent
 _CASES = ("allow", "deny")
 _SIGNED_KEYS = ("version", "alg", "backLink", "decisionDerived", "issuerAsserted")
@@ -123,7 +127,7 @@ def _verdict_recomputes(grant, args, evidence, receipt) -> bool:
 
 def _evidence_binding_resolves(evidence, receipt) -> bool:
     ref = receipt.get("decisionDerived", {}).get("evidenceRef")
-    if not isinstance(ref, dict) or ref.get("canonicalization") != "JCS":
+    if not isinstance(ref, dict) or ref.get("canonicalization") not in _JCS_ALIASES:
         return False
     return _sha256_hex(_jcs(evidence)) == ref.get("digest")
 

--- a/tests/vectors/class_gate_v0/_check_independent.py
+++ b/tests/vectors/class_gate_v0/_check_independent.py
@@ -53,6 +53,10 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
+# SPEC.md section 1: "jcs-rfc8785", "JCS" and "jcs-json-v1" are accepted
+# aliases for the same algorithm; consumers MUST accept all three.
+_JCS_ALIASES = ("jcs-rfc8785", "JCS", "jcs-json-v1")
+
 HERE = Path(__file__).resolve().parent
 _SIGNED_KEYS = ("version", "alg", "backLink", "decisionDerived", "issuerAsserted")
 
@@ -76,7 +80,7 @@ def _evidence_bound_ok(item: dict) -> bool:
         return False
     ref = item.get("record", {}).get("decisionDerived", {}).get("evidenceRef", {})
     signed = ref.get("digest")
-    if ref.get("canonicalization") != "JCS" or not isinstance(signed, str):
+    if ref.get("canonicalization") not in _JCS_ALIASES or not isinstance(signed, str):
         return False
     computed = "sha256:" + hashlib.sha256(_jcs(evidence)).hexdigest()
     return computed == signed

--- a/tests/vectors/contiguity_v0/_check_independent.py
+++ b/tests/vectors/contiguity_v0/_check_independent.py
@@ -35,6 +35,10 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
+# SPEC.md section 1: "jcs-rfc8785", "JCS" and "jcs-json-v1" are accepted
+# aliases for the same algorithm; consumers MUST accept all three.
+_JCS_ALIASES = ("jcs-rfc8785", "JCS", "jcs-json-v1")
+
 HERE = Path(__file__).resolve().parent
 _CASES = ("complete", "dropped")
 _SIGNED_KEYS = ("version", "alg", "backLink", "decisionDerived", "issuerAsserted")
@@ -63,7 +67,7 @@ def _evidence_binding_resolves(authz) -> bool:
     receipt = authz.get("record", {})
     evidence = authz.get("evidence", {})
     ref = receipt.get("decisionDerived", {}).get("evidenceRef")
-    if not isinstance(ref, dict) or ref.get("canonicalization") != "JCS":
+    if not isinstance(ref, dict) or ref.get("canonicalization") not in _JCS_ALIASES:
         return False
     return _sha256_hex(_jcs(evidence)) == ref.get("digest")
 

--- a/tests/vectors/external_evidence_v0/_check_independent.py
+++ b/tests/vectors/external_evidence_v0/_check_independent.py
@@ -45,6 +45,10 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
+# SPEC.md section 1: "jcs-rfc8785", "JCS" and "jcs-json-v1" are accepted
+# aliases for the same algorithm; consumers MUST accept all three.
+_JCS_ALIASES = ("jcs-rfc8785", "JCS", "jcs-json-v1")
+
 HERE = Path(__file__).resolve().parent
 _CASES = ("complete", "dropped")
 _SIGNED_KEYS = ("version", "alg", "backLink", "decisionDerived", "issuerAsserted")
@@ -88,7 +92,7 @@ def _slot_resolves(item: dict) -> bool:
 
 def _evidence_binding_resolves(item: dict) -> bool:
     ref = _evidence_ref(item)
-    if ref.get("canonicalization") != "JCS":
+    if ref.get("canonicalization") not in _JCS_ALIASES:
         return False
     return _sha256_hex(_jcs(item.get("evidence", {}))) == ref.get("digest")
 

--- a/tests/vectors/tap_v0/_check_independent.py
+++ b/tests/vectors/tap_v0/_check_independent.py
@@ -46,6 +46,10 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
+# SPEC.md section 1: "jcs-rfc8785", "JCS" and "jcs-json-v1" are accepted
+# aliases for the same algorithm; consumers MUST accept all three.
+_JCS_ALIASES = ("jcs-rfc8785", "JCS", "jcs-json-v1")
+
 HERE = Path(__file__).resolve().parent
 KEYS = HERE / "keys"
 _DECISION_BLOCKS = ("version", "alg", "backLink", "decisionDerived", "issuerAsserted")
@@ -68,7 +72,7 @@ def action_ref_recomputes(request: dict) -> bool:
 
 def request_binding_resolves(receipt: dict, request: dict) -> bool:
     ref = receipt.get("decisionDerived", {}).get("evidenceRef")
-    if not isinstance(ref, dict) or ref.get("canonicalization") != "JCS":
+    if not isinstance(ref, dict) or ref.get("canonicalization") not in _JCS_ALIASES:
         return False
     return _sha256_hex(_jcs(request)) == ref.get("digest")
 

--- a/tests/vectors/x402_settlement_v0/_check_independent.py
+++ b/tests/vectors/x402_settlement_v0/_check_independent.py
@@ -47,6 +47,10 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 
+# SPEC.md section 1: "jcs-rfc8785", "JCS" and "jcs-json-v1" are accepted
+# aliases for the same algorithm; consumers MUST accept all three.
+_JCS_ALIASES = ("jcs-rfc8785", "JCS", "jcs-json-v1")
+
 HERE = Path(__file__).resolve().parent
 KEYS = HERE / "keys"
 _DECISION_BLOCKS = ("version", "alg", "backLink", "decisionDerived",
@@ -71,7 +75,7 @@ def action_ref_recomputes(settlement: dict) -> bool:
 
 def settlement_binding_resolves(receipt: dict, settlement: dict) -> bool:
     ref = receipt.get("decisionDerived", {}).get("evidenceRef")
-    if not isinstance(ref, dict) or ref.get("canonicalization") != "JCS":
+    if not isinstance(ref, dict) or ref.get("canonicalization") not in _JCS_ALIASES:
         return False
     return _sha256_hex(_jcs(settlement)) == ref.get("digest")
 

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -113,6 +113,12 @@
   .links .target { font-size: 14px; color: var(--ink); word-break: break-all; }
   .links a:hover .target { color: var(--tri-bright); }
   @media (max-width: 520px) { .links { grid-template-columns: 1fr; } }
+  /* The one buying action on the page. Same grammar as .links, weighted. */
+  .cta { display: inline-block; font-family: var(--mono); font-size: 14px; letter-spacing: 0.18em; text-transform: uppercase; font-weight: 600; color: var(--panel); background: var(--tri-bright); border: 1px solid var(--tri-bright); border-radius: 12px; padding: 14px 28px; text-decoration: none; transition: background 0.15s ease, border-color 0.15s ease, transform 0.06s ease; }
+  .cta:hover { background: var(--tri); border-color: var(--tri); transform: translate(0, -1px); }
+  .cta:active { transform: translate(0, 0); }
+  .cta:focus-visible { outline: 2px solid var(--tri); outline-offset: 3px; }
+  html[data-theme="dark"] .cta { color: var(--deep); }
   footer { margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--line); font-family: var(--mono); font-size: 12px; color: var(--faint); letter-spacing: 0.04em; text-align: center; }
   .evidence { background: var(--panel); color: var(--ink); border: 1px solid var(--line); border-radius: 12px; margin: 0 0 48px; font-family: var(--mono); font-size: 14px; line-height: 1.65; overflow-x: auto; }
   .evidence-head { display: flex; justify-content: space-between; padding: 10px 18px; border-bottom: 1px solid var(--line); font-size: 12px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--faint); }
@@ -156,7 +162,10 @@
       "isAccessibleForFree": true,
       "offers": [
         { "@type": "Offer", "name": "Open source (AGPL-3.0)", "price": "0", "priceCurrency": "EUR" },
-        { "@type": "Offer", "name": "Paid pilot and commercial license", "url": "https://vaara.io/#pilots", "availability": "https://schema.org/InStock" }
+        { "@type": "Offer", "name": "Article 12 evidence pack, per system", "url": "https://vaara.io/#pilots", "availability": "https://schema.org/InStock", "priceSpecification": { "@type": "PriceSpecification", "minPrice": "4500", "priceCurrency": "EUR", "valueAddedTaxIncluded": false } },
+        { "@type": "Offer", "name": "Four-week paid pilot", "url": "https://vaara.io/#pilots", "availability": "https://schema.org/InStock", "priceSpecification": { "@type": "PriceSpecification", "minPrice": "12000", "priceCurrency": "EUR", "valueAddedTaxIncluded": false } },
+        { "@type": "Offer", "name": "Advisory and standards work, per day", "url": "https://vaara.io/#pilots", "availability": "https://schema.org/InStock", "priceSpecification": { "@type": "UnitPriceSpecification", "price": "1400", "priceCurrency": "EUR", "unitCode": "DAY", "valueAddedTaxIncluded": false } },
+        { "@type": "Offer", "name": "Commercial license", "url": "https://github.com/vaaraio/vaara/blob/main/LICENSING.md", "availability": "https://schema.org/InStock" }
       ],
       "author": { "@type": "Person", "name": "Henri Sirkkavaara" },
       "keywords": "accountable autonomy, AI agent audit trail, agentic payments, autonomous actions, tamper-evident evidence, EU AI Act Article 12, TPM 2.0, RFC 3161, SEP-2828, verifiable AI",
@@ -223,7 +232,7 @@
         {
           "@type": "Question",
           "name": "Does Vaara offer paid pilots or a commercial license?",
-          "acceptedAnswer": { "@type": "Answer", "text": "Yes. A structured four-week pilot deploys Vaara in your environment against your own agent traffic and ends with a signed evidence bundle and an auditor-ready compliance report on that traffic. A commercial license is available for building on Vaara without the AGPL's source-disclosure obligations. Contact hello@vaara.io." }
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes, and the prices are published. An Article 12 evidence pack for one system starts at EUR 4,500. A four-week pilot in your own infrastructure starts at EUR 12,000. Advisory and standards work is EUR 1,400 per day. A commercial license for building on Vaara without the AGPL's source-disclosure obligations is priced on request. All prices are fixed before the work starts and exclude VAT. Contact hello@vaara.io." }
         }
       ]
     }
@@ -286,8 +295,21 @@ conformance: <span class="ok">CONFORMS</span>
   <li>Four weeks, your environment, your traffic. Week 1: the Vaara MCP proxy goes in front of your agents in shadow mode, observing and recording without blocking anything. Weeks 2 and 3: we read the shadow report together, tune a policy and tool perimeter to your actual traffic, and flip to enforcement. Week 4: you receive a signed evidence bundle and an auditor-ready compliance report generated from your own trail.</li>
   <li>Everything runs in your infrastructure and stays there. The trail, the policy, the reports, and the archive are yours, and they stay verifiable with the standalone checker even if you never talk to us again. The evidence does not depend on the vendor; that is the point of the design.</li>
   <li>Building Vaara into a closed-source product, or running a modified version as a hosted service without releasing your changes, needs a commercial license instead of the AGPL, granted directly by the sole copyright holder. See <a href="https://github.com/vaaraio/vaara/blob/main/LICENSING.md">LICENSING.md</a>.</li>
-  <li>Contact: <a href="mailto:hello@vaara.io">hello@vaara.io</a>. A fixed fee agreed up front, with no subscription.</li>
 </ul>
+
+<p class="stamp">What it costs</p>
+<ul>
+  <li><b>Evidence pack, from EUR 4,500 per system.</b> A fixed-price Article 12 record-keeping package for one AI system: the signed trail, the per-article evidence mapping, and the trusted time anchor, in a form an assessment body or your own auditor can verify offline. Two to three weeks. If you can export your existing logs, you do not have to deploy anything.</li>
+  <li><b>Four-week pilot, from EUR 12,000.</b> The four-week engagement described above, run against your own agent traffic inside your own infrastructure.</li>
+  <li><b>Advisory and standards work, EUR 1,400 per day.</b> Article 12 and Article 14 scoping, preparation for conformity assessment, and review of a logging design you already have against the draft European standards.</li>
+  <li><b>Commercial license, priced on request.</b> Scope depends on what you are building. See <a href="https://github.com/vaaraio/vaara/blob/main/LICENSING.md">LICENSING.md</a>.</li>
+  <li>Every price is fixed and agreed before the work starts. VAT is not included. There is no subscription and no per-seat fee. All four sit below the EU and national thresholds that force a public buyer into a tender, so a public authority can award any of them directly.</li>
+</ul>
+
+<p style="text-align:center;margin:28px 0 8px;">
+  <a class="cta" href="mailto:hello@vaara.io?subject=Vaara%20pilot%20enquiry&amp;body=Which%20one%3A%20evidence%20pack%20%2F%20four-week%20pilot%20%2F%20advisory%20%2F%20commercial%20license%0A%0AThe%20system%3A%20%0A%0AOur%20deadline%3A%20%0A%0ACountry%20and%20regulator%3A%20%0A">Start a pilot</a>
+</p>
+<p style="text-align:center;font-size:14px;color:var(--muted);margin:0 0 8px;">Opens a message to hello@vaara.io with the four things needed to quote you.</p>
 
 <p class="stamp">Adoption (live)</p>
 <ul>

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -256,8 +256,9 @@
   <img class="wm-dark" src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-dark.png" alt="Vaara" width="440" height="127">
 </div>
 <p style="text-align:center;text-transform:uppercase;letter-spacing:.14em;font-weight:600;opacity:.65;margin:.1rem 0 .6rem;font-size:.95rem;">Accountable Autonomy</p>
-<h1>A verifiable receipt for every action your AI agents take, checkable by anyone.</h1>
-<p style="text-align:center;max-width:60ch;margin:0 auto 1rem;opacity:.82;line-height:1.5;">Your AI agent transferred the funds, wrote the file, called the tool. Later, someone who does not trust you asks you to prove exactly what it did and why: a regulator, an auditor, a customer after an incident. Your own logs will not settle it, because you could have edited them.</p>
+<h1>Stop an AI agent before it acts, and hold proof of every decision that anyone can check.</h1>
+<p style="text-align:center;max-width:60ch;margin:0 auto 1rem;opacity:.82;line-height:1.5;">Vaara sits in front of your agents and decides, on every single tool call, whether it runs: allow, block, or escalate to a human. Each of those decisions leaves a signed record. When someone who does not trust you asks what your agent did and why, you hand them the record instead of your word. Your own logs will not settle it, because you could have edited them.</p>
+<p style="text-align:center;max-width:62ch;margin:0 auto 1.6rem;font-size:15px;color:var(--muted);line-height:1.5;">From 9 December 2026 the EU Product Liability Directive treats software and AI as products under strict liability, and Article 10 lets a court presume your product defective if you cannot disclose the evidence. The burden of proof moves to you. This is the artifact that answers it.</p>
 <div class="hero-video">
   <video src="/vaara-launch.mp4" poster="/vaara-poster.jpg" autoplay muted loop playsinline preload="metadata" aria-label="Vaara launch demo">
   </video>
@@ -299,17 +300,24 @@ conformance: <span class="ok">CONFORMS</span>
 
 <p class="stamp">What it costs</p>
 <ul>
-  <li><b>Evidence pack, from EUR 4,500 per system.</b> A fixed-price Article 12 record-keeping package for one AI system: the signed trail, the per-article evidence mapping, and the trusted time anchor, in a form an assessment body or your own auditor can verify offline. Two to three weeks. If you can export your existing logs, you do not have to deploy anything.</li>
-  <li><b>Four-week pilot, from EUR 12,000.</b> The four-week engagement described above, run against your own agent traffic inside your own infrastructure.</li>
-  <li><b>Advisory and standards work, EUR 1,400 per day.</b> Article 12 and Article 14 scoping, preparation for conformity assessment, and review of a logging design you already have against the draft European standards.</li>
+  <li><b>Paid evaluation, EUR 4,500.</b> Sixty days. The Vaara gate goes in front of your agents in shadow mode, recording every action it would have allowed, blocked, or escalated, without blocking anything yet. You end with a report on your real traffic and a signed evidence bundle from it. The full fee is credited against any engagement below if you continue.</li>
+  <li><b>Disclosure pack, from EUR 4,500 per system.</b> For the 9 December 2026 liability change. One AI system, documented as a disclosable evidence set: the signed decision trail, the record format specification, and a trusted time anchor, in a form your counsel or an outside expert can verify without involving us. Two to three weeks. If you can export your existing logs, you do not have to deploy anything.</li>
+  <li><b>Four-week deployment, from EUR 12,000.</b> Shadow mode, then a policy and tool perimeter tuned to your actual traffic, then enforcement. Runs entirely inside your infrastructure.</li>
+  <li><b>Retained access, from EUR 1,400 per day.</b> Direct access to the person who holds the receipt format, the conformance suites, and the standards seat. Used for liability and disclosure scoping, reviewing a logging design you already have, and getting your requirements into the European standards while they are still drafts.</li>
   <li><b>Commercial license, priced on request.</b> Scope depends on what you are building. See <a href="https://github.com/vaaraio/vaara/blob/main/LICENSING.md">LICENSING.md</a>.</li>
-  <li>Every price is fixed and agreed before the work starts. VAT is not included. There is no subscription and no per-seat fee. All four sit below the EU and national thresholds that force a public buyer into a tender, so a public authority can award any of them directly.</li>
+  <li>Every price is fixed and agreed before the work starts. VAT is not included. There is no subscription and no per-seat fee.</li>
 </ul>
 
 <p style="text-align:center;margin:28px 0 8px;">
   <a class="cta" href="mailto:hello@vaara.io?subject=Vaara%20pilot%20enquiry&amp;body=Which%20one%3A%20evidence%20pack%20%2F%20four-week%20pilot%20%2F%20advisory%20%2F%20commercial%20license%0A%0AThe%20system%3A%20%0A%0AOur%20deadline%3A%20%0A%0ACountry%20and%20regulator%3A%20%0A">Start a pilot</a>
 </p>
 <p style="text-align:center;font-size:14px;color:var(--muted);margin:0 0 8px;">Opens a message to hello@vaara.io with the four things needed to quote you.</p>
+
+<p class="stamp">Buy support now</p>
+<ul>
+  <li>If you run Vaara in production and want the maintainer reachable without a contract cycle, the sponsor tiers are live and take a card immediately: <a href="https://github.com/sponsors/vaaraio">github.com/sponsors/vaaraio</a>. Monthly, cancel whenever, no procurement, no call. Companies expensing this against an OSS budget is the normal use.</li>
+  <li>Sponsoring is not a licence. Building Vaara into a closed product still needs a commercial exception, and the paid work above is still the paid work.</li>
+</ul>
 
 <p class="stamp">Adoption (live)</p>
 <ul>


### PR DESCRIPTION
SPEC.md section 1 and the Internet-Draft both state that `jcs-rfc8785`, `JCS` and `jcs-json-v1` are aliases for the same algorithm, that producers SHOULD emit `jcs-rfc8785`, and that consumers MUST accept all three.

Eight places tested for equality with `JCS` alone, so a document carrying the label the spec tells producers to emit was rejected:

- seven independent conformance checkers (ap2, authorization, class_gate, contiguity, external_evidence, tap, x402_settlement)
- `src/vaara/credential/_contiguity.py` in the shipped library

Reported against the x402 settlement suite by an outside implementer who reproduced the vectors from a clean-room second implementation. The same defect was present in seven further places.

Each checker keeps its own copy of the alias tuple, so they still import nothing shared.

Verified: all three aliases accept, an unknown label still rejects, seven checkers pass, 330 tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evidence and request validation now recognizes all supported RFC 8785 JSON canonicalization identifiers, improving compatibility across integrations.

* **New Features**
  * Added a clearer primary call to action and dedicated pilot signup option.
  * Introduced expanded service offerings with individual pricing.
  * Added published pricing, sponsor information, and an updated FAQ.

* **Documentation**
  * Updated website messaging to describe policy decisions, signed records, and EU Product Liability Directive disclosure obligations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->