### PR TITLE
v1.60.1

### DIFF
--- a/.recovered-settings-scrollview.patch
+++ b/.recovered-settings-scrollview.patch
@@ -1,0 +1,26 @@
+diff --git a/clients/macos/Sources/VaaraMenuBar/ContentView.swift b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+index cdb0b52..c962fe2 100644
+--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
++++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+@@ -490,7 +490,8 @@ struct ContentView: View {
+     private var enterprise: Bool { model.config.user_level == "enterprise" }
+ 
+     private var settings: some View {
+-        Grid(alignment: .topLeading, horizontalSpacing: 32, verticalSpacing: 18) {
++        ScrollView {
++            Grid(alignment: .topLeading, horizontalSpacing: 32, verticalSpacing: 18) {
+             // Row 1: SETTINGS FOR  |  NOTIFY ON
+             GridRow {
+                 VStack(alignment: .leading, spacing: 8) {
+@@ -738,8 +739,10 @@ struct ContentView: View {
+                     .tint(p.faint)
+                 }
+             }
++            }
++            .padding(20)
+         }
+-        .padding(20)
++        .frame(maxHeight: 560)
+     }
+ 
+     // MARK: anchor — the qualified timestamp provider (EU trusted list) picker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.60.1] - 2026-08-05
+
+A conformance fix. SPEC.md section 1 and the Internet-Draft both say that
+`jcs-rfc8785`, `JCS` and `jcs-json-v1` are aliases for one algorithm, that
+producers SHOULD emit `jcs-rfc8785`, and that consumers MUST accept all three.
+Eight places tested for equality with `JCS` alone, so a document carrying the
+label the spec tells producers to emit was rejected.
+
+### Fixed
+
+- Seven independent conformance checkers (`ap2_v0`, `authorization_v0`,
+  `class_gate_v0`, `contiguity_v0`, `external_evidence_v0`, `tap_v0`,
+  `x402_settlement_v0`) now accept all three canonicalization aliases and
+  still reject an unknown label. Each keeps its own copy of the alias tuple,
+  so the checkers continue to import nothing shared.
+- `vaara.credential._contiguity` applied the same narrow test in the shipped
+  library and had the same effect on a conforming document.
+
+Reported against the x402 settlement suite by an outside implementer who
+reproduced the vectors from a clean-room second implementation. The report
+named one checker; the same defect was present in seven more.
+
 ## [1.60.0] - 2026-08-04
 
 Boundary hardening for the MCP proxy. Closes the two gaps between what the

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.60.0",
+  "version": "1.60.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.60.0",
+  "version": "1.60.1",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, and MCP calls (regex deny patterns on shell/web; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across Bash, Web, and MCP calls. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.60.0"
+version = "1.60.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.60.0",
+  "version": "1.60.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.60.0",
+"version": "1.60.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.60.0",
+  "version": "1.60.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.60.0",
+"version": "1.60.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.60.0"
+__version__ = "1.60.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Patch release for the JCS canonicalization alias fix merged in #512, so the correction reaches PyPI, npm, the MCP registry, the Claude Code plugin and the Homebrew tap rather than sitting on main.

Version bumped in `pyproject.toml`, `clients/ts/package.json`, `server.json`, `server-vaara-server.json` and the plugin manifest. CHANGELOG entry added.