### PR TITLE
ci: drop orphaned homebrew-tap gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ opencode.json
 # NIIS meeting prep materials
 niis/
 social/
+
+# Local clone of the formulae repo (vaaraio/homebrew-tap), not a submodule
+homebrew-tap/


### PR DESCRIPTION
`homebrew-tap` sat in the tree as a submodule pointer (mode 160000) with no matching `.gitmodules` entry. Any checkout that handles submodules aborts:

```
fatal: No url found for submodule path 'homebrew-tap' in .gitmodules
The process '/usr/bin/git' failed with exit code 128
```

Scorecard has failed on every push to main since at least 3 August because of this, including the #517 merge. The formulae live in their own repo (vaaraio/homebrew-tap) and were never meant to be a submodule here.

Removes the gitlink and ignores the local clone so it cannot come back.