### PR TITLE
docs: drop the launch-video and public-beta line from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ Your AI agent transferred the funds, wrote the file, called the tool. Later, som
   <a href="https://github.com/vaaraio/vaara/releases/tag/v1.50.0"><img src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-v150-launch.gif" width="720" alt="Vaara for macOS launch demo"></a>
 </p>
 
-<p align="center"><a href="https://github.com/vaaraio/vaara/releases/tag/v1.50.0">&#9654;&nbsp; Watch the launch video (24s)</a> &middot; Vaara for macOS is in public beta</p>
-
 ## Quick start
 
 ```bash


### PR DESCRIPTION
The GIF directly above links to the same release, so the text line duplicated the pointer, and the beta status no longer belongs in the header.