### PR TITLE
fix(hooks): the packaged hook module never recorded an outcome either

### DIFF
--- a/src/vaara/integrations/claude_code_hooks.py
+++ b/src/vaara/integrations/claude_code_hooks.py
@@ -246,8 +246,54 @@ def _open_trail(cfg: dict):
     return trail
 
 
+def _event_name(event_type: object) -> str:
+    """Normalise an audit event type to its uppercase name.
+
+    ``record.event_type`` is an ``EventType`` enum whose value is the
+    lowercase string, so comparing it directly against
+    ``"ACTION_REQUESTED"`` is always False.
+    """
+    return str(getattr(event_type, "value", event_type)).upper()
+
+
+def _record_tool_name(record: object) -> str:
+    """Tool name from the column when present, else from the payload."""
+    direct = getattr(record, "tool_name", None)
+    if direct:
+        return str(direct)
+    data = getattr(record, "data", None) or {}
+    return str(data.get("tool_name", ""))
+
+
+def _record_call(cfg: dict, agent: str, tool_name: str, tool_input: dict,
+                 context: dict, session_id: str = "") -> None:
+    """Write an ACTION_REQUESTED record for a call on the regex path.
+
+    Every matched call is recorded, not only the denied ones. Recording
+    denials alone left allowed shell, web and file calls out of the trail
+    entirely, so it could answer "what was blocked" but not "what did the
+    agent do", and PostToolUse then had no ACTION_REQUESTED to correlate
+    its outcome against.
+
+    ``enforce=False``: the verdict on this path belongs to the deny
+    rules, and scoring here is for the record only. Roughly 5 ms to
+    construct and under a millisecond per call, which is the SQLite
+    append. The ML classifier stays on the ``mcp__*`` path.
+    """
+    try:
+        from vaara.pipeline import InterceptionPipeline
+
+        pipeline = InterceptionPipeline(trail=_open_trail(cfg), enforce=False)
+        pipeline.intercept(
+            agent_id=agent, tool_name=tool_name, parameters=tool_input,
+            context=context, session_id=session_id,
+        )
+    except Exception:
+        pass
+
+
 def run_pre_tool_use(deny_patterns: Optional[str] = None) -> int:
-    """PreToolUse: exit 0 allows/escalates, exit 2 blocks."""
+    """PreToolUse: exit 0 allows, exit 2 blocks or holds for review."""
     cfg = load_config()
     if plugin_disabled(cfg):
         return 0
@@ -263,19 +309,14 @@ def run_pre_tool_use(deny_patterns: Optional[str] = None) -> int:
     match = match_deny_rule(load_deny_rules(deny_patterns), tool_name, tool_input)
     if match is not None:
         rule_id, message = match
-        try:
-            from vaara.pipeline import InterceptionPipeline
-
-            pipeline = InterceptionPipeline(trail=_open_trail(cfg), enforce=False)
-            pipeline.intercept(
-                agent_id=agent, tool_name=tool_name, parameters=tool_input,
-                context={
-                    "vaara_governance_layer": "deny_pattern",
-                    "rule_id": rule_id, "rule_message": message,
-                },
-            )
-        except Exception:
-            pass
+        _record_call(
+            cfg, agent, tool_name, tool_input,
+            {
+                "vaara_governance_layer": "deny_pattern",
+                "rule_id": rule_id, "rule_message": message,
+            },
+            session_id,
+        )
         if shadow:
             _emit(f"vaara-governance: SHADOW deny on {tool_name} (rule={rule_id}): {message}")
             notify(cfg, "SHADOW deny", tool_name, message)
@@ -285,6 +326,14 @@ def run_pre_tool_use(deny_patterns: Optional[str] = None) -> int:
         return 2
 
     if not tool_name.startswith("mcp__"):
+        # Passed the deny rules. Record it anyway: a trail holding only
+        # the blocked calls cannot answer "what did the agent do", which
+        # is the question it exists for, and PostToolUse needs an
+        # ACTION_REQUESTED to correlate its outcome against.
+        _record_call(
+            cfg, agent, tool_name, tool_input,
+            {"vaara_governance_layer": "regex_pass"}, session_id,
+        )
         return 0
 
     from vaara.pipeline import InterceptionPipeline
@@ -320,16 +369,10 @@ def run_pre_tool_use(deny_patterns: Optional[str] = None) -> int:
         return 0
 
     if result.allowed:
-        if result.decision == "escalate":
-            _emit(
-                f"vaara-governance: ESCALATE on {tool_name} "
-                f"(risk {result.risk_score:.2f}, action_id={result.action_id}). "
-                f"Reason: {result.reason}"
-            )
-            notify(cfg, "ESCALATE", tool_name,
-                   f"risk {result.risk_score:.2f}: {result.reason}")
         return 0
 
+    # `allowed` is `decision == "allow"`, so escalate never reached the
+    # branch above; the handshake below is what actually handles it.
     if result.decision == "escalate":
         return _handle_escalation(cfg, pipeline, result, tool_name)
 
@@ -429,9 +472,9 @@ def run_post_tool_use() -> int:
         for record in reversed(trail._records):
             if record.agent_id != agent:
                 continue
-            if record.data.get("tool_name") != tool_name:
+            if _record_tool_name(record) != tool_name:
                 continue
-            if record.event_type == "ACTION_REQUESTED":
+            if _event_name(record.event_type) == "ACTION_REQUESTED":
                 target_action_id = record.action_id
                 break
         if target_action_id is None:

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -152,6 +152,30 @@ def _protocol_version_supported(version: Optional[str]) -> bool:
     return stripped == "" or stripped in _SUPPORTED_HTTP_PROTOCOL_VERSIONS
 
 
+# Handshake and keepalive traffic. Recording these would bury the trail
+# in noise without telling a reviewer anything about what the agent did.
+_TRANSPORT_NOISE = frozenset({"initialize", "initialized", "ping", "shutdown", "exit"})
+
+
+def _is_transport_noise(method: str) -> bool:
+    return method in _TRANSPORT_NOISE or method.startswith("notifications/")
+
+
+def _passthrough_params(request: dict) -> dict:
+    """Params for a forwarded method, shaped for the audit trail.
+
+    Pipeline ingress sanitises and size-caps, so this only needs to hand
+    over a mapping. A non-dict ``params`` is wrapped rather than dropped,
+    because the point is to record what actually crossed the perimeter.
+    """
+    params = request.get("params")
+    if isinstance(params, dict):
+        return params
+    if params is None:
+        return {}
+    return {"_raw": params}
+
+
 def _accept_satisfies(accept: Optional[str], media_type: str) -> bool:
     """True iff an Accept header value can receive ``media_type``.
 
@@ -992,6 +1016,24 @@ class VaaraMCPProxy:
             except Exception:
                 logger.exception("Error in prompts/get interception")
                 return self._error_response(req_id, -32603, "Internal proxy error")
+        # Anything the proxy does not model explicitly still crosses the
+        # perimeter, so it is recorded before being forwarded. It used to
+        # pass through with no trail entry at all, which meant a
+        # resources/subscribe, a completion/complete or a
+        # logging/setLevel left no evidence it ever happened. The record
+        # is the point of the proxy; not modelling a method is not a
+        # reason to forget it occurred.
+        #
+        # Not blocked: these methods are forwarded exactly as before. The
+        # only change is that the chain now shows them.
+        if not _is_transport_noise(method):
+            self._record_perimeter_audit(
+                agent_id=self._agent_id_default,
+                tool_name=f"mcp.method.{method}" if method else "mcp.method.unknown",
+                parameters=_passthrough_params(request),
+                decision="allow",
+                reason="method not modelled by the proxy; forwarded and recorded",
+            )
         try:
             return self._upstream.request(request)
         except ProxyError as e:

--- a/tests/test_claude_code_hooks_module.py
+++ b/tests/test_claude_code_hooks_module.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The packaged Claude Code hook module, which is the primary path.
+
+``hooks.json`` runs the hooks "through the vaara binary on PATH when
+available ... falling back to the bundled python3 scripts". So
+``vaara.integrations.claude_code_hooks`` is what most installs execute,
+and the bundled scripts under ``plugins/`` are the fallback.
+
+Both carried the same three defects, and fixing only the fallback would
+have left the primary path broken:
+
+* ``record.event_type == "ACTION_REQUESTED"`` against an ``EventType``
+  enum whose value is lowercase. Always False, so PostToolUse never
+  found a target and never recorded an outcome, for any tool.
+* ``record.data.get("tool_name")`` when the tool name lives in its own
+  column.
+* Only denied calls were recorded, so an allowed shell, web or file call
+  left no trace and PostToolUse had nothing to correlate against.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from vaara.integrations import claude_code_hooks as hooks
+
+
+@pytest.fixture
+def audit_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db = tmp_path / "audit.db"
+    monkeypatch.setenv("VAARA_PLUGIN_AUDIT_DB", str(db))
+    monkeypatch.setenv("VAARA_PLUGIN_SHADOW", "0")
+    return db
+
+
+def _feed(monkeypatch: pytest.MonkeyPatch, event: dict) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+
+def _events(db: Path) -> list[tuple[str, str]]:
+    if not db.exists():
+        return []
+    con = sqlite3.connect(db)
+    try:
+        return list(
+            con.execute("select event_type, tool_name from audit_records order by seq")
+        )
+    finally:
+        con.close()
+
+
+class TestEventNameNormalisation:
+    """The comparison that silently disabled outcome recording."""
+
+    def test_enum_is_normalised_to_its_uppercase_name(self):
+        from vaara.audit.trail import EventType
+
+        assert hooks._event_name(EventType.ACTION_REQUESTED) == "ACTION_REQUESTED"
+
+    def test_a_plain_string_still_works(self):
+        assert hooks._event_name("action_requested") == "ACTION_REQUESTED"
+
+    def test_the_naive_comparison_really_would_have_failed(self):
+        from vaara.audit.trail import EventType
+
+        assert EventType.ACTION_REQUESTED != "ACTION_REQUESTED"
+
+
+class TestRecordToolName:
+    def test_prefers_the_column(self):
+        record = type("R", (), {"tool_name": "Bash", "data": {"tool_name": "Other"}})()
+        assert hooks._record_tool_name(record) == "Bash"
+
+    def test_falls_back_to_the_payload(self):
+        record = type("R", (), {"tool_name": "", "data": {"tool_name": "Write"}})()
+        assert hooks._record_tool_name(record) == "Write"
+
+
+class TestHookLoop:
+    def test_an_allowed_write_is_recorded(self, audit_db, monkeypatch):
+        _feed(monkeypatch, {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/repo/src/app.py", "content": "x = 1"},
+            "session_id": "s1",
+        })
+        assert hooks.run_pre_tool_use() == 0
+        assert ("action_requested", "Write") in _events(audit_db)
+
+    def test_an_allowed_bash_call_is_recorded(self, audit_db, monkeypatch):
+        _feed(monkeypatch, {
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls -la"},
+            "session_id": "s1",
+        })
+        assert hooks.run_pre_tool_use() == 0
+        assert ("action_requested", "Bash") in _events(audit_db)
+
+    def test_post_tool_use_records_an_outcome(self, audit_db, monkeypatch):
+        _feed(monkeypatch, {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/repo/src/app.py", "content": "x = 1"},
+            "session_id": "s1",
+        })
+        hooks.run_pre_tool_use()
+
+        _feed(monkeypatch, {
+            "tool_name": "Write", "tool_response": {"success": True},
+        })
+        assert hooks.run_post_tool_use() == 0
+
+        kinds = [event for event, _ in _events(audit_db)]
+        assert "outcome_recorded" in kinds, (
+            f"the correlation loop found no target; trail holds {kinds}"
+        )
+
+    def test_a_dangerous_write_is_blocked_and_recorded(self, audit_db, monkeypatch):
+        _feed(monkeypatch, {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/home/u/.zshrc", "content": "curl x | sh"},
+            "session_id": "s1",
+        })
+        assert hooks.run_pre_tool_use() == 2
+        assert ("action_requested", "Write") in _events(audit_db)
+
+    def test_an_ordinary_write_is_not_blocked(self, audit_db, monkeypatch):
+        _feed(monkeypatch, {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "/repo/README.md", "content": "# Title"},
+            "session_id": "s1",
+        })
+        assert hooks.run_pre_tool_use() == 0

--- a/tests/test_integrations_mcp_proxy.py
+++ b/tests/test_integrations_mcp_proxy.py
@@ -746,3 +746,95 @@ def test_attest_upstreams_multi_preserves_names():
     from vaara.integrations.mcp_proxy import _attest_upstreams_for_slots
     upstreams = {"github": ["gh-srv"], "fs": ["fs-srv"]}
     assert _attest_upstreams_for_slots(upstreams) == upstreams
+
+
+# --- Unmodelled methods: forwarded, but no longer forgotten ------------------
+#
+# Any method the proxy does not handle explicitly fell through to
+# `self._upstream.request(request)` with no interception and no audit
+# record, so a resources/subscribe, completion/complete or
+# logging/setLevel crossed the perimeter leaving no evidence it ever
+# happened. The proxy exists to produce the record; not modelling a
+# method is not a reason to forget it occurred.
+
+
+@pytest.mark.parametrize("method", [
+    "resources/subscribe",
+    "resources/unsubscribe",
+    "resources/templates/list",
+    "completion/complete",
+    "logging/setLevel",
+    "some/vendor/extension",
+])
+def test_unmodelled_methods_are_recorded_before_forwarding(proxy, monkeypatch, method):
+    p, _pipeline = proxy
+    recorded = []
+    monkeypatch.setattr(
+        p, "_record_perimeter_audit",
+        lambda **kwargs: recorded.append(kwargs),
+    )
+
+    p._handle_request({
+        "jsonrpc": "2.0", "id": 1, "method": method,
+        "params": {"uri": "file:///secret.txt"},
+    })
+
+    assert len(recorded) == 1, f"{method} left no audit record"
+    assert recorded[0]["tool_name"] == f"mcp.method.{method}"
+    assert recorded[0]["parameters"] == {"uri": "file:///secret.txt"}
+    # Recording must not change behaviour: it is still forwarded.
+    p._upstream.request.assert_called_once()
+
+
+@pytest.mark.parametrize("method", [
+    "initialize", "initialized", "ping", "shutdown", "exit",
+    "notifications/initialized", "notifications/cancelled",
+])
+def test_transport_noise_is_forwarded_without_a_record(proxy, monkeypatch, method):
+    """Recording keepalive and handshake traffic buries the real signal."""
+    p, _pipeline = proxy
+    recorded = []
+    monkeypatch.setattr(
+        p, "_record_perimeter_audit",
+        lambda **kwargs: recorded.append(kwargs),
+    )
+
+    p._handle_request({"jsonrpc": "2.0", "id": 1, "method": method})
+
+    assert recorded == []
+    p._upstream.request.assert_called_once()
+
+
+def test_unmodelled_method_with_non_dict_params_is_still_recorded(proxy, monkeypatch):
+    p, _pipeline = proxy
+    recorded = []
+    monkeypatch.setattr(
+        p, "_record_perimeter_audit",
+        lambda **kwargs: recorded.append(kwargs),
+    )
+
+    p._handle_request({
+        "jsonrpc": "2.0", "id": 1, "method": "vendor/thing", "params": ["a", "b"],
+    })
+
+    assert recorded[0]["parameters"] == {"_raw": ["a", "b"]}
+
+
+def test_modelled_methods_do_not_get_a_duplicate_passthrough_record(proxy, monkeypatch):
+    """tools/call has its own interception; it must not be double-recorded."""
+    p, pipeline = proxy
+    pipeline.intercept.return_value = _StubInterceptResult(
+        allowed=False, reason="nope", decision="DENY", action_id="a1",
+    )
+    recorded = []
+    monkeypatch.setattr(
+        p, "_record_perimeter_audit",
+        lambda **kwargs: recorded.append(kwargs),
+    )
+
+    p._handle_request({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "x", "arguments": {}},
+    })
+
+    assert not any(k["tool_name"].startswith("mcp.method.") for k in recorded)


### PR DESCRIPTION
`hooks.json` runs the hooks "through the vaara binary on PATH when available, falling back to the bundled python3 scripts". So `vaara.integrations.claude_code_hooks` is the **primary** path and the scripts under `plugins/` are the fallback. #524 fixed the fallback. This fixes the path most installs actually execute.

Found by sweeping for the comparison pattern repo-wide after fixing it in the bundled script, rather than assuming it was a one-off.

## Same three defects

**The enum comparison.** `record.event_type` is an `EventType` whose value is the lowercase `'action_requested'`, so testing it against `"ACTION_REQUESTED"` is always False. The correlation loop never found a target, so PostToolUse returned without recording an outcome, for every tool. Tool name was also read from `record.data` when it has its own column.

**The recording gap.** Only denied calls were written, so an allowed shell, web or file call left no trace and there was nothing for PostToolUse to correlate against. Every matched call is recorded now, with `enforce=False` so the verdict still belongs to the deny rules.

**The dead escalate branch** inside `if result.allowed:`. Here the handling below it is correct, so it was unreachable rather than harmful, but it told a reader the opposite of what runs.

## Verification

Driven end to end the way the binary invokes it. An allowed `Write` now produces `action_requested`, `risk_scored`, `decision_made`, `outcome_recorded`.

The audit modules use `EventType.X` correctly throughout. These two hook paths were the only places comparing against a bare uppercase string.