### PR TITLE
v1.64.0: the hash chain forked whenever two processes shared a trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,116 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.64.0] - 2026-08-09
+
+Four defects, all on the same seam: two Vaara processes sharing one audit
+database. That is the ordinary setup rather than an edge case. The Claude
+Code hook and an MCP server both govern the same tool call and both append to
+`~/.vaara/trail/audit.db`.
+
+The first one forked the hash chain.
+
+`AuditTrail._last_hash` is per-process memory guarded by a `threading.Lock`,
+and `_append_chained` took `previous_hash` from it without ever reading the
+database. Two writers each held their own copy of the head, so both appended
+children off the same parent. A third writer starting cold began at
+`previous_hash = ""` and opened a second genesis in the middle of a live
+trail. `verify_chain` then reports a broken chain on a trail whose entire
+claim is that it is not broken, and the same property the receipt draft rests
+on, that a record verifies without asking the issuer, goes with it.
+
+The backend already knew about this hazard. `write_record` computes `seq`
+inside the INSERT with a subquery precisely so that two processes cannot cache
+`MAX(seq)+1` and collide, and the comment there names the MCP server case.
+`previous_hash` needed the same treatment and was left on the in-process path.
+
+It now gets it. `SQLiteAuditBackend.append_record` reads the chain head and
+inserts inside one `BEGIN IMMEDIATE` transaction, so a second writer blocks
+rather than reading a head that is about to go stale. `AuditTrail` delegates
+to the store when the `on_record` target can append atomically and keeps the
+old local-head path otherwise, so in-memory trails and plain callable sinks
+are unchanged.
+
+This was found by carving a damaged database and diagnosing what came out,
+not by reading the code and imagining a race. The trail carried 34 forks with
+sibling records 57 to 168 milliseconds apart, and four genesis rows sitting in
+the middle of the sequence.
+
+Writes cost 0.253 ms per record where they used to cost 0.115, so roughly
+4,000 records a second instead of 8,700. On a path where one record is one
+tool call, that headroom is not the scarce resource and the chain is.
+
+Moving the head into the store then moved the problem, which is the second
+defect. Once another process's records sit between two of ours on disk, a
+process's own `_records` list is a window onto the chain rather than the
+whole of it, and `verify_chain` walked it as though it were the whole thing.
+Every long-running process holding an existing database would have reported
+its own correctly written chain as broken from the first record on, and
+`ComplianceEngine` downgrades every article to EVIDENCE_INSUFFICIENT when
+`verify_chain` fails, so a working trail would have rendered BROKEN across
+every dashboard and signed report. `AuditTrail` now keeps the head the store
+handed it whenever that head was not its own previous record, and accepts a
+discontinuity only where it holds that evidence. Records are re-hashed
+either way, so re-parenting one to match an anchor breaks its hash instead.
+
+The third and fourth defects are in opening the file rather than writing to
+it, and both take out the process at construction. Two processes creating the
+same database at once both saw no `audit_records` table, both ran the schema,
+and the second one's `INSERT INTO audit_meta` died on the primary key. The
+narrower window was worse: a process arriving between the other's CREATE and
+its version INSERT read a fresh current database as unversioned and ran every
+migration against it. Schema creation and migration now run inside one
+`BEGIN IMMEDIATE` transaction, and an already-current database returns before
+taking any lock, so the common open neither waits nor writes.
+
+The fourth is what that lock exposed. `PRAGMA journal_mode=WAL` needs a brief
+exclusive lock and SQLite answers SQLITE_BUSY for it without consulting the
+busy handler, so the connection timeout never covered it. A process that lost
+that race raised `AuditBackendUnreadable`: "the audit trail could not be
+opened (database is locked)", a message that tells an operator their evidence
+file is damaged. The file was fine. The process had arrived half a second
+early, while another one still held the lock. The pragma now retries for half
+a second and then opens in whatever journal mode the file is already in,
+which gives worse concurrency and still records.
+
+The last two were found by a new test that spawns four real processes against
+one database, rather than simulating writers inside one interpreter. Both had
+been reachable since the backend was written.
+
+One limitation is now written down rather than fixed, in `chain_head`: an
+unscoped backend serving several tenants writes them onto one interleaved
+chain, so reloading that database filtered to a single tenant does not
+verify. `vaara trail rotate --tenant` therefore refuses to purge, and a
+per-tenant export carries `chain_intact_at_export=False`. Fixing it means
+chaining per tenant, which existing rows would not re-verify under.
+Deployments that leave `tenant_id` empty, which is every single-tenant
+install, are unaffected.
+
+A fifth defect turned up on the way, in the approval handshake rather than
+the trail. `request_approval` created `<action_id>.request.json` with
+`Path.write_text`, which truncates and then writes, so between those two
+calls the file exists and is empty. A watcher polling the directory saw it
+and read nothing: 66 of 300 requests on a warm filesystem, which is not a
+rare race. A watcher that parses what it finds raises on the empty string,
+and if that ends its poll loop the request is never answered and the gate
+blocks for its whole timeout. The module already treats an unreadable
+decision file as no consent; the request file it writes itself had no such
+protection. It is now written under a temporary name in the same directory
+and renamed into place. This had been making `tests/test_approvals.py` fail
+about one run in three, which was being read as flakiness rather than as the
+product race it was reporting.
+
+Also in this release: the x402 settlement conformance gate now has tests for
+something it only claimed. `SPEC.md` section 1 says consumers MUST accept
+`jcs-rfc8785`, `JCS` and `jcs-json-v1` as the canonicalization label, and the
+checker was widened to all three, but nothing exercised the widening, so it
+could have regressed to a bare equality check without a single test going red.
+An issuer following the spec emits `jcs-rfc8785` and would have failed a gate
+the spec is cited as defining. The committed vectors keep their `JCS` label on
+purpose, and a test now pins that too: outside implementations reproduce those
+exact bytes, so relabelling a committed vector would invalidate every digest
+they have published.
+
 ## [1.63.0] - 2026-08-09
 
 Thirteen defects across the MCP proxy, the MCP server, the inference path,

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.63.0"
+version = "1.64.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.63.0",
+  "version": "1.64.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.63.0",
+"version": "1.64.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.63.0",
+  "version": "1.64.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.63.0",
+"version": "1.64.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.63.0"
+__version__ = "1.64.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/approvals.py
+++ b/src/vaara/approvals.py
@@ -19,12 +19,32 @@ requests.
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 
 APPROVALS_DIR = Path.home() / ".vaara" / "approvals"
 
 __all__ = ["APPROVALS_DIR", "request_approval"]
+
+
+def _write_atomic(path: Path, text: str) -> None:
+    """Publish ``text`` at ``path`` in one step, or not at all.
+
+    ``Path.write_text`` opens with O_TRUNC and then writes, so between those
+    two calls the file exists and is empty. A watcher polling the directory
+    sees it and reads nothing: measured at 66 of 300 requests on a warm
+    filesystem, which is not a rare race. A watcher that calls json.loads on
+    what it finds raises there, and if that kills its poll loop the request is
+    never answered and the gate blocks for its whole timeout.
+
+    Writing under a temporary name in the same directory and renaming keeps
+    the request invisible until it is complete, since os.replace is atomic
+    within a filesystem.
+    """
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(text)
+    os.replace(tmp, path)
 
 
 def request_approval(
@@ -47,7 +67,7 @@ def request_approval(
     approvals_dir.mkdir(parents=True, exist_ok=True)
     request_file = approvals_dir / f"{action_id}.request.json"
     decision_file = approvals_dir / f"{action_id}.decision.json"
-    request_file.write_text(json.dumps({
+    _write_atomic(request_file, json.dumps({
         "action_id": action_id,
         "tool_name": tool_name,
         "reason": reason,

--- a/src/vaara/audit/sqlite_backend.py
+++ b/src/vaara/audit/sqlite_backend.py
@@ -26,6 +26,7 @@ import math
 import sqlite3
 import threading
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional
 
@@ -251,7 +252,7 @@ class SQLiteAuditBackend:
         # the fact that this is the audit trail, which sent more than one
         # investigation after the wrong thing. Say what broke and where.
         try:
-            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._enable_wal()
             self._conn.execute("PRAGMA synchronous=NORMAL")
             self._conn.execute("PRAGMA foreign_keys=ON")
         except sqlite3.DatabaseError as exc:
@@ -268,6 +269,83 @@ class SQLiteAuditBackend:
         self._init_schema()
         # Load GDPR redaction map into memory for O(1) read-time substitution.
         self._redaction_cache: dict[str, str] = self._load_redaction_cache()
+
+    # Switching journal mode needs a brief exclusive lock, and SQLite answers
+    # SQLITE_BUSY for it without consulting the busy handler, so the
+    # connect() timeout does not cover this one statement. Half a second of
+    # retries covers a peer that is mid schema-init.
+    _WAL_RETRIES = 10
+    _WAL_RETRY_SLEEP = 0.05
+
+    def _enable_wal(self) -> None:
+        """Switch to WAL, tolerating another process opening the same file.
+
+        Two Vaara processes creating one audit.db at the same moment — the
+        Claude Code hook and an MCP server starting together — had one of
+        them lose this race and die at construction, reported as
+        ``AuditBackendUnreadable``: "the audit trail could not be opened
+        (database is locked)". That message says the evidence file is
+        damaged. It was not damaged, it was half a second early.
+
+        A file already in WAL answers this pragma without needing the lock,
+        so the retry only ever runs on first creation. If the lock is still
+        held after that, the database opens in the journal mode it is already
+        in: worse concurrency, but recording evidence beats refusing to.
+        """
+        last: Optional[sqlite3.OperationalError] = None
+        for _ in range(self._WAL_RETRIES):
+            try:
+                self._conn.execute("PRAGMA journal_mode=WAL")
+                return
+            except sqlite3.OperationalError as exc:
+                msg = str(exc).lower()
+                if "locked" not in msg and "busy" not in msg:
+                    raise
+                last = exc
+                time.sleep(self._WAL_RETRY_SLEEP)
+        logger.warning(
+            "audit DB %s stayed locked while enabling WAL (%s); continuing in "
+            "the existing journal mode. Another Vaara process is opening the "
+            "same file.",
+            self._db_path, last,
+        )
+
+    @contextmanager
+    def _rollback_on_failure(self):
+        """Commit the open transaction, and never leave one open on failure.
+
+        A COMMIT that fails, on a full disk or an I/O error, leaves the
+        transaction open. Every later ``BEGIN IMMEDIATE`` on this connection
+        then raises "cannot start a transaction within a transaction" for the
+        life of the process, so one bad write would stop the audit writer
+        permanently instead of losing one record. On this path that means the
+        rest of the session goes unrecorded.
+        """
+        try:
+            yield
+        except BaseException:
+            self._rollback_quietly()
+            raise
+        try:
+            self._conn.execute("COMMIT")
+        except BaseException:
+            self._rollback_quietly()
+            raise
+
+    def _rollback_quietly(self) -> None:
+        """Roll back, tolerating a transaction SQLite has already ended.
+
+        Some errors abort the transaction themselves, and rolling back then
+        raises "no transaction is active" — a second exception that would
+        replace the real one on its way up.
+        """
+        try:
+            self._conn.execute("ROLLBACK")
+        except sqlite3.Error as exc:
+            logger.debug(
+                "audit DB %s: rollback after failure was a no-op (%s)",
+                self._db_path, exc,
+            )
 
     def _table_exists(self, name: str) -> bool:
         row = self._conn.execute(
@@ -300,10 +378,40 @@ class SQLiteAuditBackend:
            is a no-op via IF NOT EXISTS.
         4. Existing DB pre-versioning (no audit_meta or no schema_version
            row): treated as v0 and migrated forward.
+
+        Two processes open the same database at the same time as a matter of
+        course — the Claude Code hook and an MCP server share one audit.db —
+        so the create/migrate path runs inside one ``BEGIN IMMEDIATE``
+        transaction. Without it both processes saw "no audit_records", both
+        ran SCHEMA_SQL, and the second one's ``INSERT INTO audit_meta`` died
+        on the primary key, taking the whole backend down at construction.
+        The narrower window was worse: a process that arrived between the
+        other's CREATE and its version INSERT read a fresh v5 database as
+        unversioned and ran every migration against it.
+
+        Case 3, which is every open after the first, returns before taking
+        the lock. That keeps the common path free of a write lock (four
+        processes starting together would otherwise queue on it) and leaves
+        an already-current database openable without writing to it.
         """
+        if self._schema_is_current():
+            return
+        self._conn.execute("BEGIN IMMEDIATE")
+        with self._rollback_on_failure():
+            self._init_schema_locked()
+
+    def _schema_is_current(self) -> bool:
+        return (
+            self._table_exists("audit_records")
+            and self._table_exists("audit_meta")
+            and self._stored_schema_version() == SCHEMA_VERSION
+        )
+
+    def _init_schema_locked(self) -> None:
+        """The create/migrate work. Caller holds the write lock."""
         if not self._table_exists("audit_records"):
             # Fresh DB
-            self._conn.executescript(SCHEMA_SQL)
+            self._exec_script(SCHEMA_SQL)
             self._conn.execute(
                 "INSERT INTO audit_meta (key, value) VALUES ('schema_version', ?)",
                 (str(SCHEMA_VERSION),),
@@ -331,18 +439,37 @@ class SQLiteAuditBackend:
             self._run_migrations(stored, SCHEMA_VERSION)
         # SCHEMA_SQL is now safe to run idempotently. All referenced
         # columns exist because migrations have brought the DB current.
-        self._conn.executescript(SCHEMA_SQL)
+        self._exec_script(SCHEMA_SQL)
+
+    def _exec_script(self, script: str) -> None:
+        """Run a multi-statement DDL script without ending the transaction.
+
+        ``executescript`` commits whatever transaction is open before it runs
+        its first statement, which would drop the write lock ``_init_schema``
+        holds and put two processes back inside the schema at once.
+        Statements are split with ``sqlite3.complete_statement`` rather than
+        on ``;`` so a semicolon inside a literal or a trigger body cannot cut
+        one in half.
+        """
+        buf = ""
+        for line in script.splitlines(keepends=True):
+            buf += line
+            if sqlite3.complete_statement(buf):
+                self._conn.execute(buf)
+                buf = ""
+        if buf.strip():
+            self._conn.execute(buf)
 
     def _run_migrations(self, from_version: int, to_version: int) -> None:
         """Apply incremental schema migrations from_version up to to_version.
 
-        Each statement runs individually because SQLite doesn't support
-        transactional DDL for ALTER TABLE. We swallow OperationalError ONLY
-        when the message indicates an already-applied statement (duplicate
-        column / table already exists), which keeps re-runs after a partial
-        migration idempotent. Any other error propagates so schema_version
-        stays at the LAST successfully completed version — the next open
-        retries cleanly without falsely advertising a half-migrated DB.
+        Each statement runs individually, and OperationalError is swallowed
+        ONLY when the message says the statement was already applied
+        (duplicate column / table already exists), which keeps a re-run
+        idempotent. Any other error propagates to ``_init_schema``, whose
+        transaction rolls the whole migration back — including the
+        per-migration version bumps below — so the next open starts from the
+        version the database was actually at rather than a half-migrated one.
         """
         for v in range(from_version, to_version):
             sql = _MIGRATIONS.get(v)
@@ -398,9 +525,18 @@ class SQLiteAuditBackend:
         load_trail and the hash-chain integrity check below it. SQLite
         serializes writers at the transaction boundary, so the subquery
         reads MAX(seq) at the same point the INSERT takes effect.
+
+        ``previous_hash`` needs the same treatment and gets it in
+        :meth:`append_record`, which is what ``AuditTrail`` calls. This
+        method takes the record's hashes as already stamped and is kept
+        for callers that own their own chaining (migrations, imports).
         """
         with self._lock:
-            self._conn.execute(
+            self._insert_record(record)
+
+    def _insert_record(self, record: AuditRecord) -> None:
+        """Emit the INSERT. Caller holds ``self._lock``."""
+        self._conn.execute(
                 """INSERT INTO audit_records
                    (record_id, action_id, event_type, timestamp, agent_id,
                     tool_name, data, regulatory, previous_hash, record_hash, seq,
@@ -442,6 +578,67 @@ class SQLiteAuditBackend:
                     record.chain_version,
                 ),
             )
+
+    def chain_head(self) -> str:
+        """``record_hash`` of the newest stored record, or ``""`` if empty.
+
+        Scoped with the same tenant clause ``load_trail`` reconstructs under,
+        so a backend opened for one tenant chains inside that tenant and its
+        filtered reload verifies.
+
+        KNOWN LIMITATION, older than this method and not fixed by it: an
+        *unscoped* backend serving several tenants writes them all onto one
+        interleaved chain, because ``_tenant_clause`` is then ``1=1`` and the
+        head is whatever record was written last, whoever it belonged to.
+        Reloading that database filtered to one tenant returns records that
+        are not adjacent, and ``verify_chain`` reports a break — so
+        ``vaara trail rotate --tenant`` refuses to purge (rotate.py checks
+        ``chain_intact`` before it deletes anything) and any per-tenant export
+        carries ``chain_intact_at_export=False``. Chaining per tenant would
+        fix it and is a chain-format change: existing rows were written under
+        global chaining and would not re-verify under per-tenant rules.
+        Single-tenant deployments, which is every deployment where
+        ``tenant_id`` is left at ``""``, are unaffected.
+        """
+        with self._lock:
+            return self._chain_head_locked()
+
+    def _chain_head_locked(self) -> str:
+        t_clause, t_params = self._tenant_clause()
+        row = self._conn.execute(
+            f"SELECT record_hash FROM audit_records WHERE {t_clause} "
+            "ORDER BY seq DESC LIMIT 1",
+            t_params,
+        ).fetchone()
+        return (row[0] or "") if row else ""
+
+    def append_record(self, record: AuditRecord, stamp) -> str:
+        """Read the chain head and insert, atomically against other writers.
+
+        ``stamp(previous_hash)`` is the trail's finaliser: it sets
+        ``previous_hash``/``chain_version`` on the record and computes
+        ``record_hash``. Running it between the head read and the INSERT, both
+        inside one ``BEGIN IMMEDIATE`` transaction, is what makes the chain
+        correct across processes rather than only across threads.
+
+        Without this the head came from ``AuditTrail._last_hash``, per-process
+        memory. Two writers on one DB (the common deployment: a hook process
+        and an MCP server governing the same tool call) each held their own
+        copy, so both appended children off the same parent. The result is a
+        forked chain that ``verify_chain`` reports as broken, on a trail whose
+        whole claim is that it is not.
+
+        ``BEGIN IMMEDIATE`` takes SQLite's write lock up front, so a second
+        writer blocks here instead of reading a head that is about to go stale.
+        Returns the ``previous_hash`` actually used.
+        """
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            with self._rollback_on_failure():
+                head = self._chain_head_locked()
+                stamp(head)
+                self._insert_record(record)
+            return head
 
     # ── Read path ─────────────────────────────────────────────────
 

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -574,6 +574,14 @@ class AuditTrail:
         self._by_action: dict[str, list[AuditRecord]] = defaultdict(list)
         self._last_hash = ""
         self._on_record = on_record
+        # record_id -> the chain head the persistent store handed out for it,
+        # recorded only when that head was not this trail's own previous
+        # record. Once the store owns the head (see _chain_backend), _records
+        # is a window onto a chain other processes also write to, so two of
+        # our records are often not adjacent on disk. verify_chain consults
+        # this to tell a legitimate foreign predecessor from a real break,
+        # and accepts nothing it did not observe the store hand out.
+        self._store_anchors: dict[str, str] = {}
         # v0.40 multi-tenant: action_id -> tenant_id, seeded by
         # record_action_requested. Subsequent record_* calls (decision,
         # execution, escalation) look up the action_id so every record in
@@ -655,17 +663,42 @@ class AuditTrail:
         return self.verify_chain() is None
 
     def verify_chain(self) -> Optional[str]:
-        """Verify hash chain integrity.  Returns None if intact, error string if broken."""
+        """Verify hash chain integrity.  Returns None if intact, error string if broken.
+
+        A trail whose persistent store owns the chain head holds a *window*
+        onto that chain, not the whole of it: the store serializes appends
+        from every process sharing the database, so another writer's records
+        legitimately sit between two of ours. Those points are not breaks,
+        and reading them as breaks would be its own defect — ComplianceEngine
+        downgrades every article to EVIDENCE_INSUFFICIENT on a failed verify,
+        so a correctly chained trail would render BROKEN on every dashboard
+        and in every signed report.
+
+        The only discontinuities accepted are ones this trail watched the
+        store hand out, recorded in ``_store_anchors`` at write time. A
+        record re-parented onto any other hash is still a break, and every
+        record's hash is recomputed regardless — ``previous_hash`` is part of
+        the hashed content, so editing it to match an anchor breaks the hash
+        instead. An in-memory trail, or one loaded whole from the store, has
+        no anchors and is verified strictly from genesis as before.
+
+        This is the process's view. The complete chain is verified by
+        reloading it from the store, which is what ``load_trail`` does on
+        every open and what ``vaara verify`` and the export path use.
+        """
         with self._lock:
             snapshot = list(self._records)
+            anchors = dict(self._store_anchors)
         prev_hash = ""
         for i, record in enumerate(snapshot):
             if record.previous_hash != prev_hash:
-                return (
-                    f"Chain broken at record {i} ({record.record_id}): "
-                    f"expected previous_hash={prev_hash!r}, "
-                    f"got {record.previous_hash!r}"
-                )
+                anchor = anchors.get(record.record_id)
+                if anchor is None or record.previous_hash != anchor:
+                    return (
+                        f"Chain broken at record {i} ({record.record_id}): "
+                        f"expected previous_hash={prev_hash!r}, "
+                        f"got {record.previous_hash!r}"
+                    )
             expected = record.compute_hash()
             if record.record_hash != expected:
                 return (
@@ -1510,33 +1543,77 @@ class AuditTrail:
         if record.data:
             record.data = {str(k): json_safe(v) for k, v in record.data.items()}
         with self._lock:
-            record.previous_hash = self._last_hash
-            # Stamp the current chain format on every fresh record so its
-            # tenant_id is bound into the hash. Records reloaded from storage
-            # never pass through _append, so their stored version is left
-            # intact and old trails keep re-verifying.
-            record.chain_version = _CURRENT_CHAIN_VERSION
-            record.record_hash = record.compute_hash()
-            self._last_hash = record.record_hash
+            def _stamp(previous_hash: str) -> None:
+                record.previous_hash = previous_hash
+                # Stamp the current chain format on every fresh record so its
+                # tenant_id is bound into the hash. Records reloaded from
+                # storage never pass through _append, so their stored version
+                # is left intact and old trails keep re-verifying.
+                record.chain_version = _CURRENT_CHAIN_VERSION
+                record.record_hash = record.compute_hash()
 
-            self._records.append(record)
-            self._by_action[record.action_id].append(record)
-
-            if self._on_record:
+            backend = self._chain_backend()
+            if backend is not None:
+                # The store owns the head. It reads it and inserts inside one
+                # transaction, so a second writer on the same DB cannot chain
+                # off a head that is already stale. self._last_hash is a
+                # per-process cache and forks the chain when it is the
+                # authority (see SQLiteAuditBackend.append_record).
                 try:
-                    self._on_record(record)
+                    head = backend.append_record(record, _stamp)
+                    if head != self._last_hash:
+                        # Another writer appended between our previous record
+                        # and this one, so the two are not adjacent on disk.
+                        # Keep the head the store actually used: it is the
+                        # only evidence that this discontinuity is somebody
+                        # else's record rather than a missing one.
+                        self._store_anchors[record.record_id] = head
                 except Exception:
-                    # logger.exception preserves the stack trace so ops can
-                    # diagnose disk-full / locked-DB / permission errors
-                    # instead of seeing a bare error line.
+                    # Store rejected the write. Keep the in-memory chain
+                    # coherent off the local head and count the divergence,
+                    # exactly as the on_record path below does.
+                    _stamp(self._last_hash)
                     self._persistence_failures += 1
                     logger.exception(
-                        "on_record callback failed for record %s "
+                        "append_record failed for record %s "
                         "(persistent store now out of sync with in-memory "
                         "chain; failure count=%d)",
                         record.record_id,
                         self._persistence_failures,
                     )
+            else:
+                _stamp(self._last_hash)
+                if self._on_record:
+                    try:
+                        self._on_record(record)
+                    except Exception:
+                        # logger.exception preserves the stack trace so ops can
+                        # diagnose disk-full / locked-DB / permission errors
+                        # instead of seeing a bare error line.
+                        self._persistence_failures += 1
+                        logger.exception(
+                            "on_record callback failed for record %s "
+                            "(persistent store now out of sync with in-memory "
+                            "chain; failure count=%d)",
+                            record.record_id,
+                            self._persistence_failures,
+                        )
+
+            self._last_hash = record.record_hash
+            self._records.append(record)
+            self._by_action[record.action_id].append(record)
+
+    def _chain_backend(self):
+        """The store that owns the persistent chain head, or ``None``.
+
+        Exactly the object ``on_record`` would write to, and only when it can
+        append atomically. An in-memory trail, a plain callable sink, or a
+        backend predating ``append_record`` all keep the local-head path.
+        """
+        target = getattr(self._on_record, "__self__", None)
+        if target is not None and hasattr(target, "append_record"):
+            return target
+        return None
 
     def _get_regulatory_articles(
         self,

--- a/tests/test_approvals.py
+++ b/tests/test_approvals.py
@@ -95,3 +95,46 @@ def test_creates_missing_approvals_dir(tmp_path):
     result = request_approval("a", "t", "r", approvals_dir=nested, timeout=0.2)
     assert result == "timeout"
     assert nested.is_dir()
+
+
+def test_watcher_never_sees_a_half_written_request(tmp_path):
+    """The request file appears with its content already in it.
+
+    ``Path.write_text`` truncates and then writes, so a watcher polling the
+    directory could find the file and read nothing: 66 of 300 requests on a
+    warm filesystem before this was fixed. A watcher that parses what it
+    finds raises on the empty string, and if that ends its poll loop the
+    request is never answered and the gate blocks for its whole timeout.
+    This is what made the tests above fail roughly one run in three, and it
+    would do the same to any real approval surface.
+    """
+    empty_reads = 0
+    for i in range(40):
+        run_dir = tmp_path / f"run-{i}"
+        run_dir.mkdir()
+        seen: list[str] = []
+
+        def watch(d=run_dir, seen=seen) -> None:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                for req in d.glob("*.request.json"):
+                    seen.append(req.read_text())
+                    action_id = req.name.removesuffix(".request.json")
+                    (d / f"{action_id}.decision.json").write_text(
+                        json.dumps({"decision": "approve", "decided_at": time.time()})
+                    )
+                    return
+
+        thread = threading.Thread(target=watch, daemon=True)
+        thread.start()
+        result = request_approval(
+            f"act-{i}", "t", "r",
+            approvals_dir=run_dir, timeout=10, poll_interval=0.01,
+        )
+        thread.join(timeout=10)
+        assert result == "approve"
+        empty_reads += sum(1 for raw in seen if raw == "")
+
+    assert empty_reads == 0, (
+        f"a watcher read an empty request file {empty_reads} time(s) in 40 requests"
+    )

--- a/tests/test_sqlite_backend.py
+++ b/tests/test_sqlite_backend.py
@@ -1,5 +1,6 @@
 """Tests for the SQLite audit backend."""
 
+import multiprocessing
 import tempfile
 from pathlib import Path
 
@@ -27,6 +28,34 @@ def db_path():
     # Clean WAL files
     Path(str(path) + "-wal").unlink(missing_ok=True)
     Path(str(path) + "-shm").unlink(missing_ok=True)
+
+
+def _append_from_child(db_path: str, label: str, count: int) -> None:
+    """Write ``count`` records to ``db_path`` from a separate OS process.
+
+    Module level and picklable so this works under the spawn start method
+    (the default on macOS) as well as fork.
+    """
+    from vaara.audit.sqlite_backend import SQLiteAuditBackend
+    from vaara.taxonomy.actions import (
+        ActionCategory, ActionRequest, ActionType, BlastRadius, Reversibility,
+        UrgencyClass,
+    )
+
+    action_type = ActionType(
+        "tx.transfer", ActionCategory.FINANCIAL, Reversibility.IRREVERSIBLE,
+        BlastRadius.SHARED, UrgencyClass.IRREVOCABLE,
+    )
+    backend = SQLiteAuditBackend(db_path)
+    try:
+        trail = backend.load_trail()
+        for i in range(count):
+            trail.record_action_requested(ActionRequest(
+                agent_id=f"{label}-{i}", tool_name="tx.transfer",
+                action_type=action_type,
+            ))
+    finally:
+        backend.close()
 
 
 @pytest.fixture
@@ -343,3 +372,213 @@ class TestSkeletonRecordsCounter:
         status = p.status()
         assert "trail_skeleton_records" in status
         assert status["trail_skeleton_records"] == 0
+
+
+class TestCrossProcessChainHead:
+    """The hash chain must stay single-threaded across writers sharing one DB.
+
+    ``previous_hash`` came from ``AuditTrail._last_hash``, per-process memory
+    guarded by a ``threading.Lock``. Two writers on one ``audit.db`` each held
+    their own copy, so both appended children off the same parent and the chain
+    forked. ``seq`` was already immune (computed by subquery inside the INSERT,
+    see ``write_record``); ``previous_hash`` was not, and it is the half that
+    carries the tamper-evidence claim.
+
+    Observed live: 34 forks and 4 mid-trail genesis rows in a real trail, the
+    fork siblings 57-168 ms apart and split between the Claude Code hook and
+    the vaara-memory MCP server writing the same tool call.
+    """
+
+    def _write(self, trail, agent, action_type):
+        req = ActionRequest(
+            agent_id=agent, tool_name="tx.transfer", action_type=action_type,
+        )
+        return trail.record_action_requested(req)
+
+    def test_two_writers_sharing_a_db_do_not_fork_the_chain(
+            self, db_path, sample_action_type):
+        """Two backends on one file, both loaded, appending alternately."""
+        a = SQLiteAuditBackend(db_path)
+        trail_a = a.load_trail()
+        self._write(trail_a, "writer-a", sample_action_type)
+
+        # Second writer opens the same DB and loads the same head.
+        b = SQLiteAuditBackend(db_path)
+        trail_b = b.load_trail()
+
+        # Interleave. Each writer's in-process _last_hash goes stale the moment
+        # the other one appends.
+        for i in range(5):
+            self._write(trail_a, f"writer-a-{i}", sample_action_type)
+            self._write(trail_b, f"writer-b-{i}", sample_action_type)
+
+        a.close()
+        b.close()
+
+        reloaded = SQLiteAuditBackend(db_path).load_trail()
+        assert reloaded.verify_chain() is None, "chain forked across writers"
+
+    def test_second_writer_does_not_start_a_new_genesis(
+            self, db_path, sample_action_type):
+        """A trail built straight from ``on_record`` against a non-empty DB
+        must chain onto the stored tail, not restart at ``previous_hash=''``."""
+        first = SQLiteAuditBackend(db_path)
+        trail = first.load_trail()
+        self._write(trail, "writer-a", sample_action_type)
+        first.close()
+
+        second = SQLiteAuditBackend(db_path)
+        cold = AuditTrail(on_record=second.write_record)
+        self._write(cold, "writer-b", sample_action_type)
+        second.close()
+
+        reloaded = SQLiteAuditBackend(db_path).load_trail()
+        records = reloaded._records
+        assert len(records) == 2
+        assert records[1].previous_hash == records[0].record_hash, (
+            "second writer restarted the chain mid-trail")
+        assert reloaded.verify_chain() is None
+
+
+class TestWindowedTrailVerification:
+    """A live trail holds a window onto the chain, and must say so honestly.
+
+    Once the store owns the head, a process's own ``_records`` are no longer
+    the whole chain: another writer's records sit between them on disk. The
+    naive walk reads that as a break, which would be worse than the fork it
+    replaced — ``ComplianceEngine`` downgrades every article to
+    EVIDENCE_INSUFFICIENT on a failed ``verify_chain()``, so a correctly
+    chained trail would render as BROKEN on every dashboard.
+    """
+
+    def _write(self, trail, agent, action_type):
+        req = ActionRequest(
+            agent_id=agent, tool_name="tx.transfer", action_type=action_type,
+        )
+        return trail.record_action_requested(req)
+
+    def test_cold_writer_on_a_non_empty_db_verifies(
+            self, db_path, sample_action_type):
+        """The MCP server and proxy pattern: fresh trail, existing DB."""
+        first = SQLiteAuditBackend(db_path)
+        self._write(first.load_trail(), "writer-a", sample_action_type)
+        first.close()
+
+        second = SQLiteAuditBackend(db_path)
+        cold = AuditTrail(on_record=second.write_record)
+        self._write(cold, "writer-b", sample_action_type)
+
+        assert cold.verify_chain() is None
+        assert cold.chain_intact
+        second.close()
+
+    def test_interleaved_writers_each_verify_their_own_window(
+            self, db_path, sample_action_type):
+        a = SQLiteAuditBackend(db_path)
+        b = SQLiteAuditBackend(db_path)
+        trail_a = a.load_trail()
+        trail_b = b.load_trail()
+
+        for i in range(4):
+            self._write(trail_a, f"writer-a-{i}", sample_action_type)
+            self._write(trail_b, f"writer-b-{i}", sample_action_type)
+
+        assert trail_a.verify_chain() is None
+        assert trail_b.verify_chain() is None
+        a.close()
+        b.close()
+        assert SQLiteAuditBackend(db_path).load_trail().verify_chain() is None
+
+    def test_tampering_still_breaks_a_windowed_trail(
+            self, db_path, sample_action_type):
+        """The relaxation must not become a hole to hide edits in."""
+        a = SQLiteAuditBackend(db_path)
+        b = SQLiteAuditBackend(db_path)
+        trail_a = a.load_trail()
+        trail_b = b.load_trail()
+        for i in range(3):
+            self._write(trail_a, f"writer-a-{i}", sample_action_type)
+            self._write(trail_b, f"writer-b-{i}", sample_action_type)
+        assert trail_a.verify_chain() is None
+
+        trail_a._records[1].data["parameters"] = {"amount": 999_999}
+        assert trail_a.verify_chain() is not None
+        a.close()
+        b.close()
+
+    def test_forged_anchor_is_not_accepted(
+            self, db_path, sample_action_type):
+        """Only a head the store actually handed out excuses a discontinuity.
+
+        Rewriting ``previous_hash`` to an unobserved value has to break the
+        chain even where a legitimate anchor sits nearby, otherwise a record
+        could be re-parented onto any hash at all.
+        """
+        a = SQLiteAuditBackend(db_path)
+        b = SQLiteAuditBackend(db_path)
+        trail_a = a.load_trail()
+        trail_b = b.load_trail()
+        for i in range(3):
+            self._write(trail_a, f"writer-a-{i}", sample_action_type)
+            self._write(trail_b, f"writer-b-{i}", sample_action_type)
+
+        victim = trail_a._records[2]
+        victim.previous_hash = "f" * 64
+        victim.record_hash = victim.compute_hash()  # re-seal the forgery
+        assert trail_a.verify_chain() is not None
+        a.close()
+        b.close()
+
+    def test_in_memory_trail_still_verifies_strictly(self, sample_action_type):
+        """No store, no window: the genesis and every link stay mandatory."""
+        trail = AuditTrail()
+        for i in range(3):
+            self._write(trail, f"agent-{i}", sample_action_type)
+        assert trail.verify_chain() is None
+
+        trail._records[1].previous_hash = "0" * 64
+        trail._records[1].record_hash = trail._records[1].compute_hash()
+        assert trail.verify_chain() is not None
+
+
+class TestConcurrentProcessAppend:
+    """The claim, tested the way it is deployed: separate OS processes.
+
+    The tests above interleave two backends inside one interpreter, which
+    reproduces the stale-head mechanism but shares a GIL and a page cache.
+    This one spawns real processes contending for SQLite's write lock, which
+    is the only version of the claim a deployment cares about: the Claude
+    Code hook, an MCP server and `vaara check` all writing one audit.db.
+    """
+
+    def test_four_processes_writing_one_db_produce_one_chain(self, db_path):
+        writers, per_writer = 4, 15
+        ctx = multiprocessing.get_context("spawn")
+        procs = [
+            ctx.Process(
+                target=_append_from_child,
+                args=(str(db_path), f"proc-{n}", per_writer),
+            )
+            for n in range(writers)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=120)
+
+        assert all(p.exitcode == 0 for p in procs), (
+            f"writer processes failed: {[p.exitcode for p in procs]}")
+
+        backend = SQLiteAuditBackend(db_path)
+        try:
+            trail = backend.load_trail()
+            assert trail.size == writers * per_writer, (
+                "records were lost to write-lock contention")
+            assert trail.verify_chain() is None, "chain forked across processes"
+            seqs = [
+                row[0] for row in backend._conn.execute(
+                    "SELECT seq FROM audit_records ORDER BY seq")
+            ]
+            assert seqs == list(range(len(seqs))), f"seq gaps or repeats: {seqs}"
+        finally:
+            backend.close()

--- a/tests/test_x402_settlement_vectors.py
+++ b/tests/test_x402_settlement_vectors.py
@@ -98,3 +98,53 @@ def test_lifecycle_steps_have_distinct_action_refs():
         assert s0["terminal"] is False
         assert s1["terminal"] is True
         assert s0["actionRef"] != s1["actionRef"]
+
+
+def test_committed_vectors_keep_the_JCS_label():
+    """The committed label is pinned deliberately and must never be rewritten.
+
+    Five outside parties (agent-guard, nobulex, elara, payperbyte, and a live
+    Sui gasless run) reproduce these fixtures byte for byte against a
+    content-pinned copy of the checker. Relabelling a committed vector, even to
+    the SPEC-preferred ``jcs-rfc8785``, changes those bytes and invalidates
+    every digest they published. New labels belong in new vectors.
+    """
+    for rail in _RAILS:
+        for step in _STEPS:
+            ref = _load(rail, step, "receipt.json")["decisionDerived"][
+                "evidenceRef"]
+            assert ref["canonicalization"] == "JCS"
+
+
+def test_checker_accepts_every_spec_alias():
+    """SPEC.md section 1: producers SHOULD emit ``jcs-rfc8785``; consumers MUST
+    accept ``jcs-rfc8785``, ``JCS`` and ``jcs-json-v1``.
+
+    The checker was widened to all three, but nothing exercised the widening,
+    so it could regress to a bare ``== "JCS"`` and the suite would stay green.
+    That regression is not hypothetical: an issuer following our own spec emits
+    ``jcs-rfc8785`` and would fail a gate our spec is cited as defining.
+
+    Mutates in-memory copies only. The committed fixtures keep their ``JCS``
+    label (see ``test_committed_vectors_keep_the_JCS_label``).
+    """
+    checker = _load_checker()
+    settlement = _load("sui", "step1", "settlement.json")
+    receipt = _load("sui", "step1", "receipt.json")
+
+    for alias in ("jcs-rfc8785", "JCS", "jcs-json-v1"):
+        probe = json.loads(json.dumps(receipt))
+        probe["decisionDerived"]["evidenceRef"]["canonicalization"] = alias
+        assert checker.settlement_binding_resolves(probe, settlement) is True, (
+            f"consumer rejected the spec alias {alias!r}")
+
+
+def test_checker_rejects_an_unknown_canonicalization():
+    """Accepting all three aliases must not become accepting anything. A label
+    the spec does not define means the digest was computed some other way, so
+    the binding cannot be assumed to hold."""
+    checker = _load_checker()
+    settlement = _load("sui", "step1", "settlement.json")
+    probe = _load("sui", "step1", "receipt.json")
+    probe["decisionDerived"]["evidenceRef"]["canonicalization"] = "sorted-keys"
+    assert checker.settlement_binding_resolves(probe, settlement) is False


### PR DESCRIPTION
Four defects on one seam: two Vaara processes sharing a single audit database.
That is the ordinary setup rather than an edge case. The Claude Code hook and
an MCP server both govern the same tool call and both append to
`~/.vaara/trail/audit.db`.

## The chain forked

`AuditTrail._last_hash` is per-process memory guarded by a `threading.Lock`,
and `_append_chained` took `previous_hash` from it without ever reading the
database. Two writers each held their own copy of the head, so both appended
children off the same parent. A third starting cold began at
`previous_hash = ""` and opened a second genesis in the middle of a live
trail. `verify_chain` then reports a broken chain on a trail whose entire
claim is that it is not broken.

The backend already knew about this hazard. `write_record` computes `seq`
inside the INSERT with a subquery so that two processes cannot cache
`MAX(seq)+1` and collide, and the comment there names the MCP server case.
`previous_hash` was left on the in-process path.

`SQLiteAuditBackend.append_record` now reads the head and inserts inside one
`BEGIN IMMEDIATE` transaction. `AuditTrail` delegates to the store when the
`on_record` target can append atomically and keeps the old local-head path
otherwise, so in-memory trails and plain callable sinks are unchanged.

This was found by carving a damaged database and diagnosing what came out,
not by reading the code and imagining a race. The trail carried 34 forks with
sibling records 57 to 168 ms apart, and four genesis rows in the middle of the
sequence.

Writes cost 0.253 ms per record where they used to cost 0.115, so roughly
4,000 records a second instead of 8,700.

## Then the window it opened

Once another process's records sit between two of ours on disk, a process's
own `_records` list is a window onto the chain rather than the whole of it,
and `verify_chain` walked it as though it were the whole thing. Every
long-running process holding an existing database would have reported its own
correctly written chain as broken from the first record on, and
`ComplianceEngine` downgrades every article to EVIDENCE_INSUFFICIENT when
`verify_chain` fails, so a working trail would have rendered BROKEN across
every dashboard and signed report.

`AuditTrail` now keeps the head the store handed it whenever that head was
not its own previous record, and accepts a discontinuity only where it holds
that evidence. Records are re-hashed either way, so re-parenting one to match
an anchor breaks its hash instead.

## Two more in opening the file

Both take out the process at construction, and both had been reachable since
the backend was written.

Two processes creating the same database at once both saw no `audit_records`
table, both ran the schema, and the second one's `INSERT INTO audit_meta`
died on the primary key. The narrower window was worse: a process arriving
between the other's CREATE and its version INSERT read a fresh current
database as unversioned and ran every migration against it. Creation and
migration now run inside one `BEGIN IMMEDIATE` transaction, and an
already-current database returns before taking any lock, so the common open
neither waits nor writes.

`PRAGMA journal_mode=WAL` needs a brief exclusive lock and SQLite answers
SQLITE_BUSY for it without consulting the busy handler, so the connection
timeout never covered it. The process that lost that race raised
`AuditBackendUnreadable`: "the audit trail could not be opened (database is
locked)", a message that tells an operator their evidence file is damaged.
The file was fine. The pragma now retries for half a second and then opens in
whatever journal mode the file is already in.

Both of these were found by a new test that spawns four real processes
against one database rather than simulating writers inside one interpreter.

## A fifth, in the approval handshake

`request_approval` created `<action_id>.request.json` with `Path.write_text`,
which truncates and then writes, so between those two calls the file exists
and is empty. A watcher polling the directory saw it and read nothing: 66 of
300 requests on a warm filesystem. A watcher that parses what it finds raises
on the empty string, and if that ends its poll loop the request is never
answered and the gate blocks for its whole timeout. The module already treats
an unreadable decision file as no consent; the request file it writes itself
had no such protection. It is now written under a temporary name in the same
directory and renamed into place.

This had been making `tests/test_approvals.py` fail about one run in three,
which was being read as flakiness rather than as the product race it was
reporting.

## One limitation documented, not fixed

An unscoped backend serving several tenants writes them onto one interleaved
chain, so reloading that database filtered to a single tenant does not
verify. `vaara trail rotate --tenant` therefore refuses to purge, and a
per-tenant export carries `chain_intact_at_export=False`. Fixing it means
chaining per tenant, which existing rows would not re-verify under. It is
written down in `chain_head` with what it costs and what it would take.
Deployments that leave `tenant_id` empty, which is every single-tenant
install, are unaffected.

## Also

The x402 settlement conformance gate now has tests for something it only
claimed. `SPEC.md` section 1 says consumers MUST accept `jcs-rfc8785`, `JCS`
and `jcs-json-v1` as the canonicalization label, and the checker was widened
to all three, but nothing exercised the widening, so it could have regressed
to a bare equality check without a test going red. An issuer following the
spec emits `jcs-rfc8785` and would have failed a gate the spec is cited as
defining. The committed vectors keep their `JCS` label on purpose, and a test
pins that too: outside implementations reproduce those exact bytes, so
relabelling a committed vector would invalidate every digest they have
published.

## Verification

`2706 passed, 32 skipped` on the full suite, `ruff check tests/ src/` clean.

The concurrency test spawns four processes writing 15 records each, then
checks the reloaded chain verifies and `seq` has no gaps or repeats. The
approvals test drives 40 requests past a watcher that reads on first sight
and asserts it never sees an empty file; both fail against the code they
were written for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite audit-chain reliability during concurrent and cross-process writes.
  * Added safer handling for database locks, schema initialization, and interleaved tenant records.
  * Approval request files are now created atomically, preventing incomplete contents from being observed.
  * Strengthened audit-chain verification to detect tampering and invalid anchors.
  * Improved canonicalization-label validation for settlement receipts.

* **Tests**
  * Added coverage for concurrent audit writes, chain verification, atomic approval requests, and canonicalization compatibility.

* **Release**
  * Updated the project, client, plugin, and server packages to version 1.64.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->