### PR TITLE
v1.64.1: index the column every append sorts on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.64.1] - 2026-08-09
+
+An index on `seq`, which the append path has needed since the backend was
+written and needed twice as much after 1.64.0.
+
+Two queries run on every append and both order by `seq`: the subquery inside
+the INSERT that computes the next sequence number, and `chain_head`, which
+1.64.0 added to read the chain head under the write lock. Neither had an index
+to use, so SQLite scanned the whole table and built a temporary B-tree to sort
+it, once per record. The cost of writing one record therefore grew with the
+number of records already in the trail.
+
+```
+                without index      with index
+empty                0.12 ms          0.09 ms
+10,000 rows          4.70 ms          0.13 ms
+30,800 rows         15.98 ms          0.13 ms
+40,000 rows         22.07 ms          0.14 ms
+```
+
+Flat instead of linear, and about 120 times faster at 31,000 records, which is
+an ordinary size for a trail that has been recording for a few weeks. Half the
+cost was already there in the `MAX(seq)` subquery and half arrived yesterday
+with `chain_head`, so this is both an old defect and a fresh regression closed
+by the same line.
+
+Schema version 5 becomes 6, and existing trails get the index when they are
+next opened. The migration is one pass over `seq` and runs once.
+
+The tests assert the query plan rather than a wall-clock number, because a
+timing assertion on a shared runner is a flake generator and the plan is what
+actually regressed. A third test drops the index, marks a trail back to
+version 5, and checks that reopening it restores both the index and a
+verifying chain.
+
 ## [1.64.0] - 2026-08-09
 
 Four defects, all on the same seam: two Vaara processes sharing one audit

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.64.0",
+  "version": "1.64.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.64.0",
+  "version": "1.64.1",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.64.0"
+version = "1.64.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.64.0",
+  "version": "1.64.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.64.0",
+"version": "1.64.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.64.0",
+  "version": "1.64.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.64.0",
+"version": "1.64.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.64.0"
+__version__ = "1.64.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/audit/sqlite_backend.py
+++ b/src/vaara/audit/sqlite_backend.py
@@ -35,7 +35,7 @@ from vaara.auth import APIKey, Role, _hash_key, generate_api_key
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 
 def _scrub_nonfinite(obj: Any) -> Any:
@@ -97,6 +97,13 @@ CREATE INDEX IF NOT EXISTS idx_event_type  ON audit_records(event_type);
 CREATE INDEX IF NOT EXISTS idx_timestamp   ON audit_records(timestamp);
 CREATE INDEX IF NOT EXISTS idx_tool_name   ON audit_records(tool_name);
 CREATE INDEX IF NOT EXISTS idx_tenant_id   ON audit_records(tenant_id);
+-- Both writes on the append path order by seq: the seq subquery inside the
+-- INSERT and chain_head's ORDER BY seq DESC LIMIT 1. Without this index each
+-- append scanned the whole table and built a temp B-tree to sort it, so the
+-- cost of writing one record grew with the number of records already there:
+-- 0.12 ms on an empty trail, 4.7 ms at 10k, 16 ms at 31k. With it, 0.13 ms
+-- at 31k and flat.
+CREATE INDEX IF NOT EXISTS idx_seq         ON audit_records(seq);
 
 -- GDPR Article 17 (Right to Erasure) redaction table.
 CREATE TABLE IF NOT EXISTS gdpr_redactions (
@@ -179,6 +186,14 @@ _MIGRATIONS: dict[int, str] = {
         created_at    REAL NOT NULL
     );
     CREATE INDEX IF NOT EXISTS idx_pending_created ON pending_outcomes(created_at);
+    """,
+    # v5 to v6: index on seq (v1.64.1). Every append orders by seq twice, once
+    # for the seq subquery inside the INSERT and once for chain_head. Without
+    # the index both scanned the whole table, so writing one record cost more
+    # the more records the trail already held. Existing trails get the index
+    # here; the build is a single pass over seq and runs once.
+    5: """
+    CREATE INDEX IF NOT EXISTS idx_seq ON audit_records(seq);
     """,
 }
 

--- a/tests/test_sqlite_backend.py
+++ b/tests/test_sqlite_backend.py
@@ -541,6 +541,82 @@ class TestWindowedTrailVerification:
         assert trail.verify_chain() is not None
 
 
+class TestAppendPathUsesTheSeqIndex:
+    """Writing a record must not get slower as the trail gets longer.
+
+    Both queries on the append path order by seq: the subquery that computes
+    the next seq inside the INSERT, and chain_head's ORDER BY seq DESC LIMIT
+    1. With no index on seq, SQLite scanned the whole table and built a temp
+    B-tree to sort it, on every single append. Measured cost of one record:
+    0.12 ms on an empty trail, 4.7 ms at 10k rows, 16 ms at 31k. With the
+    index, 0.13 ms at 31k.
+
+    This asserts the query plan rather than a wall-clock number, because a
+    timing assertion on a shared CI runner is a flake generator. The plan is
+    the thing that actually regressed.
+    """
+
+    def test_chain_head_seeks_instead_of_scanning(self, db_path):
+        backend = SQLiteAuditBackend(db_path)
+        try:
+            plan = " ".join(
+                str(row[-1]) for row in backend._conn.execute(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT record_hash FROM audit_records WHERE 1=1 "
+                    "ORDER BY seq DESC LIMIT 1"
+                ).fetchall()
+            )
+            assert "idx_seq" in plan, f"chain_head is not using the seq index: {plan}"
+            assert "TEMP B-TREE" not in plan, (
+                f"chain_head is sorting the whole table on every append: {plan}")
+        finally:
+            backend.close()
+
+    def test_seq_subquery_does_not_scan(self, db_path):
+        backend = SQLiteAuditBackend(db_path)
+        try:
+            plan = " ".join(
+                str(row[-1]) for row in backend._conn.execute(
+                    "EXPLAIN QUERY PLAN "
+                    "SELECT COALESCE(MAX(seq), -1) + 1 FROM audit_records"
+                ).fetchall()
+            )
+            assert "SCAN" not in plan, f"the seq subquery scans the table: {plan}"
+        finally:
+            backend.close()
+
+    def test_existing_trail_gains_the_index_on_open(self, db_path, sample_action_type):
+        """A v5 trail written before this release is migrated, not left slow."""
+        import sqlite3
+
+        first = SQLiteAuditBackend(db_path)
+        trail = first.load_trail()
+        trail.record_action_requested(ActionRequest(
+            agent_id="a", tool_name="tx.transfer", action_type=sample_action_type,
+        ))
+        first._conn.execute("DROP INDEX IF EXISTS idx_seq")
+        first._conn.execute(
+            "UPDATE audit_meta SET value='5' WHERE key='schema_version'")
+        first.close()
+
+        conn = sqlite3.connect(str(db_path))
+        before = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_seq'"
+        ).fetchone()
+        conn.close()
+        assert before is None, "test setup failed to remove the index"
+
+        reopened = SQLiteAuditBackend(db_path)
+        try:
+            row = reopened._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_seq'"
+            ).fetchone()
+            assert row is not None, "reopening a v5 trail did not add the seq index"
+            assert reopened.load_trail().verify_chain() is None
+        finally:
+            reopened.close()
+
+
 class TestConcurrentProcessAppend:
     """The claim, tested the way it is deployed: separate OS processes.
 


### PR DESCRIPTION
An index on `seq`, which the append path has needed since the backend was
written and needed twice as much after 1.64.0.

## What was happening

Two queries run on every append and both order by `seq`:

- the subquery inside the INSERT that computes the next sequence number
- `chain_head`, which 1.64.0 added so the chain head is read under the write
  lock rather than from per-process memory

Neither had an index to use. The plan for `chain_head` was `SCAN
audit_records` plus `USE TEMP B-TREE FOR ORDER BY`, so SQLite read the whole
table and sorted it, once per record written. The cost of writing one record
grew with the number of records already in the trail.

```
                without index      with index
empty                0.12 ms          0.09 ms
10,000 rows          4.70 ms          0.13 ms
30,800 rows         15.98 ms          0.13 ms
40,000 rows         22.07 ms          0.14 ms
```

Flat instead of linear, and about 120 times faster at 31,000 records, which
is an ordinary size for a trail that has been recording for a few weeks.

The `MAX(seq)` subquery has been paying this cost since the backend was
written. `chain_head` started paying it again yesterday. The same index fixes
the query plan for both.

## Migration

`SCHEMA_VERSION` goes 5 to 6 and `_MIGRATIONS[5]` adds the index, so trails
written by earlier versions pick it up when they are next opened. The
migration is a single pass over `seq` and runs once. It sits inside the
transaction 1.64.0 put around schema init, so a failure rolls the whole thing
back rather than leaving a half-migrated database.

## Tests

Three, and they assert the query plan rather than a wall-clock number. A
timing assertion on a shared runner is a flake generator, and the plan is what
actually regressed:

- `chain_head` uses `idx_seq` and no longer sorts the table
- the `seq` subquery no longer scans
- a trail dropped back to version 5 regains both the index and a verifying
  chain when reopened

## Verification

`2709 passed, 32 skipped`, `ruff check tests/ src/` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved audit append and chain-head lookup performance with a new sequence index.
* **Bug Fixes**
  * Existing audit trails now receive the performance index automatically during schema migration.
  * Preserved chain verification when reopening older databases.
* **Tests**
  * Added coverage confirming efficient lookups, index restoration, and migration behavior.
* **Release**
  * Updated the project version to 1.64.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
