### PR TITLE
docs: A2 claims audit, five README and PRIVACY claims that did not match behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,28 +6,27 @@ V031 := $(ADV)/v031
 
 help:
 	@echo "Targets:"
-	@echo "  bench              reproduce the current bench doc numbers (v0.35)"
+	@echo "  bench              reproduce the current bench doc numbers (v0.39)"
 	@echo "  repro-v031-bench   reproduce the historical v0.31 bench numbers"
+	@echo ""
+	@echo "bench needs the ml extra: pip install 'vaara[ml]'"
+	@echo "The first run downloads the MiniLM embedding model, so it needs"
+	@echo "network access once. Everything after that is offline."
 
-# Current bench reproduction. Always points at the latest released
-# methodology (currently bench/vaara-bench-v0.35.md). Anyone cloning
-# at a tagged commit can run this and get the same SHAs and numbers.
+# Current bench reproduction, against bench/vaara-bench-v0.39.md and the v8
+# and v9 bundles that actually ship in src/vaara/data/.
+#
+# This target used to evaluate adversarial_classifier_v6 and _v3 against the
+# v0.35 split. Neither bundle is in the tree any more, so the target failed on
+# a missing file, while the README told a reader every published figure was
+# reproducible by running it. Pointing it at the script that produced the
+# published artifact keeps the two in step.
 bench:
-	@echo "[1/3] verify corpus integrity (includes v0.35 matched-benign additions)"
+	@echo "[1/2] verify corpus integrity"
 	cd $(ADV) && sha256sum -c MANIFEST.sha256 > /dev/null
-	@echo "[2/3] evaluate production v6 bundle on v035_split TEST"
-	$(PY) scripts/eval_v032.py \
-		--bundle src/vaara/data/adversarial_classifier_v6.joblib \
-		--split-manifest $(ADV)/v035_split.json \
-		--target-fpr 0.05 \
-		--json-out bench/v035_eval_v6.json
-	@echo "[3/3] cross-eval v3 on v035_split TEST (regression control)"
-	$(PY) scripts/eval_v032.py \
-		--bundle src/vaara/data/adversarial_classifier_v3.joblib \
-		--split-manifest $(ADV)/v035_split.json \
-		--target-fpr 0.05 \
-		--json-out bench/v035_eval_v3_cross.json
-	@echo "done. compare SHAs to bench/vaara-bench-v0.35.md."
+	@echo "[2/2] calibrate and evaluate v9 across the four v0.39 surfaces"
+	$(PY) scripts/eval_v039_v9.py --json-out bench/v039_v9_eval.json
+	@echo "done. compare against bench/vaara-bench-v0.39.md."
 
 # End-to-end reproduction of bench/vaara-bench-v0.31.md. Anyone cloning
 # the repo at a tagged commit can run this and get the same SHAs and

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last updated: 2026-05-28**
+**Last updated: 2026-08-10**
 
 Vaara is an open-source project. This page describes how the Vaara software, website, and email contact handle data.
 
@@ -8,7 +8,13 @@ Vaara is an open-source project. This page describes how the Vaara software, web
 
 The Vaara software does not send telemetry. It does not phone home, beacon, or transmit usage data to any server. The audit database is a local SQLite file on your machine; its contents do not leave your system unless you choose to share them.
 
-If you self-host an MCP proxy with Vaara, network behavior is fully under your control. Vaara does not introduce any outbound traffic of its own.
+If you self-host an MCP proxy with Vaara, network behavior is under your control. Vaara opens no connection unless you ask it to, and the complete list of times it does is:
+
+- **The optional ML classifier.** `pip install 'vaara[ml]'` downloads `sentence-transformers/all-MiniLM-L6-v2` from Hugging Face the first time a score needs an embedding, pinned to a fixed revision. It is cached after that and everything later is offline. The classifier is opt-in and the base install never reaches for it. Pre-fetch the model if you need a host that never has network access.
+- **"Check for updates" in `vaara menu`.** Fetches the published version from pypi.org, and only when you pick that item from the menu. The request carries nothing about your installation; the comparison against your installed version happens locally.
+- **Time anchoring.** Contacts the RFC 3161 or eIDAS timestamp authority you configure, at the address you give it. There is no default and no fallback authority.
+
+Nothing on that list runs on its own schedule, in the background, or as a side effect of recording evidence. A base install writing to the trail opens no socket at all.
 
 ## Website (vaara.io)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ def transfer_funds(to: str, amount: float) -> str:
     ...
 ```
 
-That is the whole thing. Every call to a governed function is risk-scored and decided against your policy before the body runs. A blocked call raises `vaara.Blocked`; an allowed call runs, and the decision, the call, and the outcome land in a hash-chained, tamper-evident record anyone can verify offline — sign it at export (`vaara trail export`) for third-party proof. Records persist to `~/.vaara/trail/audit.db` by default, so evidence survives restarts. Python 3.10+, zero runtime dependencies.
+That is the whole thing. Every call to a governed function is risk-scored and decided against your policy before the body runs. An allowed call runs, and the decision, the call, and the outcome land in a hash-chained, tamper-evident record anyone can verify offline. Sign it at export (`vaara trail export`) for third-party proof. Records persist to `~/.vaara/trail/audit.db` by default, so evidence survives restarts. Python 3.10+, zero runtime dependencies.
+
+Both `deny` and `escalate` raise `vaara.Blocked`, since an escalation means a human has not answered yet. Run the example above on a fresh install and it will raise: with no outcome history the scorer's confidence interval is wide, and a `tx.transfer` escalates on the interval's upper bound even though its point estimate sits under the allow threshold. That is the intended direction to fail, and it settles. Feeding real outcomes back through `report_outcome` narrows the interval, and the same call starts allowing after a few dozen clean results. To watch decisions without acting on them while that happens, start with `@vaara.govern(shadow=True)`.
 
 <details>
 <summary><b>Prefer the explicit pipeline?</b></summary>
@@ -164,11 +166,11 @@ Start with `--shadow`: every call is classified, scored, and recorded, nothing i
 <details>
 <summary><b>How it scores</b></summary>
 
-Each risk score blends five expert signals and keeps adapting as outcomes come back, and it carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. On a held-out adversarial corpus the classifier reaches **84.7%** recall (95% Wilson [82.4, 86.7]) at a **4.1%** false-positive rate, and **1.2%** FPR on benign calls under live injection pressure. The hot-path rule scorer adds 140 µs mean per call on commodity CPU; the ML classifier is opt-in (`vaara[ml]`) and off that path. Every figure is reproducible via `make bench`.
+Each risk score blends five expert signals and keeps adapting as outcomes come back, and it carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. On a held-out adversarial corpus the classifier reaches **84.7%** recall (95% Wilson [82.4, 86.7]) at a **4.1%** false-positive rate, and **1.2%** FPR on benign calls under live injection pressure. The hot-path rule scorer adds 140 µs mean per call on commodity CPU; the ML classifier is opt-in (`vaara[ml]`) and off that path. `make bench` reproduces the classifier figures below against the bundles that ship in the repo; it needs `pip install 'vaara[ml]'` and downloads the embedding model on first run.
 
 - 12,155-entry adversarial corpus (250 hand-curated + 11,905 LLM-generated), 70/15/15 split stratified by (category, source).
 - Classifier v9 (236 hand-features + 384-dim MiniLM embeddings) at calibrated threshold 0.9150 on held-out TEST n=1,827: recall 84.7% [82.4, 86.7] at FPR 4.1% [2.9, 5.7].
-- Cross-model held-out recall 66.8% [64.9, 68.7] over n=2,277 with no eval-set attacker model in TRAIN; the weakest sub-cell is data_exfil against a closed-weight model at 38.9%. This is the honest worst case; the in-distribution number above is the easier denominator.
+- Cross-model held-out recall 66.8% [64.9, 68.7] over n=2,277 with no eval-set attacker model in TRAIN; the weakest sub-cell is data_exfil against a closed-weight model at 38.9%. Both figures are v8 on the v0.37 surface ([bench/vaara-bench-v0.37.md](bench/vaara-bench-v0.37.md)), which is the last release that measured this surface; v9 has not been run against it. This is the honest worst case, and the in-distribution number above is the easier denominator.
 - BIPIA-pressure FPR on benign tool calls 1.2% [0.4, 3.6] across four agent backends (Claude Haiku 4.5, Llama-3.1-8B, Mistral-7B, Qwen-2.5-7B). Down from 35.2% on v8.
 - Multi-attacker PAIR robustness: 0/25 successes per attacker across Qwen2.5-32B, Qwen2.5-72B, Llama-3.3-70B on identical seeds, Wilson upper 13.3%.
 - Distribution-free conformal coverage on the score; MWU regret bound O(sqrt(T log N)).

--- a/docs/PRIOR_ART.md
+++ b/docs/PRIOR_ART.md
@@ -335,9 +335,9 @@ than a judgment of the work.
   `.ots` proof shows a digest existed no later than a block's time.
   The lineage runs back to Haber and Stornetta's linked timestamping
   (1991). Vaara shipped an `opentimestamps` receipt-anchor method from
-  v1.29.0 to v1.51.x (`src/vaara/audit/ots_anchor.py`) which produced
+  v1.29.0 to v1.52.0 (`src/vaara/audit/ots_anchor.py`) which produced
   standard `.ots` proofs over the receipt's signed-payload digest.
-  Superseded in v1.52.0 by the `scitt` transparency-log method
+  Superseded in v1.53.0 by the `scitt` transparency-log method
   (`src/vaara/audit/scitt_anchor.py`), which provides the same
   trust-minimized witness without Bitcoin finality latency.
 - **Linear Temporal Logic and runtime verification.** Pnueli (1977),

--- a/src/vaara/govern.py
+++ b/src/vaara/govern.py
@@ -167,9 +167,19 @@ def govern(
         @vaara.govern(agent_id="billing-agent", tool_name="tx.transfer")
         def transfer(to, amount): ...
 
-    Each call is classified, scored, and decided before the body runs. ``deny``
-    raises ``vaara.Blocked``; ``allow`` runs the function and reports the
-    outcome back to the scorer. Either way the decision lands in the trail.
+    Each call is classified, scored, and decided before the body runs. Only
+    ``allow`` runs the function and reports the outcome back to the scorer.
+    ``deny`` and ``escalate`` both raise ``vaara.Blocked``, because an
+    escalation means a human has not answered yet and the decorator has no
+    way to wait for one. Either way the decision lands in the trail.
+
+    On a fresh install the scorer has no outcome history, so its conformal
+    interval is wide and a call whose point estimate sits under the allow
+    threshold can still escalate on the interval's upper bound. Expect
+    ``Blocked`` from early calls on a sensitive taxonomy name such as
+    ``tx.transfer``. The interval narrows as ``report_outcome`` feeds real
+    outcomes back. Use ``shadow=True`` to record decisions without acting
+    on them while that happens.
 
     Args:
         agent_id: Identity recorded against the action ("default" if unset).

--- a/tests/test_attestation_iap.py
+++ b/tests/test_attestation_iap.py
@@ -107,8 +107,15 @@ def test_verify_rejects_tampered_envelope_cbor():
         envelope=_make_envelope(arbiter), notary_signing_key=notary,
         transparency_log=log, iap_identifier="iap-x",
     )
+    # Flip the final byte against itself. Writing a fixed 0xff there was a
+    # no-op whenever the envelope already ended in 0xff, and the last byte
+    # covers a random signature, so it did about once in 256 runs. The
+    # verifier then correctly accepted bytes it had genuinely signed and the
+    # assertion failed, which reads as a fail-open in the attestation
+    # verifier and is not one. XOR cannot produce the original byte.
     bad = Phase3Attestation(
-        envelope_cbor=att.envelope_cbor[:-1] + b"\xff",
+        envelope_cbor=att.envelope_cbor[:-1]
+        + bytes([att.envelope_cbor[-1] ^ 0xFF]),
         notary_signature=att.notary_signature,
         notary_key_identifier=att.notary_key_identifier,
         log_index=att.log_index,


### PR DESCRIPTION
A2 is the pass nobody has run: the prose against the behaviour. The mechanical
surface is already guarded, since CI checks that every flag the docs name
exists, that the COMPLIANCE.md table matches the engine, and that the openapi
spec matches the server. The sentences around all that were never checked.

## The headline example blocks on every call

Pasting the README's first code block into a clean install raises
`vaara.Blocked` on the first call and on every call after it, including a
one-cent transfer:

```
BLOCK ('acct-1', 5.0)  -> vaara blocked tx.transfer (escalate, risk=0.275): [0.085, 0.465]
BLOCK ('acct-1', 0.01) -> vaara blocked tx.transfer (escalate, risk=0.275): [0.085, 0.465]
```

Measured on a fresh trail: 44 of the first 80 calls escalate, and `tx.transfer`
first allows at call 43 once outcomes are fed back through `report_outcome`.

The behaviour is right. With no outcome history the conformal interval is wide,
so a point estimate of 0.275 escalates on an upper bound of 0.465 against a 0.4
allow threshold, which is the product failing toward review under uncertainty.
The README says only "an allowed call runs" and leaves a reader who sees an
exception to conclude the thing is broken. It now says what happens, why, that
it settles, and points at `shadow=True` for the meantime.

## govern()'s docstring said only deny raises

The code raises on any non-allow decision, escalate included. The module
docstring already said so; the decorator's own docstring did not, and that is
the one a reader reaches through `help(vaara.govern)`.

## make bench cannot run

The target evaluates `adversarial_classifier_v6` and `_v3`. Neither bundle is in
the tree, only v8 and v9 ship, so step 2 dies:

```
FileNotFoundError: src/vaara/data/adversarial_classifier_v6.joblib
```

It also pins the v0.35 split while the figures the README quotes are v0.37 and
v0.39. The README said every figure was reproducible by running it. The target
now calls `scripts/eval_v039_v9.py`, which is what produced the published
`bench/v039_v9_eval.json`, and both the Makefile and the README state that it
needs the ml extra and one network round trip for the embedding model.

## A v8 number sat inside a v9 block

The cross-model bullet quotes 66.8% [64.9, 68.7] over n=2,277 and a 38.9%
data_exfil sub-cell. Those are v8 on the v0.37 surface, exactly as recorded in
`bench/v037_eval_v8_holdout.json` (bundle `adversarial_classifier_v8`, n=2277,
recall 0.6684, CI [0.6488, 0.6875]). They sat in a list introduced as v9. v9 has
never been run against that surface: `v039_v9_eval.json` holds four surfaces and
that is not one of them. The bullet now says which model and which bench doc.

## PRIVACY.md claimed no outbound traffic at all

"Vaara does not introduce any outbound traffic of its own" has three exceptions:
the ml extra downloads `sentence-transformers/all-MiniLM-L6-v2` from Hugging
Face on first embedding, pinned to revision c9745ed1; the menu's "Check for
updates" reads pypi.org when you pick that item; and time anchoring contacts the
TSA the operator configures. PRIVACY.md now lists all three with what triggers
each and what it carries.

The no-telemetry sentence above it holds and is now measured rather than
asserted. A base install running intercept, govern, report_outcome and the audit
CLI opens no socket, checked by failing `socket.connect`, `connect_ex` and
`getaddrinfo` and running the lot. The model download is the exception worth
naming: an operator running air-gapped has to pre-fetch it, and nothing said so.

## Checked and correct, so left alone

- Zero runtime dependencies. A clean `pip install` of the package pulls nothing.
- The standalone checker runs under `cryptography` and `rfc8785` alone, with no
  Vaara installed, and matches every expected verdict.
- `scripts/conformance_runner.py`: 40 passed, 0 failed, 3 skipped across 43
  suites.
- `examples/prove-it-yourself/` end to end, including the tampered bundle
  failing with the manifest mismatch the README describes.

## The OpenTimestamps removal was dated one release early

`docs/PRIOR_ART.md` said the `opentimestamps` anchor method shipped "from
v1.29.0 to v1.51.x" and was superseded in v1.52.0. Checked against the tags:
`ots_anchor.py` is present at v1.51.0 and at v1.52.0 and absent at v1.53.0, and
the CHANGELOG entry that removes it sits under `## [1.53.0]`. Corrected to
v1.29.0 through v1.52.0, superseded in v1.53.0.

The rest of the OpenTimestamps material in the tracked tree is accurate. The
CHANGELOG entries are the historical record of the removal and belong there,
`pyproject.toml` carries no `[ots]` extra, and no source file mentions it.

## Verification

Full suite 2731 passed, 30 skipped, 0 failed. ruff clean on `src/`, `tests/`,
`scripts/`.
