### PR TITLE
fix: eleven defects found by running the software, not reading it

### DIFF
--- a/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
+++ b/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
@@ -37,10 +37,10 @@ final class AccessibilityObserver {
         // untrusted forever with only "permission not granted" in the log.
         let opts: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue(): true]
         guard AXIsProcessTrustedWithOptions(opts) else {
+            // os_log takes a StaticString, so this cannot be built by
+            // concatenation. One literal.
             os_log(.info, log: log,
-                   "accessibility permission not granted; prompted, "
-                   + "grant it in System Settings > Privacy & Security > "
-                   + "Accessibility and restart Vaara")
+                   "accessibility permission not granted; prompted. Grant it in System Settings > Privacy & Security > Accessibility, then restart Vaara")
             return
         }
 

--- a/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
+++ b/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
@@ -28,14 +28,19 @@ final class AccessibilityObserver {
     private var focusObserver: NSObjectProtocol?
 
     func start() {
-        guard checkPermission() else {
-            os_log(.info, log: log, "accessibility permission not granted")
-            return
-        }
-
+        // Ask first, then check. The prompting call has to come before any
+        // early return, or the user is never asked and the observer never
+        // runs again: AXIsProcessTrusted() is silent, so guarding on it and
+        // returning meant the one line that shows the System Settings prompt
+        // was unreachable on exactly the machines that needed it. macOS shows
+        // the prompt once per app, so an untrusted first launch stayed
+        // untrusted forever with only "permission not granted" in the log.
         let opts: NSDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue(): true]
         guard AXIsProcessTrustedWithOptions(opts) else {
-            os_log(.info, log: log, "not trusted by accessibility API")
+            os_log(.info, log: log,
+                   "accessibility permission not granted; prompted, "
+                   + "grant it in System Settings > Privacy & Security > "
+                   + "Accessibility and restart Vaara")
             return
         }
 
@@ -129,12 +134,6 @@ final class AccessibilityObserver {
             kAXFocusedWindowChangedNotification as CFString)
         let source = AXObserverGetRunLoopSource(observer)
         CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .commonModes)
-    }
-
-    // ── Permission ─────────────────────────────────────────────────
-
-    private func checkPermission() -> Bool {
-        AXIsProcessTrusted()
     }
 
     // ── Notification handler ───────────────────────────────────────

--- a/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
+++ b/clients/macos/Sources/VaaraMenuBar/AccessibilityObserver.swift
@@ -28,6 +28,12 @@ final class AccessibilityObserver {
     private var focusObserver: NSObjectProtocol?
 
     func start() {
+        // Already running: do nothing. Without this every call re-ran the
+        // prompting check, and start() is called from onAppear, so clicking
+        // the menu bar icon asked for Accessibility again on an app that
+        // already had it. isRunning existed and was only ever written.
+        guard !isRunning else { return }
+
         // Ask first, then check. The prompting call has to come before any
         // early return, or the user is never asked and the observer never
         // runs again: AXIsProcessTrusted() is silent, so guarding on it and

--- a/clients/macos/Sources/VaaraMenuBar/ContentView.swift
+++ b/clients/macos/Sources/VaaraMenuBar/ContentView.swift
@@ -89,6 +89,7 @@ struct ContentView: View {
     @State private var clients: [MCPClient] = SetupScanner.scan()
     @State private var installing = false
     @State private var installLog: String?
+    @ObservedObject private var systemExtension = SystemExtensionManager.shared
 
     private var dark: Bool { model.config.appearance != "light" }
     private var p: Palette { dark ? .dark : .light }
@@ -447,6 +448,42 @@ struct ContentView: View {
                                 .lineLimit(2).truncationMode(.middle)
                         }
                     }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    sectionLabelPlain("NETWORK FILTER")
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(filterDotColor)
+                            .frame(width: 7, height: 7)
+                        Text(filterStatusText)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(p.faint)
+                            .lineLimit(2).truncationMode(.middle)
+                    }
+                    HStack(spacing: 10) {
+                        if systemExtension.state == .active {
+                            Button("Turn off") { systemExtension.deactivate() }
+                                .buttonStyle(.plain)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(GateState.red.color)
+                        } else {
+                            Button("Install network filter") { systemExtension.activate() }
+                                .buttonStyle(.plain)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(GateState.green.color)
+                                .disabled(systemExtension.state == .awaitingUserApproval)
+                        }
+                        Button("Recheck") { systemExtension.refresh() }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 11))
+                            .foregroundStyle(p.ghost)
+                    }
+                    Text("Governs AI-bound traffic from Safari, Mail and every "
+                         + "WKWebView app. macOS asks for approval in System "
+                         + "Settings > General > Login Items & Extensions.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(p.ghost)
                 }
 
                 VStack(alignment: .leading, spacing: 6) {
@@ -991,6 +1028,29 @@ struct ContentView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+    }
+
+    /// Colour for the network-filter dot. Amber while macOS is waiting on the
+    /// user in System Settings, since that is neither working nor broken.
+    private var filterDotColor: Color {
+        switch systemExtension.state {
+        case .active: return GateState.green.color
+        case .awaitingUserApproval, .installedDisabled: return GateState.yellow.color
+        case .failed: return GateState.red.color
+        case .notInstalled, .unknown: return GateState.red.color
+        }
+    }
+
+    private var filterStatusText: String {
+        switch systemExtension.state {
+        case .unknown: return "checking..."
+        case .notInstalled: return "network filter not installed"
+        case .awaitingUserApproval:
+            return "approve Vaara in System Settings, then Recheck"
+        case .installedDisabled: return "installed, filter not enabled"
+        case .active: return "filtering AI-bound traffic"
+        case .failed(let why): return "failed: \(why)"
+        }
     }
 
     private func sectionLabelPlain(_ text: String) -> some View {

--- a/clients/macos/Sources/VaaraMenuBar/Info.plist
+++ b/clients/macos/Sources/VaaraMenuBar/Info.plist
@@ -13,7 +13,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>VaaraMenuBar</string>
+    <string>Vaara</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/clients/macos/Sources/VaaraMenuBar/Model.swift
+++ b/clients/macos/Sources/VaaraMenuBar/Model.swift
@@ -802,6 +802,22 @@ final class GateModel: ObservableObject {
     /// NSAlert, so the popover stays the single surface.
     private func handlePendingApprovals() {
         if pendingApproval != nil { return }  // one at a time; panel is up
+
+        // Forget action ids whose request file is gone. request_approval()
+        // deletes both files once it has an answer, so a later request
+        // carrying the same id is a genuinely new ask, not the answered one
+        // arriving twice. Without this the set only ever grew and any reused
+        // id was silently skipped for the life of the process: the engine
+        // wrote its request, blocked for the full timeout, and no window ever
+        // appeared. Silent is the wrong failure for the one surface a human
+        // is supposed to see.
+        let live = Set(
+            ((try? FileManager.default.contentsOfDirectory(atPath: approvalsDir.path)) ?? [])
+                .filter { $0.hasSuffix(".request.json") }
+                .map { String($0.dropLast(".request.json".count)) }
+        )
+        handledApprovals.formIntersection(live)
+
         for req in pendingApprovals() {
             guard let actionID = req["action_id"] as? String,
                   !actionID.isEmpty, !handledApprovals.contains(actionID) else { continue }

--- a/clients/macos/Sources/VaaraMenuBar/SystemExtensionManager.swift
+++ b/clients/macos/Sources/VaaraMenuBar/SystemExtensionManager.swift
@@ -33,6 +33,17 @@ final class SystemExtensionManager: NSObject, ObservableObject {
     // ── Public API ────────────────────────────────────────────────────────
 
     /// Reflect the current filter configuration into `state`.
+    ///
+    /// The saved `NEFilterManager` preference is not evidence that anything is
+    /// filtering. It survives the extension being removed, by an OS update, by
+    /// `systemextensionsctl reset`, or by the user deleting the app, and it is
+    /// written before macOS ever agrees to load the provider. Reporting
+    /// "filtering AI-bound traffic" from that alone is a status display that
+    /// fails open, which is the one direction this product must never fail.
+    ///
+    /// So the preference is only allowed to downgrade the verdict. The claim
+    /// that the filter is live has to come from the system's own list of
+    /// installed extensions.
     func refresh() {
         NEFilterManager.shared().loadFromPreferences { [weak self] error in
             Task { @MainActor in
@@ -41,13 +52,41 @@ final class SystemExtensionManager: NSObject, ObservableObject {
                     self.state = .failed(error.localizedDescription)
                     return
                 }
-                if NEFilterManager.shared().providerConfiguration == nil {
+                let configured = NEFilterManager.shared().providerConfiguration != nil
+                let enabled = NEFilterManager.shared().isEnabled
+                guard configured else {
                     self.state = .notInstalled
-                } else {
-                    self.state = NEFilterManager.shared().isEnabled ? .active : .installedDisabled
+                    return
+                }
+                self.confirmInstalled { installed in
+                    if !installed {
+                        // Configured but absent: say so rather than claiming
+                        // a filter that cannot possibly be running.
+                        self.state = .notInstalled
+                    } else {
+                        self.state = enabled ? .active : .installedDisabled
+                    }
                 }
             }
         }
+    }
+
+    /// Ask the system whether our extension is actually installed.
+    ///
+    /// A properties request also completes through
+    /// `OSSystemExtensionRequestDelegate`, and this class's delegate reacts to
+    /// completion by enabling the filter, so a refresh sharing that delegate
+    /// would turn the filter on as a side effect of looking at it. The query
+    /// gets its own delegate object for that reason.
+    private func confirmInstalled(_ done: @escaping @MainActor (Bool) -> Void) {
+        let probe = InstalledProbe(done: done)
+        let request = OSSystemExtensionRequest.propertiesRequest(
+            forExtensionWithIdentifier: extensionIdentifier,
+            queue: .main
+        )
+        request.delegate = probe
+        probe.retain = probe          // live until the delegate answers
+        OSSystemExtensionManager.shared.submitRequest(request)
     }
 
     /// Install the extension, then enable the content filter.
@@ -106,6 +145,55 @@ final class SystemExtensionManager: NSObject, ObservableObject {
                 }
             }
         }
+    }
+}
+
+/// Answers one question: does the system have this extension installed?
+///
+/// Kept apart from `SystemExtensionManager`'s own delegate so a read cannot
+/// trip the write path. `foundProperties` arrives before completion; an empty
+/// list, or a failure, both mean "not installed" and both must resolve, or a
+/// refresh would hang the status line on its previous value.
+private final class InstalledProbe: NSObject, OSSystemExtensionRequestDelegate {
+    private let done: @MainActor (Bool) -> Void
+    private var answered = false
+    var retain: InstalledProbe?
+
+    init(done: @escaping @MainActor (Bool) -> Void) {
+        self.done = done
+    }
+
+    private func answer(_ installed: Bool) {
+        guard !answered else { return }
+        answered = true
+        let done = self.done
+        Task { @MainActor in
+            done(installed)
+            self.retain = nil
+        }
+    }
+
+    func request(_ request: OSSystemExtensionRequest,
+                 foundProperties properties: [OSSystemExtensionProperties]) {
+        answer(properties.contains { $0.isEnabled || $0.isAwaitingUserApproval } )
+    }
+
+    func request(_ request: OSSystemExtensionRequest,
+                 didFinishWithResult result: OSSystemExtensionRequest.Result) {
+        answer(false)   // no properties arrived, so nothing is installed
+    }
+
+    func request(_ request: OSSystemExtensionRequest, didFailWithError error: Error) {
+        answer(false)
+    }
+
+    func requestNeedsUserApproval(_ request: OSSystemExtensionRequest) {}
+
+    func request(_ request: OSSystemExtensionRequest,
+                 actionForReplacingExtension existing: OSSystemExtensionProperties,
+                 withExtension new: OSSystemExtensionProperties)
+    -> OSSystemExtensionRequest.ReplacementAction {
+        return .cancel
     }
 }
 

--- a/clients/macos/Sources/VaaraMenuBar/VaaraApp.swift
+++ b/clients/macos/Sources/VaaraMenuBar/VaaraApp.swift
@@ -8,6 +8,9 @@ import SwiftUI
 struct VaaraApp: App {
     @StateObject private var model = GateModel()
     @State private var approvals: ApprovalWindowManager?
+    /// Startup runs from two places (the menu bar label at launch, the
+    /// popover content on first open) and must happen once.
+    @State private var started = false
 
     // XPC service the network filter extension connects to.
     private let policyService = PolicyServiceDelegate()
@@ -19,24 +22,38 @@ struct VaaraApp: App {
     var body: some Scene {
         MenuBarExtra {
             ContentView(model: model)
-                .onAppear {
-                    model.start()
-                    // Start the XPC listener the filter extension connects to.
-                    _ = policyService
-                    // Start Accessibility observer for UI context.
-                    accessibilityObserver.start()
-                    // Report whether the filter extension is installed and
-                    // enabled. Activation itself is user-initiated from
-                    // settings; macOS prompts for approval.
-                    systemExtension.refresh()
-                    if approvals == nil {
-                        approvals = ApprovalWindowManager(model: model)
-                    }
-                }
+                .onAppear { startEverything() }
         } label: {
             Image(nsImage: menuImage())
+                // The label renders as soon as the menu bar item exists, so
+                // this is the launch path. Hanging startup off the content's
+                // onAppear alone meant nothing ran until the user clicked the
+                // icon: no trail polling, no XPC listener for the filter, no
+                // Accessibility observer and no approval window. A governance
+                // app that only governs while its popover is open is not
+                // governing. Both call sites go through the same guarded
+                // helper, so opening the popover afterwards is a no-op.
+                .onAppear { startEverything() }
         }
         .menuBarExtraStyle(.window)
+    }
+
+    /// Bring up every background piece exactly once.
+    private func startEverything() {
+        guard !started else { return }
+        started = true
+        model.start()
+        // Start the XPC listener the filter extension connects to.
+        _ = policyService
+        // Start Accessibility observer for UI context.
+        accessibilityObserver.start()
+        // Report whether the filter extension is installed and enabled.
+        // Activation itself is user-initiated from Setup; macOS prompts for
+        // approval.
+        systemExtension.refresh()
+        if approvals == nil {
+            approvals = ApprovalWindowManager(model: model)
+        }
     }
 
     private func stateColor(_ state: GateState) -> NSColor {
@@ -48,12 +65,29 @@ struct VaaraApp: App {
     }
 
     private func markImage(for state: GateState) -> NSImage {
-        let bundle = Bundle.main
-        let resourcePath = bundle.resourcePath ?? ""
-        let iconPath = "\(resourcePath)/icons/vaara-\(state.rawValue).png"
-        if let img = NSImage(contentsOfFile: iconPath) {
+        let name = "vaara-\(state.rawValue)"
+
+        // Xcode collapses a foo.png / foo@2x.png pair into a single
+        // foo.tiff written to the top of Contents/Resources, so the
+        // icons/ subdirectory and the .png names the file lookup below
+        // expects do not exist in an Xcode-built bundle. That lookup failed
+        // silently and the mark fell through to the plain coloured oval,
+        // which is why an Xcode build showed a green ball where the Homebrew
+        // build, which copies icons/ verbatim, showed the Vaara mark.
+        // Asking the bundle by name finds the tiff.
+        if let img = Bundle.main.image(forResource: name) {
             return img
         }
+
+        let bundle = Bundle.main
+        let resourcePath = bundle.resourcePath ?? ""
+        for candidate in ["\(resourcePath)/icons/\(name).png",
+                          "\(resourcePath)/\(name).png"] {
+            if let img = NSImage(contentsOfFile: candidate) {
+                return img
+            }
+        }
+
         let color = stateColor(state)
         let img = NSImage(size: NSSize(width: 18, height: 18), flipped: false) { rect in
             color.setFill()

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -9,9 +9,27 @@
 
 set -euo pipefail
 
+# Run from this script's own directory. Every path below is relative to it,
+# so calling it as ./clients/macos/build.sh from the repo root used to fail on
+# a project file it was looking for in the wrong place.
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 PROJECT="VaaraMenuBar"
 SCHEME="VaaraMenuBar"
 EXTENSION="WebKitGovernance"
+
+# xcodegen writes VaaraMenuBar.xcodeproj from project.yml, and the generated
+# project is not tracked, so it does not exist in a fresh clone. This script
+# went straight to xcodebuild and failed with "'VaaraMenuBar.xcodeproj' does
+# not exist", which reads as a broken checkout rather than a missing step. CI
+# has always run `xcodegen generate` first; now so does this.
+if ! command -v xcodegen > /dev/null 2>&1; then
+    echo "xcodegen not found. Install it with: brew install xcodegen" >&2
+    exit 1
+fi
+
+echo "==> Generating $PROJECT.xcodeproj from project.yml..."
+xcodegen generate
 
 echo "==> Building $PROJECT with $EXTENSION extension..."
 

--- a/clients/macos/build.sh
+++ b/clients/macos/build.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 # Build script for Vaara macOS app + WebKit Governance extension.
-# Requires Xcode 16+ and an Apple Developer account.
+# Requires Xcode 16+. The default and release builds additionally require a
+# paid Apple Developer Program membership, because the app requests the
+# Network Extension and system-extension entitlements. `./build.sh local`
+# needs neither.
 #
 # Usage:
-#   ./build.sh              # Debug build
+#   ./build.sh              # Debug build (needs a paid Apple Developer
+#                           # provisioning profile for the Network Extension)
+#   ./build.sh local        # Debug build, ad-hoc signed, no entitlements.
+#                           # Everything but the network filter works.
 #   ./build.sh release      # Release build + codesign
 #   ./build.sh install      # Build and install to /Applications
 
@@ -39,6 +45,37 @@ else
     CONFIG="debug"
 fi
 
+# `local` builds the app without the restricted entitlements.
+#
+# VaaraMenuBar.entitlements asks for
+# com.apple.developer.networking.networkextension and
+# com.apple.developer.system-extension.install. Both are restricted: Xcode
+# refuses to sign without a provisioning profile that carries them, and only a
+# paid Apple Developer Program membership can issue one. A free personal team
+# cannot. So the default build fails on any machine without that membership,
+# with "requires a provisioning profile with the Network Extensions and System
+# Extension features", and that is Apple's rule rather than anything this
+# project can code around.
+#
+# Everything other than the network filter is unaffected: the menu bar, the
+# approval window, Setup, the trail views and the Accessibility observer need
+# no entitlement at all. That is also why the Homebrew formula produces a
+# working app, since it compiles Sources/VaaraMenuBar and Sources/Shared with a
+# plain swiftc and never touches the extension.
+#
+# This mode ad-hoc signs and drops the entitlements file, so the app builds and
+# runs and only the filter is missing. Use it to work on everything else.
+EXTRA_ARGS=()
+if [ "${1:-}" = "local" ]; then
+    echo "==> Local mode: ad-hoc signed, no Network Extension entitlements."
+    echo "    The network filter will not load. Everything else runs."
+    CODE_SIGN_IDENTITY="-"
+    EXTRA_ARGS=(
+        CODE_SIGN_ENTITLEMENTS=
+        CODE_SIGNING_REQUIRED=NO
+    )
+fi
+
 # Build the main app and extension together
 xcodebuild -project "$PROJECT.xcodeproj" \
     -scheme "$SCHEME" \
@@ -47,6 +84,7 @@ xcodebuild -project "$PROJECT.xcodeproj" \
     CODE_SIGN_STYLE="Manual" \
     CODE_SIGN_IDENTITY="${CODE_SIGN_IDENTITY:-Apple Development}" \
     DEVELOPMENT_TEAM="${DEVELOPMENT_TEAM:-}" \
+    ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} \
     build
 
 echo "==> Build complete."

--- a/clients/macos/project.yml
+++ b/clients/macos/project.yml
@@ -24,6 +24,13 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: io.vaara.menubar
       INFOPLIST_FILE: Sources/VaaraMenuBar/Info.plist
+      # Ship as Vaara.app, which is the name Homebrew installs and the name
+      # a user sees. Without this the target name won, so a local build
+      # produced VaaraMenuBar.app, which sat in /Applications
+      # next to the Homebrew Vaara.app as a second copy with its own menu bar
+      # icon, both reading the same trail. CFBundleDisplayName was already
+      # "Vaara", so the two were indistinguishable in Finder and the menu bar.
+      PRODUCT_NAME: Vaara
     entitlements:
       path: Sources/VaaraMenuBar/VaaraMenuBar.entitlements
       properties:

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -4646,6 +4646,12 @@ def _cmd_anchor_providers(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     p = _SuggestingParser(prog="vaara", description="Vaara AI Agent Execution Layer")
+    # `vaara version` existed and `vaara --version` did not, so the first
+    # thing most people type to check an install exited 2 with "unrecognized
+    # arguments". That also silently breaks any script guarding on it, since
+    # `vaara --version >/dev/null && next-thing` never reaches next-thing.
+    # Both spellings now print the same string.
+    p.add_argument("--version", action="version", version=__version__)
     sub = p.add_subparsers(dest="cmd", metavar="COMMAND")
     p.set_defaults(func=_default_entry(p))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Point the whole suite at a throwaway home directory.
+
+``InterceptionPipeline()`` with no trail resolves ``Path.home() / ".vaara" /
+"trail" / "audit.db"``, and roughly a dozen other modules bind ``Path.home()``
+into a module-level constant for approvals, policy, config, gate bundles and
+the proxy trails. There was no conftest, so running ``pytest`` on a machine
+that also runs Vaara appended test records to the operator's real audit trail.
+
+For a product whose claim is an evidence chain nobody has edited, a test run
+that writes into it is the wrong kind of surprise. It also made the suite
+flaky: a live hook writing to the same SQLite file while tests opened it
+produced ``disk I/O error`` and 58 failures that had nothing to do with the
+code under test.
+
+The redirect happens at import time rather than in a fixture. pytest imports
+conftest before it imports any test module, and constants like
+``approvals.APPROVALS_DIR`` are bound at *their* import, so a fixture would run
+too late to move them.
+
+Set ``VAARA_TEST_USE_REAL_HOME=1`` to opt out, for the rare case of debugging
+against a real trail on purpose.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+if not os.environ.get("VAARA_TEST_USE_REAL_HOME"):
+    _sandbox = Path(tempfile.mkdtemp(prefix="vaara-test-home-"))
+    (_sandbox / ".vaara").mkdir(parents=True, exist_ok=True)
+    os.environ["HOME"] = str(_sandbox)
+    # Path.home() reads HOME first but falls back to the password database,
+    # and pathlib caches nothing, so USERPROFILE matters on Windows runners.
+    os.environ["USERPROFILE"] = str(_sandbox)
+    # Anything reading the trail path from the environment follows the same
+    # sandbox rather than the operator's file.
+    os.environ.setdefault("VAARA_DB", str(_sandbox / ".vaara" / "test-audit.db"))

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -57,7 +57,14 @@ def test_usage_line_shows_metavar_not_command_wall(capsys):
     with pytest.raises(SystemExit):
         build_parser().parse_args(["--help"])
     out = capsys.readouterr().out
-    assert "usage: vaara [-h] COMMAND ..." in out.splitlines()[0]
+    first = out.splitlines()[0]
+    # The point of this test is the metavar: one word standing in for every
+    # subcommand, instead of argparse listing all of them across the usage
+    # line. Pinning the whole string made it fail the moment a top-level
+    # option was added, which is a different thing from the wall coming back.
+    assert first.startswith("usage: vaara [-h]")
+    assert first.rstrip().endswith("COMMAND ...")
+    assert "trail" not in first and "keygen" not in first
 
 
 def test_trail_export_from_sqlite_db(tmp_path, capsys):


### PR DESCRIPTION
Eleven defects, every one found by running the software rather than reading it.
Four are in the Python product, seven are in the macOS client, and the macOS
client had never been launched and observed before today. CI builds those
targets and cannot click anything, which is the honest reason none of this
surfaced earlier.

## Running the tests wrote into the operator's real audit trail

There was no `conftest.py` in the repo. `InterceptionPipeline()` with no trail
resolves `Path.home()/".vaara"/"trail"/audit.db`, and a dozen other modules bind
`Path.home()` into module-level constants for approvals, policy, config, the
gate bundles and the proxy trails. So `pytest` on any machine that also runs
Vaara appended test records to the live evidence chain.

For a product whose claim is a record nobody has edited, a test run that writes
into it is the wrong kind of surprise. It also made the suite flaky rather than
wrong: a hook writing to the same SQLite file while tests opened it returned
`disk I/O error` from the backend's fail-closed path and produced 58 failures
across `test_mcp_server`, `test_integrations`, `test_pipeline_attenuation` and
`test_trace_gen` that had nothing to do with the code under test.

The redirect runs at conftest import time rather than in a fixture, because
pytest imports conftest before any test module and those constants bind at their
own import. Verified: the real trail held 413 records before a run of the three
files that polluted it worst, and 413 after. `VAARA_TEST_USE_REAL_HOME=1` opts
out.

## `vaara --version` did not exist

`vaara version` existed; the flag did not, and exited 2 with "unrecognized
arguments". It is the first thing anyone types to check an install, and it
silently breaks any script that guards on it, since
`vaara --version >/dev/null && next-thing` never reaches next-thing. That cost a
debugging round here: a guarded command looked like the app failing to raise an
approval window when in fact the second half had never run. Both spellings now
print the same string and exit 0.

## An answered action id was skipped forever

The macOS app's `handledApprovals` set only ever grew. `request_approval()`
deletes both the request and the decision file once it has an answer, so a later
request carrying the same id is a new ask rather than the answered one arriving
twice. Reusing an id meant the engine wrote its request, blocked for its full
timeout, and no window ever appeared, with nothing logged. Ids whose request
file is gone are now dropped on every poll.

## The macOS client, seven defects

**Nothing could ever install the network filter.**
`SystemExtensionManager.activate()` had no call site anywhere in the app. The
class does the whole job, submits the `OSSystemExtensionRequest`, handles the
delegate callbacks, configures `NEFilterManager` and enables the filter, and
nothing called it. `VaaraApp` calls `refresh()` on appear and the comment beside
it says activation is "user-initiated from settings" while settings had no
control that did it. Setup now carries a NETWORK FILTER section wired to
`activate()`, `deactivate()` and `refresh()`, rendering the five states the
manager already published.

**The Accessibility permission was never asked for.** `start()` guarded on
`AXIsProcessTrusted()`, which is silent, and returned early, so the next line,
the `AXIsProcessTrustedWithOptions` call that shows the System Settings prompt,
was unreachable on precisely the machines that had not granted it. macOS shows
that prompt once per app, so an untrusted first launch stayed untrusted forever
and logged "permission not granted" on every start. The prompting call runs
first now and the silent helper is gone.

**The app did nothing until you clicked it.** `model.start()`, the XPC listener
the filter extension connects to, the Accessibility observer, the filter-state
refresh and the approval window manager all hung off `.onAppear` on the
`ContentView` inside `MenuBarExtra`. With `menuBarExtraStyle(.window)` that
content is not created until the user opens the popover. So until someone
clicked, Vaara polled no trail, vended no XPC service, observed nothing and
could not raise an approval window. Startup now also runs from the menu bar
label, which exists as soon as the item does, through one guarded helper.

**Clicking the icon re-asked for a permission it already had.** `start()`
prompts and then sets `isRunning`, but never checked it, so every `onAppear` ran
the prompting check again. `isRunning` was written and never read.

**The filter status could claim "filtering" with zero extensions installed.**
`refresh()` decided the filter was live from `NEFilterManager`'s saved
preference alone. That preference is written before macOS agrees to load the
provider and survives the extension being removed by an OS update, by
`systemextensionsctl reset`, or by deleting the app. So the status line could
report a working content filter on a machine where `systemextensionsctl list`
says `0 extension(s)`. The preference may now only downgrade the verdict;
claiming the filter is live requires the system's own list via a properties
request. The probe gets its own delegate object, because a properties request
completes through `OSSystemExtensionRequestDelegate` too and this class's
delegate responds to completion by enabling the filter, so sharing it would have
turned the filter on as a side effect of reading its state.

**The menu bar mark was a plain coloured ball.** `markImage()` looked for
`Resources/icons/vaara-<state>.png`. Xcode collapses a `foo.png` / `foo@2x.png`
pair into one `foo.tiff` at the top of `Contents/Resources`, so neither the
`icons/` directory nor the `.png` names exist in an Xcode-built bundle. The
lookup failed silently and fell through to the oval meant as a last resort. The
Homebrew formula copies `icons/` verbatim, which is why it never showed there.

**A local build produced a second app.** `PRODUCT_NAME` was unset, so the Xcode
build took the target name and made `VaaraMenuBar.app` while Homebrew installs
`Vaara.app`. Copying a local build into `/Applications` added a second bundle
beside the installed one, two menu bar icons, and `CFBundleDisplayName` was
already "Vaara" so Finder showed them identically. Related:
`CFBundleName` still said `VaaraMenuBar`, and that is the name macOS shows in
the Accessibility prompt, the Privacy lists and Login Items & Extensions, which
is exactly where a user decides whether to trust the thing.

**`build.sh` could not work in any clone.** It called `xcodebuild` against a
project `xcodegen` generates from `project.yml` and never generated it, and the
generated project is untracked, so the file has never existed in a fresh clone.
It also assumed its own directory as the working directory. It now cds to itself,
generates first, names the `brew install xcodegen` command when the tool is
missing, and gains a `local` mode that ad-hoc signs without the restricted
entitlements for machines with no paid Apple Developer membership.

## Verified on hardware

The full human-in-the-loop path ran end to end on a real Mac for the first time:
the Python engine escalated and blocked in `request_approval`, the app raised
the approval window, a click wrote the decision file, and the engine returned
`deny`. The built extension bundle was also confirmed correct in place, carrying
`CFBundlePackageType SYSX` and mapping
`com.apple.networkextension.filter-data` to `WebKitGovernance.FilterProvider`,
which is the xcodegen plist fix from #532 holding on real output.

Still unproven and stated as such in the docs: no traffic has reached
`handleNewFlow`. Installing the filter needs a provisioning profile carrying the
Network Extension and system-extension entitlements, which only a paid Apple
Developer Program membership can issue.

## Verification

Full suite 2731 passed, 30 skipped, 0 failed, run with `HOME` pointing at a real
home directory to prove the isolation holds. ruff clean on `src/`, `tests/`,
`scripts/`. The private-key guard passes over every commit in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Network Filter status, installation, disable, refresh, and approval guidance to the macOS Setup screen.
  - Added a global `--version` option to the CLI.
  - Improved macOS startup reliability and icon loading.
  - The app now displays and builds as **Vaara**.

- **Bug Fixes**
  - More accurately detects whether the Network Filter is installed or disabled.
  - Re-surfaces approval requests when previous request records are removed.
  - Accessibility permission handling now prevents duplicate startup attempts.

- **Build & Testing**
  - Added support for local macOS builds with clearer setup requirements.
  - Isolated tests from the user’s real home directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->