### PR TITLE
docs: COMPLIANCE.md described verdict values that do not exist

### DIFF
--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -283,9 +283,22 @@ its predecessor. Any insertion, deletion, or edit breaks the chain and
 is detected by `vaara trail verify`.
 
 **2. The conformity report.** A structured per-article rollup. Each
-article gets an `EvidenceStatus` (sufficient, insufficient, stale,
-error) and an `EvidenceStrength` (strong, moderate, weak) based on
+article gets an `EvidenceStatus` and an `EvidenceStrength`, based on
 how many qualifying events exist and how recent they are.
+
+| `EvidenceStatus` | Meaning |
+|---|---|
+| `evidence_sufficient` | Evidence present and within the freshness window |
+| `evidence_partial` | Some evidence, gaps remain |
+| `evidence_insufficient` | No evidence, or critical gaps |
+| `not_applicable` | The article does not apply to this system |
+
+| `EvidenceStrength` | Meaning |
+|---|---|
+| `strong` | Continuous, automated, verifiable |
+| `moderate` | Present but manual or intermittent |
+| `weak` | Indirect or insufficient |
+| `absent` | No evidence |
 
 **3. The signed regulator handoff zip.** Produced by `vaara trail
 export`. Contains the trail, a manifest, and an Ed25519 signature.

--- a/tests/test_docs_compliance_matches_engine.py
+++ b/tests/test_docs_compliance_matches_engine.py
@@ -22,7 +22,9 @@ from pathlib import Path
 
 import pytest
 
-from vaara.compliance.engine import ComplianceEngine
+from vaara.compliance.engine import (
+    ComplianceEngine, EvidenceStatus, EvidenceStrength,
+)
 
 DOC = Path(__file__).resolve().parent.parent / "docs" / "COMPLIANCE.md"
 
@@ -87,3 +89,41 @@ def test_critical_requirements_are_all_documented():
 def test_article_50_disclosure_is_documented():
     """Regression: Article 50 is the transparency obligation in force."""
     assert "50(1)" in _table_articles("EU_AI_ACT")
+
+
+def _documented_enum_values(enum_name: str) -> set[str]:
+    """Values COMPLIANCE.md lists in the table under `enum_name`."""
+    text = DOC.read_text()
+    header = re.search(rf"\|\s*`{enum_name}`\s*\|[^\n]*\n\|[-\s|]+\n", text)
+    assert header, f"no table found for {enum_name} in docs/COMPLIANCE.md"
+    values = set()
+    for line in text[header.end():].splitlines():
+        if not line.startswith("|"):
+            break
+        cell = line.split("|")[1].strip()
+        values.add(cell.strip("`"))
+    return values
+
+
+@pytest.mark.parametrize("enum_name,enum_cls", [
+    ("EvidenceStatus", EvidenceStatus),
+    ("EvidenceStrength", EvidenceStrength),
+])
+def test_documented_verdict_vocabulary_matches_the_engine(enum_name, enum_cls):
+    """The words the report can print have to be the words the doc lists.
+
+    COMPLIANCE.md described EvidenceStatus as "sufficient, insufficient,
+    stale, error". Neither `stale` nor `error` has ever existed, and
+    `evidence_partial` and `not_applicable`, both of which a report does
+    print, were missing. EvidenceStrength omitted `absent`, which the
+    README's own example output shows. An auditor reading the mapping
+    document is reading it to learn what the verdicts mean, so inventing two
+    and hiding three is the wrong direction to be wrong in.
+    """
+    documented = _documented_enum_values(enum_name)
+    real = {member.value for member in enum_cls}
+    assert documented == real, (
+        f"docs/COMPLIANCE.md {enum_name} table drifted from the engine.\n"
+        f"  documented but not real: {sorted(documented - real)}\n"
+        f"  real but not documented: {sorted(real - documented)}"
+    )


### PR DESCRIPTION
A2 continued, on the document a buyer or auditor actually opens.

The article table in COMPLIANCE.md has been CI-guarded against the engine since it drifted last time. The verdict vocabulary next to it was not, and it had drifted in both directions at once.

```
EvidenceStatus     documented  sufficient, insufficient, stale, error
                   real        evidence_sufficient, evidence_partial,
                               evidence_insufficient, not_applicable

EvidenceStrength   documented  strong, moderate, weak
                   real        strong, moderate, weak, absent
```

`stale` and `error` have never existed. `evidence_partial`, `not_applicable` and `absent` are all values a real report prints. The README's own example output shows `"strength": "absent"`, so the two documents already contradicted each other.

Someone opens the mapping document to learn what the verdicts mean. Inventing two words and hiding three is the wrong direction to be wrong in, and it is the same failure the article-table guard was written for after the previous drift.

Both lists are now tables, and a new test compares each against its enum. Confirmed it fails on the original text: removing the `absent` row reproduces `real but not documented: ['absent']`.

## Also verified by running

This section documents the regulator handoff, so the copy-paste block was run end to end against a real 51-record trail:

```
handoff-2026-04    exit=0   Verification: OK
tamper-record      exit=1   hash chain check failed: record 5: hash mismatch
tamper-manifest    exit=1   FAILED
tamper-sig         exit=1   FAILED
```

`vaara keygen --dev`, `vaara trail export` and `vaara trail verify` all work as printed, and the three tamper-detection claims beside them hold.