### PR TITLE
docs: A2 sweep of the four documents an auditor opens first

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -44,7 +44,7 @@ A receipt is a JSON object with these top-level members:
 | Field | Type | Required | Meaning |
 |---|---|---|---|
 | `version` | integer | MUST | Envelope version. `1` for this document. |
-| `alg` | string | MUST | Signature algorithm. `ES256` in v1; `ML-DSA-65` MAY be offered as a post-quantum scheme. |
+| `alg` | string | MUST | Signature algorithm. `ES256` in v1. A receipt that names anything else is rejected by the reference checkers. |
 | `backLink` | object | MUST | Binds this receipt to its attestation/predecessor: `attestationDigest`, `attestationNonce`. |
 | `decisionDerived` | object | MUST | The decision and the evidence it derives from. See Section 3. |
 | `issuerAsserted` | object | MUST | Issuer-asserted identity claims: `iss`, `sub`, `iat`, `nonce`, `alg`, `secretVersion`. |
@@ -64,6 +64,18 @@ exactly these members, in this set, with their receipt values:
 can gain anchors after signing without invalidating the signature. A consumer
 MUST verify the signature by reconstructing this payload, canonicalizing it, and
 checking it against the public key under `alg`.
+
+### 2.2 Post-quantum protection
+
+There is no post-quantum `alg` value in v1. What ships is additive and lives
+next to the classical signature rather than replacing it: an execution record
+MAY carry a `pqSignature` sibling block (`alg`, `keyid`, `sig`) under a
+registered hybrid suite, `ES256+ML-DSA-65` or `RS256+ML-DSA-65`, so a verifier
+that cannot do ML-DSA still verifies the classical signature and a verifier
+that can sees a stripped block as the downgrade it is. Vectors at
+`tests/vectors/pq_hybrid_v0/`, which needs `dilithium_py` (`vaara[pq]`) and
+skips without it. The signed handoff zip is separate again: it signs Ed25519 by
+default and ML-DSA-65 under the same extra.
 
 ## 3. Evidence binding (`decisionDerived.evidenceRef`)
 
@@ -374,7 +386,10 @@ unchanged. The signed payload is:
   optional non-authoritative `ref` locator.
 - `ingestAsserted`: `iss` / `sub` / `iat` / `nonce` / `secretVersion` / `alg`.
 - `completeness`: a per-stream `seq` and `runningCount`; a lone ingest is `seq 1`
-  of a one-record stream.
+  of a one-record stream. Note the difference from Section 5.3: the ingest
+  stream counts from 1, so `runningCount` equals `seq` here, where an
+  authorization stream counts from 0 and `runningCount` is `seq + 1`. A
+  contiguity checker written for one is wrong by one on the other.
 
 `signature` is appended over the JCS encoding of that payload.
 

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -732,11 +732,20 @@ report = pipeline.run_compliance_assessment(
 
 for article in report.articles:
     print(article.requirement.article, article.status.value)
-    # Article 9(1): evidence_sufficient
-    # Article 12(1): evidence_sufficient
-    # Article 14(1): evidence_insufficient
+    # Article 9(1) evidence_insufficient
+    # Article 11(1) evidence_partial
+    # Article 12(1) evidence_insufficient
+    # Article 73(1) evidence_sufficient
     # ...
 ```
+
+That is the real output of the block above, run start to finish on an
+empty trail, and it is mostly `evidence_insufficient` on purpose. One
+intercepted action is one action. The default requirements want 10 to 20
+qualifying events inside a 30-day window before an article reads
+`evidence_sufficient`; Article 73(1) is the exception at a single
+`OUTCOME_RECORDED`. Thresholds and how to retune them are in
+[VERDICTS.md](VERDICTS.md).
 
 ### From the CLI
 

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -131,7 +131,8 @@ article-mapping table at
 
 The adapter is thin. The mapping is the artefact. A deployer can read
 the table, dispute a row, and override mappings without touching
-adapter code. 27 rows total across the three vendors as of v0.19.0.
+adapter code. 28 rows total across the three vendors (10 Bedrock,
+9 Azure, 9 GCP).
 
 ### Category to article mapping
 
@@ -149,6 +150,7 @@ adapter code. 27 rows total across the three vendors as of v0.19.0.
 | `grounding` | Bedrock `contextualGroundingPolicy` · Azure `Groundedness` | Art. 13, Art. 15 | LLM09 |
 | `adversarial` | Bedrock `contentPolicy.PROMPT_ATTACK` · Azure `PromptShield.UserPrompt` / `Documents` · GCP `pi_and_jailbreak` | Art. 15 | LLM01 |
 | `malicious_uri` | GCP `malicious_uris` | Art. 15 | LLM05 |
+| `malicious_file` | GCP `virus_scan` | Art. 15 | LLM05 |
 | `csam` | GCP `csam` | Art. 5 + Digital Omnibus CSAM (effective 2 Dec 2026) | - |
 
 ### Where the finding lands
@@ -186,9 +188,8 @@ article-mapping table at
 OSS provider rows.
 
 41 OSS rows total across the four vendors (7 NeMo, 10 Guardrails AI,
-20 LLM Guard, 4 Rebuff) as of v0.20.0. Combined with v0.19.0's 27
-cloud rows, the published table covers 68 provider categories across
-seven upstream guardrails.
+20 LLM Guard, 4 Rebuff). Combined with the 28 cloud rows, the published
+table covers 69 provider categories across seven upstream guardrails.
 
 ### Category to article mapping (OSS providers)
 
@@ -777,8 +778,10 @@ problem:
 - **Retention policy.** Article 12(2) allows log retention periods set
   in accordance with the intended purpose and applicable law. The
   deployer picks the period. Vaara enforces it via
-  `vaara trail purge --db PATH --retention-days N` (or
-  `SQLiteAuditBackend.purge_older_than(seconds)` from Python). A
+  `vaara trail purge --db PATH --retention-days N --all-tenants` (or
+  `SQLiteAuditBackend.purge_older_than(seconds)` from Python). The
+  tenant selector is required, not optional: pass `--tenant ID` to purge
+  one tenant's records, `--all-tenants` to purge across the whole DB. A
   `--dry-run` flag reports the count without modifying the DB.
 
   **Hash-chain seam at the retention boundary.** Surviving records
@@ -810,7 +813,7 @@ Honest about the edges:
 
   | Source                                | Attack recall | Benign FPR |
   |---------------------------------------|--------------:|-----------:|
-  | Hand-curated (held-out, 250 entries)  |        97.1% |      70.0% |
+  | Hand-curated (held-out, 250 entries)  |        97.1% |      69.6% |
   | LLM-generated (in-sample, 5,705)      |        95.2% |      87.5% |
 
   Reading: full-stack = heuristic `ESCALATE`/`DENY` preserved + classifier
@@ -819,15 +822,17 @@ Honest about the edges:
   their numbers are in-sample fit, not generalization.
 
   The 1.9pp recall gap (97.1% > 95.2%) is small but goes against the
-  expected direction. The 18pp benign-FPR gap (70.0% < 87.5%) is the
+  expected direction. The 17.9pp benign-FPR gap (69.6% < 87.5%) is the
   dominant distribution-shift signal: the stack is much more confused
   about LLM-generated benigns than hand-curated ones.
 
   Note on FPR vs CHANGELOG headline: the CHANGELOG quotes "global benign
-  FPR 21.0%" which is classifier-alone 5-fold CV OOF. The full-stack
-  numbers above are dominated by the heuristic - most benign escalations
-  come from the heuristic `ESCALATE` branch, not from classifier upgrades
-  on heuristic-`ALLOW`ed entries.
+  FPR 21.0%" which is classifier-alone 5-fold CV OOF. Which layer
+  dominates the full-stack FPR depends on the source, and the ablation
+  artefact says so: on LLM-generated benigns the heuristic `ESCALATE`
+  branch does (67.4pp of a 91.3pp full-stack FPR), on hand-curated
+  benigns it is the other way round (heuristic 26.1pp of 69.6pp, the
+  rest classifier upgrades on heuristic-`ALLOW`ed entries).
 
   Detailed per-source/per-class breakdown: `tests/adversarial/distribution_shift_v0_5_3.json`.
   Reproducible via `scripts/eval_distribution_shift.py`. A proper OOF
@@ -837,10 +842,20 @@ Honest about the edges:
   decompose into independent layer contributions. `heuristic_only` recall
   is 35% / 63% (hand-curated / LLM-generated). `classifier_only` recall
   is 94% / 86%. Layers are not redundant - heuristic catches a small set
-  of attacks the classifier misses, justifying the ensemble. Most of the
-  full-stack benign FPR comes from heuristic ESCALATEs, not classifier
-  upgrades. Detailed breakdown: `tests/adversarial/stack_ablation_v0_5_3.json`.
+  of attacks the classifier misses, justifying the ensemble. The benign
+  FPR splits by source as described above: heuristic-dominated on
+  LLM-generated, classifier-dominated on hand-curated. Detailed
+  breakdown: `tests/adversarial/stack_ablation_v0_5_3.json`.
   Reproducible via `scripts/eval_stack_ablation.py`.
+
+  The two artefacts quote different full-stack figures for the
+  LLM-generated source (95.2% / 87.5% in the distribution-shift file
+  against 97.6% / 91.3% in the ablation file). That is the error
+  handling, not a disagreement about the stack:
+  `eval_distribution_shift.py` keeps ERROR outcomes in the denominator
+  (49 attack, 25 benign), `eval_stack_ablation.py` excludes them. The
+  table above quotes the distribution-shift file, which is the more
+  conservative of the two.
 - **Adaptive-attacker calibration (v0.6 measurement of v0.5.3 stack).**
   PAIR (Chao et al. 2023) iterative attacker against the full Vaara
   stack:

--- a/docs/VERDICTS.md
+++ b/docs/VERDICTS.md
@@ -91,7 +91,10 @@ the engine.
 | 14(1) | Human Oversight: Design | 1 | 720 h | 2 | 180 h | yes |
 | 14(4)(d) | Human Oversight: Override Capability | 1 | 720 h | 2 | 180 h | no |
 | 15(1) | Accuracy, Robustness and Cybersecurity | 10 | 168 h (7 d) | 20 | 42 h | yes |
+| 26(10) | Deployer Obligations: Logging | 10 | 720 h | 20 | 180 h | yes |
+| 50(1) | Transparency Obligation: AI System Disclosure | 1 | 720 h | 2 | 180 h | yes |
 | 61(1) | Post-Market Monitoring | 20 | 720 h | 40 | 180 h | yes |
+| 73(1) | Serious Incident Reporting | 1 | 720 h | 2 | 180 h | no |
 
 Article 11(1) is the external-evidence row. It does not consume runtime
 events. The threshold table is intentionally blank.

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -15,7 +15,7 @@ Native adapters in `src/vaara/integrations/` route the major Python agent framew
 
 ## Upstream-signal adapters (cloud + OSS guardrails)
 
-Adapters route findings from cloud and OSS guardrails into Vaara's audit trail and OVERT envelope. The filter runs in the deployer's environment; Vaara records the verdict, normalises 68 provider categories onto a shared vocabulary, and tags each finding against the relevant AI Act articles. Each adapter returns a `ContentSafetyFinding` the deployer routes into `pipeline.intercept(context=finding.to_audit_context())`. Article-by-article mapping in [COMPLIANCE.md](COMPLIANCE.md).
+Adapters route findings from cloud and OSS guardrails into Vaara's audit trail and OVERT envelope. The filter runs in the deployer's environment; Vaara records the verdict, normalises 69 provider categories onto a shared vocabulary, and tags each finding against the relevant AI Act articles. Each adapter returns a `ContentSafetyFinding` the deployer routes into `pipeline.intercept(context=finding.to_audit_context())`. Article-by-article mapping in [COMPLIANCE.md](COMPLIANCE.md).
 
 | Provider | Adapter | Extra | Wraps |
 |---|---|---|---|

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -11,6 +11,7 @@ pip install 'vaara[attestation]'
 ```
 
 ```python
+from vaara.attestation import envelope_to_canonical_cbor
 from vaara.attestation.overt import emit_base_envelope, make_request_commitment, encoder_binary_identity
 
 envelope = emit_base_envelope(
@@ -21,9 +22,17 @@ envelope = emit_base_envelope(
     monotonic_counter=42,
     arbiter_instance_identifier=uuid_bytes,
 )
+
+# The wire form. envelope_to_canonical_cbor is the one that produces bytes the
+# verifier accepts: canonical CBOR over all 9 fields with the raw byte values.
+Path("receipt.cbor").write_bytes(envelope_to_canonical_cbor(envelope))
+Path("pub.bin").write_bytes(
+    key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+)
 ```
 
-`vaara overt verify RECEIPT.cbor --pubkey-file PUB.bin` validates any canonical-CBOR Base Envelope. The verifier reads only the wire format and takes no dependency on Vaara's emitter, so any conformant implementation can route through it. Adjacent surfaces (`vaara.attestation.iap` notary + transparency log, `vaara.attestation.s3p` aggregate intervals, an experimental AMD SEV-SNP TEE hook) and the OVERT 1.0 Part 3 control walk are in [COMPLIANCE.md](COMPLIANCE.md). The OVERT control mapping is in [OVERT_CONTROLS.md](OVERT_CONTROLS.md).
+`vaara overt verify receipt.cbor --pubkey-file pub.bin` validates any
+canonical-CBOR Base Envelope. The public key is the raw 32 bytes, not PEM. The verifier reads only the wire format and takes no dependency on Vaara's emitter, so any conformant implementation can route through it. Adjacent surfaces (`vaara.attestation.iap` notary + transparency log, `vaara.attestation.s3p` aggregate intervals, an experimental AMD SEV-SNP TEE hook) and the OVERT 1.0 Part 3 control walk are in [COMPLIANCE.md](COMPLIANCE.md). The OVERT control mapping is in [OVERT_CONTROLS.md](OVERT_CONTROLS.md).
 
 ## Sovereign inference harness
 

--- a/tests/test_docs_adapter_table_matches_mappings.py
+++ b/tests/test_docs_adapter_table_matches_mappings.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The published adapter mapping table has to match the shipped mappings.
+
+COMPLIANCE.md sells the adapter table as the artefact: "The adapter is
+thin. The mapping is the artefact. A deployer can read the table, dispute
+a row, and override mappings without touching adapter code." A deployer
+who does that reads the counts and the category list, so both have to be
+the real ones.
+
+They were not. `_content_safety_articles.py` grew a GCP `virus_scan` ->
+`malicious_file` row when the adapters were reconciled against their
+upstream SDKs, and the doc kept saying 27 cloud rows and 68 total. The
+`malicious_file` category was missing from the cloud table entirely, so a
+deployer auditing what Vaara records for a Model Armor virus finding
+would have concluded Vaara records nothing.
+
+These tests fail the build when a mapping is added or removed without the
+published table and its counts moving with it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from vaara.integrations._content_safety_articles import (
+    AZURE_MAPPINGS, BEDROCK_MAPPINGS, GCP_MAPPINGS, GUARDRAILS_AI_MAPPINGS,
+    LLM_GUARD_MAPPINGS, NEMO_MAPPINGS, REBUFF_MAPPINGS,
+)
+
+DOC = Path(__file__).resolve().parent.parent / "docs" / "COMPLIANCE.md"
+ADAPTERS_DOC = DOC.parent / "adapters.md"
+
+CLOUD = {"Bedrock": BEDROCK_MAPPINGS, "Azure": AZURE_MAPPINGS, "GCP": GCP_MAPPINGS}
+OSS = {
+    "NeMo": NEMO_MAPPINGS,
+    "Guardrails AI": GUARDRAILS_AI_MAPPINGS,
+    "LLM Guard": LLM_GUARD_MAPPINGS,
+    "Rebuff": REBUFF_MAPPINGS,
+}
+
+CLOUD_TOTAL = sum(len(m) for m in CLOUD.values())
+OSS_TOTAL = sum(len(m) for m in OSS.values())
+
+# Table heading -> the heading that ends its section.
+_TABLES = {
+    "cloud": ("### Category to article mapping\n", "### Where the finding lands"),
+    "oss": ("### Category to article mapping (OSS providers)", "### Where the finding lands"),
+}
+
+
+def _documented_categories(which: str) -> set[str]:
+    """Vaara categories in the first column of one mapping table."""
+    text = DOC.read_text(encoding="utf-8")
+    start_heading, end_heading = _TABLES[which]
+    start = text.index(start_heading)
+    end = text.index(end_heading, start)
+    section = text[start:end]
+    return set(re.findall(r"^\|\s*`([a-z_]+)`\s*\|", section, re.MULTILINE))
+
+
+def _real_categories(groups: dict) -> set[str]:
+    return {m.vaara_category for group in groups.values() for m in group}
+
+
+@pytest.mark.parametrize("which,groups", [("cloud", CLOUD), ("oss", OSS)])
+def test_documented_categories_match_the_shipped_mappings(which, groups):
+    documented = _documented_categories(which)
+    real = _real_categories(groups)
+    assert documented == real, (
+        f"docs/COMPLIANCE.md {which} adapter table drifted from "
+        f"_content_safety_articles.py.\n"
+        f"  documented but not shipped: {sorted(documented - real)}\n"
+        f"  shipped but not documented: {sorted(real - documented)}"
+    )
+
+
+def test_cloud_row_count_is_the_real_one():
+    text = DOC.read_text(encoding="utf-8")
+    match = re.search(r"(\d+) rows total across the three vendors", text)
+    assert match, "COMPLIANCE.md no longer states a cloud row count"
+    assert int(match.group(1)) == CLOUD_TOTAL
+
+
+def test_oss_row_counts_are_the_real_ones():
+    text = DOC.read_text(encoding="utf-8")
+    match = re.search(
+        r"(\d+) OSS rows total across the four vendors \((\d+) NeMo, "
+        r"(\d+) Guardrails AI,\s*(\d+) LLM Guard, (\d+) Rebuff\)",
+        text,
+    )
+    assert match, "COMPLIANCE.md no longer states the per-vendor OSS counts"
+    total, nemo, gai, llm_guard, rebuff = (int(g) for g in match.groups())
+    assert total == OSS_TOTAL
+    assert nemo == len(NEMO_MAPPINGS)
+    assert gai == len(GUARDRAILS_AI_MAPPINGS)
+    assert llm_guard == len(LLM_GUARD_MAPPINGS)
+    assert rebuff == len(REBUFF_MAPPINGS)
+
+
+def test_combined_count_is_the_real_one_in_both_documents():
+    """COMPLIANCE.md and adapters.md quote the same combined total."""
+    combined = CLOUD_TOTAL + OSS_TOTAL
+
+    compliance = re.search(
+        r"covers (\d+) provider categories", DOC.read_text(encoding="utf-8")
+    )
+    assert compliance, "COMPLIANCE.md no longer states a combined count"
+    assert int(compliance.group(1)) == combined
+
+    adapters = re.search(
+        r"normalises (\d+) provider categories",
+        ADAPTERS_DOC.read_text(encoding="utf-8"),
+    )
+    assert adapters, "docs/adapters.md no longer states a combined count"
+    assert int(adapters.group(1)) == combined

--- a/tests/test_docs_cli_recipes_parse.py
+++ b/tests/test_docs_cli_recipes_parse.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""A command line printed in the docs has to be one the CLI accepts.
+
+COMPLIANCE.md gave the Article 12(2) retention recipe as::
+
+    vaara trail purge --db PATH --retention-days N
+
+which exits 2 without touching the database: the parser requires a
+tenant selector (``--tenant ID`` or ``--all-tenants``) that the doc never
+mentioned. A deployer following the retention section would have
+concluded the purge was broken.
+
+Two rules, both narrow enough to stay quiet on prose:
+
+* every ``vaara ...`` line inside a fenced shell block has to parse;
+* every inline ``vaara ...`` span that prints two or more flags has to
+  parse, because at that point the doc is showing a command to run, not
+  naming one.
+
+Prose that names a command (``vaara compliance report``) or illustrates a
+single flag (``vaara keygen --dev``) is deliberately left alone.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+import shlex
+from pathlib import Path
+
+import pytest
+
+from vaara.cli import build_parser
+
+ROOT = Path(__file__).resolve().parent.parent
+
+DOCS = sorted(ROOT.glob("docs/*.md")) + [
+    ROOT / name for name in ("README.md", "SPEC.md", "CAPABILITIES.md", "PRIVACY.md")
+]
+
+_FENCE = re.compile(r"```(?:bash|sh|console|shell)\n(.*?)```", re.S)
+_INLINE = re.compile(r"`(vaara [^`]+)`")
+
+# Placeholders the docs use for values a deployer substitutes.
+_PLACEHOLDERS = {
+    "PATH": "/tmp/x", "DB": "/tmp/x.db", "N": "30", "ID": "t1",
+    "POLICY_PATH": "/tmp/p.yaml", "CASES_PATH": "/tmp/c.yaml",
+    "SECONDS": "60", "URL": "https://example.invalid",
+}
+
+
+def _runnable(line: str) -> bool:
+    """Lines the docs present as something to paste, not something to name."""
+    if not line.startswith("vaara ") or line.startswith("vaara-"):
+        return False
+    # Shell plumbing, help output and elisions are not recipes to replay.
+    return not any(token in line for token in ("--help", "|", ">", "...", "<", "$("))
+
+
+def _substitute(parts: list[str]) -> list[str]:
+    return [_PLACEHOLDERS.get(p, p) for p in parts]
+
+
+def _parse(line: str) -> str | None:
+    """None if the CLI accepts the line, else the parser's complaint."""
+    try:
+        parts = _substitute(shlex.split(line))
+    except ValueError as exc:  # unbalanced quotes in the doc itself
+        return f"unparseable shell syntax: {exc}"
+    captured = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(captured), contextlib.redirect_stdout(captured):
+            build_parser().parse_args(parts[1:])
+    except SystemExit:
+        complaint = captured.getvalue().strip().splitlines()
+        return complaint[-1] if complaint else "rejected by the parser"
+    return None
+
+
+def _fenced_commands(doc: Path) -> list[str]:
+    found = []
+    for block in _FENCE.findall(doc.read_text(encoding="utf-8")):
+        for raw in block.replace("\\\n", " ").splitlines():
+            line = re.sub(r"\s+#.*$", "", raw.strip().lstrip("$ ").strip())
+            if _runnable(line):
+                found.append(" ".join(line.split()))
+    return found
+
+
+def _inline_recipes(doc: Path) -> list[str]:
+    """Inline spans that print two or more flags."""
+    found = []
+    for span in _INLINE.findall(doc.read_text(encoding="utf-8")):
+        line = " ".join(span.split())
+        if _runnable(line) and len(re.findall(r"(?<![\w-])--[a-z][\w-]*", line)) >= 2:
+            found.append(line)
+    return found
+
+
+@pytest.mark.parametrize("doc", DOCS, ids=lambda p: p.name)
+def test_fenced_command_blocks_parse(doc):
+    failures = [(line, _parse(line)) for line in _fenced_commands(doc)]
+    failures = [f for f in failures if f[1]]
+    assert not failures, "\n".join(
+        f"{doc.name}: `{line}` -> {why}" for line, why in failures
+    )
+
+
+@pytest.mark.parametrize("doc", DOCS, ids=lambda p: p.name)
+def test_inline_multi_flag_recipes_parse(doc):
+    failures = [(line, _parse(line)) for line in _inline_recipes(doc)]
+    failures = [f for f in failures if f[1]]
+    assert not failures, "\n".join(
+        f"{doc.name}: `{line}` -> {why}" for line, why in failures
+    )
+
+
+def test_the_scan_actually_finds_commands():
+    """A regex that silently matches nothing would pass every test above."""
+    fenced = sum(len(_fenced_commands(d)) for d in DOCS if d.exists())
+    inline = sum(len(_inline_recipes(d)) for d in DOCS if d.exists())
+    assert fenced >= 20, f"only {fenced} fenced command lines found"
+    assert inline >= 1, f"only {inline} inline recipes found"
+
+
+def test_the_retention_recipe_names_the_tenant_selector():
+    """Regression: the purge recipe that could not run as printed."""
+    text = (ROOT / "docs" / "COMPLIANCE.md").read_text(encoding="utf-8")
+    recipe = re.search(r"`(vaara trail purge [^`]+)`", text)
+    assert recipe, "COMPLIANCE.md no longer gives a retention recipe"
+    assert _parse(" ".join(recipe.group(1).split())) is None

--- a/tests/test_docs_cli_recipes_parse.py
+++ b/tests/test_docs_cli_recipes_parse.py
@@ -36,8 +36,13 @@ from vaara.cli import build_parser
 
 ROOT = Path(__file__).resolve().parent.parent
 
-DOCS = sorted(ROOT.glob("docs/*.md")) + [
-    ROOT / name for name in ("README.md", "SPEC.md", "CAPABILITIES.md", "PRIVACY.md")
+#: Only files that are actually in the checkout. CAPABILITIES.md, for one,
+#: is untracked in some working trees and absent on CI.
+DOCS = [
+    path
+    for path in sorted(ROOT.glob("docs/*.md"))
+    + [ROOT / name for name in ("README.md", "SPEC.md", "CAPABILITIES.md", "PRIVACY.md")]
+    if path.exists()
 ]
 
 _FENCE = re.compile(r"```(?:bash|sh|console|shell)\n(.*?)```", re.S)

--- a/tests/test_docs_compliance_example_runs.py
+++ b/tests/test_docs_compliance_example_runs.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The Python example in COMPLIANCE.md is executed, not just read.
+
+The block under "### From Python" is the one an evaluator pastes into a
+shell to see what a conformity report looks like. It printed a commented
+sample output claiming Article 9(1) and Article 12(1) come back
+`evidence_sufficient`. They do not: the block intercepts one action, and
+the default requirements want 10 to 20 qualifying events inside a 30-day
+window. Every article except 11(1) and 73(1) reads `evidence_insufficient`
+on that trail.
+
+So the test runs the documented code and compares the documented output
+to the real one. It also runs it against a temporary HOME, because the
+example uses the default pipeline, which writes to
+``~/.vaara/trail/audit.db``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "COMPLIANCE.md"
+
+
+def _python_example() -> str:
+    text = DOC.read_text(encoding="utf-8")
+    start = text.index("### From Python")
+    block = re.search(r"```python\n(.*?)```", text[start:], re.S)
+    assert block, "COMPLIANCE.md no longer carries a Python example"
+    return block.group(1)
+
+
+def _documented_statuses() -> dict[str, str]:
+    """The `# Article 9(1) evidence_insufficient` lines in the example."""
+    pairs = re.findall(
+        r"^\s*#\s*(Article [\w()]+):?\s+(evidence_\w+|not_applicable)\s*$",
+        _python_example(),
+        re.MULTILINE,
+    )
+    assert pairs, "the example no longer shows any sample output"
+    return dict(pairs)
+
+
+@pytest.fixture()
+def documented_run(tmp_path, monkeypatch, capsys):
+    """Execute the documented block verbatim against a throwaway HOME."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    namespace: dict = {"__name__": "__doc_example__"}
+    exec(compile(_python_example(), str(DOC), "exec"), namespace)  # noqa: S102
+    capsys.readouterr()  # the example prints; the report object is the subject
+    return namespace
+
+
+def test_the_example_runs_start_to_finish(documented_run):
+    assert documented_run["result"].action_id
+    assert documented_run["report"].articles
+
+
+def test_the_sample_output_is_what_the_example_prints(documented_run):
+    real = {
+        article.requirement.article: article.status.value
+        for article in documented_run["report"].articles
+    }
+    documented = _documented_statuses()
+
+    unknown = set(documented) - set(real)
+    assert not unknown, f"the example shows articles the report never emits: {sorted(unknown)}"
+
+    wrong = {
+        article: (status, real[article])
+        for article, status in documented.items()
+        if real[article] != status
+    }
+    assert not wrong, (
+        "docs/COMPLIANCE.md shows sample output the example does not produce "
+        "(article: documented -> real): "
+        + ", ".join(f"{a}: {d} -> {r}" for a, (d, r) in sorted(wrong.items()))
+    )
+
+
+def test_the_example_writes_nothing_outside_home(documented_run, tmp_path):
+    """The default pipeline persists; the reader should know where."""
+    assert (tmp_path / ".vaara" / "trail" / "audit.db").exists()

--- a/tests/test_docs_compliance_matches_engine.py
+++ b/tests/test_docs_compliance_matches_engine.py
@@ -91,6 +91,109 @@ def test_article_50_disclosure_is_documented():
     assert "50(1)" in _table_articles("EU_AI_ACT")
 
 
+VERDICTS_DOC = DOC.parent / "VERDICTS.md"
+
+#: The row VERDICTS.md leaves blank on purpose: Article 11(1) consumes no
+#: runtime events, so its thresholds are printed as `n/a`.
+_EXTERNAL_EVIDENCE_ROWS = {"11(1)"}
+
+
+#: VERDICTS.md heading -> the heading that ends its threshold table. Both
+#: domains carry an Article 12(1) and an Article 13(1), so the tables have to
+#: be read one at a time or DORA silently overwrites the EU AI Act row.
+_VERDICTS_SECTIONS = {
+    "EU_AI_ACT": ("## EU AI Act per-article thresholds", "## DORA per-article thresholds"),
+    "DORA": ("## DORA per-article thresholds", "## What an auditor sees"),
+}
+
+
+def _verdicts_threshold_rows(domain: str = "EU_AI_ACT") -> dict[str, tuple[int, float]]:
+    """Article -> (min count, staleness hours) as VERDICTS.md prints them."""
+    whole = VERDICTS_DOC.read_text(encoding="utf-8")
+    start_heading, end_heading = _VERDICTS_SECTIONS[domain]
+    start = whole.index(start_heading)
+    text = whole[start:whole.index(end_heading, start)]
+    rows: dict[str, tuple[int, float]] = {}
+    for line in text.splitlines():
+        cells = [cell.strip() for cell in line.split("|")[1:-1]]
+        if len(cells) != 7 or not re.fullmatch(r"\d+\(\d+\)(\([a-z]\))?", cells[0]):
+            continue
+        if cells[0] in _EXTERNAL_EVIDENCE_ROWS:
+            continue
+        staleness = re.match(r"(\d+)\s*h", cells[3])
+        assert staleness, f"unreadable staleness cell for {cells[0]}: {cells[3]!r}"
+        rows[cells[0]] = (int(cells[2]), float(staleness.group(1)))
+    return rows
+
+
+@pytest.mark.parametrize("domain", sorted(_VERDICTS_SECTIONS))
+def test_verdicts_documents_every_requirement_the_engine_ships(domain):
+    """VERDICTS.md is the public reference for how the engine decides.
+
+    Its EU AI Act table omitted Articles 26(10), 50(1) and 73(1) while the
+    engine enforced all three, two of them as CRITICAL. The document states
+    that the overall report status is the worst status across all critical
+    articles, so a reader working from that table could not predict the
+    verdict they would get.
+    """
+    documented = set(_verdicts_threshold_rows(domain)) | (
+        _EXTERNAL_EVIDENCE_ROWS if domain == "EU_AI_ACT" else set()
+    )
+    real = _engine_articles(domain)
+    missing = real - documented
+    assert not missing, (
+        f"docs/VERDICTS.md has no {domain} threshold row for {sorted(missing)}, "
+        f"which the engine enforces"
+    )
+    invented = documented - real
+    assert not invented, (
+        f"docs/VERDICTS.md prints {domain} thresholds for {sorted(invented)}, "
+        f"which the engine does not enforce"
+    )
+
+
+@pytest.mark.parametrize("domain", sorted(_VERDICTS_SECTIONS))
+def test_verdicts_thresholds_are_the_engine_thresholds(domain):
+    """Every number in the tables, not just the article list."""
+    documented = _verdicts_threshold_rows(domain)
+    wrong = {}
+    for requirement in ComplianceEngine().requirements:
+        if domain not in str(requirement.domain):
+            continue
+        article = requirement.article.removeprefix("Article ")
+        if article not in documented:
+            continue
+        real = (requirement.min_evidence_count, float(requirement.staleness_hours))
+        if documented[article] != real:
+            wrong[article] = (documented[article], real)
+    assert not wrong, (
+        "docs/VERDICTS.md thresholds drifted from the engine "
+        "(article: documented -> real): "
+        + ", ".join(f"{a}: {d} -> {r}" for a, (d, r) in sorted(wrong.items()))
+    )
+
+
+def test_verdicts_strong_columns_are_twice_the_minimum():
+    """The strong-count column is derived, so it can drift on its own."""
+    text = VERDICTS_DOC.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        cells = [cell.strip() for cell in line.split("|")[1:-1]]
+        if len(cells) != 7 or not re.fullmatch(r"\d+\(\d+\)(\([a-z]\))?", cells[0]):
+            continue
+        if cells[0] in _EXTERNAL_EVIDENCE_ROWS:
+            continue
+        minimum, strong = int(cells[2]), int(cells[4])
+        assert strong == 2 * minimum, (
+            f"VERDICTS.md {cells[0]}: strong-count {strong} is not 2x {minimum}"
+        )
+        staleness = float(re.match(r"(\d+)", cells[3]).group(1))
+        freshness = float(re.match(r"([\d.]+)", cells[5]).group(1))
+        assert freshness == staleness / 4, (
+            f"VERDICTS.md {cells[0]}: strong-freshness {freshness} is not "
+            f"{staleness}/4"
+        )
+
+
 def _documented_enum_values(enum_name: str) -> set[str]:
     """Values COMPLIANCE.md lists in the table under `enum_name`."""
     text = DOC.read_text()

--- a/tests/test_docs_measurements_match_artifacts.py
+++ b/tests/test_docs_measurements_match_artifacts.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Every measured number COMPLIANCE.md quotes has to be in the artefact.
+
+The "Current limits" section is the honest-numbers section: attack
+recall, benign FPR, layer ablation, and the PAIR adaptive-attacker run.
+It names the JSON files it draws from, so a reader can check it, and
+that is exactly what makes a wrong digit expensive.
+
+Two were wrong. The hand-curated benign FPR was quoted as 70.0% when the
+artefact says 69.57%, which also inflated the stated distribution-shift
+gap to 18pp. And the claim that "most benign escalations come from the
+heuristic ESCALATE branch" held only for the LLM-generated source: on
+hand-curated benigns the heuristic contributes 26.1pp of a 69.6pp
+full-stack FPR, so classifier upgrades are the larger half.
+
+These tests fail the build when a re-run moves the artefacts and the doc
+does not move with them.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+DOC = ROOT / "docs" / "COMPLIANCE.md"
+DIST = ROOT / "tests" / "adversarial" / "distribution_shift_v0_5_3.json"
+ABLATION = ROOT / "tests" / "adversarial" / "stack_ablation_v0_5_3.json"
+PAIR = ROOT / "tests" / "adversarial" / "pair_v0_5_3.json"
+
+
+def _text() -> str:
+    return DOC.read_text(encoding="utf-8")
+
+
+def _dist(key: str) -> dict:
+    buckets = json.loads(DIST.read_text())["buckets"]
+    return next(b for b in buckets if b["key"] == key)
+
+
+def _ablation(config: str, key: str) -> dict:
+    rows = json.loads(ABLATION.read_text())["rows"]
+    return next(r for r in rows if r["config"] == config and r["key"] == key)
+
+
+def _table_row(label: str) -> tuple[float, float]:
+    """The (recall, FPR) percentages COMPLIANCE.md prints for one source."""
+    match = re.search(
+        rf"\|\s*{re.escape(label)}[^|]*\|\s*([\d.]+)%\s*\|\s*([\d.]+)%\s*\|", _text()
+    )
+    assert match, f"no distribution-shift table row for {label!r}"
+    return float(match.group(1)), float(match.group(2))
+
+
+@pytest.mark.parametrize("label,source,entries", [
+    ("Hand-curated", "hand_curated", 250),
+    ("LLM-generated", "llm_generated", 5705),
+])
+def test_distribution_shift_table_matches_the_artifact(label, source, entries):
+    documented_recall, documented_fpr = _table_row(label)
+    attack = _dist(f"{source}/attack")
+    benign = _dist(f"{source}/benign")
+
+    assert round(attack["value"] * 100, 1) == documented_recall
+    assert round(benign["value"] * 100, 1) == documented_fpr
+    assert attack["n"] + benign["n"] == entries, (
+        "the entry count in the table is the corpus the artefact measured"
+    )
+
+
+def test_the_stated_gaps_follow_from_the_stated_numbers():
+    text = _text()
+    hand_recall, hand_fpr = _table_row("Hand-curated")
+    llm_recall, llm_fpr = _table_row("LLM-generated")
+
+    recall_gap = re.search(r"The ([\d.]+)pp recall gap", text)
+    fpr_gap = re.search(r"The ([\d.]+)pp benign-FPR gap", text)
+    assert recall_gap and fpr_gap, "COMPLIANCE.md no longer states the gaps"
+    assert float(recall_gap.group(1)) == round(hand_recall - llm_recall, 1)
+    assert float(fpr_gap.group(1)) == round(llm_fpr - hand_fpr, 1)
+
+
+def test_layer_ablation_recalls_match_the_artifact():
+    text = _text()
+    for config in ("heuristic_only", "classifier_only"):
+        match = re.search(rf"`{config}` recall\s*\n?\s*is (\d+)% / (\d+)%", text)
+        assert match, f"COMPLIANCE.md no longer states {config} recall"
+        hand, llm = (int(g) for g in match.groups())
+        assert hand == round(_ablation(config, "hand_curated/attack")["value"] * 100)
+        assert llm == round(_ablation(config, "llm_generated/attack")["value"] * 100)
+
+
+def test_the_fpr_attribution_matches_the_ablation():
+    """Which layer dominates the benign FPR is a per-source claim."""
+    text = _text()
+    match = re.search(
+        r"heuristic `ESCALATE`\s*\n?\s*branch does \(([\d.]+)pp of a ([\d.]+)pp "
+        r"full-stack FPR\), on hand-curated\s*\n?\s*benigns it is the other way "
+        r"round \(heuristic ([\d.]+)pp of ([\d.]+)pp",
+        text,
+    )
+    assert match, "COMPLIANCE.md no longer attributes the benign FPR per source"
+    llm_heuristic, llm_full, hand_heuristic, hand_full = (
+        float(g) for g in match.groups()
+    )
+
+    real = {
+        "llm_heuristic": _ablation("heuristic_only", "llm_generated/benign")["value"],
+        "llm_full": _ablation("full_stack", "llm_generated/benign")["value"],
+        "hand_heuristic": _ablation("heuristic_only", "hand_curated/benign")["value"],
+        "hand_full": _ablation("full_stack", "hand_curated/benign")["value"],
+    }
+    assert llm_heuristic == round(real["llm_heuristic"] * 100, 1)
+    assert llm_full == round(real["llm_full"] * 100, 1)
+    assert hand_heuristic == round(real["hand_heuristic"] * 100, 1)
+    assert hand_full == round(real["hand_full"] * 100, 1)
+
+    # The direction claimed in prose has to be the direction in the data.
+    assert real["llm_heuristic"] > real["llm_full"] - real["llm_heuristic"]
+    assert real["hand_heuristic"] < real["hand_full"] - real["hand_heuristic"]
+
+
+def test_the_two_artifacts_diverge_only_where_the_doc_says_they_do():
+    """The doc explains the LLM-generated divergence as ERROR handling."""
+    text = _text()
+    match = re.search(
+        r"against ([\d.]+)% / ([\d.]+)% in the ablation file", text
+    )
+    assert match, "COMPLIANCE.md no longer reconciles the two artefacts"
+    recall, fpr = (float(g) for g in match.groups())
+    assert recall == round(_ablation("full_stack", "llm_generated/attack")["value"] * 100, 1)
+    assert fpr == round(_ablation("full_stack", "llm_generated/benign")["value"] * 100, 1)
+
+    errors = re.search(r"\((\d+) attack, (\d+) benign\)", text)
+    assert errors, "COMPLIANCE.md no longer states the ERROR counts"
+    assert int(errors.group(1)) == _dist("llm_generated/attack")["error"]
+    assert int(errors.group(2)) == _dist("llm_generated/benign")["error"]
+
+
+def test_pair_calibration_numbers_match_the_artifact():
+    text = _text()
+    pair = json.loads(PAIR.read_text())
+    verdicts = [h["vaara"] for r in pair["results"] for h in r["history"]]
+
+    asr = re.search(r"\*\*ASR: ([\d.]+)% \((\d+)/(\d+)\)\*\*", text)
+    assert asr, "COMPLIANCE.md no longer states the PAIR ASR"
+    assert float(asr.group(1)) == pair["asr"] * 100
+    assert int(asr.group(2)) == pair["n_successes"]
+    assert int(asr.group(3)) == pair["n_seeds"]
+
+    counts = re.search(
+        r"Across (\d+) candidate prompts, Vaara\s*\n?\s*escalated (\d+) and "
+        r"allowed (\d+)", text,
+    )
+    assert counts, "COMPLIANCE.md no longer states the PAIR outcome counts"
+    total, escalated, allowed = (int(g) for g in counts.groups())
+    assert total == len(verdicts)
+    assert escalated == verdicts.count("ESCALATE")
+    assert allowed == verdicts.count("ALLOW")
+
+    iters = re.search(r"Max iterations per seed: (\d+)", text)
+    assert iters and int(iters.group(1)) == pair["max_iters"]
+    assert pair["attacker_model"] in text
+    assert pair["judge_model"] in text

--- a/tests/test_docs_standards_overt_example_runs.py
+++ b/tests/test_docs_standards_overt_example_runs.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The OVERT example in standards.md is executed end to end.
+
+The page emitted an envelope in Python and then said `vaara overt verify
+RECEIPT.cbor --pubkey-file PUB.bin` validates it. The step between the
+two was missing, and the two obvious guesses both fail:
+``canonical_cbor(envelope)`` raises ``CBOREncodeError`` because the
+envelope is a dataclass, and canonical CBOR over ``envelope.to_dict()``
+produces a file the verifier rejects. The one function that works,
+``envelope_to_canonical_cbor``, was never named on the page.
+
+This test runs the documented Python, writes the two files the way the
+page now says to, and shells out to the documented command. It fails if
+either half drifts.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cbor2")
+pytest.importorskip("cryptography")
+
+from cryptography.hazmat.primitives import serialization  # noqa: E402
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # noqa: E402
+    Ed25519PrivateKey,
+)
+
+import vaara  # noqa: E402
+from vaara.attestation import envelope_to_canonical_cbor  # noqa: E402
+from vaara.attestation.overt import (  # noqa: E402
+    emit_base_envelope, encoder_binary_identity, make_request_commitment,
+)
+
+DOC = Path(__file__).resolve().parents[1] / "docs" / "standards.md"
+
+
+def _emit():
+    key = Ed25519PrivateKey.generate()
+    envelope = emit_base_envelope(
+        signing_key=key,
+        request_commitment=make_request_commitment(b"payload", operator_key=b"k" * 32),
+        encoder_binary_identity=encoder_binary_identity(
+            arbiter_version=f"vaara/{vaara.__version__}", policy_hash=b"h" * 32,
+        ),
+        non_content_metadata={"action_class": "tx.transfer", "decision": "escalate"},
+        monotonic_counter=42,
+        arbiter_instance_identifier=uuid.uuid4().bytes,
+    )
+    return key, envelope
+
+
+def test_the_documented_emit_and_verify_round_trips(tmp_path):
+    key, envelope = _emit()
+    receipt = tmp_path / "receipt.cbor"
+    pubkey = tmp_path / "pub.bin"
+    receipt.write_bytes(envelope_to_canonical_cbor(envelope))
+    pubkey.write_bytes(
+        key.public_key().public_bytes(
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw,
+        )
+    )
+
+    done = subprocess.run(
+        [sys.executable, "-m", "vaara.cli", "overt", "verify",
+         str(receipt), "--pubkey-file", str(pubkey)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert '"valid": true' in done.stdout
+
+
+def test_the_page_names_the_serializer_that_works(tmp_path):
+    """Regression: the page skipped from an envelope object to a .cbor file."""
+    text = DOC.read_text(encoding="utf-8")
+    assert "envelope_to_canonical_cbor" in text, (
+        "standards.md shows `vaara overt verify RECEIPT.cbor` without saying "
+        "how to produce RECEIPT.cbor, and the obvious guesses do not work"
+    )
+    command = re.search(r"`vaara overt verify ([^`]+)`", text)
+    assert command, "standards.md no longer shows the verify command"
+    assert "--pubkey-file" in command.group(1)
+
+
+def test_the_envelope_carries_the_nine_documented_fields():
+    """"closed 9-field schema" is a claim about the wire form."""
+    import dataclasses
+
+    _, envelope = _emit()
+    assert len(dataclasses.fields(envelope)) == 9

--- a/tests/test_spec_matches_the_vectors.py
+++ b/tests/test_spec_matches_the_vectors.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""SPEC.md is normative, so its claims are checked against what ships.
+
+Two of them were not true.
+
+Section 2 offered `ML-DSA-65` as an `alg` value "as a post-quantum
+scheme". No producer emits it, no vector carries it, and the reference
+checkers reject any receipt whose `alg` is not `ES256`. An implementer
+who took the table at its word would have emitted receipts Vaara refuses.
+The post-quantum path that does ship is a `pqSignature` sibling block
+under a hybrid suite, which is a different construction in a different
+place.
+
+Section 6 gave the ingest stream a `completeness` block with the same two
+field names as Section 5.3 and the opposite base: ingest counts from 1,
+authorization counts from 0. Both are true of the shipped vectors, and
+the document said neither.
+
+The tests below pin the envelope shape, the algorithm set, both
+completeness conventions, and the standing claim that every named vector
+directory carries a checker that runs on the standard library plus
+`cryptography` and `rfc8785`.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vaara.attestation._decision_conformance import VALID_VERDICTS
+from vaara.attestation._receipt_conformance import VALID_ALGS
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = ROOT / "SPEC.md"
+VECTORS = ROOT / "tests" / "vectors"
+
+#: Third-party imports SPEC.md Section "This document packages..." allows a
+#: checker to make. Everything else has to be the standard library.
+ALLOWED_THIRD_PARTY = {"cryptography", "rfc8785", "dilithium_py", "asn1crypto"}
+
+#: Exit code the checkers use for "optional dependency missing".
+SKIP = 77
+
+
+def _spec() -> str:
+    return SPEC.read_text(encoding="utf-8")
+
+
+def _named_vector_dirs() -> list[Path]:
+    """Every `tests/vectors/<name>/` path SPEC.md points a reader at."""
+    names = sorted(set(re.findall(r"tests/vectors/(\w+)/", _spec())))
+    assert names, "SPEC.md no longer names any vector directory"
+    return [VECTORS / name for name in names]
+
+
+def _receipts(obj, where: str):
+    """Every receipt envelope inside a vector file, at any nesting."""
+    if isinstance(obj, dict):
+        if isinstance(obj.get("decisionDerived"), dict) and "issuerAsserted" in obj:
+            yield where, obj
+        for key, value in obj.items():
+            yield from _receipts(value, f"{where}.{key}")
+    elif isinstance(obj, list):
+        for index, value in enumerate(obj):
+            yield from _receipts(value, f"{where}[{index}]")
+
+
+def _profile_receipts() -> list[tuple[str, dict]]:
+    """Receipts under the profiles Section 5.1 registers."""
+    registered = ("x402_settlement_v0", "authorization_v0", "contiguity_v0",
+                  "ap2_v0", "tap_v0", "external_evidence_v0", "class_gate_v0")
+    found = []
+    for name in registered:
+        for path in sorted((VECTORS / name).rglob("*.json")):
+            try:
+                doc = json.loads(path.read_text())
+            except json.JSONDecodeError:
+                continue
+            found.extend(
+                (f"{path.relative_to(VECTORS)}:{where}", receipt)
+                for where, receipt in _receipts(doc, "")
+            )
+    assert found, "no receipts found under the registered profiles"
+    return found
+
+
+@pytest.mark.parametrize("directory", _named_vector_dirs(), ids=lambda p: p.name)
+def test_every_vector_directory_spec_names_exists(directory):
+    assert directory.is_dir(), f"SPEC.md points at {directory}, which is absent"
+    assert (directory / "_check_independent.py").exists(), (
+        f"{directory.name} has no independent checker; SPEC.md Section 7 calls "
+        f"the committed vectors plus _check_independent.py the reference suite"
+    )
+
+
+@pytest.mark.parametrize("directory", _named_vector_dirs(), ids=lambda p: p.name)
+def test_checkers_import_only_what_the_spec_promises(directory):
+    """"imports only the standard library, cryptography, and rfc8785"."""
+    source = (directory / "_check_independent.py").read_text()
+    imported = set()
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported.add(node.module.split(".")[0])
+    third_party = {
+        name for name in imported
+        if name not in sys.stdlib_module_names and not name.startswith("_")
+    }
+    assert third_party <= ALLOWED_THIRD_PARTY, (
+        f"{directory.name}/_check_independent.py imports {sorted(third_party - ALLOWED_THIRD_PARTY)}, "
+        f"which breaks the claim that a third party can replay the vectors "
+        f"with no Vaara installed"
+    )
+    assert "vaara" not in imported
+
+
+@pytest.mark.parametrize("directory", _named_vector_dirs(), ids=lambda p: p.name)
+def test_checkers_pass_without_vaara_importable(directory, tmp_path):
+    """Run each checker with Vaara removed from the import path."""
+    checker = directory / "_check_independent.py"
+    if "sys.argv" in checker.read_text() and directory.name == "article12_fold_v0":
+        pytest.skip("takes a package path as an argument, not a self-contained run")
+    done = subprocess.run(
+        [sys.executable, "-I", str(checker)],
+        cwd=directory, capture_output=True, text=True, timeout=300,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+    )
+    if done.returncode == SKIP:
+        pytest.skip(done.stdout.strip() or "optional dependency missing")
+    assert done.returncode == 0, (
+        f"{directory.name}/_check_independent.py exited {done.returncode}\n"
+        f"{done.stdout[-2000:]}\n{done.stderr[-2000:]}"
+    )
+
+
+def test_registered_profile_receipts_have_the_documented_envelope():
+    documented = {"version", "alg", "backLink", "decisionDerived",
+                  "issuerAsserted", "signature"}
+    for where, receipt in _profile_receipts():
+        assert documented <= set(receipt), f"{where} is missing {sorted(documented - set(receipt))}"
+        assert set(receipt) - documented <= {"timestampAnchors"}, (
+            f"{where} carries members Section 2 does not document: "
+            f"{sorted(set(receipt) - documented - {'timestampAnchors'})}"
+        )
+        assert receipt["version"] == 1
+        assert receipt["alg"] == "ES256", f"{where} uses {receipt['alg']}"
+        assert re.fullmatch(r"[0-9a-f]{128}", receipt["signature"]), (
+            f"{where} signature is not the documented 64-byte r||s pair"
+        )
+        assert receipt["decisionDerived"]["decision"] in VALID_VERDICTS
+
+
+def test_spec_offers_no_algorithm_the_checkers_reject():
+    """Regression: Section 2 offered ML-DSA-65 as an `alg` value."""
+    row = re.search(r"^\|\s*`alg`\s*\|.*$", _spec(), re.MULTILINE)
+    assert row, "SPEC.md no longer documents the alg field"
+    offered = set(re.findall(r"`([A-Za-z0-9+-]+)`", row.group(0))) - {"alg", "string"}
+    assert offered, "the alg row names no algorithm"
+    assert offered <= VALID_ALGS, (
+        f"SPEC.md offers {sorted(offered - VALID_ALGS)} as a receipt `alg`, "
+        f"which the reference checkers reject"
+    )
+
+
+def test_both_completeness_conventions_are_the_shipped_ones():
+    """Section 5.3 counts from 0; Section 6 counts from 1. Both are real."""
+    authorization = [
+        block
+        for path in sorted((VECTORS / "contiguity_v0" / "complete").glob("*.json"))
+        for block in [json.loads(path.read_text())["evidence"]["completeness"]]
+    ]
+    assert authorization, "no contiguity vectors found"
+    assert min(b["seq"] for b in authorization) == 0
+    assert all(b["runningCount"] == b["seq"] + 1 for b in authorization)
+
+    ingest = [
+        json.loads(path.read_text())["record"]["completeness"]
+        for path in sorted((VECTORS / "ingest_v0" / "cases").glob("*.json"))
+    ]
+    assert ingest, "no ingest vectors carry a completeness block"
+    assert all(b["seq"] == 1 and b["runningCount"] == 1 for b in ingest), (
+        "SPEC.md Section 6 says a lone ingest is seq 1 of a one-record stream"
+    )
+
+    spec = " ".join(_spec().split())
+    assert "the ingest stream counts from 1" in spec, (
+        "SPEC.md no longer warns that the two conventions differ"
+    )

--- a/tests/test_spec_matches_the_vectors.py
+++ b/tests/test_spec_matches_the_vectors.py
@@ -135,6 +135,12 @@ def test_checkers_pass_without_vaara_importable(directory, tmp_path):
     )
     if done.returncode == SKIP:
         pytest.skip(done.stdout.strip() or "optional dependency missing")
+    # `cryptography` and `rfc8785` are the two the checkers are allowed to
+    # need, and both are extras. On a base install they are absent, which is
+    # the environment's business and not a claim failing.
+    missing = re.search(r"No module named '([\w.]+)'", done.stderr)
+    if missing and missing.group(1).split(".")[0] in ALLOWED_THIRD_PARTY:
+        pytest.skip(f"{missing.group(1)} not installed in this environment")
     assert done.returncode == 0, (
         f"{directory.name}/_check_independent.py exited {done.returncode}\n"
         f"{done.stdout[-2000:]}\n{done.stderr[-2000:]}"


### PR DESCRIPTION
A2 continued across `docs/COMPLIANCE.md`, `SPEC.md`, `docs/verifying-evidence.md` and `docs/standards.md`, the four a visitor opens first. Everything here was found by running what the document points at.

## What was wrong

**COMPLIANCE.md**

1. The adapter table lost a row. `_content_safety_articles.py` grew a GCP `virus_scan` to `malicious_file` mapping when the adapters were reconciled against their upstream SDKs, and the published table never moved. The document said 27 cloud rows and 68 total against a real 28 and 69, and carried no `malicious_file` row at all, so a deployer auditing what Vaara records for a Model Armor virus finding would have concluded it records nothing. docs/adapters.md quoted the same stale 68.
2. Hand-curated benign FPR was quoted as 70.0%. The artefact says 0.6956, so 69.6%, which also inflated the stated distribution-shift gap from 17.9pp to 18pp.
3. "Most benign escalations come from the heuristic ESCALATE branch" was true for one source and false for the other: 67.4pp of 91.3pp on LLM-generated benigns, 26.1pp of 69.6pp on hand-curated, where classifier upgrades are the larger half. Now stated per source. The two shipped artefacts also disagree on the LLM-generated full-stack figures, which turned out to be error handling in the scripts rather than a disagreement about the stack, so the document says which file keeps ERROR outcomes in the denominator.
4. The Article 12(2) retention recipe could not run as printed. `vaara trail purge --db PATH --retention-days N` exits 2, because the parser requires a tenant selector the document never mentioned.
5. The conformity-report example showed output it does not produce, claiming Article 9(1) and 12(1) come back `evidence_sufficient` after a single intercepted action. Both come back `evidence_insufficient`.

**SPEC.md**, which says "normative, stable" at the top

6. Section 2 offered `ML-DSA-65` as an `alg` value. Nothing emits it, no vector carries it, and the reference checkers require `ES256`. The post-quantum path that ships is a different construction in a different place: an additive `pqSignature` block under the hybrid suites `ES256+ML-DSA-65` and `RS256+ML-DSA-65`. New Section 2.2 says so.
7. Section 6 gave the ingest stream a `completeness` block with the same field names as Section 5.3 and the opposite base. Ingest counts from 1, authorization counts from 0. Both are true of the vectors and the document said neither.

**standards.md**

8. The OVERT section emits an envelope in Python, then documents `vaara overt verify RECEIPT.cbor`, with nothing in between. Both obvious guesses fail: `canonical_cbor(envelope)` raises, and canonical CBOR over `to_dict()` produces bytes the verifier rejects. The function that works, `envelope_to_canonical_cbor`, was never named on the page.

## Guards

Each was confirmed to fail on the text it replaces.

| Guard | What it pins |
|---|---|
| `test_docs_adapter_table_matches_mappings.py` | both adapter tables and all three counts against the mapping module |
| `test_docs_measurements_match_artifacts.py` | every measured percentage in "Current limits" against the JSON it cites |
| `test_docs_cli_recipes_parse.py` | every command line the docs print, against the real CLI parser |
| `test_docs_compliance_example_runs.py` | executes the Python example and compares its sample output to the real report |
| `test_spec_matches_the_vectors.py` | envelope shape, algorithm set, both completeness conventions, and that every vector directory SPEC.md names carries a checker that imports no Vaara and exits 0 under `python -I` |
| `test_docs_standards_overt_example_runs.py` | emits, serializes and shells out to the documented verify command |

## Verified in passing, no change needed

- 40 of the 43 shipped conformance checkers pass with only `cryptography` and `rfc8785` installed and no Vaara on the path. Two skip on optional dependencies, one takes a package path as an argument.
- `verify-bundle` behaves as documented across all eight bundle vectors. The sentence that matters most, "a bundle that proves inclusion and non-revocation but never verifies a signature is not ok", is the `unauthenticated_in_log` case: authenticity established False, exit 1.
- Purge behaviour and the documented retention seam both hold. Purging 6 of 9 records leaves `verify` reporting a break at the boundary.
- `conformance-statement`, `verify-records`, `audit-summary`, `verify-contiguity` and `vaara overt verify` all run as printed against the shipped corpus and vectors.