### PR TITLE
docs: paths and citations that a reader cannot open

### DIFF
--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -646,7 +646,7 @@ relevant measurement primitive that ties everything above together.
 
 The [MIT AI Risk Repository v4](https://airisk.mit.edu/) (MIT FutureTech, Slattery et al., updated 2025-12-03, CC BY 4.0) is a meta-taxonomy of 1,835 risk-bearing entries drawn from 74 source papers, organised into 7 domains. Vaara has direct runtime evidence shape against roughly 740 of those entries (~46% of the sub-domain-tagged set), concentrated in Privacy & Security, Malicious Actors & Misuse, Human-Computer Interaction, parts of AI System Safety, and the Governance Failure sub-domain. Vaara does not cover the model-side, content-level, and structural risks that live elsewhere in the taxonomy.
 
-The full per-sub-domain map lives at [mit_ai_risk_repository_mapping.md](mit_ai_risk_repository_mapping.md). Local copies of the v4 database and the companion AI Risk Mitigations sheet are tracked under `../research/external/` for reproducibility.
+The full per-sub-domain map lives at [mit_ai_risk_repository_mapping.md](mit_ai_risk_repository_mapping.md). The v4 database and the companion AI Risk Mitigations sheet are not redistributed here; download them from [airisk.mit.edu](https://airisk.mit.edu/) to reproduce the mapping against the same release.
 
 ## EU Product Liability Directive 2024/2853
 

--- a/docs/PRIOR_ART.md
+++ b/docs/PRIOR_ART.md
@@ -335,8 +335,9 @@ than a judgment of the work.
   `.ots` proof shows a digest existed no later than a block's time.
   The lineage runs back to Haber and Stornetta's linked timestamping
   (1991). Vaara shipped an `opentimestamps` receipt-anchor method from
-  v1.29.0 to v1.52.0 (`src/vaara/audit/ots_anchor.py`) which produced
-  standard `.ots` proofs over the receipt's signed-payload digest.
+  v1.29.0 to v1.52.0, which produced standard `.ots` proofs over the
+  receipt's signed-payload digest. The module went with the method, so
+  that is history rather than a path to open in the tree.
   Superseded in v1.53.0 by the `scitt` transparency-log method
   (`src/vaara/audit/scitt_anchor.py`), which provides the same
   trust-minimized witness without Bitcoin finality latency.

--- a/docs/conformance-profile.md
+++ b/docs/conformance-profile.md
@@ -23,7 +23,7 @@ reproduce the published verdicts under the same checker. The aggregate runner
 `scripts/conformance_runner.py` discovers every suite, runs each checker in a
 subprocess, and returns a single pass/fail.
 
-Profile v1 covers the 37 suites listed below, at the `v0` vector format. The
+Profile v1 covers the 43 suites listed below, at the `v0` vector format. The
 authoritative, always-current enumeration for any tagged release is the runner's
 own `--list` output at that tag.
 
@@ -38,9 +38,11 @@ pip install rfc8785 cryptography
 ```
 
 `rfc8785` is JCS canonicalization (RFC 8785); `cryptography` covers the Ed25519
-and ECDSA signature paths. The `pq_hybrid_v0` suite additionally needs
-`dilithium_py`. None of these is Vaara. The point of the profile is that you run
-standard public crypto, never the producer's stack.
+and ECDSA signature paths. Two suites need one more each: `pq_hybrid_v0` needs
+`dilithium_py` and `qualified_time_v0` needs `asn1crypto`. Both skip cleanly
+when their dependency is absent rather than failing the run. None of these is
+Vaara. The point of the profile is that you run standard public crypto, never
+the producer's stack.
 
 ## The one command
 
@@ -74,11 +76,17 @@ Inside a checker, two kinds of assertion are distinguished:
 - **Advisory** checks report a deviation without failing the suite (for example,
   a signature that is well-formed but not the expected length for its algorithm).
 
-One suite is reported `SKIP`, not pass, in an aggregate run:
+Suites reported `SKIP`, not pass, in an aggregate run:
 
 - `article12_fold_v0` validates a bundle handed to it on the command line rather
-  than a bare directory of case files. The runner lists it explicitly so the gap
-  reads as a gap, not as silent coverage.
+  than a bare directory of case files. It skips on every run. The runner lists
+  it explicitly so the gap reads as a gap, not as silent coverage.
+- `pq_hybrid_v0` and `qualified_time_v0` skip when their optional dependency is
+  missing, with the reason printed. Install `dilithium_py` and `asn1crypto` and
+  both run.
+
+So a clean checkout with `rfc8785` and `cryptography` alone grades 40 passed,
+0 failed, 3 skipped across the 43 suites.
 
 ## What a pass means, and what it does not
 
@@ -94,24 +102,28 @@ grows; conformance is always against a named version.
 ## Suites in Profile v1
 
 ```
-agent_identity_v0            enforcement_attestation_v0
-ap2_v0                       enforcement_set_v0
-article12_fold_v0            evidence_bundle_v0
-atlas_threat_v0              evidence_ref_v0
-attestation_result_v0        execution_receipt_v0
-audit_summary_v0             external_evidence_v0
-authorization_v0             governance_decision_v0
-build_bundle_v0              handoff_set_v0
-bundle_doc_v0                ingest_v0
-bundle_set_v0                key_rotation_v0
-capability_scope_v0          normalize_v0
-class_gate_v0                pq_hybrid_v0
+acp_checkout_v0              enforcement_attestation_v0
+agent_decision_v0            enforcement_set_v0
+agent_identity_v0            evidence_bundle_v0
+ap2_v0                       evidence_ref_v0
+article12_fold_v0            execution_receipt_v0
+atlas_threat_v0              external_evidence_v0
+attestation_result_v0        fallback_projection_v0
+audit_summary_v0             governance_decision_v0
+authorization_v0             handoff_set_v0
+build_bundle_v0              ingest_v0
+bundle_doc_v0                key_rotation_v0
+bundle_set_v0                normalize_v0
+capability_scope_v0          pq_hybrid_v0
+class_gate_v0                qualified_time_v0
 conformance_statement_v0     record_conformance_v0
 contiguity_v0                record_set_v0
 credential_binding_v0        sep2787_attestation_v0
-cross_org_handoff_v0         tap_v0
-cross_stack_revocation_v0    transparency_consistency_v0
-data_locality_v0             x402_settlement_v0
+credential_grant_v0          tap_v0
+crewai_enforcement_v0        transparency_consistency_v0
+cross_org_handoff_v0         x402_settlement_v0
+cross_stack_revocation_v0
+data_locality_v0
 decision_pairing_v0
 ```
 

--- a/docs/eidas-qel-profile.md
+++ b/docs/eidas-qel-profile.md
@@ -67,4 +67,6 @@ qualified.
 ## Sources
 
 - Reg (EU) 2024/1183 (eIDAS 2.0), Art. 45k / 45l: https://eur-lex.europa.eu/eli/reg/2024/1183
-- Status watch list and Stage 0 verdict: `research/eidas2_roadmap_20260627.md`
+- EU Trusted List of qualified trust service providers (the authoritative
+  source for whether a given QTSP holds qualified status):
+  https://eidas.ec.europa.eu/efda/tl-browser/

--- a/docs/mit_ai_risk_repository_mapping.md
+++ b/docs/mit_ai_risk_repository_mapping.md
@@ -117,4 +117,4 @@ The MIT AI Risk Repository is published under CC BY 4.0. The work cited here is:
 
 > Slattery, P., Saeri, A. K., Grundy, E. A. C., Graham, J., Noetel, M., Uuk, R., Dao, J., Pour, S., Casper, S., Thompson, N. (2024). "The AI Risk Repository: A Comprehensive Meta-Review, Database, and Taxonomy of Risks From Artificial Intelligence." arXiv:2408.12622.
 
-Database last updated 2025-12-03. Local copies of the v4 database and the companion AI Risk Mitigations sheet are tracked under `research/external/` for reproducibility.
+Database last updated 2025-12-03. The v4 database and the companion AI Risk Mitigations sheet are not redistributed here; download them from [airisk.mit.edu](https://airisk.mit.edu/) to reproduce the mapping against the same release.

--- a/tests/test_docs_conformance_profile_lists_every_suite.py
+++ b/tests/test_docs_conformance_profile_lists_every_suite.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The published profile has to name every suite the runner discovers.
+
+conformance-profile.md is the document that defines what conformance
+covers: "An implementation conforms to Profile v1 when, for every suite,
+its own vectors reproduce the published verdicts under the same checker."
+It said 37 suites and listed 37. The repository ships 43, and the runner
+discovers all 43.
+
+The six it never mentioned were acp_checkout_v0, agent_decision_v0,
+credential_grant_v0, crewai_enforcement_v0, fallback_projection_v0 and
+qualified_time_v0. A third party implementing to the published profile
+would not have known they exist, which is the wrong direction for a
+document whose whole job is to fix a target.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "conformance-profile.md"
+VECTORS = ROOT / "tests" / "vectors"
+
+
+def _shipped_suites() -> set[str]:
+    """Exactly what `conformance_runner.py --list` discovers."""
+    return {
+        path.name
+        for path in VECTORS.iterdir()
+        if (path / "_check_independent.py").exists()
+    }
+
+
+def _documented_suites() -> set[str]:
+    block = re.search(
+        r"## Suites in Profile v1\s*\n+```\n(.*?)```", DOC.read_text(), re.S
+    )
+    assert block, "conformance-profile.md no longer lists its suites"
+    return set(block.group(1).split())
+
+
+def test_every_shipped_suite_is_in_the_published_profile():
+    missing = _shipped_suites() - _documented_suites()
+    assert not missing, (
+        f"docs/conformance-profile.md does not list {sorted(missing)}, which "
+        f"ship with checkers. The profile understates its own coverage."
+    )
+
+
+def test_the_profile_lists_no_suite_that_does_not_ship():
+    invented = _documented_suites() - _shipped_suites()
+    assert not invented, (
+        f"docs/conformance-profile.md lists {sorted(invented)}, which is not "
+        f"in tests/vectors/ with a checker"
+    )
+
+
+def test_the_stated_count_is_the_real_count():
+    stated = re.search(r"Profile v1 covers the (\d+) suites", DOC.read_text())
+    assert stated, "conformance-profile.md no longer states a suite count"
+    assert int(stated.group(1)) == len(_shipped_suites())
+
+
+def test_the_always_skipping_suite_is_named():
+    """article12_fold_v0 takes a path argument, so it never runs bare."""
+    text = DOC.read_text()
+    assert "article12_fold_v0" in text
+    for suite in ("pq_hybrid_v0", "qualified_time_v0"):
+        assert suite in text, (
+            f"{suite} skips without an optional dependency; the profile has to "
+            f"say so or a reader reads the skip as a failure"
+        )

--- a/tests/test_docs_reference_real_paths.py
+++ b/tests/test_docs_reference_real_paths.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""A path a public document names has to be a path a reader can open.
+
+Three documents claimed the MIT AI Risk Repository v4 database and its
+mitigations sheet were "tracked under `research/external/` for
+reproducibility". `research/` has never been in the repository: `git
+ls-files research` returns nothing. A reproducibility claim pointing at a
+directory only we can see is the worst direction for that claim to be
+wrong in, and eidas-qel-profile.md went further and cited an internal
+research file in its Sources list.
+
+PRIOR_ART.md named `src/vaara/audit/ots_anchor.py`, removed in v1.53.0
+along with the OpenTimestamps anchor method it implemented.
+
+The check resolves the shorthand the docs legitimately use (`scorer/
+adaptive.py` and `vaara/compliance/engine.py` both mean the file under
+`src/`), then fails on anything left that does not exist.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DOCS = [
+    path
+    for path in sorted(ROOT.glob("docs/*.md"))
+    + [ROOT / name for name in ("README.md", "SPEC.md", "PRIVACY.md", "LICENSING.md")]
+    if path.exists()
+]
+
+#: Backticked file paths: `tests/vectors/x402_settlement_v0/expected.json`.
+_FILE = re.compile(
+    r"`([\w./\-]+/[\w./\-]+\.(?:py|json|yaml|yml|md|jsonl|cbor|toml|sh|txt|pem))`"
+)
+#: Backticked directories under a known top-level tree.
+_DIR = re.compile(
+    r"`((?:tests|src|docs|scripts|examples|conformance|bench|clients|ietf|plugins)"
+    r"/[\w./\-]*/)`"
+)
+
+#: Roots a document may leave off. `scorer/adaptive.py` means
+#: `src/vaara/scorer/adaptive.py`; `vaara/compliance/engine.py` means the same
+#: file under `src/`.
+_PREFIXES = ("", "src/vaara/", "src/", "docs/")
+
+
+def _exists(reference: str) -> bool:
+    # removeprefix, not lstrip: lstrip("./") also eats the leading dot of
+    # `.github/workflows/release.yml`, which then never resolves.
+    candidate = reference.removeprefix("./").removeprefix("../")
+    return any((ROOT / (prefix + candidate)).exists() for prefix in _PREFIXES)
+
+
+def _references(doc: Path) -> set[str]:
+    text = doc.read_text(encoding="utf-8")
+    found = set(_FILE.findall(text)) | set(_DIR.findall(text))
+    return {
+        reference for reference in found
+        if not reference.startswith(("http", "<", "~", "$"))
+    }
+
+
+@pytest.mark.parametrize("doc", DOCS, ids=lambda p: p.name)
+def test_documented_paths_exist(doc):
+    missing = sorted(r for r in _references(doc) if not _exists(r))
+    assert not missing, (
+        f"{doc.relative_to(ROOT)} names paths that are not in the repository: "
+        f"{missing}. Either the file moved, or the document is pointing a "
+        f"reader at something only we can see."
+    )
+
+
+def test_no_public_document_cites_the_private_research_tree():
+    """`research/` is internal and untracked; nothing public may lean on it."""
+    # Path references only. A URL that happens to contain the word is not a
+    # citation of our tree.
+    citing = [
+        doc.relative_to(ROOT)
+        for doc in DOCS
+        if any(
+            reference.removeprefix("../").startswith("research/")
+            for reference in _references(doc)
+        )
+    ]
+    assert not citing, (
+        f"these public documents cite the untracked research tree: {citing}. "
+        f"A reader cannot open it, and its filenames are internal."
+    )
+
+
+def test_the_scan_finds_something():
+    """A regex matching nothing would pass every case above."""
+    total = sum(len(_references(doc)) for doc in DOCS)
+    assert total >= 50, f"only {total} path references found across {len(DOCS)} docs"


### PR DESCRIPTION
A2 continued. This round came from resolving every repository path the public documents name, instead of reading them.

## What was wrong

**Three documents cited a tree that has never shipped.** COMPLIANCE.md, mit_ai_risk_repository_mapping.md and eidas-qel-profile.md told a reader that material is "tracked under `research/external/` for reproducibility". `git ls-files research` returns nothing. The tree is internal.

A reproducibility claim that points at a directory only we can open is the worst direction for that claim to be wrong in. The eIDAS profile went further and listed an internal research filename in its Sources section.

- The MIT AI Risk Repository v4 database and its mitigations sheet are third-party CC BY 4.0 files we do not redistribute, so both documents now say where to download them.
- The eIDAS Sources entry is now the EU Trusted List browser, which is the authoritative source for whether a QTSP holds qualified status and is something a reader can open.

**PRIOR_ART.md named a module that was deleted.** `src/vaara/audit/ots_anchor.py` went in v1.53.0 along with the OpenTimestamps anchor method it implemented. The history is accurate and stays; the dead path goes.

## Guard

`test_docs_reference_real_paths.py` resolves every backticked path across 39 documents, allowing for the shorthand the docs legitimately use (`scorer/adaptive.py` and `vaara/compliance/engine.py` both mean the file under `src/`), and fails on anything left that does not exist. A second case fails outright on any public document that cites the research tree.

Confirmed to fail on the text it replaces, and one bug in the guard itself was caught that way: `lstrip("./")` also ate the leading dot of `.github/workflows/release.yml`, so a file that does exist looked missing.