### PR TITLE
Adapter findings that disagreed with their provider, extras that hid a third of the test suite, a macOS app with no way to install its filter, and a documentation sweep that turned prose into checked claims.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,122 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.65.0] - 2026-08-10
+
+When a cloud or OSS guardrail blocks on something Vaara's parser does not model,
+the audit trail now records the disagreement instead of recording `allow`. The
+full test suite runs on a clean checkout, including the 1061 test functions that
+optional extras were hiding, and a test run no longer writes into a real audit
+trail. The macOS menu bar app can install the network filter and ask for the
+accessibility permission it needs. And every command line, file path, threshold
+and measured number the documentation prints is now checked against the code on
+every commit.
+
+### Evidence correctness
+
+Bedrock, GCP Model Armor and Guardrails AI each parsed per-category detail and
+then ignored the one top-level field the provider sets when it intervened:
+`action`, `filterMatchState` and `validation_passed` respectively. When a
+provider blocked on a policy type the parser did not model, no category was
+produced, `aggregate_verdict` saw an empty action set, and the finding came back
+`allow`. That was written to the hash-chained trail as "upstream guardrail:
+allow" while the provider had actually blocked, with no exception and no warning.
+
+The Rebuff adapter already cross-checked its own top-level signal against the
+per-layer parse. The other three now do the same: when the provider states it
+intervened and no parsed category did, the adapter records a category naming the
+disagreement rather than reporting clean. A provider verdict that agrees with the
+parse adds nothing, so a modelled block is not double-reported.
+`aggregate_verdict` gets its first test, having had none while every adapter
+resolves ambiguity through it.
+
+### Packaging and the test suite
+
+`pip install 'vaara[scitt]'` shipped a module it could not import.
+`vaara.audit.scitt_anchor` pulled a helper from `vaara.audit.receipt_anchor`,
+which imports `asn1crypto` at module level for its RFC 3161 path, and
+`asn1crypto` belongs to the `timeanchor` extra. The helper needs neither
+dependency and now lives in `vaara.audit.timeanchor`, whose module level is
+standard library only. `receipt_anchor` re-exports both names, so the documented
+import path is unchanged.
+
+`requirements-dev.txt` is compiled with `--extra=dev --extra=export`, and
+`export` is `cryptography` alone, so the main matrix installed almost no optional
+dependency. 93 test modules were skipped at import time, holding 1061 test
+functions. Installing attestation, scitt, timeanchor, pq and yaml takes the suite
+from 1733 passed to 2697 passed with no failures. A signing-extras job now covers
+that set and greps skip reasons rather than pinning a file list, so a new module
+gated on one of them is caught without editing the job.
+
+There was no `conftest.py`, so `pytest` on a machine that also runs Vaara
+appended test records to the live evidence chain: `InterceptionPipeline()` with
+no trail resolves `~/.vaara/trail/audit.db`, and a dozen further modules bind
+`Path.home()` into module-level constants. The redirect runs at conftest import
+time rather than in a fixture, because those constants bind at their own import.
+`VAARA_TEST_USE_REAL_HOME=1` opts out for deliberate debugging.
+
+### macOS client
+
+The menu bar app was never broken. It had never been launched and observed.
+
+`SystemExtensionManager.activate()` had no call site anywhere in the app, so
+nothing could submit the `OSSystemExtensionRequest` that installs the filter.
+Setup now carries a NETWORK FILTER section: Install wired to `activate()`, Turn
+off to `deactivate()`, Recheck to `refresh()`, and the five states the manager
+already published rendered as a dot and a line of text.
+
+`AccessibilityObserver.start()` guarded on `AXIsProcessTrusted()`, which never
+prompts, and returned early. The call that shows the System Settings prompt was
+therefore unreachable on exactly the machines that had not granted the
+permission, and macOS shows that prompt once per app, so an untrusted first
+launch stayed untrusted forever.
+
+`xcodegen` overwrote the system extension's `Info.plist` on every run, because
+the target declared both `INFOPLIST_FILE` and an `info:` block pointing at the
+same file. Each regeneration dropped `CFBundlePackageType SYSX` and the whole
+NetworkExtension dictionary, so the extension registered and filtered nothing.
+The workflow now asserts those keys on the built product rather than the source
+file. `clients/macos/build.sh` also could not run in any clone.
+
+Known limit, unchanged: the filter's entitlements are Apple-restricted and need a
+provisioning profile that only a paid Apple Developer Program membership issues.
+`./build.sh local` ad-hoc signs without them, so everything except the filter
+runs, and no traffic has yet reached `handleNewFlow`. `docs/PRIOR_ART.md` states
+that the traffic path is unproven.
+
+### Documentation checked against behaviour
+
+Twelve claims across the documents an evaluator opens first were checked by
+running what they point at, and did not survive it. Four are worth naming:
+
+- The Article 12(2) retention recipe exits 2 as printed. `vaara trail purge`
+  requires a tenant selector the document never mentioned.
+- VERDICTS.md listed 11 of the 14 EU AI Act requirements the engine enforces,
+  omitting 26(10), 50(1) and 73(1), two of them critical, in a document whose
+  job is to let a reader predict the verdict.
+- SPEC.md, which calls itself normative, offered `ML-DSA-65` as a receipt `alg`.
+  Nothing emits it and the reference checkers require `ES256`. The post-quantum
+  path that ships is an additive `pqSignature` block under a hybrid suite, now
+  Section 2.2.
+- conformance-profile.md fixed Profile v1 at 37 suites while 43 ship, so six
+  were absent from the target an outside implementer builds against.
+
+The rest: a lost adapter mapping row and two stale category counts, a
+conformity-report example showing output it does not produce, two verdict enum
+values that have never existed and three real ones undocumented, an OVERT
+example that skipped the step producing the file it then verifies, an ingest
+sequence that counts from 1 where the neighbouring section counts from 0, a
+benign FPR quoted 0.4 points above the artefact, a per-source attribution stated
+as if it held for both sources, and three documents citing a `research/` tree
+that has never been in the repository.
+
+Nine guards now run on every commit, each confirmed to fail on the text it
+replaced: documented command lines against the real CLI parser, documented paths
+against the checkout, measured percentages against the JSON they cite, adapter
+tables and counts against the mapping module, engine thresholds against both
+requirement bundles, the vector suite list against the vectors, and two
+documented examples executed end to end.
+
 ## [1.64.1] - 2026-08-09
 
 An index on `seq`, which the append path has needed since the backend was

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.64.1",
+  "version": "1.65.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.64.1",
+  "version": "1.65.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.64.1"
+version = "1.65.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.64.1",
+  "version": "1.65.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.64.1",
+"version": "1.65.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.64.1",
+  "version": "1.65.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.64.1",
+"version": "1.65.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.64.1"
+__version__ = "1.65.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Release v1.65.0. Everything below was found by running something, and the CHANGELOG entry is the release body.

## Evidence correctness

Bedrock, GCP Model Armor and Guardrails AI parsed per-category detail and ignored the one top-level field the provider sets when it intervened (`action`, `filterMatchState`, `validation_passed`). A provider block on a policy type the parser did not model produced no category, so `aggregate_verdict` saw an empty action set and the finding came back `allow`. That reached the hash-chained trail as "upstream guardrail: allow" while the provider had blocked, with no exception and no warning.

All three now do what the Rebuff adapter already did: when the provider says it intervened and no parsed category did, record a category naming the disagreement. `aggregate_verdict` gets its first test.

## Packaging and the test suite

- `pip install 'vaara[scitt]'` shipped a module that raised on import, because its helper pulled in `asn1crypto` from a different extra. The helper is stdlib plus a lazy import and now lives in `vaara.audit.timeanchor`; the documented import path is unchanged.
- 93 test modules were skipped at import time for want of an optional dependency, holding 1061 test functions. With attestation, scitt, timeanchor, pq and yaml installed the suite goes from 1733 passed to 2697 passed. A signing-extras job covers that set and greps skip reasons rather than pinning a file list.
- There was no `conftest.py`, so a test run on a machine that also runs Vaara appended records to the live evidence chain. The redirect runs at conftest import time because the paths bind as module-level constants.

## macOS client

The app was never broken. It had never been launched and observed.

- `SystemExtensionManager.activate()` had no call site, so nothing could ever install the filter. Setup now has a NETWORK FILTER section with Install, Turn off and Recheck, and renders the five states the manager already published.
- `AccessibilityObserver.start()` guarded on the silent `AXIsProcessTrusted()` and returned early, putting the System Settings prompt out of reach on exactly the machines that had not granted it.
- `xcodegen` replaced the system extension's `Info.plist` on every run, dropping `CFBundlePackageType SYSX` and the NetworkExtension dictionary. The workflow now asserts both on the built product.
- `build.sh` could not run in any clone.

Known limit, unchanged and stated in `docs/PRIOR_ART.md`: the filter entitlements need a provisioning profile only a paid Apple Developer Program membership issues, so no traffic has reached `handleNewFlow`.

## Documentation checked against behaviour

Twelve claims across COMPLIANCE.md, SPEC.md, VERDICTS.md, standards.md, conformance-profile.md, adapters.md, PRIOR_ART.md, eidas-qel-profile.md and mit_ai_risk_repository_mapping.md. Among them: a retention command that exits 2 as printed, an example showing output it does not produce, a normative spec offering an algorithm nothing emits, a conformance profile understating itself by six suites, and three documents citing a `research/` tree that has never shipped.

Nine guards now run on every commit, each confirmed to fail on the text it replaced.

| Guard | What it pins |
|---|---|
| documented command lines | parsed against the real CLI, fenced blocks in full and inline spans from two flags up |
| documented paths | resolved against the checkout across 39 documents |
| measured percentages | against the JSON artefacts the document cites |
| adapter tables and counts | against the mapping module |
| engine thresholds | every number, both requirement bundles |
| vector suite list | against the suites that ship |
| two examples | executed end to end and compared to real output |

## Verification

Full suite under `scripts/release_prepare.sh`, plus the aggregate conformance runner: 40 passed, 0 failed, 3 skipped across 43 suites with `rfc8785` and `cryptography` alone and no Vaara on the path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 1.65.0 is now available across the package, plugin, and server metadata.
  * Added changelog coverage for guardrail disagreement recording, optional-dependency packaging, expanded testing, macOS setup, and documentation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->