### PR TITLE
docs: four documents claimed things the code does not

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -30,11 +30,12 @@ unless anonymity is requested.
 
 | Version | Supported |
 | ------- | --------- |
-| 0.4.x   | Yes       |
-| < 0.4   | No        |
+| 1.65.x  | Yes       |
+| < 1.65  | No        |
 
 Only the latest minor release receives security fixes. Older minor lines may
-receive patches at our discretion for severe issues.
+receive patches at our discretion for severe issues. Releases are frequent, so
+treat this table as naming the current line rather than a long-term window.
 
 ## Scope
 
@@ -62,8 +63,9 @@ receive patches at our discretion for severe issues.
 ## Security Considerations for Users
 
 - Always pin vaara to a specific version in production.
-- Verify PyPI artefacts against published checksums and (future) Sigstore
-  attestations.
+- Verify PyPI artefacts against published checksums and the Sigstore
+  attestations, which ship with every release and are produced by the
+  release workflow alongside SLSA provenance.
 - When deploying signed audit exports, protect the signing private key using
   OS-level key management (hardware-backed keystore or HSM recommended).
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -27,9 +27,10 @@ terms directly. Contact: hello@vaara.io.
 
 ## History
 
-Releases up to and including v0.71.0 were published under the Apache
-License 2.0 and remain available under those terms. From the next
-release onward, Vaara is licensed under AGPL-3.0-or-later.
+Releases up to and including v0.70.0 were published under the Apache
+License 2.0 and remain available under those terms. The relicensing
+commit landed after that tag, and v1.0.0 is the first release published
+under AGPL-3.0-or-later. Every release from v1.0.0 onward is AGPL.
 
 ## Contributions
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,13 +8,24 @@ Vaara is an open-source project. This page describes how the Vaara software, web
 
 The Vaara software does not send telemetry. It does not phone home, beacon, or transmit usage data to any server. The audit database is a local SQLite file on your machine; its contents do not leave your system unless you choose to share them.
 
-If you self-host an MCP proxy with Vaara, network behavior is under your control. Vaara opens no connection unless you ask it to, and the complete list of times it does is:
+If you self-host an MCP proxy with Vaara, network behavior is under your control. Vaara opens no connection on its own account. Every outbound request is either one you invoked or one aimed at an address you chose, and they fall into three groups.
+
+**Endpoints you configure.** Vaara contacts these only at the address you supply, and only when you use the feature that needs them.
+
+- **Time anchoring.** The RFC 3161 or eIDAS timestamp authority you configure. There is no default and no fallback authority.
+- **A remote scorer**, if you compose one into scoring.
+- **The x402 payment facilitator**, if you run the payment surface.
+- **Proxy and cross-check upstreams**: whatever sits behind the MCP proxy, the LLM proxy, and the inference cross-check.
+- **Your own Vaara server**, when the CLI reloads a policy against it.
+
+**Fetches Vaara makes for itself.** Two, both opt-in.
 
 - **The optional ML classifier.** `pip install 'vaara[ml]'` downloads `sentence-transformers/all-MiniLM-L6-v2` from Hugging Face the first time a score needs an embedding, pinned to a fixed revision. It is cached after that and everything later is offline. The classifier is opt-in and the base install never reaches for it. Pre-fetch the model if you need a host that never has network access.
 - **"Check for updates" in `vaara menu`.** Fetches the published version from pypi.org, and only when you pick that item from the menu. The request carries nothing about your installation; the comparison against your installed version happens locally.
-- **Time anchoring.** Contacts the RFC 3161 or eIDAS timestamp authority you configure, at the address you give it. There is no default and no fallback authority.
 
-Nothing on that list runs on its own schedule, in the background, or as a side effect of recording evidence. A base install writing to the trail opens no socket at all.
+**Identity resolution during verification.** This one is neither of the above, so it is named separately. Verifying a receipt whose issuer identity is a `did:web` identifier resolves that identifier over HTTPS, which means a request to the issuer's own domain. The fetch is HTTPS-only, size-capped, and refuses redirects. Deployers who need host allowlisting, pinning, or proxy egress inject their own fetcher instead.
+
+Nothing here runs on its own schedule, in the background, or as a side effect of recording evidence. A base install writing to the trail opens no socket at all.
 
 ## Website (vaara.io)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-How Vaara processes a tool call, how it scores, and how the audit trail is anchored in time. The formal guarantees (MWU regret bound, conformal coverage, security properties) are in [formal_specification.md](formal_specification.md); the benchmark numbers are in the project [README](../README.md#how-it-scores) and under [bench/](../bench/).
+How Vaara processes a tool call, how it scores, and how the audit trail is anchored in time. The formal guarantees (MWU regret bound, conformal coverage, security properties) are in [formal_specification.md](formal_specification.md); the benchmark numbers are under [bench/](../bench/).
 
 ## How it works
 


### PR DESCRIPTION
Continuing the A2 sweep, this time by resolving each claim against the code
instead of reading the prose.

**LICENSING.md** placed the Apache-to-AGPL boundary at v0.71.0. That tag has
never existed. The repository has 172 tags and none is named that. The
relicensing commit landed after `v0.70.0`, and the first version tag
containing it is `v1.0.0`. The boundary now reads v0.70.0 as the last Apache
release and v1.0.0 as the first AGPL one.

**PRIVACY.md** promised "the complete list" of the times Vaara opens a
connection, then gave three items. The package makes outbound requests in
more places: a remote scorer, the x402 facilitator, the CLI reloading a
policy against your own server, the proxy and inference cross-check
upstreams, and `did:web` identity resolution during verification. Every one
of those is either invoked by the operator or aimed at an address the
operator supplies, so the substance of the promise held and the enumeration
did not. It is now grouped three ways: endpoints you configure, fetches
Vaara makes for itself, and identity resolution during verification, which
is called out separately because it is neither of the first two.

Checked in the same pass and deliberately left alone: none of the three
hardcoded hosts in the package is ever fetched. `api.melious.ai` is an
example in `--help` text, `kdsintf.amd.com` appears in a docstring about
work that does not ship, and the EU List of Trusted Lists URL is a constant
the operator picks from. There is no default timestamp authority, and the
embedding model is pinned to a fixed revision, both exactly as documented.

**SECURITY.md** listed 0.4.x as the supported line. The current release is
1.65.0, so a reader running a current version would have concluded it was
unsupported. It also described Sigstore attestations as "(future)" when
every release ships them alongside SLSA provenance.

**docs/architecture.md** linked to `README.md#how-it-scores`. The README has
four headings and that is not among them, so the anchor landed at the top of
the file.

**README.md** was audited in the same pass and needed no change. Every local
path resolves, every CLI verb it names exists, the dependency list really is
empty, and the documented default trail path matches `cli.py`.

Documentation only. No code paths touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported release information and clarified Sigstore and SLSA provenance coverage.
  * Documented licensing history, including the transition to AGPL-3.0-or-later.
  * Expanded privacy documentation to describe outbound network requests and configurable fetch controls.
  * Updated architecture documentation with links to benchmark scoring information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->