### PR TITLE
fix: two tests that quietly reported the wrong thing

### DIFF
--- a/tests/test_receipt_identity.py
+++ b/tests/test_receipt_identity.py
@@ -182,14 +182,21 @@ def test_signature_matches_second_key_in_document():
 def test_tampered_signature_does_not_bind():
     priv = ec.generate_private_key(ec.SECP256R1())
     receipt = _emit(alg="ES256", signing_material=priv)
+    # Overwriting the first byte with a constant does not tamper with anything
+    # when the signature already starts with that constant, which is roughly 1
+    # run in 256. The receipt then verifies correctly and the assertion below
+    # fails against a verifier that did nothing wrong. Inverting the byte always
+    # changes it, and the guard makes a silent no-op impossible.
+    flipped = f"{int(receipt.signature[:2], 16) ^ 0xFF:02x}"
     tampered = receipt.__class__(
         version=receipt.version,
         alg=receipt.alg,
         back_link=receipt.back_link,
         receipt_asserted=receipt.receipt_asserted,
         outcome_derived=receipt.outcome_derived,
-        signature="00" + receipt.signature[2:],
+        signature=flipped + receipt.signature[2:],
     )
+    assert tampered.signature != receipt.signature
     doc = _did_document(_ec_jwk(priv.public_key()))
     assert verify_receipt_identity(tampered, doc).bound is False
 

--- a/tests/test_spec_matches_the_vectors.py
+++ b/tests/test_spec_matches_the_vectors.py
@@ -134,7 +134,13 @@ def test_checkers_pass_without_vaara_importable(directory, tmp_path):
         env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
     )
     if done.returncode == SKIP:
-        pytest.skip(done.stdout.strip() or "optional dependency missing")
+        # The reason goes to stderr, prefixed "SKIP: ", which is the convention
+        # scripts/conformance_runner.py already reads. Reading stdout here meant
+        # every skip reported the generic fallback, so a third party running the
+        # corpus saw a suite decline to run and was told nothing about why.
+        lines = done.stderr.strip().splitlines()
+        reason = lines[-1].removeprefix("SKIP: ") if lines else ""
+        pytest.skip(reason or "optional dependency missing")
     # `cryptography` and `rfc8785` are the two the checkers are allowed to
     # need, and both are extras. On a base install they are absent, which is
     # the environment's business and not a claim failing.


### PR DESCRIPTION
Two test-side defects found while auditing why the suite cannot reach 100
percent. Neither is a product bug, and one of them looks exactly like one
until you measure it.

## A skipped conformance suite told the reader nothing

`test_checkers_pass_without_vaara_importable` read a skipping checker's reason
from stdout. The checkers print it to stderr, prefixed `SKIP: `, which is the
convention `scripts/conformance_runner.py` already reads at its line 99. The
branch therefore always fell through to its generic fallback, and every skip
surfaced as "optional dependency missing".

The effect landed on the exact claim the corpus exists to support. A third
party running the suites saw one decline to run and was told nothing about
which dependency was missing or how to install it, while the checker had
composed that sentence and printed it the whole time.

Now reads stderr and strips the prefix, the same way the runner does. The skip
reports `pq_hybrid_v0 needs an optional dependency not installed: dilithium_py
(pip install 'vaara[pq]')`.

## The tamper test did not always tamper

`test_tampered_signature_does_not_bind` forged its receipt by overwriting the
first hex byte of the signature with `00`. When a signature already began with
`00`, the forged receipt was byte-identical to the original,
`verify_receipt_identity` correctly reported `bound=True`, and the test failed
against a verifier that had done nothing wrong.

Measured over 3000 freshly generated ES256 signatures, 6 start with `00`, so
this was a 0.2 percent flake. It fired on the signing-extras job of the first
run of this PR and reads on sight like a fail-open in identity binding. It is
not one.

Inverting the byte always changes it, and an added assertion that the two
signatures differ makes a silent no-op impossible rather than merely unlikely.
Verified over 400 consecutive runs, no failures.

## Measured in the same pass, no change needed

41 of the 43 checkers pass in an environment carrying `asn1crypto`,
`article12_fold_v0` takes a package path on the command line by design, and
`pq_hybrid_v0` skips without the pq extra. `docs/conformance-profile.md` states
"40 passed, 0 failed, 3 skipped" for a clean checkout with `rfc8785` and
`cryptography` alone, where `qualified_time_v0` skips as well. That is correct
for the environment it names and is left as written.
