### PR TITLE
fix(action): shorten the description below the Marketplace limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.66.1] - 2026-08-12
+
+### Fixed
+
+- The action's description was 147 characters. GitHub Marketplace rejects
+  anything from 125, so publishing the action was blocked. Shortened to 114.
+  The long form stays in the README.
+
 ## [1.66.0] - 2026-08-12
 
 Vaara can now run as a step in someone else's build, and its conformance vectors

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,7 @@
 name: 'Vaara policy check'
-description: 'Validate a Vaara policy, run its test cases, and verify a signed audit trail. Fails the build on a policy error, a failing case, or a broken trail.'
+# GitHub Marketplace rejects a description of 125 characters or more, so this
+# stays short deliberately. The long form lives in the README.
+description: 'Validate a Vaara policy, run its test cases, and verify a signed audit trail. Fails the build on any of the three.'
 author: 'Vaara'
 
 branding:

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.66.0"
+version = "1.66.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.66.0"
+__version__ = "1.66.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
GitHub Marketplace rejects an action description of 125 characters or more. The action's description was 147, which blocked publishing it.

Shortened to 114 characters. The full sentence stays in the README, and a comment in `action.yml` records the limit so it does not creep back.

Released as 1.66.1 so the published tag carries the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shortened the GitHub Action description to meet Marketplace publication requirements without changing functionality.

* **Release**
  * Updated the project version to 1.66.1 across supported packages.
  * Added changelog documentation for the 1.66.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->