### PR TITLE
fix(action): create the v1 tag the docs already tell people to use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,11 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Full versions only. The floating major tag (v1) that GitHub Actions
+      # consumers pin to is moved on every release, and 'v*' would fire this
+      # workflow for it, derive VERSION=1, and fail looking for a CHANGELOG
+      # entry that cannot exist.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions: read-all
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.66.2] - 2026-08-12
+
+### Fixed
+
+- **The documented way to use the action did not work.** The README and
+  `docs/github-action.md` tell consumers `uses: vaaraio/vaara@v1`, which is the
+  GitHub Actions convention, but no `v1` tag existed. Anyone copying that line
+  got "unable to resolve action vaaraio/vaara@v1". A floating `v1` tag now
+  exists and moves with each release.
+- The release workflow triggered on `v*`, which would have fired it for the
+  floating `v1` tag, derived version "1", and failed looking for a changelog
+  entry that cannot exist. It now triggers only on full version tags.
+- One example in `docs/github-action.md` pinned `v1.65.0`, a release that
+  predates the action existing.
+
+### Changed
+
+- The action's display name is now "Vaara Policy Check". This is the title
+  GitHub Marketplace shows. The listing URL is unaffected.
+
 ## [1.66.1] - 2026-08-12
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Vaara policy check'
+name: 'Vaara Policy Check'
 # GitHub Marketplace rejects a description of 125 characters or more, so this
 # stays short deliberately. The long form lives in the README.
 description: 'Validate a Vaara policy, run its test cases, and verify a signed audit trail. Fails the build on any of the three.'

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.66.1",
+  "version": "1.66.2",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -79,7 +79,7 @@ also writes a summary to the job page listing every issue and every failing case
 to reproduce later, pin both the action and the package:
 
 ```yaml
-      - uses: vaaraio/vaara@v1.65.0
+      - uses: vaaraio/vaara@v1.66.1
         with:
           policy: policies/production.yaml
           version: 1.65.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.66.1"
+version = "1.66.2"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.66.1"
+__version__ = "1.66.2"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
The Marketplace listing went live today and the documented usage was broken.

## The defect

`README.md` and `docs/github-action.md` instruct consumers to pin `uses: vaaraio/vaara@v1`, which is the standard GitHub Actions convention. **No `v1` tag existed.** Anyone copying that line from the listing or the README got `unable to resolve action vaaraio/vaara@v1`.

## The fix

A floating `v1` tag, moved on each release, as `actions/checkout` and every other published action does.

That required narrowing the release trigger. It matched `v*`, so moving `v1` would have started a release, derived `VERSION=1` from the tag, and failed looking for a changelog entry for version 1. It now matches full version tags only.

Also fixed: one example pinned `v1.65.0`, which predates the action existing.

## Changed

The action's display name is now "Vaara Policy Check", which is the title Marketplace shows. The listing URL is derived from a lowercased slug so it does not move.