### PR TITLE
feat: key search in the Resin, rules in the dashboard, favicon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ where = ["src"]
 # dashboard.html is read at runtime by dashboard.py. include-package-data is
 # false, so without this line `vaara dashboard` works from a checkout and fails
 # for everyone who installed the wheel.
-vaara = ["data/adversarial_classifier_v9.joblib", "py.typed", "dashboard.html", "assets/*.png"]
+vaara = ["data/adversarial_classifier_v9.joblib", "py.typed", "dashboard.html", "assets/*.png", "assets/*.svg"]
 # Declarative source-profile specs loaded at runtime by _declarative.py.
 "vaara.attestation" = ["profiles/*.json"]
 # Default deny patterns for the Claude Code hook runner (vaara hook).

--- a/src/vaara/assets/favicon.svg
+++ b/src/vaara/assets/favicon.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Vaara">
+  <rect x="4" y="4" width="56" height="56" rx="11" ry="11"
+        fill="#1A2226" stroke="#7B9C8A" stroke-width="1.5"/>
+  <polygon points="32,22 44,42 20,42" fill="#78A08A"/>
+</svg>

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -739,6 +739,7 @@ def _cmd_dashboard(args: argparse.Namespace) -> int:
     return serve(
         db=args.db,
         trail=args.trail,
+        policy=args.policy,
         host=args.host,
         port=port,
         open_browser=not args.no_browser,
@@ -4826,6 +4827,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="Serve a local read-only dashboard (any OS, no extra dependencies)",
     )
     _add_trail_source_args(pdash)
+    pdash.add_argument("--policy", default=None,
+                       help="Policy file to show and edit thresholds in "
+                            "(.yaml/.yml/.json). Read-only without it.")
     pdash.add_argument("--host", default="127.0.0.1",
                        help="Bind address. Defaults to loopback only.")
     pdash.add_argument("--port", type=int, default=0,

--- a/src/vaara/dashboard.html
+++ b/src/vaara/dashboard.html
@@ -12,6 +12,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Vaara</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <style>
   :root {
     color-scheme: light;
@@ -149,6 +150,10 @@
     you run <code>vaara trail publish-head</code>.
   </p>
 
+  <p class="stamp">Rules</p>
+  <div id="rules" class="panel"></div>
+  <p class="muted" style="font-size:.78rem;margin-top:8px" id="pol-path"></p>
+
   <p class="stamp">Settings</p>
   <div id="settings" class="panel"></div>
   <p class="muted" style="font-size:.78rem;margin-top:8px" id="cfg-path"></p>
@@ -263,6 +268,68 @@ async function saveSetting(key, value, el) {
   setTimeout(() => { el.textContent = ""; }, 2500);
 }
 
+async function loadRules() {
+  let p;
+  try { p = await (await fetch("/api/policy")).json(); }
+  catch (e) { $("rules").innerHTML = "could not read policy: " + esc(e.message); return; }
+
+  if (!p.loaded) {
+    $("rules").innerHTML =
+      `<div class="field"><div class="lbl"><div class="n">No policy loaded</div>`
+      + `<div class="h">${esc(p.reason || "")}</div></div></div>`;
+    $("pol-path").textContent = p.path
+      ? "Tried " + p.path : "Start with --policy PATH to read and edit the rules here.";
+    return;
+  }
+
+  // Thresholds decide whether an agent is stopped, so they are edited against
+  // the same validator the pipeline loads with, and refused if it objects.
+  $("rules").innerHTML = `
+    <div class="field">
+      <div class="lbl"><div class="n">Escalate above</div>
+        <div class="h">A score above this asks a human instead of allowing.</div></div>
+      <input id="th-esc" type="number" step="0.01" min="0" max="1"
+             value="${esc(p.escalate)}" style="width:6.5rem">
+      <span class="saved" id="s-th"></span>
+    </div>
+    <div class="field">
+      <div class="lbl"><div class="n">Deny above</div>
+        <div class="h">A score above this is refused outright. Must be higher than escalate.</div></div>
+      <input id="th-deny" type="number" step="0.01" min="0" max="1"
+             value="${esc(p.deny)}" style="width:6.5rem">
+      <button id="th-save" style="margin:0">Save</button>
+    </div>
+    <div class="field">
+      <div class="lbl"><div class="n">Action classes</div>
+        <div class="h">${esc(p.action_class_count)} declared${
+          p.issues && p.issues.length ? " · " + esc(p.issues.length) + " validator note(s)" : ""}</div></div>
+    </div>`;
+  $("pol-path").textContent = "Rules live in " + p.path
+    + ". A backup is written beside it before any change, and an edit the "
+    + "validator rejects is never written.";
+
+  $("th-save").addEventListener("click", async () => {
+    const el = $("s-th");
+    try {
+      const res = await fetch("/api/policy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Vaara-Token": TOKEN },
+        body: JSON.stringify({
+          escalate: parseFloat($("th-esc").value),
+          deny: parseFloat($("th-deny").value),
+        }),
+      });
+      const r = await res.json();
+      el.textContent = r.error ? r.error : "saved";
+      el.style.color = r.error ? "var(--deny)" : "var(--allow)";
+      if (!r.error) loadRules();
+    } catch (e) {
+      el.textContent = e.message; el.style.color = "var(--deny)";
+    }
+    setTimeout(() => { el.textContent = ""; }, 4000);
+  });
+}
+
 async function loadSettings() {
   let c;
   try { c = await (await fetch("/api/config")).json(); }
@@ -320,7 +387,7 @@ async function loadSettings() {
 })();
 
 load();
-loadSettings();
+loadSettings().then(loadRules);
 setInterval(load, 5000);
 </script>
 </body>

--- a/src/vaara/dashboard.py
+++ b/src/vaara/dashboard.py
@@ -36,9 +36,43 @@ from typing import Any, Optional
 _PAGE = Path(__file__).with_name("dashboard.html")
 _ASSET_DIR = Path(__file__).with_name("assets")
 _ASSETS = {
-    "/vaara-wordmark-light.png": _ASSET_DIR / "vaara-wordmark-light.png",
-    "/vaara-wordmark-dark.png": _ASSET_DIR / "vaara-wordmark-dark.png",
+    "/vaara-wordmark-light.png": (_ASSET_DIR / "vaara-wordmark-light.png", "image/png"),
+    "/vaara-wordmark-dark.png": (_ASSET_DIR / "vaara-wordmark-dark.png", "image/png"),
+    "/favicon.svg": (_ASSET_DIR / "favicon.svg", "image/svg+xml"),
 }
+
+
+def _policy_state(path: Optional[Path]) -> dict:
+    """Read the active policy and validate it, without importing the pipeline.
+
+    Rules are the sharpest thing on this page: they decide what an agent is
+    allowed to do. So the dashboard reports what is loaded, what the validator
+    says about it, and where it came from, rather than showing thresholds with
+    no indication of whether the file is even sound.
+    """
+    if not path or not path.exists():
+        return {"path": str(path) if path else "", "loaded": False,
+                "reason": "no policy file configured (--policy)"}
+    try:
+        from vaara.policy.validate import validate_source
+
+        policy, report = validate_source(path)
+        if policy is None:
+            return {"path": str(path), "loaded": False,
+                    "reason": "policy did not parse",
+                    "issues": [str(i) for i in report.issues][:20]}
+        th = policy.thresholds_default
+        return {
+            "path": str(path),
+            "loaded": True,
+            "escalate": th.escalate,
+            "deny": th.deny,
+            "action_classes": sorted(policy.action_classes)[:40],
+            "action_class_count": len(policy.action_classes),
+            "issues": [str(i) for i in report.issues][:20],
+        }
+    except Exception as exc:
+        return {"path": str(path), "loaded": False, "reason": repr(exc)}
 
 
 def _load_trail(db_path: Optional[Path], trail_path: Optional[Path]) -> Any:
@@ -134,6 +168,7 @@ _SETTINGS: dict[str, dict] = {
 class _Handler(BaseHTTPRequestHandler):
     db_path: Optional[Path] = None
     trail_path: Optional[Path] = None
+    policy_path: Optional[Path] = None
     # A page in another tab can POST to 127.0.0.1 without ever reading the
     # response. It cannot read this token, which is only in the page we serve,
     # so requiring it on writes closes that door.
@@ -162,8 +197,9 @@ class _Handler(BaseHTTPRequestHandler):
                 return
             if path in _ASSETS:
                 # Served from the installed package, not fetched. The real
-                # wordmark, and it still renders with the network off.
-                self._send(_ASSETS[path].read_bytes(), "image/png")
+                # assets, and they still render with the network off.
+                asset, ctype = _ASSETS[path]
+                self._send(asset.read_bytes(), ctype)
                 return
             if path == "/api/summary":
                 trail = _load_trail(self.db_path, self.trail_path)
@@ -172,6 +208,9 @@ class _Handler(BaseHTTPRequestHandler):
             if path == "/api/history":
                 trail = _load_trail(self.db_path, self.trail_path)
                 self._json(_history(trail, 200))
+                return
+            if path == "/api/policy":
+                self._json(_policy_state(self.policy_path))
                 return
             if path == "/api/config":
                 from vaara.menu import CONFIG_PATH, _load_config
@@ -189,7 +228,7 @@ class _Handler(BaseHTTPRequestHandler):
 
     def do_POST(self) -> None:  # noqa: N802  (BaseHTTPRequestHandler API)
         path = self.path.split("?", 1)[0]
-        if path != "/api/config":
+        if path not in ("/api/config", "/api/policy"):
             self._json({"error": "not found"}, 404)
             return
         if self.headers.get("X-Vaara-Token", "") != self.token:
@@ -200,6 +239,10 @@ class _Handler(BaseHTTPRequestHandler):
             payload = json.loads(self.rfile.read(length) or b"{}")
         except Exception as exc:
             self._json({"error": f"unreadable body: {exc!r}"}, 400)
+            return
+
+        if path == "/api/policy":
+            self._write_thresholds(payload)
             return
 
         from vaara.menu import CONFIG_PATH, _load_config, _save_config
@@ -225,6 +268,66 @@ class _Handler(BaseHTTPRequestHandler):
             return
         self._json({"saved": changed, "path": str(CONFIG_PATH)})
 
+    def _write_thresholds(self, payload: dict) -> None:
+        """Write escalate/deny back to the policy file, validator-gated.
+
+        A threshold decides whether an agent is stopped, so this refuses
+        anything the policy validator would reject rather than writing a file
+        the pipeline will then fail to load.
+        """
+        import json as _json
+
+        path = self.policy_path
+        if not path or not path.exists():
+            self._json({"error": "no policy file configured (--policy)"}, 400)
+            return
+        try:
+            esc = float(payload["escalate"]); deny = float(payload["deny"])
+        except Exception:
+            self._json({"error": "escalate and deny must be numbers"}, 400)
+            return
+        if not (0.0 <= esc <= 1.0 and 0.0 <= deny <= 1.0):
+            self._json({"error": "thresholds must be in [0,1]"}, 400)
+            return
+        if esc >= deny:
+            self._json({"error": f"escalate ({esc}) must be below deny ({deny})"}, 400)
+            return
+
+        text = path.read_text()
+        is_yaml = path.suffix in (".yaml", ".yml")
+        if is_yaml:
+            try:
+                import yaml
+            except ImportError:
+                self._json({"error": "editing a YAML policy needs the yaml extra"}, 400)
+                return
+            data = yaml.safe_load(text) or {}
+        else:
+            data = _json.loads(text or "{}")
+
+        # The document key is thresholds.default. thresholds_default is the
+        # dataclass field name, and writing that instead produced a block the
+        # loader ignored while the write reported success.
+        th = data.setdefault("thresholds", {}).setdefault("default", {})
+        th["escalate"], th["deny"] = esc, deny
+
+        # Validate the whole edited document before it replaces anything.
+        from vaara.policy.validate import validate_source
+
+        policy, report = validate_source(data)
+        if policy is None:
+            self._json({"error": "the edit would not validate",
+                        "issues": [str(i) for i in report.issues][:10]}, 400)
+            return
+
+        new_text = (yaml.safe_dump(data, sort_keys=False) if is_yaml
+                    else _json.dumps(data, indent=2) + "\n")
+        backup = path.with_suffix(path.suffix + ".bak")
+        backup.write_text(text)
+        path.write_text(new_text)
+        self._json({"saved": {"escalate": esc, "deny": deny},
+                    "path": str(path), "backup": str(backup)})
+
     def log_message(self, *args: Any) -> None:
         """Silence the default stderr access log; this is a desktop tool."""
 
@@ -233,6 +336,7 @@ def serve(
     *,
     db: Optional[str] = None,
     trail: Optional[str] = None,
+    policy: Optional[str] = None,
     host: str = "127.0.0.1",
     port: int = 7517,
     open_browser: bool = True,
@@ -243,6 +347,7 @@ def serve(
 
     _Handler.db_path = Path(db).expanduser() if db else None
     _Handler.trail_path = Path(trail).expanduser() if trail else None
+    _Handler.policy_path = Path(policy).expanduser() if policy else None
     _Handler.token = secrets.token_urlsafe(24)
 
     try:

--- a/webpage/verify.html
+++ b/webpage/verify.html
@@ -98,7 +98,7 @@
   /* Same wordmark treatment as index.html, keyed off the same data-theme
      attribute the shared toggle sets. */
   .wordmark { margin:8px auto 0; text-align:center; }
-  .wordmark img { width:min(60vw,340px); height:auto; display:inline-block; }
+  .wordmark img { width:min(60vw,440px); height:auto; display:inline-block; }
   .wordmark .wm-dark { display:none; }
   html[data-theme="dark"] .wordmark .wm-light { display:none; }
   html[data-theme="dark"] .wordmark .wm-dark { display:inline-block; }
@@ -137,8 +137,8 @@
 </div>
 <main>
   <div class="wordmark">
-    <a href="/"><img class="wm-light" src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-light.png" alt="Vaara" width="340" height="98"></a>
-    <a href="/"><img class="wm-dark" src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-dark.png" alt="Vaara" width="340" height="98"></a>
+    <a href="/"><img class="wm-light" src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-light.png" alt="Vaara" width="440" height="127"></a>
+    <a href="/"><img class="wm-dark" src="https://raw.githubusercontent.com/vaaraio/vaara/main/docs/vaara-wordmark-dark.png" alt="Vaara" width="440" height="127"></a>
   </div>
   <p class="stance">Accountable Autonomy</p>
 
@@ -163,11 +163,17 @@
       <div class="tile"><div class="k">entries</div><div class="v" id="t-size">—</div></div>
       <div class="tile"><div class="k">root</div><div class="v" id="t-root">—</div></div>
     </div>
-    <input id="q" spellcheck="false" placeholder="sha256 digest, or verify a receipt above first">
+    <input id="q" spellcheck="false" placeholder="sha256 digest, or paste your public key to see everything you published">
     <div>
       <button id="look">Look up</button>
       <button id="latest" class="ghost">Latest entries</button>
     </div>
+    <p class="sub" style="margin:.7rem 0 0">
+      Paste a public key and the log returns every head published with it. No
+      account, no sign-in: the key is the identity, and the answer comes from the
+      log rather than from us. Your private key is never involved and must never
+      be pasted anywhere.
+    </p>
     <div id="rolls" style="margin-top:.9rem"></div>
     <p class="sub" style="margin:1rem 0 0">
       <strong>Before you opt in.</strong> A digest reveals no content, no size and no
@@ -454,6 +460,19 @@ function esc(s) {
     ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
 }
 
+async function rekorSearchByKey(pem) {
+  const b64 = btoa(pem.trim());
+  const res = await fetch(`${REKOR}/api/v1/index/retrieve`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    // format must be one of pgp/x509/minisign/ssh/tuf; a SubjectPublicKeyInfo
+    // PEM is x509 here, and the content is that PEM base64-encoded again.
+    body: JSON.stringify({ publicKey: { format: "x509", content: b64 } }),
+  });
+  if (!res.ok) throw new Error(`index/retrieve returned ${res.status}`);
+  return res.json();
+}
+
 async function rekorSearchByHash(hexDigest) {
   const res = await fetch(`${REKOR}/api/v1/index/retrieve`, {
     method: "POST",
@@ -500,11 +519,37 @@ function renderEntries(list, total) {
     </div>`).join("");
 }
 
-async function lookup(hexDigest) {
-  const clean = (hexDigest || "").trim().replace(/^sha256:/i, "").toLowerCase();
+async function lookup(input) {
+  const raw = (input || "").trim();
+
+  // A pasted public key means "show me everything I published". Refuse a
+  // private key outright: nobody should ever be typing one into a web page,
+  // and a tool that quietly accepts it teaches a dangerous habit.
+  if (/-----BEGIN [A-Z ]*PRIVATE KEY-----/.test(raw)) {
+    $("rolls").innerHTML = row("no", "That is a private key. Do not paste it anywhere",
+      "Only the public half is needed here, and nothing on this page ever needs "
+      + "a private key. Close this tab and treat that key as compromised.");
+    $("q").value = "";
+    return;
+  }
+  if (/-----BEGIN PUBLIC KEY-----/.test(raw)) {
+    $("rolls").innerHTML = row("dim", "Asking the public log…");
+    try {
+      const uuids = (await rekorSearchByKey(raw)) || [];
+      const entries = [];
+      for (const u of uuids.slice(0, 20)) entries.push(await rekorEntry(u));
+      entries.sort((a, b) => b.integratedTime - a.integratedTime);
+      renderEntries(entries, uuids.length);
+    } catch (e) {
+      $("rolls").innerHTML = row("warn", "Could not reach the public log", esc(e.message));
+    }
+    return;
+  }
+
+  const clean = raw.replace(/^sha256:/i, "").toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(clean)) {
-    $("rolls").innerHTML = row("no", "That is not a sha256 digest",
-      "Expecting 64 hex characters.");
+    $("rolls").innerHTML = row("no", "That is not a sha256 digest or a public key",
+      "Expecting 64 hex characters, or a PEM public key block.");
     return;
   }
   $("rolls").innerHTML = row("dim", "Asking the public log…");


### PR DESCRIPTION
This work was pushed to the 558 branch after auto-merge had already squashed it, so it never landed. Same commit, recovered onto a fresh branch.

## Search the Resin by public key

Paste a public key and the log returns every head published with it. No account, no sign-in: the key is the identity, and the answer comes from the log rather than from us.

Rekor wants `format: x509` with the PEM base64-encoded again. Verified against the drawer's own key, which returns its four heads.

A pasted **private** key is refused outright with a warning rather than searched. Nobody should be typing one into a web page, and a tool that quietly accepts it teaches a dangerous habit.

## The dashboard reads and writes the rules

Not just the preferences. It shows the loaded policy, its thresholds, its action classes, and what the validator says about it.

Threshold edits go through the same validator the pipeline loads with. A backup is written beside the file first, and an edit the validator rejects is never written.

That write initially targeted `thresholds_default`, which is the dataclass field name and not the document key. It produced a block the loader ignored while reporting success. The key is `thresholds.default`, and the round trip is now verified:

```
before        (0.55, 0.85)
write         0.33 / 0.77 -> saved
after         (0.33, 0.77)
reject        escalate 0.9 above deny 0.5 -> refused
unchanged     (0.33, 0.77)
```

## Smaller

Favicon ships in the package and is served locally, so the dashboard looks right offline like the rest of it.

The Resin wordmark was 340px against the homepage's 440px and jumped when moving between the two. Both are 440 now.