### PR TITLE
fix: qualify the Vaara Resin mark, and stop the dashboard calling itself read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   log the emitter operates proves the chain is internally consistent; it cannot
   prove the emitter kept one history. What leaves the machine is one digest and
   a signature over it. Offline verification never calls it.
+- **`AuditTrail.enable_auto_publish`** does for publication what
+  `enable_auto_anchor` does for anchoring: publish the head every
+  `every_records` appends, default 256, to a log the operator does not run.
+  The window in which records could still be dropped or reordered is then a
+  configured number a verifier reads rather than guesses. Opt-in, and an
+  unreachable log records a chained `ANCHOR_GAP` marker instead of raising,
+  so the unpublished stretch is itself visible in the chain.
+- **`vaara dashboard`** serves a local dashboard on any OS with nothing beyond
+  the standard library, bound to loopback. It shows the current gate verdict,
+  trail and witness counts with their gaps, and history, reading the same
+  `config.json` the macOS client writes. Settings and the escalate/deny policy
+  thresholds can be written from the page: writes carry a per-run token that
+  exists only in the page served, accept declared keys with declared values
+  only, and a threshold edit is refused unless the same validator the pipeline
+  uses accepts it.
 
 ## [1.66.2] - 2026-08-12
 

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -732,7 +732,7 @@ _EU_OPERATED_LOGS: tuple[str, ...] = ("localhost", "127.0.0.1", ".eu/", ".eu:")
 
 
 def _cmd_dashboard(args: argparse.Namespace) -> int:
-    """Serve the local read-only dashboard."""
+    """Serve the local dashboard."""
     from vaara.dashboard import free_port, serve
 
     port = args.port if args.port else free_port()
@@ -4824,7 +4824,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     pdash = sub.add_parser(
         "dashboard",
-        help="Serve a local read-only dashboard (any OS, no extra dependencies)",
+        help="Serve a local dashboard (any OS, no extra dependencies)",
     )
     _add_trail_source_args(pdash)
     pdash.add_argument("--policy", default=None,

--- a/src/vaara/dashboard.html
+++ b/src/vaara/dashboard.html
@@ -123,7 +123,7 @@
      nothing else on this page does, so it is marked as an outbound link and
      the dashboard keeps working when it cannot be reached. -->
 <nav class="nav-jump"><a href="https://vaara.io/verify.html" target="_blank"
-  rel="noopener noreferrer" title="Opens vaara.io in a new tab">Resin &#8599;</a></nav>
+  rel="noopener noreferrer" title="Opens vaara.io in a new tab">Vaara Resin &#8599;</a></nav>
 <div class="theme-toggle" role="group" aria-label="Color theme">
   <button type="button" data-set-theme="light" aria-pressed="true">light</button>
   <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>

--- a/src/vaara/dashboard.py
+++ b/src/vaara/dashboard.py
@@ -361,7 +361,8 @@ def serve(
     print(f"Vaara dashboard on {url}")
     print(f"  reading   {source}")
     print(f"  bound to  {host} only, not reachable from the network")
-    print("  read-only, Ctrl-C to stop")
+    print("  settings and policy thresholds are writable from the page")
+    print("  writes need a token served only in that page, Ctrl-C to stop")
     if open_browser:
         threading.Timer(0.4, lambda: webbrowser.open(url)).start()
     try:

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -306,7 +306,7 @@ conformance: <span class="ok">CONFORMS</span>
 
 <span class="dim">no signing key, no access to the system that produced it</span></pre>
 </div>
-<p style="text-align:center;margin:0 0 40px"><a class="cta" href="/verify.html">Explore the Resin</a></p>
+<p style="text-align:center;margin:0 0 40px"><a class="cta" href="/verify.html">Explore the Vaara Resin</a></p>
 <p class="stamp">What's shipped</p>
 <ul>
   <li>Check any record yourself: <code>vaara verify-record</code> tests any JSON against the published vaara.receipt/v1 format, including a record Vaara never produced, with no signing key and no access to the system that made it. <code>vaara verify-bundle</code> runs the full evidence set and prints a single pass or fail, fail-closed on authenticity.</li>

--- a/webpage/verify.html
+++ b/webpage/verify.html
@@ -178,14 +178,14 @@
 
   <h1>Explore the Vaara Resin</h1>
   <p class="sub">
-    Resin is Vaara's chain of autonomous-action receipts. Every allow, escalate and
+    Vaara Resin is the chain of autonomous-action receipts. Every allow, escalate and
     deny an agent produced, hash-chained so a removed one stops reconciling, and
     checkable by someone who does not trust whoever ran it. Drop a receipt below to
     verify it here in your tab, or look one up in the public log underneath.
   </p>
 
   <section id="search">
-    <h2>Search the Resin</h2>
+    <h2>Search the Vaara Resin</h2>
     <p class="search-by">by receipt digest, entry digest, or public key</p>
     <div class="searchrow">
       <input id="q" spellcheck="false" placeholder="sha256 digest, or paste your public key to see everything you published">
@@ -202,7 +202,7 @@
   </section>
 
   <section id="explorer">
-    <h2>The Resin</h2>
+    <h2>The Vaara Resin</h2>
     <p class="sub" style="margin:0 0 .8rem">
       Resin sets around what it caught and keeps it exactly as it was, checkable
       by whoever finds it later without trusting whoever left it there. This is the
@@ -239,7 +239,7 @@
   </section>
 
   <p class="stamp-lead">Have a receipt? Check it here</p>
-  <p class="sub" style="margin:0 0 .8rem">Optional. The Resin above needs nothing from you.</p>
+  <p class="sub" style="margin:0 0 .8rem">Optional. The Vaara Resin above needs nothing from you.</p>
   <div class="drop" id="drop">
     Drop a receipt file here, or paste one below. It is read in this tab and
     never sent anywhere, so there is nothing to upload and no account to make.


### PR DESCRIPTION
Three things, all of them text that did not match reality.

**Resin standing alone read as the name.** Resin is a name other products already carry, so the house mark now qualifies it everywhere it stood in for the brand: the homepage call to action, the verify page's two section headings and its opening sentence, the line about the checker below it, and the dashboard's corner pill out to the page. Left alone: "Resin sets around what it caught and keeps it exactly as it was." That sentence uses the common noun the name comes from and explains the choice rather than naming the product.

**The dashboard is not read-only.** It said so in three places: the startup banner, the command docstring and the `--help` line. `/api/config` writes the `config.json` the gate reads, and `/api/policy` writes the escalate and deny thresholds. Those thresholds decide whether an agent is stopped, so an operator who was told the surface is read-only was told the wrong thing about the part that matters most. The banner now states that settings and thresholds are writable, and that writes need the per-run token served only in that page.

**1.67.0 shipped two features its changelog never recorded.** `vaara dashboard` and `AuditTrail.enable_auto_publish` are both in the v1.67.0 tag with no entry. That is not cosmetic. `docs/PRIOR_ART.md` cites v1.67.0 for both, and its own preamble says the changelog entry for each version carries the substantive description, so a priority-date claim was pointing at a release whose changelog had no record of the feature. Both entries added, written from the code rather than from the release notes.

Verified by serving the dashboard and reading the banner back, by rendering `vaara dashboard --help`, and by running `tests/test_prior_art_dates.py` against the live GitHub and PyPI records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic transparency-log publishing for audit-trail updates, with configurable cadence and opt-in controls.
  - The local dashboard now displays gate, trail, witness, gap, and history information.
  - Dashboard settings and policy thresholds can be edited securely with token protection and validation.
  - Unreachable publications are recorded as gaps and unpublished stretches are visible.

- **Documentation**
  - Updated release documentation with transparency-log and dashboard details.

- **Style**
  - Updated user-facing branding and navigation labels to “Vaara Resin.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->