### PR TITLE
Every fix in this release was found by opening the pages and looking at them, which is the only reason they were found at all. There is no browser in the build environment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.67.1] - 2026-08-14
+
+Everything here was found by opening the pages and looking at them.
+
+### Fixed
+
+- **The dashboard called itself read-only in three places and is not.**
+  The startup banner, the command docstring and the `--help` line all said so,
+  while `/api/config` writes the `config.json` the gate reads and `/api/policy`
+  writes the escalate and deny thresholds. Those thresholds decide whether an
+  agent is stopped, so an operator was told the wrong thing about the part that
+  matters most. The banner now states that settings and thresholds are writable
+  and that writes need the per-run token served only in that page.
+- **The theme toggle did nothing.** An explicit light choice removed the
+  `data-theme` attribute and fell through to the operating system rule, so
+  choosing light on a dark machine changed nothing.
+- **The Resin and the dashboard applied the stored theme after first paint**,
+  so both rendered in the operating system colourway and then snapped to the
+  saved choice when the body script ran. Only the homepage did this correctly.
+- **Both pages fetched the wordmark from raw.githubusercontent.com.** That was
+  the only third-party request either page made, on a page whose central claim
+  is that nothing leaves your tab and that it works with the network off. With
+  the network off the mark was the one thing that did not render. The marks now
+  ship in `webpage/` and load from the same origin, and
+  `tests/test_webpage_assets.py` fails if any `src` on either page ever points
+  off-origin again.
+- The Resin asked for a receipt file before showing anything, and its wording
+  read like an upload on a page that uploads nothing.
+- The dashboard wordmark was `min(58vw,300px)` against `min(60vw,440px)` on the
+  other two surfaces, so the mark changed size depending on which one you
+  opened.
+
+### Added
+
+- **Search the Resin by public key.** Paste a public key and the log returns
+  every head published with it. No account and no sign-in, because the key is
+  the identity, and the answer comes from the log rather than from us. A pasted
+  private key is refused outright with a warning.
+- **A log entry renders in the page's own layout** instead of sending the
+  reader to the log's raw API response: log index, integrated time, entry type,
+  data digest, log id, tree size at inclusion, root hash, inclusion proof path
+  length, checkpoint and signed entry timestamp. The raw response stays one
+  click away, because that is the authority and this is a render of it.
+- **The dashboard reads and writes the policy thresholds** through the same
+  validator the pipeline uses, backing the file up first and refusing any edit
+  the validator rejects.
+- The search moved into its own card at the top of the Resin, favicons, and a
+  corner link from the dashboard to the Resin marked as outbound because it is
+  the only thing on that page that leaves the machine.
+
+### Changed
+
+- **`Resin` standing alone now reads `Vaara Resin` wherever it stood in for the
+  brand**: the homepage call to action, the verify page's section headings and
+  opening sentence, and the dashboard's corner link. The sentence explaining
+  where the name comes from keeps the common noun.
+- The demo receipt states that `agent-decision/v0.1` is Vaara's own open
+  proposal on in-toto/attestation#554 rather than a registered in-toto
+  predicate. Reading the URL alone, in-toto looked like it had endorsed it.
+- `docs/PRIOR_ART.md` carries the v1.67.0 rows, now that the release date is
+  public and checkable against GitHub and PyPI.
+
 ## [1.67.0] - 2026-08-14
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.65.0",
+  "version": "1.67.1",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.67.0"
+version = "1.67.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.65.0",
+  "version": "1.67.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.65.0",
+"version": "1.67.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.65.0",
+  "version": "1.67.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.65.0",
+"version": "1.67.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.67.0"
+__version__ = "1.67.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Patch release. Every fix in it was found by opening the pages and looking at them, which is worth stating because there is no browser in the build environment and none of these would have been caught by CI.

**The dashboard called itself read-only and is not.** It said so in the startup banner, the command docstring and the `--help` line. Meanwhile `/api/config` writes the `config.json` the gate reads and `/api/policy` writes the escalate and deny thresholds. A threshold decides whether an agent is stopped, so an operator was told the wrong thing about the highest-consequence part of that surface. The banner now states what is writable and that writes carry the per-run token served only in that page.

**The Resin gains search by public key.** Paste a public key and the log returns every head published with it. No account, no sign-in, because the key is the identity and the answer comes from the log rather than from us. A pasted private key is refused outright with a warning. A log entry now renders in the page's own layout instead of sending the reader to the log's raw API response, with the raw response one click away because that is the authority and this is a render of it.

**Both pages fetched their wordmark from GitHub.** That was the only third-party request either page made, on a page whose central claim is that nothing leaves your tab and that it works with the network off. Offline, the mark was the one thing that did not render. The PNGs now ship in `webpage/` and `tests/test_webpage_assets.py` fails if any `src` on either page ever points off-origin again.

**Theme handling.** An explicit light choice removed the `data-theme` attribute and fell through to the operating system rule, so choosing light on a dark machine did nothing. Separately, only the homepage applied the stored theme before first paint, so the Resin and the dashboard rendered in the operating system colourway and then snapped to the saved choice.

**Naming.** `Resin` alone read as the product's name, and other products already carry it, so the house mark qualifies it everywhere it stood in for the brand. The sentence explaining where the name comes from keeps the common noun. The demo receipt now states that `agent-decision/v0.1` is Vaara's open proposal on in-toto/attestation#554 rather than a registered in-toto predicate.

`docs/PRIOR_ART.md` also carries the v1.67.0 rows now that the release date is public and checkable against both GitHub and PyPI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard writeability and token-related messaging.
  * Fixed light-theme rendering and first-paint theme behavior.
  * Improved wordmark sizing and same-origin asset handling.
  * Simplified Resin receipt presentation and enhanced search results.
  * Added rendered log-entry details and improved dashboard navigation.
  * Added validation and backups when editing policy thresholds.
  * Clarified provenance for `agent-decision/v0.1` and updated release information.

* **Chores**
  * Updated the project, client, plugin, server, and package versions to 1.67.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->