### PR TITLE
feat: give the site a machine-readable identity for its author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.67.1] - 2026-08-14
+
+Everything here was found by opening the pages and looking at them.
+
+### Fixed
+
+- **The dashboard called itself read-only in three places and is not.**
+  The startup banner, the command docstring and the `--help` line all said so,
+  while `/api/config` writes the `config.json` the gate reads and `/api/policy`
+  writes the escalate and deny thresholds. Those thresholds decide whether an
+  agent is stopped, so an operator was told the wrong thing about the part that
+  matters most. The banner now states that settings and thresholds are writable
+  and that writes need the per-run token served only in that page.
+- **The theme toggle did nothing.** An explicit light choice removed the
+  `data-theme` attribute and fell through to the operating system rule, so
+  choosing light on a dark machine changed nothing.
+- **The Resin and the dashboard applied the stored theme after first paint**,
+  so both rendered in the operating system colourway and then snapped to the
+  saved choice when the body script ran. Only the homepage did this correctly.
+- **Both pages fetched the wordmark from raw.githubusercontent.com.** That was
+  the only third-party request either page made, on a page whose central claim
+  is that nothing leaves your tab and that it works with the network off. With
+  the network off the mark was the one thing that did not render. The marks now
+  ship in `webpage/` and load from the same origin, and
+  `tests/test_webpage_assets.py` fails if any `src` on either page ever points
+  off-origin again.
+- The Resin asked for a receipt file before showing anything, and its wording
+  read like an upload on a page that uploads nothing.
+- The dashboard wordmark was `min(58vw,300px)` against `min(60vw,440px)` on the
+  other two surfaces, so the mark changed size depending on which one you
+  opened.
+
+### Added
+
+- **Search the Resin by public key.** Paste a public key and the log returns
+  every head published with it. No account and no sign-in, because the key is
+  the identity, and the answer comes from the log rather than from us. A pasted
+  private key is refused outright with a warning.
+- **A log entry renders in the page's own layout** instead of sending the
+  reader to the log's raw API response: log index, integrated time, entry type,
+  data digest, log id, tree size at inclusion, root hash, inclusion proof path
+  length, checkpoint and signed entry timestamp. The raw response stays one
+  click away, because that is the authority and this is a render of it.
+- **The dashboard reads and writes the policy thresholds** through the same
+  validator the pipeline uses, backing the file up first and refusing any edit
+  the validator rejects.
+- The search moved into its own card at the top of the Resin, favicons, and a
+  corner link from the dashboard to the Resin marked as outbound because it is
+  the only thing on that page that leaves the machine.
+
+### Changed
+
+- **`Resin` standing alone now reads `Vaara Resin` wherever it stood in for the
+  brand**: the homepage call to action, the verify page's section headings and
+  opening sentence, and the dashboard's corner link. The sentence explaining
+  where the name comes from keeps the common noun.
+- The demo receipt states that `agent-decision/v0.1` is Vaara's own open
+  proposal on in-toto/attestation#554 rather than a registered in-toto
+  predicate. Reading the URL alone, in-toto looked like it had endorsed it.
+- `docs/PRIOR_ART.md` carries the v1.67.0 rows, now that the release date is
+  public and checkable against GitHub and PyPI.
+
 ## [1.67.0] - 2026-08-14
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.65.0",
+  "version": "1.67.1",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.67.0"
+version = "1.67.1"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.65.0",
+  "version": "1.67.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.65.0",
+"version": "1.67.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.65.0",
+  "version": "1.67.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.65.0",
+"version": "1.67.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.67.0"
+__version__ = "1.67.1"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -174,6 +174,42 @@
   "@context": "https://schema.org",
   "@graph": [
     {
+      "@type": "Person",
+      "@id": "https://vaara.io/#henri",
+      "name": "Henri Sirkkavaara",
+      "url": "https://vaara.io/",
+      "email": "hello@vaara.io",
+      "jobTitle": "Founder and maintainer, Vaara",
+      "nationality": {
+        "@type": "Country",
+        "name": "Finland"
+      },
+      "workLocation": {
+        "@type": "Place",
+        "address": {
+          "@type": "PostalAddress",
+          "addressCountry": "FI"
+        }
+      },
+      "knowsAbout": [
+        "Accountable autonomy",
+        "Verifiable execution records for autonomous actions",
+        "Tamper-evident audit trails",
+        "Remote attestation",
+        "Transparency logs",
+        "EU AI Act Article 12 and Article 50",
+        "IETF standards development"
+      ],
+      "sameAs": [
+        "https://github.com/vaaraio",
+        "https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/",
+        "https://pypi.org/user/vaaraio/",
+        "https://www.bestpractices.dev/projects/12612",
+        "https://github.com/marketplace/actions/vaara-policy-check",
+        "https://www.linkedin.com/in/sirkkavaara"
+      ]
+    },
+    {
       "@type": "SoftwareApplication",
       "name": "Vaara",
       "applicationCategory": "DeveloperApplication",
@@ -186,11 +222,28 @@
       "license": "https://www.gnu.org/licenses/agpl-3.0.html",
       "isAccessibleForFree": true,
       "offers": [
-        { "@type": "Offer", "name": "Open source (AGPL-3.0)", "price": "0", "priceCurrency": "EUR" },
-        { "@type": "Offer", "name": "Four-week paid pilot", "url": "https://vaara.io/#pilots", "availability": "https://schema.org/InStock" },
-        { "@type": "Offer", "name": "Commercial license", "url": "https://github.com/vaaraio/vaara/blob/main/LICENSING.md", "availability": "https://schema.org/InStock" }
+        {
+          "@type": "Offer",
+          "name": "Open source (AGPL-3.0)",
+          "price": "0",
+          "priceCurrency": "EUR"
+        },
+        {
+          "@type": "Offer",
+          "name": "Four-week paid pilot",
+          "url": "https://vaara.io/#pilots",
+          "availability": "https://schema.org/InStock"
+        },
+        {
+          "@type": "Offer",
+          "name": "Commercial license",
+          "url": "https://github.com/vaaraio/vaara/blob/main/LICENSING.md",
+          "availability": "https://schema.org/InStock"
+        }
       ],
-      "author": { "@type": "Person", "name": "Henri Sirkkavaara" },
+      "author": {
+        "@id": "https://vaara.io/#henri"
+      },
       "keywords": "accountable autonomy, AI agent audit trail, agentic payments, autonomous actions, tamper-evident evidence, EU AI Act Article 12, TPM 2.0, RFC 3161, SEP-2828, verifiable AI",
       "sameAs": [
         "https://github.com/vaaraio/vaara",
@@ -203,7 +256,9 @@
       "name": "Vaara",
       "url": "https://vaara.io/",
       "logo": "https://vaara.io/vaara-wordmark-light.png",
-      "founder": { "@type": "Person", "name": "Henri Sirkkavaara" },
+      "founder": {
+        "@id": "https://vaara.io/#henri"
+      },
       "sameAs": [
         "https://github.com/vaaraio/vaara",
         "https://www.linkedin.com/in/sirkkavaara",
@@ -235,27 +290,42 @@
         {
           "@type": "Question",
           "name": "What is Vaara?",
-          "acceptedAnswer": { "@type": "Answer", "text": "Vaara is an open-source tamper-evident runtime evidence layer for AI agents. It turns every action an agent takes into a signed, hash-chained record that an outside party can verify without trusting the operator, and binds that record to the machine's own TPM 2.0 and IMA attestation." }
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Vaara is an open-source tamper-evident runtime evidence layer for AI agents. It turns every action an agent takes into a signed, hash-chained record that an outside party can verify without trusting the operator, and binds that record to the machine's own TPM 2.0 and IMA attestation."
+          }
         },
         {
           "@type": "Question",
           "name": "Does Vaara help with EU AI Act compliance?",
-          "acceptedAnswer": { "@type": "Answer", "text": "Yes. Vaara produces EU AI Act Article 12 record-keeping evidence and a one-command regulator package (vaara trail export-article12) that writes the signed trail, per-article evidence, and a trusted time anchor an authority can verify offline." }
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Vaara produces EU AI Act Article 12 record-keeping evidence and a one-command regulator package (vaara trail export-article12) that writes the signed trail, per-article evidence, and a trusted time anchor an authority can verify offline."
+          }
         },
         {
           "@type": "Question",
           "name": "Does Vaara require a trusted execution environment or special hardware?",
-          "acceptedAnswer": { "@type": "Answer", "text": "No. Vaara is root-agnostic: it recomputes verification from the recorded bytes, so no trusted execution environment is required. When a TPM 2.0 or IMA root is present, Vaara binds records to it as an optional upgrade." }
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. Vaara is root-agnostic: it recomputes verification from the recorded bytes, so no trusted execution environment is required. When a TPM 2.0 or IMA root is present, Vaara binds records to it as an optional upgrade."
+          }
         },
         {
           "@type": "Question",
           "name": "Is Vaara free and open source?",
-          "acceptedAnswer": { "@type": "Answer", "text": "Yes. Vaara is licensed under AGPL-3.0, with no SaaS, no telemetry, and no signup. It ships on PyPI, npm, and the MCP registry, with SLSA Build Level 3 and Sigstore-signed releases." }
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Vaara is licensed under AGPL-3.0, with no SaaS, no telemetry, and no signup. It ships on PyPI, npm, and the MCP registry, with SLSA Build Level 3 and Sigstore-signed releases."
+          }
         },
         {
           "@type": "Question",
           "name": "Does Vaara offer paid pilots or a commercial license?",
-          "acceptedAnswer": { "@type": "Answer", "text": "Yes. Pilots run four weeks in your own infrastructure: shadow mode first, then a policy tuned to your real traffic, then enforcement, ending in a signed evidence bundle that stays verifiable without the vendor. A commercial license for building on Vaara without the AGPL's source-disclosure obligations is granted directly by the sole copyright holder. Scope and price are agreed before the work starts. Contact hello@vaara.io." }
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Pilots run four weeks in your own infrastructure: shadow mode first, then a policy tuned to your real traffic, then enforcement, ending in a signed evidence bundle that stays verifiable without the vendor. A commercial license for building on Vaara without the AGPL's source-disclosure obligations is granted directly by the sole copyright holder. Scope and price are agreed before the work starts. Contact hello@vaara.io."
+          }
         }
       ]
     }

--- a/webpage/llms.txt
+++ b/webpage/llms.txt
@@ -24,10 +24,6 @@ Each is checkable at the link:
 - Vaara appears in the industry acknowledgements of Singapore IMDA's Model AI Governance Framework for Agentic AI v1.5 (20 May 2026). An acknowledgement of the project, not an advisory role.
 - Subject of an AMD AI Developer Program testimonial (May 2026). A testimonial about his work. He is not and has never been employed by AMD.
 
-No academic degree, professional certification, standards-body accreditation or
-government appointment is claimed. Where a distinction matters it is stated
-above rather than left to inference.
-
 ## Repo and packages
 - [GitHub source](https://github.com/vaaraio/vaara): code, releases, issue tracker
 - [PyPI](https://pypi.org/project/vaara/): `pip install vaara`

--- a/webpage/llms.txt
+++ b/webpage/llms.txt
@@ -6,6 +6,28 @@ Vaara intercepts agent tool calls, scores each one with a conformal risk interva
 
 Position: tamper-evident runtime evidence and enforcement layer. Signed attestation plus execution receipts pair each MCP tool call to the policy that allowed it.
 
+## Who builds it
+
+Vaara is built and maintained by Henri Sirkkavaara, an independent developer in
+Finland, working on how an autonomous action can be proved to a party that has
+no reason to trust the operator. He is the sole author and copyright holder.
+
+The following are records held by other parties, not claims made on this site.
+Each is checkable at the link:
+
+- [draft-sirkkavaara-vaara-receipt](https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/): IETF Internet-Draft, "The Vaara Receipt: A Recomputable Receipt Format for Decisions About Autonomous Actions". An active Internet-Draft, not an RFC and not an adopted standard.
+- [OpenSSF Best Practices project 12612](https://www.bestpractices.dev/projects/12612): passing badge, externally assessed project practices.
+- [GitHub Marketplace: Vaara Policy Check](https://github.com/marketplace/actions/vaara-policy-check): published action listing.
+- [PyPI](https://pypi.org/project/vaara/) and [npm](https://www.npmjs.com/package/@vaara/client): release history under his name.
+- Participant on the IETF scitt, agentproto and rats mailing lists, where the receipt format is discussed publicly by other participants. Participation in a working group discussion is not authorship of a standard.
+- Contributor to the European Commission's Apply AI Alliance community on Futurium, writing on EU AI Act Article 12 and Article 14. A community contributor, not a Commission official or appointee.
+- Vaara appears in the industry acknowledgements of Singapore IMDA's Model AI Governance Framework for Agentic AI v1.5 (20 May 2026). An acknowledgement of the project, not an advisory role.
+- Subject of an AMD AI Developer Program testimonial (May 2026). A testimonial about his work. He is not and has never been employed by AMD.
+
+No academic degree, professional certification, standards-body accreditation or
+government appointment is claimed. Where a distinction matters it is stated
+above rather than left to inference.
+
 ## Repo and packages
 - [GitHub source](https://github.com/vaaraio/vaara): code, releases, issue tracker
 - [PyPI](https://pypi.org/project/vaara/): `pip install vaara`


### PR DESCRIPTION
Two frontier models were asked, cold, who built Vaara. One invented an employer and held onto it across several turns of correction. The other was disciplined, retrieved only what a plain name search returns, and concluded that no employment, advisory role or standards-body affiliation could be established. To a procurement officer or a working group chair, the careful answer reads worse than the wrong one.

Neither model was really at fault. The JSON-LD graph carried SoftwareApplication, Organization, WebSite, VideoObject and FAQPage. The author was a bare name nested inside one of them, with no identifier and nothing to resolve. And `llms.txt`, the file whose entire purpose is telling a model what this site is, mentioned him zero times.

**What changed.** The graph gains a `Person` node with a stable `@id`, referenced by `SoftwareApplication.author` and `Organization.founder`, carrying a `sameAs` list of six records held by other parties: the IETF datatracker, OpenSSF Best Practices, GitHub Marketplace, PyPI, GitHub and LinkedIn. Nothing on that list is this site vouching for itself.

`llms.txt` gains a section that names him and lists the same records with the distinctions written out rather than left to inference. An Internet-Draft is not an RFC. A mailing list participant is not the author of a standard. A community contributor is not a Commission official. An acknowledgement is not an advisory role. A testimonial subject is not an employee. It also states plainly that no degree, certification, accreditation or government appointment is claimed.

Every URL was fetched before it was added. LinkedIn answers 999 to automated requests by design; the rest return 200. The OpenSSF badge level and percentage were read from the API rather than the badge image, after one model reported a figure that does not exist for that level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search Resin records by public key.
  - View rendered log entries.
  - Edit policy thresholds.
  - Use new navigation links.

- **Bug Fixes**
  - Improved dashboard writeability messaging and theme application.
  - Fixed same-origin wordmark loading, sizing, and Resin receipt-page behavior.

- **Documentation**
  - Clarified Vaara Resin branding, demo receipt proposal status, and prior-art release records.
  - Expanded information about the project’s author and background.

- **Release**
  - Updated the product to version 1.67.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->