### PR TITLE
feat: deploy Vaara on Kubernetes with a Helm chart and a container image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# The image build copies only pyproject.toml, MANIFEST.in, README.md, LICENSE
+# and src/. Everything else is context the daemon would still transfer, and
+# this repository carries hundreds of megabytes of it: virtualenvs, a Swift
+# build tree, model bundles, and the private .shared exchange.
+#
+# .shared is first on purpose. It is gitignored and must never reach an image
+# layer either.
+.shared/
+.venv/
+.venv-mac/
+.git/
+.github/
+.hypothesis/
+.ruff_cache/
+.serena/
+.claude/
+.claude-plugin/
+.clusterfuzzlite/
+.githooks/
+
+bench/
+clients/
+conformance/
+core/
+deploy/
+docs/
+examples/
+fuzz/
+homebrew-tap/
+ietf/
+plugins/
+release-anchors/
+scripts/
+tests/
+webpage/
+
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+*.egg-info/
+build/
+dist/
+*.db
+*.sqlite
+*.sqlite3
+.coverage
+.pytest_cache/
+.mypy_cache/

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,13 @@
 # this repository carries hundreds of megabytes of it: virtualenvs, a Swift
 # build tree, model bundles, and the private .shared exchange.
 #
+# This file is shared with the ClusterFuzzLite build, which uses the same
+# root context and a different Dockerfile (.clusterfuzzlite/Dockerfile). That
+# build does `COPY . $SRC/vaara` and then compiles every fuzz/fuzz_*.py, so
+# .clusterfuzzlite/ and fuzz/ have to stay in the context even though the
+# image below does not read them. Excluding them fails the fuzz build with
+# "/.clusterfuzzlite/build.sh: not found".
+#
 # .shared is first on purpose. It is gitignored and must never reach an image
 # layer either.
 .shared/
@@ -15,7 +22,6 @@
 .serena/
 .claude/
 .claude-plugin/
-.clusterfuzzlite/
 .githooks/
 
 bench/
@@ -25,7 +31,6 @@ core/
 deploy/
 docs/
 examples/
-fuzz/
 homebrew-tap/
 ietf/
 plugins/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,32 @@ jobs:
       - name: mypy
         run: mypy src/vaara/policy/
 
+  helm-chart:
+    name: Helm chart renders
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install pinned deps
+        run: pip install --require-hashes -r requirements-dev.txt
+
+      - name: Install Vaara (editable, no deps)
+        run: pip install -e . --no-deps
+
+      # tests/test_helm_chart.py skips the render checks when helm is absent,
+      # which is right for a laptop and wrong for CI: a silent skip here would
+      # report a green build for a chart nobody rendered.
+      - name: Require helm
+        run: helm version
+
+      - name: Chart tests
+        run: pytest -q tests/test_helm_chart.py
+
   preflight:
     name: Pre-release smoke test (wheel + classifier)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,14 +268,26 @@ jobs:
       - name: Install Vaara (editable, no deps)
         run: pip install -e . --no-deps
 
-      # tests/test_helm_chart.py skips the render checks when helm is absent,
-      # which is right for a laptop and wrong for CI: a silent skip here would
-      # report a green build for a chart nobody rendered.
+      - name: Install the yaml extra (the chart tests parse the render)
+        run: pip install 'pyyaml>=6.0'
+
+      # tests/test_helm_chart.py skips checks whose tools are absent, which is
+      # right for a laptop and wrong for CI: a silent skip here would report a
+      # green build for a chart nobody rendered. Fail loudly if the runner
+      # image stops shipping helm.
       - name: Require helm
         run: helm version
 
+      # -p no:randomly and -rs so the summary lists anything skipped; the next
+      # line fails the job if the count is not zero.
       - name: Chart tests
-        run: pytest -q tests/test_helm_chart.py
+        run: |
+          set -euo pipefail
+          pytest -q -rs tests/test_helm_chart.py | tee /tmp/chart-tests.txt
+          if grep -qE "[0-9]+ skipped" /tmp/chart-tests.txt; then
+            echo "chart tests skipped in CI, which defeats the point of this job" >&2
+            exit 1
+          fi
 
   preflight:
     name: Pre-release smoke test (wheel + classifier)

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,91 @@
+name: Container image
+
+# The Helm chart's default image is ghcr.io/vaaraio/vaara:<appVersion>. That
+# tag has to exist before the chart installs, so this builds and pushes on
+# every published release, and on demand for a test tag.
+#
+# Kept out of release.yml on purpose: a failure here must not be able to abort
+# a PyPI or npm publish that has already started.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to push (e.g. dev). Leave empty to use the package version."
+        required: false
+        type: string
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/container.yml"
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Pushing to GHCR needs a token that can write packages. Pull requests
+      # get the read-only default, and the push step below is skipped for
+      # them, so a fork PR cannot publish an image.
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Read the version being built
+        id: version
+        run: |
+          set -euo pipefail
+          package_version="$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)"
+          chart_version="$(grep -m1 '^appVersion: ' deploy/helm/vaara/Chart.yaml | cut -d'"' -f2)"
+          if [ "$package_version" != "$chart_version" ]; then
+            echo "pyproject version ($package_version) and chart appVersion ($chart_version) disagree" >&2
+            exit 1
+          fi
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tags
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302  # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/vaara
+          tags: |
+            type=raw,value=${{ inputs.tag || steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+
+      # arm64 is not decoration: Rancher clusters on Ampere and on Apple
+      # silicon development machines are both common, and SUSE publishes BCI
+      # for both.
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            VCS_REF=${{ github.sha }}
+          provenance: true
+          sbom: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A Helm chart and a container image, so Vaara can be deployed on
+  Kubernetes.** `deploy/helm/vaara` installs the model-endpoint proxy in front
+  of an in-cluster model endpoint: a StatefulSet with one replica, a
+  ClusterIP Service, a ServiceAccount with no API token mounted, and a
+  PersistentVolumeClaim holding the trail. The image is built on
+  `registry.suse.com/bci/python:3.12`, runs as UID 10001 with a read-only root
+  filesystem, and is published to `ghcr.io/vaaraio/vaara` on release for
+  linux/amd64 and linux/arm64.
+
+  The chart has no replica count. One hash chain has exactly one writer, and a
+  second pod appending to the same volume produces a chain neither pod can
+  verify, so the invariant is enforced by the shape of the chart rather than
+  documented next to a knob that breaks it.
+
+  Three configurations that would fail in the cluster now fail at template
+  time with the reason: `enforce` mode with no allow list and no approvals
+  directory (every tool call gated, clients appear to lose their tools),
+  signing with no Secret named (the chart will not mint a key that rotates on
+  every upgrade), and signing without persistence (signed evidence discarded
+  on restart).
+
+- **`GET /healthz` on the model-endpoint proxy.** Every other path on the
+  proxy forwards upstream, so a liveness probe had no way to ask about the
+  proxy rather than about the model: an orchestrator would restart Vaara
+  whenever the model was slow to load, and bill a request per probe. The route
+  answers locally with status, version and mode, names no internal host, and
+  does not shadow the `/health` that vLLM serves.
+
+- **`docs/kubernetes-rancher.md`** covering install, storage, turning on
+  enforcement, signed receipts, and the NetworkPolicy that makes the proxy the
+  only route to the model. **`docs/supported-platforms.md`** lists the Python,
+  container and Kubernetes versions Vaara supports, and separately records
+  which platform versions a release has actually been run against.
+
 ## [1.67.1] - 2026-08-14
 
 Everything here was found by opening the pages and looking at them.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Container image for `vaara proxy`, the model-endpoint proxy that fronts an
+# OpenAI-compatible or ollama server and records every tool call the model
+# requests into a hash-chained audit trail.
+#
+# The base is SUSE's own SLE Base Container Image. BCI needs no subscription
+# to pull or redistribute, and building on it means the certified artifact and
+# the platform it is certified against share a userland.
+#
+# Build:
+#   docker build -t ghcr.io/vaaraio/vaara:dev .
+# Run:
+#   docker run -p 8788:8788 -v vaara-trail:/var/lib/vaara ghcr.io/vaaraio/vaara:dev
+
+FROM registry.suse.com/bci/python:3.12 AS build
+
+WORKDIR /src
+COPY pyproject.toml MANIFEST.in README.md LICENSE ./
+COPY src/ ./src/
+
+# --no-cache-dir everywhere: the layer is thrown away, and a pip cache in an
+# intermediate stage still costs build time and disk on the runner.
+RUN python3 -m pip install --no-cache-dir build \
+    && python3 -m build --wheel --outdir /dist
+
+
+FROM registry.suse.com/bci/python:3.12
+
+ARG VERSION=0.0.0
+ARG VCS_REF=unknown
+
+LABEL org.opencontainers.image.title="Vaara" \
+      org.opencontainers.image.description="Governance and receipt layer for AI agents: policy-gated tool calls and a hash-chained, independently verifiable audit trail" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.licenses="AGPL-3.0-or-later" \
+      org.opencontainers.image.source="https://github.com/vaaraio/vaara" \
+      org.opencontainers.image.url="https://vaara.io" \
+      org.opencontainers.image.vendor="Vaara" \
+      org.opencontainers.image.base.name="registry.suse.com/bci/python:3.12"
+
+# proxy: fastapi, uvicorn, httpx (the listener and the upstream client).
+# attestation: cbor2, cryptography, rfc8785 (signed attestation and receipt
+# pairs). Without the second extra --signing-key fails at import time, which
+# is the one flag an evidence deployment is most likely to set.
+COPY --from=build /dist/*.whl /tmp/
+RUN python3 -m pip install --no-cache-dir "$(ls /tmp/vaara-*.whl)[proxy,attestation]" \
+    && rm -f /tmp/*.whl
+
+# Fixed UID so a PersistentVolume written by one release stays writable by the
+# next. The chart sets the same number in fsGroup; changing it here without
+# changing it there leaves an existing trail unwritable and the pod crash-looping.
+RUN groupadd --gid 10001 vaara \
+    && useradd --uid 10001 --gid 10001 --home-dir /var/lib/vaara \
+       --no-create-home --shell /sbin/nologin vaara \
+    && mkdir -p /var/lib/vaara /var/lib/vaara/receipts \
+    && chown -R 10001:10001 /var/lib/vaara
+
+USER 10001:10001
+WORKDIR /var/lib/vaara
+
+# The audit trail is a hash chain with exactly one writer, so this path must
+# be a volume owned by one pod. See docs/multi-replica-deployment.md.
+VOLUME ["/var/lib/vaara"]
+
+EXPOSE 8788
+
+ENTRYPOINT ["vaara"]
+CMD ["proxy", \
+     "--listen", "0.0.0.0:8788", \
+     "--upstream", "http://ollama:11434", \
+     "--trail", "/var/lib/vaara/audit.db"]

--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ The public surface is fixed: the signed envelope (`vaara.receipt/v1`), capabilit
 | [docs/adapters.md](docs/adapters.md) | Framework and cloud/OSS guardrail adapters, multi-tenant proxy |
 | [docs/COMPLIANCE.md](docs/COMPLIANCE.md) | EU AI Act and DORA article mapping, eval numbers |
 | [docs/multi-replica-deployment.md](docs/multi-replica-deployment.md) | Scaling past one proxy process: per-replica chains, rotation, archive index |
+| [docs/kubernetes-rancher.md](docs/kubernetes-rancher.md) | Running the proxy on Kubernetes with Rancher: chart, storage, enforcement, network isolation |
+| [docs/supported-platforms.md](docs/supported-platforms.md) | Python, container and Kubernetes versions Vaara supports, and which have been verified |
 | [CHANGELOG.md](CHANGELOG.md) | Version-by-version evolution |
 | [docs/PRIOR_ART.md](docs/PRIOR_ART.md) | When each concept first shipped, plus adjacent work |
 </details>

--- a/deploy/helm/vaara/.helmignore
+++ b/deploy/helm/vaara/.helmignore
@@ -1,0 +1,11 @@
+.DS_Store
+.git/
+.gitignore
+*.tgz
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.idea/
+.vscode/

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+apiVersion: v2
+name: vaara
+description: >-
+  Governance and receipt layer for AI agents. Fronts an in-cluster model
+  endpoint, passes traffic through unchanged, and records every tool call the
+  model requests into a hash-chained, independently verifiable audit trail.
+type: application
+
+# Chart version, bumped when the templates change.
+version: 0.1.0
+
+# Application version. tests/test_helm_chart.py asserts this equals
+# vaara.__version__, so a release that bumps the package without bumping the
+# chart fails the build instead of shipping a chart that installs an older
+# image than it claims.
+appVersion: "1.67.1"
+
+# StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
+# and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of
+# upstream support, but nothing here needs anything newer.
+kubeVersion: ">=1.27.0-0"
+
+home: https://vaara.io
+icon: https://vaara.io/vaara-wordmark-dark.png
+sources:
+  - https://github.com/vaaraio/vaara
+keywords:
+  - ai
+  - governance
+  - audit
+  - eu-ai-act
+  - receipts
+  - accountable-autonomy
+maintainers:
+  - name: Henri Sirkkavaara
+    email: hello@vaara.io
+    url: https://vaara.io
+annotations:
+  artifacthub.io/license: AGPL-3.0-or-later
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/deploy/helm/vaara/templates/NOTES.txt
+++ b/deploy/helm/vaara/templates/NOTES.txt
@@ -1,0 +1,41 @@
+Vaara {{ .Chart.AppVersion }} is installed as {{ include "vaara.fullname" . }}.
+
+Mode: {{ .Values.proxy.mode }}{{ if eq .Values.proxy.mode "observe" }} (records every tool call the model requests, changes nothing){{ else }} (gates: denied tool calls are rewritten out of the response){{ end }}
+Upstream: {{ .Values.upstream.url }}
+Trail: {{ .Values.trail.path }}{{ if not .Values.persistence.enabled }}  <-- on an emptyDir, discarded when the pod restarts{{ end }}
+Signing: {{ if .Values.signing.enabled }}on, key from secret {{ .Values.signing.existingSecret }}{{ else }}off (no attestation or receipt pairs are produced){{ end }}
+
+1. Point your agents at Vaara instead of at the model:
+
+     base_url = http://{{ include "vaara.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+2. Confirm the proxy is answering:
+
+     kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "vaara.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+     curl -s localhost:{{ .Values.service.port }}/healthz
+
+3. The trail is a SQLite file on the volume. To hand it to someone who does
+   not have cluster access, export it signed and let them verify the export:
+
+     kubectl -n {{ .Release.Namespace }} exec {{ include "vaara.fullname" . }}-0 -- vaara trail export --db {{ .Values.trail.path }} --out /var/lib/vaara/handoff.zip --key KEY
+     vaara-audit verify handoff.zip
+
+{{ if not .Values.persistence.enabled }}
+WARNING: persistence.enabled is false. The audit trail is on an emptyDir and
+every pod restart starts a new chain with no history. Use this for a smoke
+test only.
+{{ end }}
+{{- if eq .Values.proxy.mode "observe" }}
+Nothing is being blocked. Run in observe until the trail shows you what your
+agents actually call, then set proxy.mode=enforce with an allow list.
+{{- end }}
+{{- if not .Values.signing.enabled }}
+
+Receipts are off. In observe mode Vaara records what happened; with
+signing.enabled it also emits signed attestation and receipt pairs a third
+party can verify without access to this cluster. Create the key with
+`vaara keygen`, put it in a Secret, and set signing.existingSecret.
+{{- end }}
+
+Supported platforms and the versions this release was tested against:
+https://github.com/vaaraio/vaara/blob/main/docs/supported-platforms.md

--- a/deploy/helm/vaara/templates/_helpers.tpl
+++ b/deploy/helm/vaara/templates/_helpers.tpl
@@ -1,0 +1,73 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/}}
+
+{{- define "vaara.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "vaara.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "vaara.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "vaara.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: vaara
+{{- end -}}
+
+{{- define "vaara.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vaara.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "vaara.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "vaara.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "vaara.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Configuration that cannot be caught by a schema, checked once so a bad install
+fails at template time with an explanation instead of crash-looping in the
+cluster with an argparse error in the logs.
+*/}}
+{{- define "vaara.validate" -}}
+{{- if not (has .Values.proxy.mode (list "observe" "enforce")) -}}
+{{- fail (printf "proxy.mode must be \"observe\" or \"enforce\", got %q" .Values.proxy.mode) -}}
+{{- end -}}
+{{- if eq .Values.proxy.mode "enforce" -}}
+{{- if and (not .Values.proxy.allow) (not .Values.proxy.approvals.enabled) -}}
+{{- fail "proxy.mode=enforce needs proxy.allow (tool-name globs) and/or proxy.approvals.enabled. With neither, every tool call is gated and clients appear to lose their tools. Nothing is damaged, but the session is unusable. Start with proxy.allow: ['mcp__*'] and tighten, or run observe first." -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.signing.enabled -}}
+{{- if not .Values.signing.existingSecret -}}
+{{- fail "signing.enabled requires signing.existingSecret. This chart does not generate signing keys: a key minted in a template would rotate on every upgrade and every receipt signed by the old one would stop verifying. Run `vaara keygen`, create the Secret, and name it here." -}}
+{{- end -}}
+{{- end -}}
+{{- if not .Values.persistence.enabled -}}
+{{- if .Values.signing.enabled -}}
+{{- fail "signing.enabled with persistence.enabled=false writes receipts to a container filesystem that is discarded on restart. Signed evidence that does not survive a pod restart is not evidence." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/vaara/templates/service.yaml
+++ b/deploy/helm/vaara/templates/service.yaml
@@ -1,0 +1,28 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+ClusterIP by default. Agents inside the cluster point their base_url here
+instead of at the model service, and a NetworkPolicy should make that the
+only route to the model. A LoadBalancer or NodePort puts an unauthenticated
+governance surface on the network, so change the type deliberately.
+*/}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vaara.fullname" . }}
+  labels:
+    {{- include "vaara.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "vaara.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/vaara/templates/serviceaccount.yaml
+++ b/deploy/helm/vaara/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+The proxy talks to the model endpoint and writes to its own volume. It never
+calls the Kubernetes API, so the token is not mounted.
+*/}}
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vaara.serviceAccountName" . }}
+  labels:
+    {{- include "vaara.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/helm/vaara/templates/statefulset.yaml
+++ b/deploy/helm/vaara/templates/statefulset.yaml
@@ -1,0 +1,163 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+A StatefulSet with one replica, not a Deployment.
+
+The audit trail is a hash chain: every record binds to its predecessor, so a
+chain has exactly one writer. Two pods appending to one volume interleave
+records and produce a chain neither can verify. A StatefulSet gives stable
+identity and a volume that is not reattached to a second pod while the first
+still holds it, and there is no replicaCount value to raise.
+
+Read docs/multi-replica-deployment.md before reaching for horizontal scale:
+the answer is one chain per proxy, verified independently, not one chain
+shared by several.
+*/}}
+{{- include "vaara.validate" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "vaara.fullname" . }}
+  labels:
+    {{- include "vaara.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "vaara.fullname" . }}
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "vaara.selectorLabels" . | nindent 6 }}
+  {{- if .Values.persistence.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ if .Values.persistence.retainOnDelete }}Retain{{ else }}Delete{{ end }}
+    whenScaled: Retain
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "vaara.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "vaara.serviceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: proxy
+          image: {{ include "vaara.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - proxy
+            - --listen
+            - 0.0.0.0:{{ .Values.proxy.listenPort }}
+            - --upstream
+            - {{ .Values.upstream.url | quote }}
+            - --trail
+            - {{ .Values.trail.path | quote }}
+            {{- if eq .Values.proxy.mode "enforce" }}
+            - --enforce
+            {{- range .Values.proxy.allow }}
+            - --allow
+            - {{ . | quote }}
+            {{- end }}
+            {{- if .Values.proxy.approvals.enabled }}
+            - --approvals-dir
+            - {{ .Values.proxy.approvals.path | quote }}
+            - --approvals-timeout
+            - {{ .Values.proxy.approvals.timeoutSeconds | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.signing.enabled }}
+            - --signing-key
+            - {{ printf "/etc/vaara/signing/%s" .Values.signing.secretKey | quote }}
+            - --receipts-dir
+            - {{ .Values.signing.receiptsDir | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.proxy.listenPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/vaara
+            # readOnlyRootFilesystem is on, and Python wants somewhere to
+            # write temporary files.
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.signing.enabled }}
+            - name: signing-key
+              mountPath: /etc/vaara/signing
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if not .Values.persistence.enabled }}
+        # No PVC: the trail lives and dies with the pod. Acceptable for a
+        # smoke test, never for a deployment whose output is evidence.
+        - name: data
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.signing.enabled }}
+        - name: signing-key
+          secret:
+            secretName: {{ .Values.signing.existingSecret | quote }}
+            defaultMode: 0400
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "vaara.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ .Values.persistence.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+        {{- if .Values.persistence.storageClass }}
+        storageClassName: {{ .Values.persistence.storageClass | quote }}
+        {{- end }}
+  {{- end }}

--- a/deploy/helm/vaara/templates/tests/test-connection.yaml
+++ b/deploy/helm/vaara/templates/tests/test-connection.yaml
@@ -1,0 +1,48 @@
+{{/*
+SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+SPDX-License-Identifier: AGPL-3.0-or-later
+
+`helm test` target. Reads the proxy's own health endpoint, which answers
+locally, so the check passes or fails on Vaara and does not depend on the
+model server being loaded.
+*/}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "vaara.fullname" . }}-test-connection
+  labels:
+    {{- include "vaara.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 10001
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: healthz
+      image: {{ include "vaara.image" . }}
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      command:
+        - python3
+        - -c
+        - |
+          import json, sys, urllib.request
+          url = "http://{{ include "vaara.fullname" . }}:{{ .Values.service.port }}/healthz"
+          with urllib.request.urlopen(url, timeout=10) as response:
+              body = json.load(response)
+          print(json.dumps(body))
+          if body.get("status") != "ok":
+              sys.exit(1)
+          if body.get("mode") != "{{ .Values.proxy.mode }}":
+              print("running mode does not match the release values", file=sys.stderr)
+              sys.exit(1)

--- a/deploy/helm/vaara/values.yaml
+++ b/deploy/helm/vaara/values.yaml
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Default values for the Vaara chart.
+# Every key here is read by a template; the test suite fails the build if a
+# template reads a key this file does not define.
+
+# Object naming. Empty means the chart name and the release name decide.
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/vaaraio/vaara
+  # Empty means "use the chart's appVersion". Pin a digest in production.
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+# The model endpoint Vaara sits in front of. Point this at the in-cluster
+# service, not at an external address: Vaara is the thing that decides what
+# leaves, so it should be the only workload that can reach the model directly.
+upstream:
+  url: http://ollama.suse-ai.svc.cluster.local:11434
+
+proxy:
+  listenPort: 8788
+
+  # observe records every tool call the model requests and changes nothing.
+  # enforce also gates: denied calls are rewritten out of the response and
+  # escalations block on the approvals handshake.
+  # Start on observe. An enforce deployment with no allow list gates every
+  # tool call, and clients see their tools vanish.
+  mode: observe
+
+  # Tool-name globs that pass without gating under enforce. Ignored in
+  # observe mode. Allowed calls are still recorded.
+  allow: []
+
+  approvals:
+    # Mounts a directory a human decision writes into. Without it, an
+    # escalation under enforce fails closed when it times out.
+    enabled: false
+    timeoutSeconds: 60
+    # Subdirectory of the data volume. Must be on the volume: the root
+    # filesystem is read-only.
+    path: /var/lib/vaara/approvals
+
+# The hash-chained SQLite trail. One chain has exactly one writer, which is
+# why this chart deploys a StatefulSet with a single replica and refuses to
+# scale. See docs/multi-replica-deployment.md.
+trail:
+  path: /var/lib/vaara/audit.db
+
+# Signed attestation and receipt pairs for every chat call.
+# The chart never generates a key: a template-generated key would rotate on
+# every upgrade and land in the release secret. Create the Secret yourself
+# from `vaara keygen` output and name it here.
+signing:
+  enabled: false
+  existingSecret: ""
+  secretKey: signing_key.pem
+  receiptsDir: /var/lib/vaara/receipts
+
+persistence:
+  enabled: true
+  # Empty uses the cluster default. On RKE2 that is usually local-path.
+  storageClass: ""
+  size: 8Gi
+  accessMode: ReadWriteOnce
+  # Kept on uninstall so the evidence outlives the release. Set to Delete
+  # only if you have exported the trail first.
+  retainOnDelete: true
+
+service:
+  type: ClusterIP
+  port: 8788
+  annotations: {}
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# Modest by default: the proxy is I/O bound and holds one SQLite connection.
+# Raise limits.memory if you enable signing on high request volume.
+resources:
+  requests:
+    cpu: 100m
+    memory: 192Mi
+  limits:
+    cpu: "1"
+    memory: 512Mi
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  # Must match the image's UID or an existing volume becomes unwritable.
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+livenessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 20
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+readinessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+priorityClassName: ""

--- a/docs/kubernetes-rancher.md
+++ b/docs/kubernetes-rancher.md
@@ -1,0 +1,198 @@
+# Running Vaara on Kubernetes with Rancher
+
+Vaara's model-endpoint proxy fronts an OpenAI-compatible or ollama server,
+passes traffic through unchanged, and records every tool call the model
+requests into a hash-chained audit trail. On Kubernetes that means one
+workload sitting between your agents and the model service, and one volume
+holding the evidence.
+
+This page covers a cluster managed by SUSE Rancher running RKE2 or K3s. The
+chart has nothing Rancher-specific in it, so any conformant cluster works, but
+the versions in [supported-platforms.md](supported-platforms.md) are the ones
+Vaara is documented against.
+
+## What gets deployed
+
+A StatefulSet with one replica, a ClusterIP Service, a ServiceAccount with no
+API token mounted, and a PersistentVolumeClaim for the trail.
+
+One replica is not a starting point to scale from. The audit trail is a hash
+chain: every record binds to its predecessor, so a chain has exactly one
+writer. Two pods appending to one volume interleave records and produce a
+chain neither of them can verify. If you need more throughput, run more
+proxies, each with its own chain and its own volume, and verify each one
+independently. [multi-replica-deployment.md](multi-replica-deployment.md)
+explains the reasoning in full.
+
+## Install
+
+```
+helm install vaara ./deploy/helm/vaara \
+  --namespace vaara --create-namespace \
+  --set upstream.url=http://ollama.suse-ai.svc.cluster.local:11434
+```
+
+Point your agents at the Service instead of at the model:
+
+```
+base_url = http://vaara.vaara.svc.cluster.local:8788
+```
+
+Nothing is blocked yet. The default mode is observe: Vaara records what the
+model asks for and forwards everything. Run it that way until the trail shows
+you what your agents actually call.
+
+Check that the proxy is up without involving the model:
+
+```
+kubectl -n vaara port-forward svc/vaara 8788:8788
+curl -s localhost:8788/healthz
+```
+
+The `/healthz` route is answered by Vaara. Every other path is forwarded, so a
+probe against `/` or `/health` reports the model server's state rather than
+the proxy's.
+
+## Storage
+
+The trail is a SQLite file on the volume, so the StorageClass needs
+ReadWriteOnce and it must not be backed by anything that reorders or delays
+writes. On RKE2 the default `local-path` provisioner is fine for a single
+node. Longhorn works and gives you replication, which is worth having when
+the file is your evidence.
+
+```
+--set persistence.storageClass=longhorn --set persistence.size=20Gi
+```
+
+The claim is kept when the release is deleted. That is deliberate: uninstalling
+a Helm release should not destroy an audit trail. Set
+`persistence.retainOnDelete=false` if you have exported the trail and want the
+volume to go with the release.
+
+Export before you need it. The export is signed, so it needs a key, which
+means this step assumes you have turned on signing (see below):
+
+```
+kubectl -n vaara exec vaara-0 -- vaara trail export \
+  --db /var/lib/vaara/audit.db \
+  --out /var/lib/vaara/handoff.zip \
+  --key /etc/vaara/signing/signing_key.pem
+```
+
+## Turning on enforcement
+
+Enforce mode gates instead of observing. Denied tool calls are rewritten out
+of the model's response and escalations block on the approvals handshake.
+
+An enforce deployment with no allow list gates every tool call, and clients
+see their tools disappear. Nothing is damaged and the trail records all of
+it, but the session is unusable. The chart refuses to render that
+configuration rather than let you find out in a crash loop.
+
+Start wide and tighten:
+
+```
+helm upgrade vaara ./deploy/helm/vaara \
+  --namespace vaara \
+  --set proxy.mode=enforce \
+  --set 'proxy.allow[0]=mcp__*'
+```
+
+## Signed receipts
+
+Observe and enforce both record. Signing also emits an attestation and receipt
+pair per chat call, which is the part a third party can verify without access
+to your cluster.
+
+The chart never generates a key. A key minted in a template would rotate on
+every upgrade, and every receipt signed by the old one would stop verifying.
+Create it yourself and hand the chart a Secret:
+
+```
+vaara keygen --dev --out signing_key.pem
+kubectl -n vaara create secret generic vaara-signing \
+  --from-file=signing_key.pem=signing_key.pem
+
+helm upgrade vaara ./deploy/helm/vaara --namespace vaara \
+  --set signing.enabled=true \
+  --set signing.existingSecret=vaara-signing
+```
+
+`vaara keygen --dev` produces a development key. For anything whose receipts
+you intend to show someone, use a key from your own KMS or HSM and mount it
+the same way. [signing-keys.md](signing-keys.md) covers the options.
+
+## Keeping the model reachable only through Vaara
+
+A governance layer an agent can route around governs nothing. Once Vaara is
+in place, restrict the model service so the proxy is the only client:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: model-through-vaara-only
+  namespace: suse-ai
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ollama
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: vaara
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vaara
+```
+
+RKE2 ships Canal, which enforces NetworkPolicy. Confirm your CNI does before
+relying on this.
+
+## Where Vaara sits next to SUSE AI
+
+SUSE AI serves models in-cluster through Ollama, vLLM and LiteLLM, and SUSE
+Observability reports on how those workloads are behaving. Vaara answers a
+different question: what did the agent ask the model to do, and can someone
+outside this cluster check the answer. It runs in front of the model endpoint
+and produces a record that verifies on its own.
+
+Both positions are useful in the same cluster. A deployment that governs an
+in-cluster model and also governs what that model can reach on the way out
+runs the proxy on both sides, each with its own trail.
+
+## Verifying the trail
+
+Verification runs over a signed export rather than over the live database, so
+the party checking it never needs access to your cluster. Copy the zip out and
+verify it with the auditor CLI, which is the same command a third party would
+run:
+
+```
+kubectl -n vaara cp vaara/vaara-0:/var/lib/vaara/handoff.zip ./handoff.zip
+vaara-audit verify ./handoff.zip
+```
+
+Add `--pubkey` if the checker holds the public key separately instead of
+taking the copy inside the zip.
+
+Verification is the point of the whole arrangement, so run it on a schedule
+and not only when something looks wrong. A chain that fails verification tells
+you the file was altered, which is information you want early.
+
+## Uninstalling
+
+```
+helm uninstall vaara --namespace vaara
+```
+
+The PersistentVolumeClaim stays behind by default and so does the trail.
+Delete it explicitly once you have the export:
+
+```
+kubectl -n vaara delete pvc data-vaara-0
+```

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,0 +1,75 @@
+# Supported platforms
+
+Vaara 1.67.1, Helm chart 0.1.0.
+
+Vaara is a Python package with no runtime dependencies and a container image
+built on SUSE's SLE Base Container Image. This page lists what it runs on and,
+separately, what it has been run on.
+
+## Package
+
+| Requirement | Supported |
+| --- | --- |
+| Python | 3.10, 3.11, 3.12, 3.13 |
+| Runtime dependencies | none for the base install |
+| Operating system | any platform CPython supports |
+
+The proxy needs the `proxy` extra (fastapi, uvicorn, httpx). Signed
+attestation and receipt pairs need the `attestation` extra (cbor2,
+cryptography, rfc8785). The container image ships both.
+
+## Container image
+
+| | |
+| --- | --- |
+| Image | `ghcr.io/vaaraio/vaara` |
+| Base | `registry.suse.com/bci/python:3.12` |
+| Architectures | linux/amd64, linux/arm64 |
+| Runs as | UID 10001, non-root, read-only root filesystem |
+| Exposed port | 8788 |
+
+The base image is SUSE's own BCI, which needs no subscription to pull or
+redistribute.
+
+## Kubernetes
+
+| Requirement | Supported |
+| --- | --- |
+| Kubernetes | 1.27 and later |
+| Distributions | RKE2, K3s |
+| Management | SUSE Rancher, or none |
+| Helm | 3.8 and later |
+| Storage | a StorageClass providing ReadWriteOnce |
+| CNI | any; NetworkPolicy support needed only for the model-isolation step |
+
+Deployment instructions are in
+[kubernetes-rancher.md](kubernetes-rancher.md).
+
+The chart deploys a StatefulSet with one replica and does not offer a replica
+count. The audit trail is a hash chain with exactly one writer, so a second
+pod appending to the same volume produces a chain neither pod can verify.
+[multi-replica-deployment.md](multi-replica-deployment.md) covers what to do
+instead when one proxy is not enough.
+
+## Verified releases
+
+A row here means the listed Vaara version was installed on the listed platform
+versions and the deployment was exercised end to end: an agent routed through
+the proxy, tool calls recorded, the trail exported and the export verified.
+
+| Vaara | Chart | Platform | Verified on |
+| --- | --- | --- | --- |
+| | | | |
+
+The table is empty. Vaara has run on Rancher in development for years, but no
+run has been recorded against a named platform version in the form above, and
+this page reports only what has. Rows are added as runs are completed.
+
+## Support
+
+Commercial support for Vaara on the platforms listed here is available from
+the maintainer at hello@vaara.io. The software is AGPL-3.0-or-later; see
+[LICENSING.md](../LICENSING.md).
+
+Security issues and serious bugs are disclosed in the
+[changelog](../CHANGELOG.md) with the release that fixes them.

--- a/src/vaara/integrations/_infer_proxy_app.py
+++ b/src/vaara/integrations/_infer_proxy_app.py
@@ -67,6 +67,28 @@ def build_app(
         app, allowed_origins=allowed_origins, surface="vaara-infer-proxy",
     )
 
+    # Registered before the catch-all below, because Starlette matches routes
+    # in registration order and every path on this app otherwise forwards
+    # upstream. A probe that forwards reports the MODEL's health, not the
+    # proxy's, so an orchestrator would restart Vaara whenever the model was
+    # slow to load. "/healthz" rather than "/health": vLLM serves /health and
+    # shadowing it would hide the upstream's own check from anyone routing
+    # through the proxy. The path is in the origin guard's exempt set, so a
+    # probe arriving with a foreign Origin is not refused.
+    @app.get("/healthz")
+    async def healthz() -> dict:
+        from vaara import __version__
+
+        return {
+            "status": "ok",
+            "version": __version__,
+            "mode": "enforce" if gating else "observe",
+            # No upstream URL: this answers to anything that can reach the
+            # port, and naming an internal model host is free reconnaissance.
+            "upstream_configured": bool(upstream),
+            "signing": emitter is not None,
+        }
+
     def _record_requested_tools(output: Any, model_name: str) -> None:
         if pipeline is None or not isinstance(output, dict):
             return

--- a/tests/test_docs_cli_flags_exist.py
+++ b/tests/test_docs_cli_flags_exist.py
@@ -40,6 +40,13 @@ NOT_OURS = {
     "--vectors-dir",  # scripts/conformance_runner.py
     "--list",         # scripts/conformance_runner.py
     "--skip-invalid",  # article12-export-spec.md says there is no such flag
+    # helm and kubectl, in docs/kubernetes-rancher.md. The deployment guide
+    # has to show the commands that install the chart, and those belong to
+    # other tools. Keep this list to flags a reader types into helm/kubectl,
+    # never a Vaara flag that "should" exist.
+    "--create-namespace",  # helm install
+    "--namespace",         # helm, kubectl
+    "--from-file",         # kubectl create secret generic
 }
 
 

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The deployment chart has to agree with the software it deploys.
+
+A Helm chart is a second copy of facts that already live in the package: the
+version, the UID the image runs as, the path the trail is written to, the
+flags the CLI accepts, the route a probe polls. Every one of those can drift
+without anything failing until an operator installs the chart and reads a
+crash loop.
+
+Most of these checks are plain text and run everywhere. The two that shell out
+to ``helm`` skip when the binary is absent and do the real render in CI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+import vaara
+
+ROOT = Path(__file__).resolve().parents[1]
+CHART = ROOT / "deploy" / "helm" / "vaara"
+TEMPLATES = CHART / "templates"
+DOCKERFILE = ROOT / "Dockerfile"
+
+#: The image creates this user and the chart runs as it. One number, three
+#: files, and a mismatch makes an existing volume unwritable.
+EXPECTED_UID = 10001
+
+#: Keys the templates read that Helm supplies or that only appear via
+#: --set at install time.
+BUILTIN_PREFIXES = ("Values.nameOverride", "Values.fullnameOverride")
+
+
+def _chart() -> dict:
+    return yaml.safe_load((CHART / "Chart.yaml").read_text(encoding="utf-8"))
+
+
+def _values() -> dict:
+    return yaml.safe_load((CHART / "values.yaml").read_text(encoding="utf-8"))
+
+
+def _template_text() -> str:
+    return "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(TEMPLATES.rglob("*"))
+        if path.is_file()
+    )
+
+
+def _lookup(values: dict, dotted: str) -> bool:
+    node = values
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return False
+        node = node[part]
+    return True
+
+
+# --- the chart agrees with the package -------------------------------------
+
+
+def test_chart_appversion_matches_the_package():
+    """A release that bumps vaara without bumping the chart ships a chart
+    whose default image tag points at the previous version."""
+    assert _chart()["appVersion"] == vaara.__version__
+
+
+def test_every_value_a_template_reads_is_declared():
+    """Catches `.Values.proxy.allowed` when the key is `allow`.
+
+    Helm renders an undefined value as empty and carries on, so the typo
+    reaches the cluster as a missing flag rather than an error.
+    """
+    values = _values()
+    referenced = set(re.findall(r"\.Values\.([a-zA-Z0-9_.]+)", _template_text()))
+    missing = sorted(
+        ref for ref in referenced
+        if not _lookup(values, ref) and not ref.startswith(BUILTIN_PREFIXES)
+    )
+    assert not missing, f"templates read values.yaml does not define: {missing}"
+
+
+def test_the_uid_is_the_same_in_the_image_and_the_chart():
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    assert f"--uid {EXPECTED_UID}" in dockerfile
+    assert f"USER {EXPECTED_UID}:{EXPECTED_UID}" in dockerfile
+    security = _values()["podSecurityContext"]
+    assert security["runAsUser"] == EXPECTED_UID
+    assert security["fsGroup"] == EXPECTED_UID, (
+        "fsGroup must match the image UID or the mounted volume is not "
+        "writable and the pod crash-loops on the first write"
+    )
+
+
+def test_the_trail_is_written_onto_the_mounted_volume():
+    """A trail under / would be lost on restart, and the root filesystem is
+    read-only, so it would not even be written."""
+    values = _values()
+    mount = "/var/lib/vaara"
+    assert values["trail"]["path"].startswith(mount + "/")
+    assert values["signing"]["receiptsDir"].startswith(mount)
+    assert values["proxy"]["approvals"]["path"].startswith(mount)
+    assert f"mountPath: {mount}" in (TEMPLATES / "statefulset.yaml").read_text()
+
+
+def test_the_chart_does_not_offer_to_scale_the_chain():
+    """One hash chain has one writer. There must be no replicaCount knob and
+    the replica count must be literal."""
+    statefulset = (TEMPLATES / "statefulset.yaml").read_text(encoding="utf-8")
+    assert "kind: StatefulSet" in statefulset
+    assert re.search(r"^\s+replicas: 1$", statefulset, re.M)
+    # The prose in these files explains why there is no such knob, so look
+    # for the knob itself rather than the word.
+    assert ".Values.replicaCount" not in _template_text()
+    assert "replicaCount" not in _values()
+
+
+# --- the chart agrees with the CLI and the app -----------------------------
+
+
+def test_probe_path_is_a_route_the_proxy_answers_itself():
+    """The probe must not be forwarded to the model server."""
+    app_source = (
+        ROOT / "src" / "vaara" / "integrations" / "_infer_proxy_app.py"
+    ).read_text(encoding="utf-8")
+    assert '@app.get("/healthz")' in app_source
+    assert "path: /healthz" in (TEMPLATES / "statefulset.yaml").read_text()
+
+
+def test_chart_flags_exist_in_the_cli():
+    """Every `--flag` the templates pass has to be one `vaara proxy` accepts."""
+    script = Path(__import__("sys").executable).parent / "vaara"
+    if not script.exists():
+        script_path = shutil.which("vaara")
+        if not script_path:
+            pytest.skip("vaara console script is not installed")
+        script = Path(script_path)
+    help_text = subprocess.run(
+        [str(script), "proxy", "--help"],
+        capture_output=True, text=True, timeout=60,
+    )
+    accepted = set(re.findall(r"(--[a-z][\w-]+)", help_text.stdout + help_text.stderr))
+    assert accepted, "vaara proxy --help produced no flags"
+    used = set(re.findall(r"- (--[a-z][\w-]+)", (TEMPLATES / "statefulset.yaml").read_text()))
+    assert used, "the statefulset passes no flags at all"
+    assert used <= accepted, f"chart passes flags vaara proxy rejects: {sorted(used - accepted)}"
+
+
+# --- the documented platforms agree with the chart -------------------------
+
+
+def test_supported_platforms_names_the_image_and_the_chart_version():
+    """SUSE Ready certification requires published documentation naming the
+    supported versions. If the page and the chart disagree, the published
+    claim is the wrong one."""
+    page = (ROOT / "docs" / "supported-platforms.md").read_text(encoding="utf-8")
+    chart = _chart()
+    assert vaara.__version__ in page
+    assert f"chart {chart['version']}" in page or f"chart version {chart['version']}" in page
+    assert _values()["image"]["repository"] in page
+
+
+# --- the real thing, when helm is available --------------------------------
+
+
+def _helm() -> str:
+    path = shutil.which("helm") or str(Path.home() / ".local" / "bin" / "helm")
+    if not Path(path).exists():
+        pytest.skip("helm is not installed")
+    return path
+
+
+def test_helm_lint_passes():
+    done = subprocess.run(
+        [_helm(), "lint", str(CHART)], capture_output=True, text=True, timeout=120,
+    )
+    assert done.returncode == 0, done.stdout + done.stderr
+
+
+def test_default_render_is_valid_yaml_and_holds_one_replica():
+    done = subprocess.run(
+        [_helm(), "template", "release", str(CHART)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert done.returncode == 0, done.stderr
+    docs = [doc for doc in yaml.safe_load_all(done.stdout) if doc]
+    kinds = {doc["kind"] for doc in docs}
+    assert {"StatefulSet", "Service", "ServiceAccount"} <= kinds
+    sts = next(doc for doc in docs if doc["kind"] == "StatefulSet")
+    assert sts["spec"]["replicas"] == 1
+    container = sts["spec"]["template"]["spec"]["containers"][0]
+    assert container["args"][0] == "proxy"
+    assert container["securityContext"]["readOnlyRootFilesystem"] is True
+    assert container["livenessProbe"]["httpGet"]["path"] == "/healthz"
+
+
+def test_enforce_without_an_allow_list_refuses_to_render():
+    """The CLI refuses this at startup. The chart refuses it at install, so
+    the operator reads the reason instead of a crash loop."""
+    done = subprocess.run(
+        [_helm(), "template", "release", str(CHART), "--set", "proxy.mode=enforce"],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert done.returncode != 0
+    assert "proxy.allow" in done.stderr
+
+
+def test_signing_without_a_secret_refuses_to_render():
+    done = subprocess.run(
+        [_helm(), "template", "release", str(CHART), "--set", "signing.enabled=true"],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert done.returncode != 0
+    assert "signing.existingSecret" in done.stderr
+
+
+def test_signing_mounts_the_named_secret_read_only():
+    done = subprocess.run(
+        [
+            _helm(), "template", "release", str(CHART),
+            "--set", "signing.enabled=true",
+            "--set", "signing.existingSecret=vaara-signing",
+        ],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert done.returncode == 0, done.stderr
+    sts = next(
+        doc for doc in yaml.safe_load_all(done.stdout)
+        if doc and doc["kind"] == "StatefulSet"
+    )
+    spec = sts["spec"]["template"]["spec"]
+    volume = next(v for v in spec["volumes"] if v["name"] == "signing-key")
+    assert volume["secret"]["secretName"] == "vaara-signing"
+    mount = next(
+        m for m in spec["containers"][0]["volumeMounts"] if m["name"] == "signing-key"
+    )
+    assert mount["readOnly"] is True
+
+
+def test_the_helm_test_pod_checks_vaara_not_the_model():
+    done = subprocess.run(
+        [_helm(), "template", "release", str(CHART)],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert done.returncode == 0, done.stderr
+    pod = next(
+        doc for doc in yaml.safe_load_all(done.stdout)
+        if doc and doc["kind"] == "Pod"
+    )
+    assert pod["metadata"]["annotations"]["helm.sh/hook"] == "test"
+    command = json.dumps(pod["spec"]["containers"][0]["command"])
+    assert "/healthz" in command

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -8,8 +8,11 @@ flags the CLI accepts, the route a probe polls. Every one of those can drift
 without anything failing until an operator installs the chart and reads a
 crash loop.
 
-Most of these checks are plain text and run everywhere. The two that shell out
-to ``helm`` skip when the binary is absent and do the real render in CI.
+Some of these checks are plain text and run everywhere. The rest need pyyaml
+(an optional extra) or the helm binary, and skip without them. The
+``helm-chart`` CI job installs both and fails if either is missing, so the
+render is verified on every pull request rather than skipped into a green
+build.
 """
 
 from __future__ import annotations
@@ -21,7 +24,6 @@ import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 
 import vaara
 
@@ -39,12 +41,21 @@ EXPECTED_UID = 10001
 BUILTIN_PREFIXES = ("Values.nameOverride", "Values.fullnameOverride")
 
 
+def _yaml():
+    """pyyaml is an optional extra, so the main test job does not have it.
+
+    The dedicated `helm-chart` CI job installs it alongside helm, which is
+    where these checks are guaranteed to run rather than skip.
+    """
+    return pytest.importorskip("yaml")
+
+
 def _chart() -> dict:
-    return yaml.safe_load((CHART / "Chart.yaml").read_text(encoding="utf-8"))
+    return _yaml().safe_load((CHART / "Chart.yaml").read_text(encoding="utf-8"))
 
 
 def _values() -> dict:
-    return yaml.safe_load((CHART / "values.yaml").read_text(encoding="utf-8"))
+    return _yaml().safe_load((CHART / "values.yaml").read_text(encoding="utf-8"))
 
 
 def _template_text() -> str:
@@ -191,7 +202,7 @@ def test_default_render_is_valid_yaml_and_holds_one_replica():
         capture_output=True, text=True, timeout=120,
     )
     assert done.returncode == 0, done.stderr
-    docs = [doc for doc in yaml.safe_load_all(done.stdout) if doc]
+    docs = [doc for doc in _yaml().safe_load_all(done.stdout) if doc]
     kinds = {doc["kind"] for doc in docs}
     assert {"StatefulSet", "Service", "ServiceAccount"} <= kinds
     sts = next(doc for doc in docs if doc["kind"] == "StatefulSet")
@@ -233,7 +244,7 @@ def test_signing_mounts_the_named_secret_read_only():
     )
     assert done.returncode == 0, done.stderr
     sts = next(
-        doc for doc in yaml.safe_load_all(done.stdout)
+        doc for doc in _yaml().safe_load_all(done.stdout)
         if doc and doc["kind"] == "StatefulSet"
     )
     spec = sts["spec"]["template"]["spec"]
@@ -252,7 +263,7 @@ def test_the_helm_test_pod_checks_vaara_not_the_model():
     )
     assert done.returncode == 0, done.stderr
     pod = next(
-        doc for doc in yaml.safe_load_all(done.stdout)
+        doc for doc in _yaml().safe_load_all(done.stdout)
         if doc and doc["kind"] == "Pod"
     )
     assert pod["metadata"]["annotations"]["helm.sh/hook"] == "test"

--- a/tests/test_infer_proxy_health.py
+++ b/tests/test_infer_proxy_health.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Henri Sirkkavaara
+"""The proxy answers its own liveness probe without calling the model.
+
+Every path on the inference proxy is a catch-all that forwards upstream, so
+before this endpoint existed a Kubernetes readiness probe had exactly two
+options: poll a model-server path (which reports the MODEL's health, restarts
+Vaara when the model is slow to load, and bills a request per probe) or use a
+bare TCP check (which says a socket is open and nothing else).
+
+``/healthz`` is answered locally. It is already in the origin guard's exempt
+set, so a load balancer polling from another origin is not refused.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+
+import pytest
+
+for _mod in ("httpx", "fastapi"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            f"inference-proxy deps not installed: no {_mod}",
+            allow_module_level=True,
+        )
+
+import httpx  # noqa: E402
+
+import vaara  # noqa: E402
+from vaara.integrations._infer_proxy_app import build_app  # noqa: E402
+
+
+class _CountingUpstream:
+    """Mock upstream that fails the test if the probe ever reaches it."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        return httpx.Response(200, json={"upstream": "reached"})
+
+
+def _get(app, path: str) -> httpx.Response:
+    async def drive():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://proxy",
+        ) as client:
+            return await client.get(path)
+
+    return asyncio.run(drive())
+
+
+def _build(enforce: bool = False, upstream_calls=None):
+    counter = upstream_calls if upstream_calls is not None else _CountingUpstream()
+    client = httpx.AsyncClient(transport=httpx.MockTransport(counter))
+    pipeline = None
+    if enforce:
+        class _Enforcing:
+            _enforce = True
+
+        pipeline = _Enforcing()
+    app = build_app(
+        emitter=None, upstream="http://ollama", client=client, pipeline=pipeline,
+    )
+    return app, counter
+
+
+def test_healthz_answers_without_touching_upstream():
+    app, counter = _build()
+    resp = _get(app, "/healthz")
+    assert resp.status_code == 200
+    assert counter.calls == 0, (
+        "the liveness probe was forwarded to the model server"
+    )
+
+
+def test_healthz_reports_status_and_version():
+    app, _ = _build()
+    body = _get(app, "/healthz").json()
+    assert body["status"] == "ok"
+    assert body["version"] == vaara.__version__
+
+
+def test_healthz_reports_observe_mode_by_default():
+    app, _ = _build()
+    assert _get(app, "/healthz").json()["mode"] == "observe"
+
+
+def test_healthz_reports_enforce_mode_when_gating():
+    app, _ = _build(enforce=True)
+    assert _get(app, "/healthz").json()["mode"] == "enforce"
+
+
+def test_healthz_does_not_disclose_the_upstream_url():
+    """A probe endpoint reachable from the cluster names no internal host."""
+    app, _ = _build()
+    assert "ollama" not in _get(app, "/healthz").text
+
+
+def test_other_paths_still_reach_the_upstream():
+    """The local route must not shadow the passthrough it sits in front of."""
+    app, counter = _build()
+    resp = _get(app, "/api/tags")
+    assert resp.status_code == 200
+    assert resp.json() == {"upstream": "reached"}
+    assert counter.calls == 1
+
+
+def test_upstream_health_path_is_not_shadowed():
+    """vLLM serves /health. Vaara claims /healthz so both stay reachable."""
+    app, counter = _build()
+    resp = _get(app, "/health")
+    assert counter.calls == 1
+    assert resp.json() == {"upstream": "reached"}
+
+
+def test_healthz_ignores_a_foreign_origin_header():
+    """The origin guard exempts health paths so load balancers are not refused."""
+    app, _ = _build()
+
+    async def drive():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://proxy",
+        ) as client:
+            return await client.get(
+                "/healthz", headers={"origin": "https://elsewhere.test"},
+            )
+
+    assert asyncio.run(drive()).status_code == 200


### PR DESCRIPTION
Vaara had no Kubernetes story. No image, no manifests, and no page in `docs/` mentioning Kubernetes, Rancher, RKE2 or K3s. Running the proxy in a cluster meant writing the deployment yourself and guessing at the parts that matter.

## The chart

`deploy/helm/vaara` installs the model-endpoint proxy in front of an in-cluster model endpoint: a StatefulSet with one replica, a ClusterIP Service, a ServiceAccount with no API token mounted, and a PersistentVolumeClaim holding the trail.

There is no replica count. One hash chain has exactly one writer, and a second pod appending to the same volume produces a chain neither pod can verify. The invariant is enforced by the shape of the chart rather than documented next to a knob that breaks it.

Three configurations that would fail in the cluster now fail at template time with the reason:

- `enforce` mode with no allow list and no approvals directory. Every tool call is gated and clients appear to lose their tools.
- Signing with no Secret named. The chart will not mint a key, because a key minted in a template rotates on every upgrade and every receipt signed by the old one stops verifying.
- Signing without persistence. Signed evidence discarded on pod restart is not evidence.

## The image

Built on `registry.suse.com/bci/python:3.12`, SUSE's own base image, which needs no subscription to pull or redistribute. Runs as UID 10001, non-root, read-only root filesystem, no capabilities. Published to `ghcr.io/vaaraio/vaara` on release for linux/amd64 and linux/arm64.

## GET /healthz

Every other path on the proxy forwards upstream, so a liveness probe had no way to ask about the proxy rather than about the model. An orchestrator would have restarted Vaara whenever the model was slow to load, and billed a request per probe. The route answers locally with status, version and mode, names no internal host, and does not shadow the `/health` that vLLM serves.

## Docs

`docs/kubernetes-rancher.md` covers install, storage, turning on enforcement, signed receipts, and the NetworkPolicy that makes the proxy the only route to the model.

`docs/supported-platforms.md` lists the Python, container and Kubernetes versions Vaara supports, and separately records which platform versions a release has actually been run against. That table is currently empty and says so.

## Tests

28 new tests, 2963 passing overall. The chart tests render the chart with helm and assert on the output, including that the signing Secret mounts read-only and that enforce without an allow list refuses to render. They skip when helm is absent, so a CI job requires the binary and a silent skip cannot report a green build for a chart nobody rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes and Rancher deployment support through a Helm chart.
  * Added container image support for multi-platform deployments.
  * Added a local `/healthz` endpoint reporting service status, version, mode, and signing availability.
  * Added configurable persistence, signing, enforcement, health probes, and service settings.

* **Documentation**
  * Added Kubernetes/Rancher deployment guidance and supported-platform information.
  * Updated the changelog and README with deployment resources.

* **Validation**
  * Added deployment-time configuration checks and Helm chart tests for safer deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->