### PR TITLE
feat: grade a conformance statement proved, unproved or false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- **A conformance statement now grades every check as `proved`, `unproved` or
+  `false` instead of true or false.** A boolean cannot tell a reader whether a
+  check ran and failed or was never reached, and those need different repairs.
+  A suite the runner cannot place and a record file that will not parse both
+  used to land on `conforms: false`, next to a genuine disagreement with the
+  spec, which reports more than the run established.
+
+  `unproved` is only ever produced by an execution state the runner recorded,
+  never inferred from a primary check that failed. A suite reports `runnable`;
+  an unreadable record is listed by name. Where a run mixes states the worst
+  one wins, because a check that ran and failed is a stronger claim than one
+  that never ran. Records stay optional: supplying none leaves the section
+  absent and contributes no grade, which is a different statement from
+  supplying records that could not be read.
+
+  The rendered page no longer prints NON-CONFORMING over an unreached check.
+  It prints UNPROVED, names which check could not be reached, and says the
+  statement establishes nothing either way.
+
+  `schemaVersion` goes to 2. The change is additive: `conforms` keeps its
+  meaning and every previously conforming statement still conforms.
+
+  A fifth vector scenario, `unproved`, carries records that all conform plus one
+  file that will not parse, which is the case a boolean cannot express. The
+  Vaara-free checker re-derives the grade itself with its own worst-first fold
+  and fails if a page or golden ever claims `proved` where it derived
+  `unproved`, so the new field is checked rather than asserted.
+
 - **A Helm chart and a container image, so Vaara can be deployed on
   Kubernetes.** `deploy/helm/vaara` installs the model-endpoint proxy in front
   of an in-cluster model endpoint: a StatefulSet with one replica, a

--- a/scripts/build_conformance_statement_vectors.py
+++ b/scripts/build_conformance_statement_vectors.py
@@ -18,6 +18,10 @@ the rendered Markdown page (``pages/<scenario>.md``):
 * ``flawed`` - emitter records with one non-conforming record.
 * ``duplicate`` - records that each conform but fail a required set property
   (two outcomes pin one call), so the set does not conform.
+* ``unproved`` - the clean records plus one file that will not parse. Nothing
+  read disagrees with the spec, and the set check never saw the third file, so
+  the statement grades ``unproved`` rather than ``false``. This is the case a
+  boolean cannot express.
 
 Run: ``python scripts/build_conformance_statement_vectors.py``. Commit the
 result; the test fails if the committed goldens drift from this output or from
@@ -41,21 +45,38 @@ VECTORS = REPO / "tests" / "vectors" / "conformance_statement_v0"
 EMITTER = VECTORS / "emitter_records"
 PAGES = VECTORS / "pages"
 
-SCENARIOS = ["selftest_only", "clean", "flawed", "duplicate"]
+SCENARIOS = ["selftest_only", "clean", "flawed", "duplicate", "unproved"]
 
 
-def _load_records(scenario: str) -> list[tuple[str, object]] | None:
+def _load_records(
+    scenario: str,
+) -> tuple[list[tuple[str, object]] | None, list[tuple[str, str]]]:
+    """Read a scenario's records the way the CLI reads a real directory.
+
+    A file that will not parse is reported as unreadable rather than dropped, so
+    the statement can say the check never saw it instead of quietly narrowing
+    the set it claims to have checked.
+    """
     if scenario == "selftest_only":
-        return None
-    paths = sorted((EMITTER / scenario).glob("*.json"))
-    return [(p.name, json.loads(p.read_text(encoding="utf-8"))) for p in paths]
+        return None, []
+    records: list[tuple[str, object]] = []
+    unreadable: list[tuple[str, str]] = []
+    for path in sorted((EMITTER / scenario).glob("*.json")):
+        try:
+            records.append((path.name, json.loads(path.read_text(encoding="utf-8"))))
+        except (json.JSONDecodeError, OSError) as exc:
+            unreadable.append((path.name, type(exc).__name__))
+    return records, unreadable
 
 
 def build() -> None:
     PAGES.mkdir(parents=True, exist_ok=True)
     expected: dict[str, object] = {}
     for scenario in SCENARIOS:
-        statement = build_conformance_statement(CORPUS, records=_load_records(scenario))
+        records, unreadable = _load_records(scenario)
+        statement = build_conformance_statement(
+            CORPUS, records=records, unreadable=unreadable
+        )
         expected[scenario] = statement.to_dict()
         (PAGES / f"{scenario}.md").write_text(
             render_conformance_statement(statement), encoding="utf-8"

--- a/src/vaara/attestation/_conformance_statement.py
+++ b/src/vaara/attestation/_conformance_statement.py
@@ -20,6 +20,19 @@ The statement has three parts:
 * **Records** (optional) - the emitter's own records run through the same
   keyless set check, with the verdict reported beside the self-test.
 
+Every part grades to one of three states rather than a boolean:
+
+* ``proved`` - the check ran and the property holds.
+* ``unproved`` - the check could not be reached, so nothing is asserted.
+* ``false`` - the check ran and the property does not hold.
+
+A boolean cannot tell a reader whether a check failed or was never reached, and
+those call for different repairs. ``unproved`` is only ever produced by an
+explicit execution state the runner recorded (a suite it could not place, a
+record file it could not read), never inferred from a primary check that failed.
+Where a run mixes states, the worst one wins: a check that ran and failed
+outranks one that never ran.
+
 Deterministic and keyless. There is no clock: an ``as_of`` date is echoed
 verbatim when the caller supplies one and is never read from the system, so the
 same inputs render the same statement byte for byte. The whole check needs no
@@ -41,7 +54,30 @@ from vaara.attestation._record_set_conformance import check_record_set
 from vaara.attestation._record_set_findings import SetFinding
 
 STATEMENT_SCHEMA = "sep2828-conformance-statement"
-STATEMENT_SCHEMA_VERSION = 1
+STATEMENT_SCHEMA_VERSION = 2
+
+#: The check ran and the property holds.
+PROVED = "proved"
+#: The check could not be reached, so the statement asserts nothing either way.
+UNPROVED = "unproved"
+#: The check ran and the property does not hold.
+FALSE = "false"
+
+#: Worst-first. A check that ran and failed outranks one that never ran, because
+#: a known failure is a stronger claim than an absence of evidence.
+_GRADE_ORDER = (FALSE, UNPROVED, PROVED)
+
+
+def combine_grades(grades: Sequence[str]) -> str:
+    """Fold sub-grades into one, worst first.
+
+    ``FALSE`` dominates ``UNPROVED`` dominates ``PROVED``. An empty sequence is
+    ``UNPROVED``: nothing was checked, so nothing is asserted.
+    """
+    for grade in _GRADE_ORDER:
+        if grade in grades:
+            return grade
+    return UNPROVED
 
 
 class ConformanceCorpusError(ValueError):
@@ -63,6 +99,11 @@ class CorpusIntegrity:
     verified: bool
     problems: tuple[str, ...]
 
+    @property
+    def grade(self) -> str:
+        """Corpus integrity is always reachable: the bytes are here or they are not."""
+        return PROVED if self.verified else FALSE
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,
@@ -71,6 +112,7 @@ class CorpusIntegrity:
             "corpusDigest": self.corpus_digest,
             "fileCount": self.file_count,
             "verified": self.verified,
+            "grade": self.grade,
             "problems": list(self.problems),
         }
 
@@ -85,10 +127,24 @@ class SuiteResult:
     reproduced: int
     mismatches: tuple[str, ...]
 
+    @property
+    def grade(self) -> str:
+        """``UNPROVED`` when the suite could not be run at all.
+
+        ``runnable`` is an execution state recorded by the runner, not an
+        inference drawn from a failed check. A suite it cannot place never
+        reaches a verdict, so the statement asserts nothing about it rather than
+        reporting it as a disagreement.
+        """
+        if not self.runnable:
+            return UNPROVED
+        return FALSE if self.mismatches else PROVED
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "name": self.name,
             "runnable": self.runnable,
+            "grade": self.grade,
             "cases": self.cases,
             "reproduced": self.reproduced,
             "mismatches": list(self.mismatches),
@@ -104,9 +160,15 @@ class SelfTest:
     reproduced: int
     suites: tuple[SuiteResult, ...]
 
+    @property
+    def grade(self) -> str:
+        """Worst suite grade wins; no suites at all is ``UNPROVED``."""
+        return combine_grades([s.grade for s in self.suites])
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "conforms": self.conforms,
+            "grade": self.grade,
             "cases": self.cases,
             "reproduced": self.reproduced,
             "suites": [s.to_dict() for s in self.suites],
@@ -124,9 +186,27 @@ class RecordsResult:
     nonconforming: tuple[tuple[str, tuple[str, ...]], ...]
     unreadable: tuple[tuple[str, str], ...]
 
+    @property
+    def grade(self) -> str:
+        """A file that could not be read is ``UNPROVED``, never ``FALSE``.
+
+        Being unreadable is an execution state: the set check never saw the
+        record, so nothing is established about it. Grading it as a failure
+        would claim more than the run supports. A record that was read and did
+        not conform, or a required finding across the set, is ``FALSE``.
+        """
+        if self.nonconforming or any(f.severity == "required" for f in self.findings):
+            return FALSE
+        if self.unreadable:
+            return UNPROVED
+        if self.total == 0:
+            return UNPROVED
+        return PROVED
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "conforms": self.conforms,
+            "grade": self.grade,
             "total": self.total,
             "conforming": self.conforming,
             "findings": [
@@ -150,11 +230,26 @@ class ConformanceStatement:
     conforms: bool
     as_of: Optional[str]
 
+    @property
+    def grade(self) -> str:
+        """Worst grade across the checks that were in scope for this run.
+
+        Records are optional. When none were supplied the section is absent
+        entirely and contributes no grade, which is different from supplying
+        records that could not be read. Not requested and not reachable are not
+        the same claim.
+        """
+        grades = [self.corpus.grade, self.self_test.grade]
+        if self.records is not None:
+            grades.append(self.records.grade)
+        return combine_grades(grades)
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "schema": STATEMENT_SCHEMA,
             "schemaVersion": STATEMENT_SCHEMA_VERSION,
             "conforms": self.conforms,
+            "grade": self.grade,
             "asOf": self.as_of,
             "corpus": self.corpus.to_dict(),
             "selfTest": self.self_test.to_dict(),
@@ -386,15 +481,22 @@ def build_conformance_statement(
         _records_result(records, unreadable) if records is not None else None
     )
 
-    conforms = (
-        corpus.verified
-        and self_test.conforms
-        and (records_result is None or records_result.conforms)
+    # One source of truth: the statement conforms exactly when every in-scope
+    # check reached a verdict and that verdict held. An unreachable check leaves
+    # the statement not-conforming without claiming the property is false.
+    provisional = ConformanceStatement(corpus, self_test, records_result, False, as_of)
+    return ConformanceStatement(
+        corpus, self_test, records_result, provisional.grade == PROVED, as_of
     )
-    return ConformanceStatement(corpus, self_test, records_result, conforms, as_of)
 
 
 # ── Render ────────────────────────────────────────────────────────────────────
+
+_VERDICT_WORD = {
+    PROVED: "CONFORMS",
+    UNPROVED: "UNPROVED",
+    FALSE: "NON-CONFORMING",
+}
 
 _HOW = (
     "This statement is keyless and reproducible. Anyone holding the same corpus "
@@ -414,10 +516,17 @@ def render_conformance_statement(statement: ConformanceStatement) -> str:
     inputs render byte-identical every time.
     """
     c = statement.corpus
-    verdict = "CONFORMS" if statement.conforms else "NON-CONFORMING"
+    verdict = _VERDICT_WORD[statement.grade]
     lines: list[str] = ["# SEP-2828 conformance statement", ""]
     lines.append(f"**Statement: {verdict}**")
     lines.append("")
+    if statement.grade == UNPROVED:
+        lines.append(
+            "At least one check could not be reached, so this statement does not "
+            "establish the property either way. That is a different result from a "
+            "check that ran and failed, and the sections below name which."
+        )
+        lines.append("")
     lines.append(
         f"Checked against corpus `{_safe(c.name)}` version {_safe(c.version)} "
         f"(corpusDigest `{_safe(c.corpus_digest)}`)."
@@ -450,7 +559,10 @@ def render_conformance_statement(statement: ConformanceStatement) -> str:
     lines.append("")
     for s in st.suites:
         if not s.runnable:
-            lines.append(f"- `{s.name}`: not runnable ({_names(s.mismatches)})")
+            lines.append(
+                f"- `{s.name}`: unproved, the suite could not be run "
+                f"({_names(s.mismatches)}). No verdict is claimed for it."
+            )
         else:
             tail = "" if not s.mismatches else f"; mismatched {_names(s.mismatches)}"
             lines.append(f"- `{s.name}`: {s.reproduced}/{s.cases} reproduced{tail}")
@@ -469,9 +581,15 @@ def render_conformance_statement(statement: ConformanceStatement) -> str:
 def _render_records(r: RecordsResult, lines: list[str]) -> None:
     lines.append("## Your records")
     lines.append("")
-    rv = "CONFORM" if r.conforms else "do NOT conform"
+    rv = {
+        PROVED: "CONFORM",
+        FALSE: "do NOT conform",
+        UNPROVED: "are unproved: what was read conformed, but the set was not complete",
+    }[r.grade]
     if r.total == 0:
-        lines.append("No records were supplied to this run.")
+        lines.append(
+            "No readable records were supplied to this run, so nothing is established."
+        )
     else:
         lines.append(
             f"{r.total} record{_s(r.total)} checked, {r.conforming} "
@@ -505,7 +623,10 @@ def _render_records(r: RecordsResult, lines: list[str]) -> None:
 
     if r.unreadable:
         names = ", ".join(_safe(n) for n, _ in r.unreadable)
-        lines.append(f"> Note: {len(r.unreadable)} file(s) could not be read: {names}")
+        lines.append(
+            f"> Unproved: {len(r.unreadable)} file(s) could not be read, so the set "
+            f"check never saw them and claims nothing about them: {names}"
+        )
         lines.append("")
 
 

--- a/src/vaara/attestation/receipt.py
+++ b/src/vaara/attestation/receipt.py
@@ -59,7 +59,10 @@ from vaara.attestation._audit_summary import (
     render_record_set_summary,
 )
 from vaara.attestation._conformance_statement import (
+    FALSE,
+    PROVED,
     STATEMENT_SCHEMA,
+    UNPROVED,
     ConformanceCorpusError,
     ConformanceStatement,
     CorpusIntegrity,
@@ -67,6 +70,7 @@ from vaara.attestation._conformance_statement import (
     SelfTest,
     SuiteResult,
     build_conformance_statement,
+    combine_grades,
     render_conformance_statement,
     verify_corpus_integrity,
 )
@@ -305,6 +309,10 @@ __all__ = [
     "SUMMARY_SCHEMA",
     "render_record_set_summary",
     "STATEMENT_SCHEMA",
+    "PROVED",
+    "UNPROVED",
+    "FALSE",
+    "combine_grades",
     "ConformanceCorpusError",
     "ConformanceStatement",
     "CorpusIntegrity",

--- a/tests/test_conformance_statement.py
+++ b/tests/test_conformance_statement.py
@@ -34,18 +34,27 @@ EXPECTED = json.loads((VECTORS / "expected.json").read_text(encoding="utf-8"))
 
 SCENARIO_RECORDS = {
     "selftest_only": None, "clean": "clean", "flawed": "flawed", "duplicate": "duplicate",
+    "unproved": "unproved",
 }
 
 
 def _records(scenario: str):
+    """Mirror how the CLI reads a real directory: unparseable files stay visible."""
     sub = SCENARIO_RECORDS[scenario]
     if sub is None:
-        return None
-    return [(p.name, json.loads(p.read_text())) for p in sorted((EMITTER / sub).glob("*.json"))]
+        return None, []
+    records, unreadable = [], []
+    for p in sorted((EMITTER / sub).glob("*.json")):
+        try:
+            records.append((p.name, json.loads(p.read_text())))
+        except (json.JSONDecodeError, OSError) as exc:
+            unreadable.append((p.name, type(exc).__name__))
+    return records, unreadable
 
 
 def _build(scenario: str):
-    return build_conformance_statement(CORPUS, records=_records(scenario))
+    records, unreadable = _records(scenario)
+    return build_conformance_statement(CORPUS, records=records, unreadable=unreadable)
 
 
 # ── Goldens ───────────────────────────────────────────────────────────────────
@@ -64,8 +73,47 @@ def test_render_matches_golden_page(scenario):
 
 def test_all_scenarios_present():
     assert sorted(p.stem for p in PAGES.glob("*.md")) == [
-        "clean", "duplicate", "flawed", "selftest_only"
+        "clean", "duplicate", "flawed", "selftest_only", "unproved"
     ]
+
+
+# ── The three states ──────────────────────────────────────────────────────────
+
+
+def test_grades_separate_a_failed_check_from_an_unreached_one():
+    """The distinction a boolean cannot carry, pinned end to end."""
+    assert _build("clean").grade == "proved"
+    assert _build("flawed").grade == "false"
+    assert _build("unproved").grade == "unproved"
+
+
+def test_unproved_run_does_not_claim_the_records_failed():
+    statement = _build("unproved")
+    assert statement.records is not None
+    # Nothing that was read disagreed with the spec.
+    assert statement.records.nonconforming == ()
+    assert statement.records.conforming == statement.records.total
+    # The unread file is why, and it is named rather than folded into a failure.
+    assert [n for n, _ in statement.records.unreadable] == ["broken.json"]
+    assert statement.records.grade == "unproved"
+    assert statement.conforms is False
+
+
+def test_unproved_page_never_says_non_conforming():
+    page = render_conformance_statement(_build("unproved"))
+    assert "**Statement: UNPROVED**" in page
+    assert "NON-CONFORMING" not in page
+    assert "do NOT conform" not in page
+
+
+def test_a_real_failure_outranks_an_unreached_check():
+    from vaara.attestation.receipt import combine_grades
+
+    assert combine_grades(["proved", "unproved", "false"]) == "false"
+    assert combine_grades(["proved", "unproved"]) == "unproved"
+    assert combine_grades(["proved", "proved"]) == "proved"
+    # Nothing checked establishes nothing.
+    assert combine_grades([]) == "unproved"
 
 
 def test_independent_checker_confirms_statements():

--- a/tests/vectors/conformance_statement_v0/README.md
+++ b/tests/vectors/conformance_statement_v0/README.md
@@ -21,6 +21,17 @@ pages/<scenario>.md           the rendered Markdown statement (deterministic)
 _check_independent.py         stdlib only, no Vaara import
 ```
 
+## Grades
+
+Every part of a statement grades to one of three states rather than a boolean:
+`proved` (the check ran and the property holds), `unproved` (the check could not
+be reached, so nothing is asserted), and `false` (the check ran and the property
+does not hold). Worst wins when a run mixes them.
+
+`unproved` comes only from an execution state the runner recorded, such as a
+suite it could not place or a record file it could not read. It is never
+inferred from a primary check that failed.
+
 ## Scenarios
 
 - `selftest_only`: no emitter records, just the corpus self-test. Conforms.
@@ -28,6 +39,12 @@ _check_independent.py         stdlib only, no Vaara import
 - `flawed`: emitter records with one non-conforming record. NON-CONFORMING,
   even though the corpus self-test passes, because the supplied records do not
   all conform.
+- `duplicate`: records that each conform but fail a required set property, so
+  the set does not conform.
+- `unproved`: the `clean` records plus `broken.json`, which will not parse.
+  Nothing read disagrees with the spec and the set check never saw the third
+  file, so the statement is UNPROVED rather than NON-CONFORMING. This is the
+  case the old boolean could not express.
 
 The `clean` and `flawed` records are byte copies of the `proper_pair` and
 `mixed_nonconforming` sets from the `record_set_v0` vectors, so their set

--- a/tests/vectors/conformance_statement_v0/_check_independent.py
+++ b/tests/vectors/conformance_statement_v0/_check_independent.py
@@ -44,7 +44,18 @@ HEX_RE = re.compile(r"^[0-9a-f]+$")
 
 SCENARIO_RECORDS = {
     "selftest_only": None, "clean": "clean", "flawed": "flawed", "duplicate": "duplicate",
+    "unproved": "unproved",
 }
+
+PROVED, UNPROVED, FALSE = "proved", "unproved", "false"
+
+
+def combine(grades):
+    """Worst first, independently of Vaara's own fold."""
+    for g in (FALSE, UNPROVED, PROVED):
+        if g in grades:
+            return g
+    return UNPROVED
 
 
 # ── Independent corpus + self-test derivation ─────────────────────────────────
@@ -154,7 +165,14 @@ def records_facts(scenario):
     sub = SCENARIO_RECORDS[scenario]
     if sub is None:
         return None
-    docs = [(p.name, json.loads(p.read_text())) for p in sorted((EMITTER / sub).glob("*.json"))]
+    docs = []
+    unreadable = []
+    for p in sorted((EMITTER / sub).glob("*.json")):
+        try:
+            docs.append((p.name, json.loads(p.read_text())))
+        except (json.JSONDecodeError, OSError):
+            # Never seen by the set check, so nothing is established about it.
+            unreadable.append(p.name)
     conforming = 0
     outcomes = []
     for _name, d in docs:
@@ -169,23 +187,39 @@ def records_facts(scenario):
         key = (bl["attestationDigest"], bl["attestationNonce"])
         by_call[key] = by_call.get(key, 0) + 1
     duplicate = any(count > 1 for count in by_call.values())
+    read_all_conform = conforming == len(docs) and not duplicate
+    if not read_all_conform:
+        grade = FALSE
+    elif unreadable or not docs:
+        grade = UNPROVED
+    else:
+        grade = PROVED
     return {
         "total": len(docs),
         "conforming": conforming,
-        "conforms": conforming == len(docs) and not duplicate,
+        "conforms": read_all_conform and not unreadable,
+        "unreadable": unreadable,
+        "grade": grade,
     }
 
 
 # ── Page parsing ──────────────────────────────────────────────────────────────
 
-_VERDICT = re.compile(r"^\*\*Statement: (CONFORMS|NON-CONFORMING)\*\*$", re.M)
+_VERDICT = re.compile(r"^\*\*Statement: (CONFORMS|NON-CONFORMING|UNPROVED)\*\*$", re.M)
 _CORPUS = re.compile(
     r"^Checked against corpus `(.+?)` version (\S+) \(corpusDigest `(sha256:[0-9a-f]{64})`\)\.$",
     re.M)
 _VERIFIED = re.compile(r"^Verified: all (\d+) fixture files match", re.M)
 _SUITE = re.compile(r"^- `(\S+?)`: (\d+)/(\d+) reproduced", re.M)
 _RECORDS = re.compile(
-    r"^(\d+) records? checked, (\d+) conforms?; your records (CONFORM|do NOT conform)\.$", re.M)
+    r"^(\d+) records? checked, (\d+) conforms?; your records "
+    r"(CONFORM|do NOT conform|are unproved)[^.]*\.$", re.M)
+_UNREAD = re.compile(r"^> Unproved: (\d+) file\(s\) could not be read", re.M)
+
+_PAGE_GRADE = {"CONFORMS": PROVED, "NON-CONFORMING": FALSE, "UNPROVED": UNPROVED}
+_RECORD_WORD_GRADE = {
+    "CONFORM": PROVED, "do NOT conform": FALSE, "are unproved": UNPROVED,
+}
 
 
 def parse_page(text):
@@ -202,6 +236,8 @@ def parse_page(text):
         "has_records": "## Your records" in text,
         "records": (int(rec.group(1)), int(rec.group(2)), rec.group(3) == "CONFORM")
         if rec else None,
+        "recordsGrade": _RECORD_WORD_GRADE[rec.group(3)] if rec else None,
+        "unreadCount": int(unread.group(1)) if (unread := _UNREAD.search(text)) else 0,
     }
 
 
@@ -216,9 +252,15 @@ def main() -> int:
 
     for scenario in sorted(SCENARIO_RECORDS):
         rec = records_facts(scenario)
-        want_verdict = "CONFORMS" if (
-            corpus["verified"] and reproduces_all and (rec is None or rec["conforms"])
-        ) else "NON-CONFORMING"
+        # Grade every in-scope check independently, then fold worst-first.
+        corpus_grade = PROVED if corpus["verified"] else FALSE
+        selftest_grade = PROVED if reproduces_all else FALSE
+        grades = [corpus_grade, selftest_grade]
+        if rec is not None:
+            grades.append(rec["grade"])
+        want_grade = combine(grades)
+        want_verdict = {PROVED: "CONFORMS", FALSE: "NON-CONFORMING",
+                        UNPROVED: "UNPROVED"}[want_grade]
 
         page = parse_page((PAGES / f"{scenario}.md").read_text())
         problems = []
@@ -236,11 +278,30 @@ def main() -> int:
         if rec is not None and page["records"] != (
                 rec["total"], rec["conforming"], rec["conforms"]):
             problems.append(f"records line {page['records']} != {rec}")
+        if rec is not None and page["recordsGrade"] != rec["grade"]:
+            problems.append(f"records grade {page['recordsGrade']} != {rec['grade']}")
+        want_unread = len(rec["unreadable"]) if rec is not None else 0
+        if page["unreadCount"] != want_unread:
+            problems.append(f"unreadable count {page['unreadCount']} != {want_unread}")
+        # An unproved page must never carry the words for a failed check.
+        page_text = (PAGES / f"{scenario}.md").read_text()
+        if want_grade == UNPROVED and (
+            "NON-CONFORMING" in page_text or "do NOT conform" in page_text
+        ):
+            problems.append("unproved page claims non-conformance")
 
         # The structured expected.json must agree with the same derivation.
         exp = expected[scenario]
         if exp["conforms"] != (want_verdict == "CONFORMS"):
             problems.append("expected.json conforms disagrees")
+        if exp.get("grade") != want_grade:
+            problems.append(f"expected.json grade {exp.get('grade')} != {want_grade}")
+        if exp["corpus"].get("grade") != corpus_grade:
+            problems.append("expected.json corpus grade disagrees")
+        if exp["selfTest"].get("grade") != selftest_grade:
+            problems.append("expected.json selfTest grade disagrees")
+        if rec is not None and exp["records"].get("grade") != rec["grade"]:
+            problems.append("expected.json records grade disagrees")
         if exp["corpus"]["corpusDigest"] != corpus["corpusDigest"]:
             problems.append("expected.json corpusDigest disagrees")
         if exp["selfTest"]["reproduced"] != sum(r for _c, r in per_suite.values()):

--- a/tests/vectors/conformance_statement_v0/emitter_records/unproved/broken.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/unproved/broken.json
@@ -1,0 +1,1 @@
+{ "this file is deliberately not valid JSON"

--- a/tests/vectors/conformance_statement_v0/emitter_records/unproved/decision.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/unproved/decision.json
@@ -1,0 +1,21 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "decisionDerived": {
+    "decidedAt": "2026-06-01T10:00:00Z",
+    "decision": "allow"
+  },
+  "issuerAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "d1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "226d2a3c2998ecbd0366ac8080e27b5ce255e2680c8178fa478f69dceac571fb",
+  "version": 1
+}

--- a/tests/vectors/conformance_statement_v0/emitter_records/unproved/outcome.json
+++ b/tests/vectors/conformance_statement_v0/emitter_records/unproved/outcome.json
@@ -1,0 +1,26 @@
+{
+  "alg": "HS256",
+  "backLink": {
+    "attestationDigest": "sha256:9429a30b849cdd7a8ed41680a667ef2e6516aa533320a9450eef87d31fdd6a44",
+    "attestationNonce": "call-A"
+  },
+  "outcomeDerived": {
+    "completedAt": "2026-06-01T10:00:00Z",
+    "decisionDigest": "sha256:bc1a28955291e73f991374b6ba5a72be528db6049ed2f53042d6d429fbe9ac9b",
+    "resultCommitment": {
+      "projection": "{\"digest\":\"sha256:8b7262647fbf76fb7ae30d664e65069eaffc35aa793718beaee239309c9055cf\"}",
+      "projectionDigest": "sha256:ca6005c73a4e80aacec2d23cfa734c18d5c8c303cf2f54e63d7693df474b422b"
+    },
+    "status": "executed"
+  },
+  "receiptAsserted": {
+    "alg": "HS256",
+    "iat": "2026-06-01T10:00:00Z",
+    "iss": "issuer://test",
+    "nonce": "r1",
+    "secretVersion": "v1",
+    "sub": "agent:reader"
+  },
+  "signature": "f4b87ef796407eef8d6644ca001a616deb09838b4d2584a809c4fbb4ee3c9db6",
+  "version": 1
+}

--- a/tests/vectors/conformance_statement_v0/expected.json
+++ b/tests/vectors/conformance_statement_v0/expected.json
@@ -5,29 +5,34 @@
     "corpus": {
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
+      "grade": "proved",
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
       "verified": true,
       "version": "1.0.0"
     },
+    "grade": "proved",
     "records": {
       "conforming": 2,
       "conforms": true,
       "findings": [],
+      "grade": "proved",
       "nonconforming": [],
       "total": 2,
       "unreadable": []
     },
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 1,
+    "schemaVersion": 2,
     "selfTest": {
       "cases": 17,
       "conforms": true,
+      "grade": "proved",
       "reproduced": 17,
       "suites": [
         {
           "cases": 10,
+          "grade": "proved",
           "mismatches": [],
           "name": "record_conformance_v0",
           "reproduced": 10,
@@ -35,6 +40,7 @@
         },
         {
           "cases": 7,
+          "grade": "proved",
           "mismatches": [],
           "name": "record_set_v0",
           "reproduced": 7,
@@ -49,12 +55,14 @@
     "corpus": {
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
+      "grade": "proved",
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
       "verified": true,
       "version": "1.0.0"
     },
+    "grade": "false",
     "records": {
       "conforming": 2,
       "conforms": false,
@@ -68,19 +76,22 @@
           "severity": "required"
         }
       ],
+      "grade": "false",
       "nonconforming": [],
       "total": 2,
       "unreadable": []
     },
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 1,
+    "schemaVersion": 2,
     "selfTest": {
       "cases": 17,
       "conforms": true,
+      "grade": "proved",
       "reproduced": 17,
       "suites": [
         {
           "cases": 10,
+          "grade": "proved",
           "mismatches": [],
           "name": "record_conformance_v0",
           "reproduced": 10,
@@ -88,6 +99,7 @@
         },
         {
           "cases": 7,
+          "grade": "proved",
           "mismatches": [],
           "name": "record_set_v0",
           "reproduced": 7,
@@ -102,16 +114,19 @@
     "corpus": {
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
+      "grade": "proved",
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
       "verified": true,
       "version": "1.0.0"
     },
+    "grade": "false",
     "records": {
       "conforming": 1,
       "conforms": false,
       "findings": [],
+      "grade": "false",
       "nonconforming": [
         {
           "name": "bad.json",
@@ -124,14 +139,16 @@
       "unreadable": []
     },
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 1,
+    "schemaVersion": 2,
     "selfTest": {
       "cases": 17,
       "conforms": true,
+      "grade": "proved",
       "reproduced": 17,
       "suites": [
         {
           "cases": 10,
+          "grade": "proved",
           "mismatches": [],
           "name": "record_conformance_v0",
           "reproduced": 10,
@@ -139,6 +156,7 @@
         },
         {
           "cases": 7,
+          "grade": "proved",
           "mismatches": [],
           "name": "record_set_v0",
           "reproduced": 7,
@@ -153,22 +171,26 @@
     "corpus": {
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
+      "grade": "proved",
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
       "verified": true,
       "version": "1.0.0"
     },
+    "grade": "proved",
     "records": null,
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 1,
+    "schemaVersion": 2,
     "selfTest": {
       "cases": 17,
       "conforms": true,
+      "grade": "proved",
       "reproduced": 17,
       "suites": [
         {
           "cases": 10,
+          "grade": "proved",
           "mismatches": [],
           "name": "record_conformance_v0",
           "reproduced": 10,
@@ -176,6 +198,62 @@
         },
         {
           "cases": 7,
+          "grade": "proved",
+          "mismatches": [],
+          "name": "record_set_v0",
+          "reproduced": 7,
+          "runnable": true
+        }
+      ]
+    }
+  },
+  "unproved": {
+    "asOf": null,
+    "conforms": false,
+    "corpus": {
+      "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
+      "fileCount": 32,
+      "grade": "proved",
+      "name": "sep2828-execution-record-conformance",
+      "problems": [],
+      "spec": "SEP-2828",
+      "verified": true,
+      "version": "1.0.0"
+    },
+    "grade": "unproved",
+    "records": {
+      "conforming": 2,
+      "conforms": false,
+      "findings": [],
+      "grade": "unproved",
+      "nonconforming": [],
+      "total": 2,
+      "unreadable": [
+        {
+          "error": "JSONDecodeError",
+          "name": "broken.json"
+        }
+      ]
+    },
+    "schema": "sep2828-conformance-statement",
+    "schemaVersion": 2,
+    "selfTest": {
+      "cases": 17,
+      "conforms": true,
+      "grade": "proved",
+      "reproduced": 17,
+      "suites": [
+        {
+          "cases": 10,
+          "grade": "proved",
+          "mismatches": [],
+          "name": "record_conformance_v0",
+          "reproduced": 10,
+          "runnable": true
+        },
+        {
+          "cases": 7,
+          "grade": "proved",
           "mismatches": [],
           "name": "record_set_v0",
           "reproduced": 7,

--- a/tests/vectors/conformance_statement_v0/pages/unproved.md
+++ b/tests/vectors/conformance_statement_v0/pages/unproved.md
@@ -1,0 +1,28 @@
+# SEP-2828 conformance statement
+
+**Statement: UNPROVED**
+
+At least one check could not be reached, so this statement does not establish the property either way. That is a different result from a check that ran and failed, and the sections below name which.
+
+Checked against corpus `sep2828-execution-record-conformance` version 1.0.0 (corpusDigest `sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a`).
+
+## Corpus integrity
+
+Verified: all 32 fixture files match `MANIFEST.json` and the corpusDigest recomputes.
+
+## Self-test
+
+This implementation's keyless conformance check reproduced 17 of 17 recorded verdicts.
+
+- `record_conformance_v0`: 10/10 reproduced
+- `record_set_v0`: 7/7 reproduced
+
+## Your records
+
+2 records checked, 2 conform; your records are unproved: what was read conformed, but the set was not complete.
+
+> Unproved: 1 file(s) could not be read, so the set check never saw them and claims nothing about them: broken.json
+
+---
+
+This statement is keyless and reproducible. Anyone holding the same corpus version can re-run `vaara conformance-statement` and reach the same verdict. It covers the wire schema, the record's self-proving digest, and the cross-record set properties; it is not signature verification, issuer trust, or time-anchor verification, which need external material and are checked separately.


### PR DESCRIPTION
A boolean cannot tell a reader whether a check ran and failed or was never reached, and those need different repairs. A suite the runner could not place and a record file that would not parse both landed on `conforms: false`, sitting next to a genuine disagreement with the spec. That reports more than the run established.

Every part of a statement now grades to `proved`, `unproved` or `false`.

`unproved` is produced only by an execution state the runner recorded: a suite reports `runnable`, an unreadable record is listed by name. It is never inferred from a primary check that failed, because a rule that reads `unproved` off a failure cannot tell the two apart in the one case that matters. Where a run mixes states the worst one wins, since a check that ran and failed is a stronger claim than one that never ran.

Records stay optional. Supplying none leaves the section absent and contributes no grade, which is a different statement from supplying records that could not be read.

The rendered page no longer prints NON-CONFORMING over an unreached check. It prints UNPROVED, names which check could not be reached, and says the statement establishes nothing either way.

`schemaVersion` goes to 2. The change is additive: `conforms` keeps its meaning and every previously conforming statement still conforms.

A fifth vector scenario carries records that all conform plus one file that will not parse, which is the case a boolean cannot express. The Vaara-free checker re-derives the grade with its own worst-first fold and fails if a page or a golden ever claims `proved` where it derived `unproved`, so the new field is checked rather than asserted. Verified by tampering with the golden: the checker reports the disagreement and exits 1.

3017 tests pass, 26 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conformance statements now report `proved`, `unproved`, or `false` grades instead of simple boolean results.
  * Added worst-case grade aggregation across integrity checks, self-tests, and records.
  * Unreadable records and unrunnable checks are clearly identified as unverifiable.
  * Updated serialized statements to schema version 2 with detailed component grades.
  * Added an `unproved` conformance scenario and corresponding report output.

* **Documentation**
  * Updated changelog and conformance examples to explain grading behavior and verdict rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->