### PR TITLE
fix: do not use WAL journalling on filesystems that cannot support it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,29 @@ Everything here was found by opening the pages and looking at them.
 
 ### Fixed
 
+- **The audit trail turned on WAL journalling everywhere, including on
+  filesystems that cannot support it, and corrupted itself there.** SQLite's
+  WAL journal coordinates readers and writers through a shared-memory segment,
+  and SQLite's documentation states that WAL needs coherent shared memory and
+  working file locking. virtiofs, 9p, NFS, SMB and FUSE mounts provide neither.
+  There the write still goes through and the database corrupts, in the one file
+  whose purpose is being evidence.
+
+  This is the ordinary way people try the tool. The trail defaults to
+  `~/.vaara/trail/audit.db`, and a container with the host home directory bind
+  mounted in puts that on virtiofs or FUSE without anyone choosing it. Docker
+  Desktop, Rancher Desktop, Colima, Lima and OrbStack all mount that way, as do
+  WSL2 writing to `/mnt/c` and NFS or SMB network homes. On one such machine
+  the trail was damaged four times in twelve days.
+
+  Vaara now reads `/proc/mounts` when it opens a trail, and on a filesystem
+  that cannot support WAL it uses the DELETE journal instead and logs one line
+  naming the path, the filesystem type and what it did. Everywhere else is
+  unchanged. `VAARA_TRAIL_JOURNAL_MODE=wal|delete` overrides the choice in
+  either direction. Detection is Linux-only, because a filesystem type is not
+  readable on macOS or Windows without platform calls. Those keep WAL, and
+  `docs/supported-platforms.md` states that limit. 12 tests in
+  `tests/test_journal_mode_shared_fs.py`.
 - **The dashboard called itself read-only in three places and is not.**
   The startup banner, the command docstring and the `--help` line all said so,
   while `/api/config` writes the `config.json` the gate reads and `/api/policy`

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -51,6 +51,40 @@ pod appending to the same volume produces a chain neither pod can verify.
 [multi-replica-deployment.md](multi-replica-deployment.md) covers what to do
 instead when one proxy is not enough.
 
+## Filesystems for the audit trail
+
+SQLite's WAL journal coordinates readers and writers through a shared-memory
+segment, and SQLite's own documentation states that WAL needs coherent shared
+memory and working file locking. Several filesystems people mount a home
+directory from provide neither. On those the write still goes through and the
+database corrupts.
+
+Vaara reads `/proc/mounts` when it opens a trail and, if the file sits on one
+of these, uses the DELETE journal instead and logs one line saying so:
+
+`9p`, `afpfs`, `ceph`, `cifs`, `glusterfs`, `lustre`, `ncpfs`, `nfs`, `nfs4`,
+`smb2`, `smb3`, `smbfs`, `vboxsf`, `virtiofs`, `vmhgfs`, and any `fuse*`
+filesystem.
+
+That covers the common cases: a container with the host home directory bind
+mounted in (Docker Desktop, Rancher Desktop, Colima, Lima, OrbStack all use
+virtiofs or FUSE), WSL2 writing to `/mnt/c`, and NFS or SMB network homes.
+
+| | |
+| --- | --- |
+| Detection | Linux only; `/proc/mounts` is the only portable source of a filesystem type |
+| Elsewhere | macOS and Windows keep WAL, since the type is not readable without platform calls |
+| Override | `VAARA_TRAIL_JOURNAL_MODE=wal` or `=delete`, in either direction |
+
+DELETE journalling costs concurrency. Readers block writers where WAL would let
+them run together, and durability is unaffected. For a trail written by one
+process, which is what the hash chain requires anyway, the difference does not
+show.
+
+If the trail lives on a network or virtual filesystem, the better answer is to
+move it. In a container, put it on a named volume rather than a bind mount, so
+it sits on the container runtime's own filesystem with real POSIX locking.
+
 ## Verified releases
 
 A row here means the listed Vaara version was installed on the listed platform

--- a/src/vaara/audit/sqlite_backend.py
+++ b/src/vaara/audit/sqlite_backend.py
@@ -7,7 +7,8 @@ to SQLite as it arrives (via on_record callback) and can reconstruct the
 full trail from disk.
 
 Design principles:
-- **WAL mode** for concurrent read/write (readers never block writers)
+- **WAL mode** for concurrent read/write (readers never block writers), except
+  on filesystems that cannot support it — see ``_journal_mode_for``
 - **Append-only** — no UPDATE or DELETE, matching the immutability guarantee
 - **Hash chain verified on load** — detects on-disk tampering
 - **Regulatory domain indexed** — fast compliance queries by regulation
@@ -23,6 +24,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 import sqlite3
 import threading
 import time
@@ -57,6 +59,115 @@ def _scrub_nonfinite(obj: Any) -> Any:
 
 def _strict_json_dumps(obj: Any) -> str:
     return json.dumps(_scrub_nonfinite(obj), allow_nan=False, default=str)
+
+
+# WAL coordinates readers and writers through an mmap'd shared-memory segment,
+# the "-shm" file. SQLite's documentation is explicit that WAL needs coherent
+# shared memory and working file locking, and that it does not work on network
+# filesystems. Where those are missing the failure is not a refused write: the
+# database corrupts. That is the worst possible outcome for the one file whose
+# purpose is being evidence, so on these filesystems the trail uses DELETE
+# journalling instead, which needs no shared memory at all.
+_WAL_UNSAFE_FSTYPES = frozenset({
+    "9p",           # QEMU / WSL1 style host shares
+    "afpfs",
+    "ceph",
+    "cifs",
+    "glusterfs",
+    "lustre",
+    "ncpfs",
+    "nfs",
+    "nfs4",
+    "smb2",
+    "smb3",
+    "smbfs",
+    "virtiofs",     # Docker Desktop, Rancher Desktop, Colima, Lima, OrbStack
+    "vboxsf",
+    "vmhgfs",
+})
+
+# Every FUSE filesystem goes through a userspace server, and none of them
+# promise SQLite's shared-memory semantics. gRPC-FUSE (Docker Desktop's other
+# mount type), sshfs, s3fs and gcsfuse all land here.
+_FUSE_PREFIX = "fuse"
+
+_PROC_MOUNTS = Path("/proc/mounts")
+
+_JOURNAL_MODE_ENV = "VAARA_TRAIL_JOURNAL_MODE"
+
+
+def _unescape_mount_field(field: str) -> str:
+    # /proc/mounts octal-escapes space, tab, newline and backslash.
+    for escape, char in (
+        (r"\040", " "), (r"\011", "\t"), (r"\012", "\n"), (r"\134", "\\"),
+    ):
+        field = field.replace(escape, char)
+    return field
+
+
+def _fstype_for(path: Path) -> Optional[str]:
+    """Return the filesystem type ``path`` sits on, or None if unknown.
+
+    Linux only, deliberately. ``/proc/mounts`` is the one place a filesystem
+    type is available without ctypes or a subprocess, and Linux is where the
+    real-world exposure is: containers with the home directory bind-mounted
+    in, WSL2 writing to /mnt/c, and NFS home directories. On macOS and
+    Windows this returns None and the caller keeps the old behaviour rather
+    than pretending to a coverage it does not have.
+    """
+    try:
+        raw = _PROC_MOUNTS.read_text()
+    except OSError:
+        return None
+
+    target = str(path)
+    best_len, best_fstype = -1, None
+    for line in raw.splitlines():
+        fields = line.split()
+        if len(fields) < 3:
+            continue
+        mount_point = _unescape_mount_field(fields[1])
+        # A mount at /home covers /home/x but not /homework.
+        if target == mount_point or target.startswith(mount_point.rstrip("/") + "/"):
+            if len(mount_point) > best_len:
+                best_len, best_fstype = len(mount_point), _unescape_mount_field(fields[2])
+    return best_fstype
+
+
+def _is_wal_unsafe(fstype: Optional[str]) -> bool:
+    if not fstype:
+        return False
+    return fstype in _WAL_UNSAFE_FSTYPES or fstype.split(".")[0] == _FUSE_PREFIX
+
+
+def _journal_mode_for(db_path: Path, in_memory: bool = False) -> str:
+    """Pick WAL or DELETE for this trail, and say so once if it is not WAL."""
+    override = os.environ.get(_JOURNAL_MODE_ENV, "").strip().lower()
+    if override in {"wal", "delete"}:
+        fstype = None if in_memory else _fstype_for(db_path)
+        if override == "wal" and _is_wal_unsafe(fstype):
+            logger.warning(
+                "%s=wal forces WAL journalling for the audit trail at %s, which "
+                "is on %s. That filesystem cannot provide the shared memory WAL "
+                "needs, and the trail may corrupt. Unset the variable to let "
+                "Vaara choose.",
+                _JOURNAL_MODE_ENV, db_path, fstype,
+            )
+        return override
+
+    if in_memory:
+        return "wal"
+
+    fstype = _fstype_for(db_path)
+    if _is_wal_unsafe(fstype):
+        logger.warning(
+            "the audit trail at %s is on a %s filesystem, which cannot support "
+            "the shared memory WAL journalling needs; using DELETE journal mode "
+            "instead to keep the trail intact. Set %s=wal to override.",
+            db_path, fstype, _JOURNAL_MODE_ENV,
+        )
+        return "delete"
+    return "wal"
 
 # Schema v2 — full DDL for fresh databases.
 # Migrations for v1 to v2 upgrades are in _MIGRATIONS below.
@@ -267,7 +378,9 @@ class SQLiteAuditBackend:
         # the fact that this is the audit trail, which sent more than one
         # investigation after the wrong thing. Say what broke and where.
         try:
-            self._enable_wal()
+            self._set_journal_mode(
+                _journal_mode_for(self._db_path, in_memory=str(db_path) == ":memory:")
+            )
             self._conn.execute("PRAGMA synchronous=NORMAL")
             self._conn.execute("PRAGMA foreign_keys=ON")
         except sqlite3.DatabaseError as exc:
@@ -292,8 +405,14 @@ class SQLiteAuditBackend:
     _WAL_RETRIES = 10
     _WAL_RETRY_SLEEP = 0.05
 
-    def _enable_wal(self) -> None:
-        """Switch to WAL, tolerating another process opening the same file.
+    @property
+    def journal_mode(self) -> str:
+        """The journal mode this trail is actually running in, lowercased."""
+        with self._lock:
+            return str(self._conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+
+    def _set_journal_mode(self, mode: str) -> None:
+        """Switch journal mode, tolerating another process opening the file.
 
         Two Vaara processes creating one audit.db at the same moment — the
         Claude Code hook and an MCP server starting together — had one of
@@ -302,15 +421,17 @@ class SQLiteAuditBackend:
         (database is locked)". That message says the evidence file is
         damaged. It was not damaged, it was half a second early.
 
-        A file already in WAL answers this pragma without needing the lock,
-        so the retry only ever runs on first creation. If the lock is still
-        held after that, the database opens in the journal mode it is already
-        in: worse concurrency, but recording evidence beats refusing to.
+        A file already in the requested mode answers this pragma without
+        needing the lock, so the retry only ever runs on first creation or on
+        a real change of mode. If the lock is still held after that, the
+        database opens in the journal mode it is already in: worse
+        concurrency, but recording evidence beats refusing to.
         """
+        statement = f"PRAGMA journal_mode={mode.upper()}"
         last: Optional[sqlite3.OperationalError] = None
         for _ in range(self._WAL_RETRIES):
             try:
-                self._conn.execute("PRAGMA journal_mode=WAL")
+                self._conn.execute(statement)
                 return
             except sqlite3.OperationalError as exc:
                 msg = str(exc).lower()
@@ -319,10 +440,10 @@ class SQLiteAuditBackend:
                 last = exc
                 time.sleep(self._WAL_RETRY_SLEEP)
         logger.warning(
-            "audit DB %s stayed locked while enabling WAL (%s); continuing in "
-            "the existing journal mode. Another Vaara process is opening the "
-            "same file.",
-            self._db_path, last,
+            "audit DB %s stayed locked while setting journal mode %s (%s); "
+            "continuing in the existing journal mode. Another Vaara process is "
+            "opening the same file.",
+            self._db_path, mode.upper(), last,
         )
 
     @contextmanager

--- a/tests/test_journal_mode_shared_fs.py
+++ b/tests/test_journal_mode_shared_fs.py
@@ -1,0 +1,158 @@
+"""The audit trail must not run WAL on filesystems that cannot support it.
+
+WAL coordinates readers and writers through an mmap'd shared-memory segment
+(the ``-shm`` file). virtiofs, 9p, NFS, SMB and FUSE mounts do not give
+SQLite coherent shared memory or working file locking, and the result is a
+corrupt trail rather than a refused write. Four corruption events in twelve
+days on one container-mounted home directory produced this file.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from vaara.audit import sqlite_backend
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+
+
+def _mounts(tmp_path: Path, fstype: str) -> Path:
+    """A /proc/mounts whose longest matching entry covers ``tmp_path``."""
+    mounts = tmp_path / "mounts"
+    mounts.write_text(
+        "proc /proc proc rw,relatime 0 0\n"
+        "/dev/vda1 / ext4 rw,relatime 0 0\n"
+        f"host {tmp_path.resolve()} {fstype} rw,relatime 0 0\n"
+    )
+    return mounts
+
+
+@pytest.fixture
+def trail(tmp_path):
+    return tmp_path / "audit.db"
+
+
+def test_wal_is_declined_on_virtiofs(tmp_path, trail, monkeypatch):
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "virtiofs"))
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    backend = SQLiteAuditBackend(str(trail))
+
+    assert backend.journal_mode == "delete"
+    assert not Path(str(trail) + "-shm").exists()
+
+
+def test_wal_is_used_on_a_local_filesystem(tmp_path, trail, monkeypatch):
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "ext4"))
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    backend = SQLiteAuditBackend(str(trail))
+
+    assert backend.journal_mode == "wal"
+
+
+def test_any_fuse_filesystem_declines_wal(tmp_path, trail, monkeypatch):
+    monkeypatch.setattr(
+        sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "fuse.gcsfuse")
+    )
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    assert SQLiteAuditBackend(str(trail)).journal_mode == "delete"
+
+
+def test_the_decline_names_the_path_the_fstype_and_the_reason(
+    tmp_path, trail, monkeypatch, caplog
+):
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "nfs4"))
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    with caplog.at_level("WARNING", logger="vaara.audit.sqlite_backend"):
+        SQLiteAuditBackend(str(trail))
+
+    warning = "\n".join(r.getMessage() for r in caplog.records)
+    assert str(trail.resolve()) in warning
+    assert "nfs4" in warning
+    assert "DELETE" in warning.upper()
+
+
+def test_env_override_forces_wal_on_an_unsafe_filesystem(tmp_path, trail, monkeypatch):
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "virtiofs"))
+    monkeypatch.setenv("VAARA_TRAIL_JOURNAL_MODE", "wal")
+
+    assert SQLiteAuditBackend(str(trail)).journal_mode == "wal"
+
+
+def test_env_override_forces_delete_on_a_local_filesystem(tmp_path, trail, monkeypatch):
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "ext4"))
+    monkeypatch.setenv("VAARA_TRAIL_JOURNAL_MODE", "DELETE")
+
+    assert SQLiteAuditBackend(str(trail)).journal_mode == "delete"
+
+
+def test_an_unreadable_env_override_is_ignored_not_fatal(tmp_path, trail, monkeypatch):
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "ext4"))
+    monkeypatch.setenv("VAARA_TRAIL_JOURNAL_MODE", "banana")
+
+    assert SQLiteAuditBackend(str(trail)).journal_mode == "wal"
+
+
+def test_no_proc_mounts_keeps_the_previous_behaviour(tmp_path, trail, monkeypatch):
+    """macOS and Windows have no /proc/mounts. Detection is Linux-only and
+    says so; everywhere else the trail opens exactly as it did before."""
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", tmp_path / "no-such-file")
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    assert SQLiteAuditBackend(str(trail)).journal_mode == "wal"
+
+
+def test_an_existing_wal_trail_on_an_unsafe_mount_is_converted(
+    tmp_path, trail, monkeypatch
+):
+    """The trail that produced this defect already exists and is in WAL. The
+    fix has to move it off WAL, not only spare new files."""
+    conn = sqlite3.connect(str(trail))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.close()
+
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "virtiofs"))
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    assert SQLiteAuditBackend(str(trail)).journal_mode == "delete"
+
+
+def test_in_memory_trails_do_not_consult_the_filesystem(tmp_path, monkeypatch):
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", _mounts(tmp_path, "virtiofs"))
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    # ":memory:" is not on any mount; detection must not crash or downgrade it.
+    assert SQLiteAuditBackend(":memory:").journal_mode in {"wal", "memory"}
+
+
+def test_the_longest_matching_mount_wins(tmp_path, trail, monkeypatch):
+    """A virtiofs mount deeper than an ext4 one must not be masked by it."""
+    mounts = tmp_path / "mounts"
+    mounts.write_text(
+        "/dev/vda1 / ext4 rw,relatime 0 0\n"
+        f"host {tmp_path.resolve().parent} ext4 rw,relatime 0 0\n"
+        f"host {tmp_path.resolve()} virtiofs rw,relatime 0 0\n"
+    )
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", mounts)
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    assert SQLiteAuditBackend(str(trail)).journal_mode == "delete"
+
+
+def test_mount_points_with_escaped_spaces_are_parsed(tmp_path, monkeypatch):
+    """/proc/mounts octal-escapes spaces in mount points as \\040."""
+    spaced = tmp_path / "my trail"
+    spaced.mkdir()
+    mounts = tmp_path / "mounts"
+    escaped = str(spaced.resolve()).replace(" ", r"\040")
+    mounts.write_text(
+        "/dev/vda1 / ext4 rw,relatime 0 0\n"
+        f"host {escaped} virtiofs rw,relatime 0 0\n"
+    )
+    monkeypatch.setattr(sqlite_backend, "_PROC_MOUNTS", mounts)
+    monkeypatch.delenv("VAARA_TRAIL_JOURNAL_MODE", raising=False)
+
+    assert SQLiteAuditBackend(str(spaced / "audit.db")).journal_mode == "delete"


### PR DESCRIPTION
SQLite's WAL journal coordinates readers and writers through a shared memory segment, the `-shm` file. SQLite's documentation states that WAL needs coherent shared memory and working file locking. virtiofs, 9p, NFS, SMB and FUSE mounts provide neither. There the write still goes through and the database corrupts.

`SQLiteAuditBackend` ran `PRAGMA journal_mode=WAL` on every trail it opened, with no check of what the file was sitting on.

## Why this reaches ordinary users

The trail defaults to `~/.vaara/trail/audit.db`. A container with the host home directory bind mounted in puts that path on virtiofs or FUSE, and nobody chooses it. Docker Desktop, Rancher Desktop, Colima, Lima and OrbStack all mount that way. So do WSL2 writing to `/mnt/c` and NFS or SMB network homes.

On one machine running Vaara in a Rancher Desktop container the trail was damaged four times in twelve days. `PRAGMA integrity_check` on the live file returned `btreeInitPage() returns error code 11` on four pages and two indexes with the wrong entry count. 24,209 records were recovered by rebuilding the file table by table.

## What changed

`src/vaara/audit/sqlite_backend.py` reads `/proc/mounts` when it opens a trail, takes the longest mount point that covers the resolved path, and reads its filesystem type. On `9p`, `afpfs`, `ceph`, `cifs`, `glusterfs`, `lustre`, `ncpfs`, `nfs`, `nfs4`, `smb2`, `smb3`, `smbfs`, `vboxsf`, `virtiofs`, `vmhgfs` or any `fuse*` filesystem it uses the DELETE journal and logs one line naming the path, the filesystem type and what it did. Everywhere else opens in WAL exactly as before.

`VAARA_TRAIL_JOURNAL_MODE=wal|delete` overrides the choice in either direction. Forcing WAL onto a filesystem that cannot support it logs a warning and then does it.

An existing trail already in WAL on such a mount is converted on open, so this repairs machines that are already exposed.

DELETE journalling costs concurrency. Readers block writers where WAL would let them run together, and durability is unaffected. The hash chain requires a single writer anyway.

## Limits, stated rather than papered over

Detection is Linux-only. A filesystem type is not readable on macOS or Windows without ctypes work or a subprocess, so those platforms keep WAL. That leaves a macOS SMB home directory exposed, and `docs/supported-platforms.md` says so. Linux is where the container, WSL2 and NFS cases live, which is the bulk of the real exposure.

## Tests

12 new tests in `tests/test_journal_mode_shared_fs.py`, each pointing the backend at a fake `/proc/mounts`: virtiofs declines WAL, ext4 keeps it, any `fuse*` type declines, the warning names the path and the filesystem type, both directions of the environment override, an unreadable override value is ignored, no `/proc/mounts` keeps the old behaviour, an existing WAL file is converted, `:memory:` does not consult the filesystem, the longest matching mount wins over a shallower one, and mount points with octal-escaped spaces parse.

Full suite: 3075 passed, 27 skipped. Ruff clean.