### PR TITLE
test: an empty GitHub releases list is a service fault, not a date claim

### DIFF
--- a/tests/test_prior_art_dates.py
+++ b/tests/test_prior_art_dates.py
@@ -67,6 +67,12 @@ def _github_dates() -> dict[str, str]:
 
     Unauthenticated and paginated; a rate-limited or offline run skips
     rather than failing, same as the PyPI check.
+
+    An empty first page is treated the same way. On 2026-08-17 this endpoint
+    answered HTTP 200 with ``[]`` for a repository holding more than eighty
+    releases, while the per-tag endpoint served every one of them. Reading
+    that as "these releases do not exist" turned a service fault into a
+    failed date claim.
     """
     dates: dict[str, str] = {}
     for page in range(1, 4):
@@ -84,6 +90,11 @@ def _github_dates() -> dict[str, str]:
             pytest.skip(f"GitHub releases unreachable: {exc}")
             return {}  # unreachable, same reason as _pypi_dates
         if not batch:
+            if page == 1:
+                pytest.skip(
+                    "GitHub returned an empty releases list; this repository "
+                    "has many releases, so the endpoint is not answering"
+                )
             break
         for release in batch:
             stamp = release.get("published_at") or release.get("created_at")


### PR DESCRIPTION
`tests/test_prior_art_dates.py` checks every row of `docs/PRIOR_ART.md` against the GitHub releases API or PyPI, and skips when either is unreachable, so an offline run does not fail.

Today the releases *list* endpoint answered HTTP 200 with `[]` for a repository holding more than eighty releases, while `GET /releases/tags/v1.56.0` served each one normally. A 200 raises no exception, so the skip path never fired and the empty answer was read as evidence:

```
AssertionError: PRIOR_ART dates no public record supports:
  v1.55.0 says 2026-07-30, records say ['2026-07-31'];
  v1.56.0 says 2026-07-31, records say ['no public record']
```

Both rows are correct. v1.55.0 has a GitHub release dated 2026-07-30 and a PyPI upload a day later, which is the case the test's own docstring describes. v1.56.0 never went to PyPI and its GitHub release is dated 2026-07-31.

`main` is red on this test for as long as the endpoint stays empty. An empty first page now skips, like every other answer the endpoint cannot give.