### PR TITLE
release: 1.68.0, Kubernetes deployment and Northern Lights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.68.0] - 2026-08-17
 
 ### Added
 
@@ -115,9 +115,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   container and Kubernetes versions Vaara supports, and separately records
   which platform versions a release has actually been run against.
 
-## [1.67.1] - 2026-08-14
+- **The conformance runner prints one link that opens the results form with
+  the run already in it.** The runner printed a table of verdicts and stopped
+  there, so anyone who wanted their reproduction listed had to read the numbers
+  off a terminal and retype them. The commit, the suites and the totals are all
+  known at the end of a run, so they are now carried into the form. The link is
+  printed for a failing run as well, because a result that did not pass is a
+  legitimate row and gating the link behind a green run would collect only the
+  results that passed. `--no-submit-link` omits it for CI and scripted runs.
 
-Everything here was found by opening the pages and looking at them.
+- **The rendered text of `draft-sirkkavaara-vaara-receipt-07` is in the tree.**
+  The `ietf/` directory carried 00 through 06 and the -07 text lived only on
+  the datatracker, so the readable timeline of the format had a hole in it at
+  the newest revision.
 
 ### Fixed
 
@@ -144,6 +154,13 @@ Everything here was found by opening the pages and looking at them.
   readable on macOS or Windows without platform calls. Those keep WAL, and
   `docs/supported-platforms.md` states that limit. 12 tests in
   `tests/test_journal_mode_shared_fs.py`.
+
+## [1.67.1] - 2026-08-14
+
+Everything here was found by opening the pages and looking at them.
+
+### Fixed
+
 - **The dashboard called itself read-only in three places and is not.**
   The startup banner, the command docstring and the `--help` line all said so,
   while `/api/config` writes the `config.json` the gate reads and `/api/policy`

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.67.1",
+  "version": "1.68.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.67.1"
+appVersion: "1.68.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.67.1, Helm chart 0.1.0.
+Vaara 1.68.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.67.1",
+  "version": "1.68.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.67.1"
+version = "1.68.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/scripts/release_prepare.sh
+++ b/scripts/release_prepare.sh
@@ -16,7 +16,8 @@
 #      working tree clean except for the staged release changes.
 #   2. Bumps version in pyproject.toml + clients/ts/package.json +
 #      src/vaara/__init__.py + server.json + server-vaara-server.json +
-#      the Claude Code plugin manifest.
+#      the Claude Code plugin manifest + the Helm chart appVersion +
+#      docs/supported-platforms.md.
 #   3. ruff check on changed Python paths.
 #   4. pytest --no-header on the full suite (skips the adversarial data dir).
 #   5. Stages explicit paths (no `git add -A`).
@@ -93,6 +94,13 @@ sed "${SED_I[@]}" "s/(\"version\": \")[0-9]+\.[0-9]+\.[0-9]+(\")/\1${VERSION}\2/
 PLUGIN_MANIFEST="plugins/claude-code-vaara-governance/.claude-plugin/plugin.json"
 sed "${SED_I[@]}" "s/^  \"version\": \"[0-9]+\.[0-9]+\.[0-9]+\",$/  \"version\": \"${VERSION}\",/" \
   "$PLUGIN_MANIFEST"
+# Helm chart appVersion and the platform support page. tests/test_helm_chart.py
+# asserts both equal vaara.__version__, so leaving them out of the bump fails
+# the suite at step 4 after eight minutes rather than at the sed above.
+CHART="deploy/helm/vaara/Chart.yaml"
+PLATFORMS="docs/supported-platforms.md"
+sed "${SED_I[@]}" "s/^appVersion: \"[0-9]+\.[0-9]+\.[0-9]+\"$/appVersion: \"${VERSION}\"/" "$CHART"
+sed "${SED_I[@]}" "s/^Vaara [0-9]+\.[0-9]+\.[0-9]+, Helm chart/Vaara ${VERSION}, Helm chart/" "$PLATFORMS"
 
 grep -E "^version = \"${VERSION}\"$" pyproject.toml >/dev/null
 grep -E "\"version\": \"${VERSION}\"" clients/ts/package.json >/dev/null
@@ -100,6 +108,8 @@ grep -E "^__version__ = \"${VERSION}\"$" src/vaara/__init__.py >/dev/null
 grep -E "\"version\": \"${VERSION}\"" server.json >/dev/null
 grep -E "\"version\": \"${VERSION}\"" server-vaara-server.json >/dev/null
 grep -E "\"version\": \"${VERSION}\"" "$PLUGIN_MANIFEST" >/dev/null
+grep -E "^appVersion: \"${VERSION}\"$" "$CHART" >/dev/null
+grep -E "^Vaara ${VERSION}, Helm chart" "$PLATFORMS" >/dev/null
 
 # 3. Lint changed paths (best-effort; lint all of src + tests if no
 # precise change list)
@@ -129,6 +139,7 @@ fi
 git add CHANGELOG.md pyproject.toml clients/ts/package.json src/vaara/__init__.py \
   server.json server-vaara-server.json \
   plugins/claude-code-vaara-governance/.claude-plugin/plugin.json \
+  deploy/helm/vaara/Chart.yaml docs/supported-platforms.md \
   scripts/release_prepare.sh
 # Re-add any other paths the caller has already staged
 git status --short

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.67.1",
+  "version": "1.68.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.67.1",
+"version": "1.68.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.67.1",
+  "version": "1.68.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.67.1",
+"version": "1.68.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.67.1"
+__version__ = "1.68.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Minor release, everything merged since v1.67.1.

**Vaara runs on Kubernetes.** `deploy/helm/vaara` installs the model-endpoint proxy in front of an in-cluster model endpoint: a StatefulSet with one replica, a ClusterIP Service, a ServiceAccount with no API token mounted, and a PersistentVolumeClaim holding the trail. The image is built on `registry.suse.com/bci/python:3.12`, runs as UID 10001 with a read-only root filesystem, and is published to `ghcr.io/vaaraio/vaara` on release for linux/amd64 and linux/arm64. The chart has no replica count. One hash chain has exactly one writer, and a second pod appending to the same volume produces a chain neither pod can verify, so that invariant is enforced by the shape of the chart rather than documented next to a knob that breaks it. Three configurations that would fail in the cluster now fail at template time with the reason: enforce mode with no allow list and no approvals directory, signing with no Secret named, and signing without persistence.

**Northern Lights: a decision carries the route it took, and an outcome travels back along it.** Routing a decision forward is ordinary. Without a return path the record is write-only, so the next decision is made in the same ignorance as the last one. Trust moves at two scales under one rule: a criterion carries a prior that decides whether its signal counts at a node, a node carries a weight that decides whether its vote counts in a panel, outcomes move both, and both decay back toward trust so one bad week does not become permanent policy. In a panel, standing follows being right rather than agreeing. A majority that carries a call which turns out wrong loses weight while the objector gains it, until the lone voice cannot be outvoted, and dissent stays in the record instead of being discarded at the tally. Standard library only, `docs/northern-lights.md`, 44 tests.

**A conformance statement grades every check as `proved`, `unproved` or `false`.** A boolean cannot tell a reader whether a check ran and failed or was never reached, and those need different repairs. A suite the runner cannot place and a record file that will not parse both used to land on `conforms: false`, next to a genuine disagreement with the spec. `unproved` is only ever produced by an execution state the runner recorded. Where a run mixes states the worst one wins. `schemaVersion` goes to 2 and the change is additive: `conforms` keeps its meaning and every previously conforming statement still conforms.

**The conformance runner prints a link that opens the results form already filled in.** The commit, the suites and the totals are known at the end of a run. The link is printed for a failing run as well, because a result that did not pass is a legitimate row and gating the link behind a green run would collect only the results that passed. `--no-submit-link` omits it for CI.

**`GET /healthz` on the model-endpoint proxy.** Every other path forwards upstream, so a liveness probe had no way to ask about the proxy rather than about the model. An orchestrator would restart Vaara whenever the model was slow to load, and bill a request per probe.

**Fixed: the audit trail turned on WAL journalling everywhere, including on filesystems that cannot support it, and corrupted itself there.** SQLite's WAL journal needs coherent shared memory and working file locking. virtiofs, 9p, NFS, SMB and FUSE provide neither, and there the write still goes through and the database corrupts, in the one file whose purpose is being evidence. This is the ordinary way people try the tool: the trail defaults to `~/.vaara/trail/audit.db`, and a container with the host home directory bind mounted in puts that on virtiofs or FUSE without anyone choosing it. On one such machine the trail was damaged four times in twelve days. Vaara now reads `/proc/mounts` when it opens a trail and uses the DELETE journal where WAL cannot work, logging one line naming the path, the filesystem type and what it did. Detection is Linux-only, and `docs/supported-platforms.md` states that limit.

Also in this release: `COMMERCIAL.md` states the buyer-facing half of the dual licence and says plainly that AGPL compliance costs nothing and is not a lesser tier; `docs/kubernetes-rancher.md` and `docs/supported-platforms.md`; the rendered `-07` draft text, which was never tracked; and machine-readable author identity on the site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conformance results now include a prefilled results-form link.
  * Added an option to disable submission links.
  * Added support for the `draft-sirkkavaara-vaara-receipt-07` text.

* **Release**
  * Released version 1.68.0 across the package, plugin, server configuration, Helm chart, and supported-platform documentation.
  * Updated release preparation checks to keep version information synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->