### PR TITLE
ci: build the release image when the version tag is pushed

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,8 +6,17 @@ name: Container image
 #
 # Kept out of release.yml on purpose: a failure here must not be able to abort
 # a PyPI or npm publish that has already started.
+#
+# The trigger is the tag push, not the published release. release.yml creates
+# the GitHub Release with the default GITHUB_TOKEN, and a release created that
+# way does not start other workflows, so `release: published` never fired here
+# and no versioned image was ever pushed. The `release` trigger is kept for a
+# release published by hand.
 
 on:
+  push:
+    tags:
+      - "v*"
   release:
     types: [published]
   workflow_dispatch:
@@ -71,7 +80,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/vaara
           tags: |
             type=raw,value=${{ inputs.tag || steps.version.outputs.version }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v') }}
 
       # arm64 is not decoration: Rancher clusters on Ampere and on Apple
       # silicon development machines are both common, and SUSE publishes BCI


### PR DESCRIPTION
## What this fixes

The container workflow listened for `release: published`. release.yml creates
that release with the default `GITHUB_TOKEN`, and GitHub does not start
workflows from events raised by that token, so the job never ran on a release.

The registry state confirms it: `ghcr.io/vaaraio/vaara` held a single `dev` tag
before today. The Helm chart defaults its image to
`ghcr.io/vaaraio/vaara:<appVersion>`, so an operator installing the chart at a
released version pulled a tag that did not exist.

## The change

- Build on `v*` tag pushes, the same event release.yml already runs on.
- Push `latest` on a tag build. It was enabled only for the release event, so
  it had never been published.
- The `release: published` trigger stays, for a release published by hand.

## Verification

`ghcr.io/vaaraio/vaara:1.68.0` exists now, pushed from a manual dispatch while
verifying the 1.68.0 release. The next release tag will run this path.
