### PR TITLE
fix: cap corrupt-row logging and decode blob text columns on reload

### DIFF
--- a/src/vaara/audit/sqlite_backend.py
+++ b/src/vaara/audit/sqlite_backend.py
@@ -39,6 +39,29 @@ logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 6
 
+# How many individual corrupt rows get a detailed log line before the rest
+# collapse into a single count. A trail damaged by an older writer holds tens
+# of thousands of bad rows at once, and one line each turns every reload into
+# megabytes of stderr — which hook-driven callers persist to disk, so the
+# logging becomes a larger failure than the corruption it reports. The count
+# is always exact; only the per-row detail is capped.
+CORRUPT_ROW_LOG_LIMIT = 5
+
+
+def _as_text(value: Any) -> str:
+    """Coerce a column value to str, decoding bytes.
+
+    A writer that bound Python ``bytes`` instead of ``str`` leaves TEXT
+    columns holding BLOBs. Those values reach skeleton records unchanged, and
+    ``AuditRecord.compute_hash`` then dies on ``json.dumps`` of bytes — so a
+    reload that was supposed to degrade gracefully takes the whole process
+    down instead. Decode here so the skeleton is hashable and the chain
+    verification can report the damage rather than crash on it.
+    """
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return value if isinstance(value, str) else ""
+
 
 def _scrub_nonfinite(obj: Any) -> Any:
     # Strict JSON (RFC 8259) forbids NaN/Infinity tokens. Python's default
@@ -372,6 +395,7 @@ class SQLiteAuditBackend:
             check_same_thread=False,
         )
         self._lock = threading.Lock()
+        self._corrupt_query_rows = 0
         # sqlite3.connect() does not touch the file, so a damaged database
         # first surfaces here, on the pragma that reads page 1. The raw
         # DatabaseError ("file is not a database") names neither the path nor
@@ -815,33 +839,34 @@ class SQLiteAuditBackend:
         for row in rows:
             try:
                 record = self._row_to_record(row)
-            except (json.JSONDecodeError, ValueError, KeyError) as exc:
+            except (json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:
                 # Single-row corruption must not destroy the rest of the
                 # audit reload. Reconstruct a "skeleton" record with empty
                 # dicts and the raw hashes preserved; verify_chain() will
                 # then flag the row via hash mismatch (original data was
                 # part of the hash input), so corruption stays visible.
                 corrupt_rows += 1
-                logger.error(
-                    "load_trail: corrupt record row seq=%s record_id=%s (%s: %s) — "
-                    "loading skeleton; hash-chain verification will flag it",
-                    row[10], row[0], type(exc).__name__, exc,
-                )
+                if corrupt_rows <= CORRUPT_ROW_LOG_LIMIT:
+                    logger.error(
+                        "load_trail: corrupt record row seq=%s record_id=%s (%s: %s) — "
+                        "loading skeleton; hash-chain verification will flag it",
+                        row[10], row[0], type(exc).__name__, exc,
+                    )
                 try:
-                    skeleton_event_type = EventType(row[2])
+                    skeleton_event_type = EventType(_as_text(row[2]))
                 except (ValueError, KeyError):
                     skeleton_event_type = EventType.ACTION_REQUESTED
                 record = AuditRecord(
-                    record_id=row[0],
-                    action_id=row[1],
+                    record_id=_as_text(row[0]),
+                    action_id=_as_text(row[1]),
                     event_type=skeleton_event_type,
                     timestamp=row[3] if isinstance(row[3], (int, float)) else 0.0,
-                    agent_id=row[4] or "",
-                    tool_name=row[5] or "",
+                    agent_id=_as_text(row[4]),
+                    tool_name=_as_text(row[5]),
                     data={"_corrupt": True, "_error": str(exc)},
                     regulatory_articles=[],
-                    previous_hash=row[8] or "",
-                    record_hash=row[9] or "",
+                    previous_hash=_as_text(row[8]),
+                    record_hash=_as_text(row[9]),
                 )
             # Inject directly into the trail (bypass on_record to avoid re-write)
             trail._records.append(record)
@@ -854,6 +879,14 @@ class SQLiteAuditBackend:
         # (write side). Regulator-facing dashboards / Article 12(2)
         # monitoring should surface both.
         trail._skeleton_records = corrupt_rows
+        if corrupt_rows > CORRUPT_ROW_LOG_LIMIT:
+            logger.error(
+                "load_trail: %d corrupt record rows in %s (%d detailed above, "
+                "%d not logged) — loaded as skeletons; run `vaara verify-chain` "
+                "for the full picture",
+                corrupt_rows, self._db_path, CORRUPT_ROW_LOG_LIMIT,
+                corrupt_rows - CORRUPT_ROW_LOG_LIMIT,
+            )
 
         chain_error = trail.verify_chain()
         if chain_error:
@@ -879,16 +912,45 @@ class SQLiteAuditBackend:
             ).fetchone()
         return row[0]
 
+    @property
+    def corrupt_query_rows(self) -> int:
+        """Corrupt rows skipped by the query path over this backend's life.
+
+        The read-path analogue of ``AuditTrail.skeleton_records``. Per-row
+        logging is capped (see ``CORRUPT_ROW_LOG_LIMIT``), so this counter is
+        the reliable signal for ops dashboards.
+        """
+        return self._corrupt_query_rows
+
     def _safe_row_to_record(self, row: tuple) -> Optional[AuditRecord]:
         """Convert a DB row to AuditRecord, returning None on corrupt rows."""
         try:
             return self._row_to_record(row)
         except (json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:
-            logger.error(
-                "query: corrupt record row seq=%s record_id=%s (%s: %s) — skipped",
-                row[10] if len(row) > 10 else "?", row[0] if row else "?",
-                type(exc).__name__, exc,
-            )
+            # Unlike load_trail, this runs once per row per query, so the cap
+            # has to hold for the life of the backend rather than one call —
+            # otherwise a damaged trail re-floods the log on every query.
+            self._corrupt_query_rows += 1
+            seen = self._corrupt_query_rows
+            if seen <= CORRUPT_ROW_LOG_LIMIT:
+                logger.error(
+                    "query: corrupt record row seq=%s record_id=%s (%s: %s) — skipped",
+                    row[10] if len(row) > 10 else "?", row[0] if row else "?",
+                    type(exc).__name__, exc,
+                )
+                if seen == CORRUPT_ROW_LOG_LIMIT:
+                    logger.error(
+                        "query: further corrupt rows in %s will be counted but not "
+                        "logged (see backend.corrupt_query_rows); enable DEBUG for "
+                        "per-row detail",
+                        self._db_path,
+                    )
+            else:
+                logger.debug(
+                    "query: corrupt record row seq=%s record_id=%s (%s: %s) — skipped",
+                    row[10] if len(row) > 10 else "?", row[0] if row else "?",
+                    type(exc).__name__, exc,
+                )
             return None
 
     def query_by_action(self, action_id: str) -> list[AuditRecord]:

--- a/tests/test_sqlite_backend.py
+++ b/tests/test_sqlite_backend.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.audit.sqlite_backend import CORRUPT_ROW_LOG_LIMIT, SQLiteAuditBackend
 from vaara.audit.trail import AuditTrail, EventType
 from vaara.taxonomy.actions import (
     ActionCategory,
@@ -364,6 +364,120 @@ class TestSkeletonRecordsCounter:
         fresh = AuditTrail()
         assert fresh.skeleton_records == 0
         assert fresh.persistence_failures == 0
+
+    def test_corrupt_row_logging_is_capped(
+        self, db_path, sample_action_type, caplog
+    ):
+        """A trail damaged by an older writer holds tens of thousands of bad
+        rows. One ERROR line each turned every reload into megabytes of
+        stderr, and hook-driven callers persist stderr to disk, so the log
+        itself became the bigger failure. Cap the detail, keep the count.
+        """
+        import logging
+        import sqlite3
+
+        backend = SQLiteAuditBackend(db_path)
+        trail = AuditTrail(on_record=backend.write_record)
+        for i in range(12):
+            trail.record_action_requested(
+                ActionRequest(
+                    agent_id=f"agent-{i}", tool_name="tx.transfer",
+                    action_type=sample_action_type,
+                )
+            )
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE audit_records SET data = 'not-json'")
+        conn.commit()
+        conn.close()
+
+        with caplog.at_level(logging.ERROR, logger="vaara.audit.sqlite_backend"):
+            reloaded = backend.load_trail()
+
+        per_row = [
+            r for r in caplog.records
+            if r.getMessage().startswith("load_trail: corrupt record row")
+        ]
+        summary = [
+            r for r in caplog.records
+            if "corrupt record rows" in r.getMessage()
+        ]
+        assert reloaded.skeleton_records == 12   # every bad row still counted
+        assert len(per_row) == CORRUPT_ROW_LOG_LIMIT
+        assert len(summary) == 1
+        assert "12" in summary[0].getMessage()   # the total is not lost
+
+    def test_query_corrupt_row_logging_is_capped(
+        self, db_path, sample_action_type, caplog
+    ):
+        """Same defect on the query path: _safe_row_to_record logged once per
+        bad row, on every query, for the life of the process.
+        """
+        import logging
+        import sqlite3
+
+        backend = SQLiteAuditBackend(db_path)
+        trail = AuditTrail(on_record=backend.write_record)
+        for i in range(12):
+            trail.record_action_requested(
+                ActionRequest(
+                    agent_id="agent", tool_name="tx.transfer",
+                    action_type=sample_action_type,
+                )
+            )
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE audit_records SET data = 'not-json'")
+        conn.commit()
+        conn.close()
+
+        with caplog.at_level(logging.ERROR, logger="vaara.audit.sqlite_backend"):
+            backend.query_by_agent("agent")      # 12 bad rows, 5 logged
+            backend.query_by_agent("agent")      # second query stays quiet
+
+        per_row = [
+            r for r in caplog.records
+            if r.getMessage().startswith("query: corrupt record row")
+        ]
+        assert len(per_row) == CORRUPT_ROW_LOG_LIMIT
+        assert backend.corrupt_query_rows >= 12   # the count keeps rising
+
+    def test_blob_text_columns_do_not_crash_load(self, db_path, sample_action_type):
+        """A writer that bound bytes instead of str leaves every TEXT column
+        holding a BLOB. Those values reached the skeleton record unchanged and
+        compute_hash() then died on json.dumps(bytes), so load_trail raised
+        TypeError instead of degrading — the opposite of the guarantee. Seen
+        on a real trail: 19,417 rows, every text column a BLOB.
+        """
+        import sqlite3
+
+        backend = SQLiteAuditBackend(db_path)
+        trail = AuditTrail(on_record=backend.write_record)
+        for i in range(3):
+            trail.record_action_requested(
+                ActionRequest(
+                    agent_id=f"agent-{i}", tool_name="tx.transfer",
+                    action_type=sample_action_type,
+                )
+            )
+
+        conn = sqlite3.connect(str(db_path))
+        for col in ("record_id", "action_id", "event_type", "agent_id",
+                    "tool_name", "data", "regulatory", "previous_hash",
+                    "record_hash"):
+            conn.execute(
+                f"UPDATE audit_records SET {col} = CAST({col} AS BLOB)"
+            )
+        conn.commit()
+        conn.close()
+
+        reloaded = backend.load_trail()          # must not raise
+        assert reloaded.skeleton_records == 3
+        # The damage stays visible rather than crashing the reader.
+        assert reloaded.verify_chain() is not None
+        # Skeletons carry decoded identifiers, not b'...' repr noise.
+        assert isinstance(reloaded._records[0].record_id, str)
+        assert not reloaded._records[0].record_id.startswith("b'")
 
     def test_pipeline_status_exposes_skeleton_count(self):
         # Fresh pipeline has zero skeletons


### PR DESCRIPTION
load_trail logged one ERROR line per corrupt row. A trail damaged by an older writer holds every bad row at once, so one reload emitted tens of thousands of lines. Hook-driven callers persist stderr to disk, so each reload wrote about 4 MB into the transcript on a real trail with 19,417 bad rows.

The per-row detail now stops after 5 lines, and one further line gives the exact total. `trail.skeleton_records` still counts every affected row.

The query path had the same defect and a longer reach. `_safe_row_to_record` logged once per bad row on every query, for the life of the process. Its cap holds across the whole backend lifetime, the running total is available as `backend.corrupt_query_rows`, and per-row detail drops to DEBUG after the cap.

A writer that bound bytes instead of str leaves TEXT columns holding BLOBs. Those values reached the skeleton record unchanged and `compute_hash` died on `json.dumps` of bytes, so `load_trail` raised TypeError on a trail it was supposed to load with skeletons. Skeleton values are decoded now, and `load_trail` catches TypeError alongside the other row-level errors, so chain verification reports the damage instead of the load failing.

## Testing

Three new tests cover the load-path cap, the query-path cap, and a reload of a trail whose text columns are all BLOB. Full suite: 3078 passed, 26 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when SQLite audit records contain malformed or binary data.
  * BLOB-backed text values are now safely converted to readable text.
  * Loading and querying corrupted records no longer causes failures.
  * Corruption details are logged with limits to reduce excessive log output.

* **New Features**
  * Added an aggregate count of corrupted audit records for monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->