### PR TITLE
fix: detect a second Vaara governance layer in front of the MCP proxy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,28 @@ Every tool call an agent makes passes through Vaara before it runs:
 
 The scoring blends five expert signals and keeps adapting as outcomes come back, and each risk score carries a confidence interval with a coverage guarantee that holds regardless of the input distribution. Those are the properties an auditor can check independently; the math is in [formal_specification.md](formal_specification.md) and a plain-language version for compliance reviewers and legal counsel is in [conformal-prediction.md](conformal-prediction.md).
 
+## One interception layer per call
+
+The interception points in step 1 are alternatives. Pick the one that matches your client.
+
+| Client | Use | Why |
+|---|---|---|
+| Has a hook Vaara can register in (Claude Code, and any framework with a pre-call hook) | The hook | It sees every call the client makes, MCP calls included, and it does not own any other process |
+| Has no hook (a bare MCP client, a custom runtime) | The MCP proxy | Sitting in the stdio pipe is the only interception point available |
+
+Registering both puts two decision points on the same action. Each MCP call is then scored and decided twice and written to the trail twice, under two different names: the client's namespaced name from the hook (`mcp__server__tool`) and the bare wire name from the proxy (`tool`). The chain stays intact and every verifier still passes, so nothing reports an error. The trail simply counts one action as two, which shifts any figure derived from event counts.
+
+The proxy detects this at startup and names the layer it found:
+
+```
+vaara-mcp-proxy: a second Vaara governance layer is already in front of this proxy.
+  found: ~/.claude/settings.json: vaara hook pre-tool-use
+```
+
+Control it with `--stacked warn` (default), `--stacked fail` to refuse to start, or `--stacked ignore`. Detection reports and never changes what is recorded, because the proxy owns the upstream server's process and anything that can abort there takes the upstream down with it.
+
+Process lifetime differs between the two. Under stdio, the proxy starts the upstream MCP server as a child process, since owning the pipe is what makes the traffic readable. The upstream's lifetime is therefore bound to the proxy's, and a proxy that exits takes the MCP server down with it. A hook has no such relationship. On clients that offer one, the hook is the smaller commitment.
+
 ## External time anchor
 
 The hash chain proves order and integrity but not *when* it existed: every timestamp comes from your own clock, so a compromised signing key could in principle be used to forge a backdated chain. Vaara can anchor the current chain head to an external RFC 3161 Time-Stamp Authority, the standard behind eIDAS qualified electronic timestamps. The authority signs the chain head and the time, so the chain's existence is provable against a clock you do not control. Verification is offline.

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -1804,6 +1804,68 @@ class VaaraMCPProxy:
             self._backend.close()
 
 
+_STACKED_HOOK_MARKER = "vaara hook pre-tool-use"
+
+
+def _vaara_deciding_hook(path: Path) -> Optional[str]:
+    """Return the PreToolUse command that runs Vaara in ``path``, or None.
+
+    Only PreToolUse counts. PostToolUse reports an outcome for a call that
+    was already decided, so it is not a second decision point.
+    """
+    try:
+        data = json.loads(path.read_text())
+    except Exception:
+        return None  # advisory only; see detect_stacked_governance
+    if not isinstance(data, dict):
+        return None
+    for entry in (data.get("hooks") or {}).get("PreToolUse") or []:
+        if not isinstance(entry, dict):
+            continue
+        for hook in entry.get("hooks") or []:
+            command = (hook or {}).get("command") if isinstance(hook, dict) else None
+            if isinstance(command, str) and _STACKED_HOOK_MARKER in command:
+                return command
+    return None
+
+
+def detect_stacked_governance(env: Optional[dict[str, str]] = None) -> Optional[str]:
+    """Detect a second Vaara governance layer in front of this proxy.
+
+    Returns a human-readable "<settings file>: <command>" when the client is
+    Claude Code and a Vaara PreToolUse hook is registered, else None.
+
+    Why this exists. The hook decides every tool call the client makes; this
+    proxy decides the MCP wire traffic. Both are correct in isolation, and
+    running both means one action is decided twice and written to the trail
+    twice under two names — namespaced (``mcp__serena__find_symbol``) from
+    the hook, bare (``find_symbol``) from here. The chain stays valid and
+    every verifier still passes. It just counts one thing as two, and no
+    line of code is wrong, which is why a code-level audit walks past it.
+
+    Advisory by construction. This never raises and never changes what gets
+    recorded, because this proxy owns the upstream MCP server's process:
+    anything that can abort here takes the operator's tooling down with it.
+    Detection reports; the operator removes a layer.
+    """
+    env = dict(os.environ) if env is None else env
+    if not env.get("CLAUDECODE"):
+        return None
+    candidates: list[Path] = []
+    home = env.get("HOME")
+    if home:
+        candidates.append(Path(home) / ".claude" / "settings.json")
+    project_dir = env.get("CLAUDE_PROJECT_DIR")
+    if project_dir:
+        candidates.append(Path(project_dir) / ".claude" / "settings.json")
+        candidates.append(Path(project_dir) / ".claude" / "settings.local.json")
+    for path in candidates:
+        command = _vaara_deciding_hook(path)
+        if command is not None:
+            return f"{path}: {command}"
+    return None
+
+
 def main(argv: Optional[list[str]] = None) -> None:
     parser = argparse.ArgumentParser(
         prog="vaara-mcp-proxy",
@@ -1966,10 +2028,41 @@ def main(argv: Optional[list[str]] = None) -> None:
                         help="Directory to write OVERT Base Envelopes into "
                              "(one canonical-CBOR file per envelope). Required when "
                              "--overt-signing-key is set.")
+    parser.add_argument(
+        "--stacked", choices=("warn", "fail", "ignore"), default="warn",
+        help="What to do when a second Vaara governance layer is detected in "
+             "front of this proxy (the Claude Code PreToolUse hook): 'warn' "
+             "names it on stderr and continues (default), 'fail' refuses to "
+             "start, 'ignore' says nothing. Detection never changes what is "
+             "recorded.")
     args = parser.parse_args(argv)
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(name)s %(levelname)s %(message)s",
                         stream=sys.stderr)
+    if args.stacked != "ignore":
+        stacked = detect_stacked_governance()
+        if stacked is not None:
+            print(
+                "vaara-mcp-proxy: a second Vaara governance layer is already "
+                "in front of this proxy.\n"
+                f"  found: {stacked}\n"
+                "  That hook decides every tool call the client makes, "
+                "including MCP ones.\n"
+                "  Running both means each MCP call is decided twice and "
+                "written to the trail\n"
+                "  twice, under two names: namespaced from the hook "
+                "(mcp__server__tool) and bare\n"
+                "  from this proxy (tool). The chain stays valid and "
+                "verification still passes;\n"
+                "  the trail counts one action as two.\n"
+                "  Pick one layer. Under Claude Code the hook already covers "
+                "MCP, so the proxy\n"
+                "  is for clients that have no hook to sit in. Silence this "
+                "with --stacked ignore.",
+                file=sys.stderr,
+            )
+            if args.stacked == "fail":
+                sys.exit(2)
     tool_allow = set(args.allow_tools) if args.allow_tools else None
     tool_deny = set(args.deny_tools) if args.deny_tools else set()
     resource_allow = set(args.allow_resources) if args.allow_resources else None

--- a/tests/test_mcp_proxy_stacked_governance.py
+++ b/tests/test_mcp_proxy_stacked_governance.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 
 import json
 
-import pytest
-
 from vaara.integrations.mcp_proxy import detect_stacked_governance
 
 

--- a/tests/test_mcp_proxy_stacked_governance.py
+++ b/tests/test_mcp_proxy_stacked_governance.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Stacked governance detection for the MCP proxy.
+
+The gap this closes. Two Vaara layers can govern the same call without
+either knowing about the other: the Claude Code hook (``vaara hook
+pre-tool-use``, which sees every tool call the client makes) and this
+proxy (which sees the MCP wire traffic). Run both and every MCP call is
+decided twice and written to the trail twice, under two different names:
+the client's namespaced ``mcp__serena__find_symbol`` from the hook, and
+the bare ``find_symbol`` from the proxy.
+
+Nothing was wrong in either layer, which is why a code-level audit does
+not find it. The trail stays hash-linked and every verifier still passes;
+it simply counts one action as two. The proxy has the evidence to notice
+(``CLAUDECODE`` in its environment, and the hook registration readable
+via ``CLAUDE_PROJECT_DIR``) and did not look.
+
+Detection only. The proxy does not silently drop records when it finds a
+second layer, because quietly changing what lands in someone's evidence
+trail is the same class of mistake as quietly duplicating it. It says
+which layer is doubling and lets the operator remove one.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vaara.integrations.mcp_proxy import detect_stacked_governance
+
+
+def _write_settings(path, commands, event="PreToolUse"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "hooks": {event: [{"hooks": [{"type": "command", "command": c} for c in commands]}]}
+    }))
+
+
+def test_no_detection_outside_claude_code(tmp_path):
+    """Nothing to stack against when the client is not Claude Code."""
+    _write_settings(tmp_path / ".claude" / "settings.json", ["vaara hook pre-tool-use"])
+    assert detect_stacked_governance(
+        env={"HOME": str(tmp_path), "CLAUDE_PROJECT_DIR": str(tmp_path)},
+    ) is None
+
+
+def test_no_detection_when_no_vaara_hook(tmp_path):
+    """Claude Code alone is not a second governance layer."""
+    _write_settings(tmp_path / ".claude" / "settings.json", ["rtk hook claude", "python3 other.py"])
+    assert detect_stacked_governance(
+        env={"CLAUDECODE": "1", "HOME": str(tmp_path), "CLAUDE_PROJECT_DIR": str(tmp_path)},
+    ) is None
+
+
+def test_detects_user_level_hook(tmp_path):
+    _write_settings(
+        tmp_path / ".claude" / "settings.json",
+        ["rtk hook claude", "/home/claude/.local/bin/vaara hook pre-tool-use"],
+    )
+    found = detect_stacked_governance(
+        env={"CLAUDECODE": "1", "HOME": str(tmp_path), "CLAUDE_PROJECT_DIR": str(tmp_path)},
+    )
+    assert found is not None
+    assert "vaara hook pre-tool-use" in found
+    assert "settings.json" in found
+
+
+def test_detects_project_local_settings(tmp_path):
+    """settings.local.json counts; it is where per-box wiring usually lands."""
+    home = tmp_path / "home"
+    proj = tmp_path / "proj"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude" / "settings.json").write_text("{}")
+    _write_settings(proj / ".claude" / "settings.local.json", ["vaara hook pre-tool-use"])
+    found = detect_stacked_governance(
+        env={"CLAUDECODE": "1", "HOME": str(home), "CLAUDE_PROJECT_DIR": str(proj)},
+    )
+    assert found is not None
+    assert "settings.local.json" in found
+
+
+def test_post_tool_use_alone_does_not_count(tmp_path):
+    """Only the deciding hook stacks. PostToolUse records an outcome, it does
+    not decide the call, so it is not a second decision point."""
+    _write_settings(
+        tmp_path / ".claude" / "settings.json",
+        ["vaara hook post-tool-use"],
+        event="PostToolUse",
+    )
+    assert detect_stacked_governance(
+        env={"CLAUDECODE": "1", "HOME": str(tmp_path), "CLAUDE_PROJECT_DIR": str(tmp_path)},
+    ) is None
+
+
+def test_unreadable_settings_never_raises(tmp_path):
+    """Detection is advisory. A malformed or unreadable settings file must not
+    take the proxy down, because the proxy owns the MCP server's process."""
+    bad = tmp_path / ".claude" / "settings.json"
+    bad.parent.mkdir(parents=True)
+    bad.write_text("{ this is not json")
+    assert detect_stacked_governance(
+        env={"CLAUDECODE": "1", "HOME": str(tmp_path), "CLAUDE_PROJECT_DIR": str(tmp_path)},
+    ) is None
+
+
+def test_missing_project_dir_falls_back_to_home(tmp_path):
+    _write_settings(tmp_path / ".claude" / "settings.json", ["vaara hook pre-tool-use"])
+    found = detect_stacked_governance(env={"CLAUDECODE": "1", "HOME": str(tmp_path)})
+    assert found is not None


### PR DESCRIPTION
## What

The client hook (`src/vaara/integrations/claude_code_hooks.py`) and the MCP proxy are alternative interception points. Nothing stopped an operator from registering both, and nothing told them what it costs.

With both active, one action gets two decision points. The hook decides every tool call the client makes, MCP calls included. The proxy then decides the same call again on the wire. Each MCP call lands in the trail twice, under two names:

```
1007  mcp__vaara-memory__mem_save     from the hook, namespaced by the client
 496  mem_save                        from the proxy, the bare wire name
```

The chain stays intact and every verifier passes, so nothing reports an error. The trail counts one action as two, which moves any figure derived from event counts.

## The fix

`detect_stacked_governance()` reads the effective client settings and reports the layer it finds. The proxy already had the evidence: `CLAUDECODE` is in its environment and `CLAUDE_PROJECT_DIR` points at the settings that register the hook.

New `--stacked {warn,fail,ignore}`, defaulting to `warn`:

```
vaara-mcp-proxy: a second Vaara governance layer is already in front of this proxy.
  found: ~/.claude/settings.json: vaara hook pre-tool-use
```

Two properties held deliberately:

Detection never changes what is recorded. Under stdio the proxy starts the upstream MCP server as a child, so it owns that process, and anything that can abort in the proxy takes the operator's MCP server down with it. Reporting is the safe action; silently dropping records from someone's evidence trail is the same class of error as silently duplicating them.

Only `PreToolUse` counts. `PostToolUse` reports an outcome for a call that was already decided, so it is not a second decision point.

## Docs

`docs/architecture.md` gains a section stating that the interception points are alternatives, which one suits which client, and the process-lifetime difference between them: a hook has no ownership relationship with anything, while a stdio proxy holds the upstream server's lifetime.

## Tests

`tests/test_mcp_proxy_stacked_governance.py`, 7 cases covering user-level and project-local settings, the PostToolUse exclusion, absence of the client, absence of a Vaara hook, and the guarantee that malformed settings never raise.

Local run: 509 passed, 13 skipped across the proxy, integration and hook suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added startup detection for overlapping Claude Code governance hooks.
  * Added `--stacked` options to warn, block startup, or ignore detected overlaps.
  * Added guidance for selecting a single Vaara interception layer.

* **Bug Fixes**
  * Improved handling of malformed settings and missing project directories during detection.

* **Tests**
  * Added coverage for user- and project-level hooks, environment checks, and excluded hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->