### PR TITLE
fix: take receipt and attestation identity from the signed blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `inference_receipt_digest` and `inference_attestation_digest` now hash the signed blocks, with the signature excluded, using the module's existing `_receipt_signing_payload` and `_attestation_signing_payload`. Both previously hashed the full wire bytes with the signature included, to pin every receipt byte-for-byte. An ES256 signature is not byte-unique for one signing act: given a valid `(r, s)` over P-256, `(r, n - s)` is also valid over the same payload and the same key, and `verify_es256` accepts it because it decodes the pair and re-encodes to DER. Measured against this implementation, 200 of 200 signatures produced a verifying twin. So the byte-for-byte pin was not achievable, and one signing act could yield two receipts that both verify and carry different identities, with the second producible in transit by anyone holding no key. Those digests are used as `receiptDigest` in the session manifest and `subject_receipt_digest` in the crosscheck. `vaara.audit.timeanchor._signed_payload_digest` has always hashed the signed payload, which is why `anchoredDigest` was never affected. Raised on the SCITT list by Anton Sokolov, 2026-08-18.
+
+  **Compatibility:** a `receiptDigest` or attestation digest recorded before this change will not match one computed after it. Signature verification is unaffected and no signature is invalidated.
+
 ## [1.68.0] - 2026-08-17
 
 ### Added

--- a/src/vaara/attestation/_inference_emit.py
+++ b/src/vaara/attestation/_inference_emit.py
@@ -281,19 +281,42 @@ def verify_inference_attestation(
 
 
 def inference_attestation_digest(att: InferenceAttestation) -> str:
-    """``sha256:<hex>`` over the full attestation wire bytes (signature included)."""
-    return "sha256:" + hashlib.sha256(canonical_json(att.to_dict())).hexdigest()
+    """``sha256:<hex>`` over the attestation's signed blocks, signature excluded.
+
+    See :func:`inference_receipt_digest` for why the signature is out.
+    """
+    return "sha256:" + hashlib.sha256(
+        _attestation_signing_payload(att)
+    ).hexdigest()
 
 
 def inference_receipt_digest(receipt: InferenceReceipt) -> str:
-    """``sha256:<hex>`` over the full receipt wire bytes (signature included).
+    """``sha256:<hex>`` over the receipt's signed blocks, signature excluded.
 
     The receipt twin of :func:`inference_attestation_digest`. A session
-    manifest pins both digests per inference, so the same JCS-over-wire formula
-    is used for both: binding the manifest to a hardware root transitively pins
-    every receipt byte-for-byte.
+    manifest pins both digests per inference, so both use the same formula.
+
+    These hashed the full wire bytes with the signature included until
+    2026-08-18, to pin every receipt byte-for-byte. An ES256 signature is not
+    byte-unique for one signing act: given a valid ``(r, s)`` over P-256,
+    ``(r, n - s)`` is also valid over the same payload and the same key, and
+    ``verify_es256`` accepts it because it decodes the pair and re-encodes to
+    DER. Measured here: 200 of 200 signatures produced a verifying twin.
+
+    So the byte-for-byte pin was not achievable, and taking identity from
+    those bytes meant one signing act could yield two receipts that both
+    verify and disagree about which receipt they are. Anyone in transit could
+    produce the second without holding the key. Hashing the signed blocks
+    gives one identity per signing act and still moves whenever signed content
+    moves, which is the property the manifest actually needs.
+
+    ``vaara.audit.timeanchor._signed_payload_digest`` has always worked this
+    way, which is why ``anchoredDigest`` was never exposed. Raised on the SCITT
+    list by Anton Sokolov, 2026-08-18.
     """
-    return "sha256:" + hashlib.sha256(canonical_json(receipt.to_dict())).hexdigest()
+    return "sha256:" + hashlib.sha256(
+        _receipt_signing_payload(receipt)
+    ).hexdigest()
 
 
 def make_inference_back_link(att: InferenceAttestation) -> BackLink:

--- a/tests/test_inference_digest_malleability.py
+++ b/tests/test_inference_digest_malleability.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Receipt and attestation identity must survive ECDSA signature malleability.
+
+An ES256 signature is not byte-unique for one signing act. Given a valid
+``(r, s)`` over P-256, ``(r, n - s)`` is also valid over the same payload and
+the same key, and ``verify_es256`` accepts it because it decodes the pair and
+re-encodes to DER. Nothing is forged: an observer in transit can produce the
+twin without holding the key, and both copies carry identical authority.
+
+That is harmless until something takes identity from bytes that include the
+signature. ``inference_receipt_digest`` did, by its own docstring, and its
+value is used as ``receiptDigest`` in the session manifest and as
+``subject_receipt_digest`` in the crosscheck. One signing act could therefore
+produce two receipts that both verify and disagree about which receipt they
+are. The stated intent, pinning every receipt byte-for-byte, is the thing
+malleability defeats, because the bytes are not unique for one act.
+
+The rest of the tree already had this right. ``_signed_payload_digest`` in
+``vaara.audit.timeanchor`` hashes only the signed blocks under JCS, which is
+why ``anchoredDigest`` was never exposed. These digests now use the module's
+own ``_receipt_signing_payload`` and ``_attestation_signing_payload``, so
+identity comes from what was signed rather than from one encoding of the
+signature over it.
+
+Raised on the SCITT list by Anton Sokolov, 2026-08-18, and measured against
+this implementation the same day: 200 of 200 signatures produced a verifying
+twin with a different digest.
+"""
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import replace
+
+import pytest
+
+for _mod in ("rfc8785", "cryptography"):
+    if importlib.util.find_spec(_mod) is None:
+        pytest.skip(
+            "attestation extra not installed (pip install 'vaara[attestation]')",
+            allow_module_level=True,
+        )
+
+from cryptography.hazmat.primitives.asymmetric import ec  # noqa: E402
+
+from vaara.attestation._attest_signing import sign_es256, verify_es256  # noqa: E402
+from vaara.attestation.inference import (  # noqa: E402
+    InferenceOutcome,
+    ModelDerived,
+    RequestDeclared,
+    emit_inference_attestation,
+    emit_inference_receipt,
+    inference_attestation_digest,
+    inference_receipt_digest,
+    make_inference_back_link,
+    make_output_commitment,
+    make_request_commitment,
+)
+
+# Order of the P-256 base point (SEC 2, secp256r1).
+P256_N = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+
+MESSAGES = [{"role": "user", "content": "Summarize the Q3 report."}]
+SAMPLING = {"temperature": 0.7, "top_p": 0.9, "top_k": 40, "seed": 42}
+OUTPUT = {"content": "The Q3 report covers three regions.", "toolCalls": []}
+MODEL = ModelDerived(
+    model_ref="qwen3:30b-a3b",
+    manifest_digest="sha256:" + "a" * 64,
+    gguf_metadata_hash="sha256:" + "b" * 64,
+    quantization="Q4_K_M",
+    param_count="30B",
+)
+
+
+def malleate(signature_hex: str) -> str:
+    """The other valid encoding of the same ECDSA signature: (r, n - s)."""
+    r = int(signature_hex[:64], 16)
+    s = int(signature_hex[64:], 16)
+    return format(r, "064x") + format(P256_N - s, "064x")
+
+
+@pytest.fixture
+def es256_key():
+    return ec.generate_private_key(ec.SECP256R1())
+
+
+@pytest.fixture
+def es256_attestation(es256_key):
+    return emit_inference_attestation(
+        request_declared=RequestDeclared(
+            intent="inference/chat/qwen3:30b-a3b",
+            request_commitment=make_request_commitment(
+                messages=MESSAGES, sampling=SAMPLING
+            ),
+        ),
+        model_derived=MODEL,
+        iss="vaara-infer-proxy",
+        sub="vaara/homeserver",
+        secret_version="v1",
+        alg="ES256",
+        signing_material=es256_key,
+    )
+
+
+@pytest.fixture
+def es256_receipt(es256_key, es256_attestation):
+    return emit_inference_receipt(
+        back_link=make_inference_back_link(es256_attestation),
+        outcome_derived=InferenceOutcome(
+            status="completed",
+            completed_at="2026-06-14T22:00:00Z",
+            tier="integrity",
+            output_commitment=make_output_commitment(OUTPUT),
+            eval_stats={"promptEvalCount": 11, "evalCount": 256},
+        ),
+        iss="vaara-infer-proxy",
+        sub="vaara/homeserver",
+        secret_version="v1",
+        alg="ES256",
+        signing_material=es256_key,
+    )
+
+
+def test_the_twin_verifies_so_the_premise_holds(es256_key):
+    """Guard the assumption the rest of this file rests on.
+
+    If this fails, malleability stopped applying here and the tests below are
+    checking a condition that cannot arise.
+    """
+    payload = b'{"one":"act"}'
+    sig = sign_es256(payload, private_key=es256_key)
+    twin = malleate(sig)
+    assert sig != twin
+    assert verify_es256(payload, signature_hex=sig, public_key=es256_key.public_key())
+    assert verify_es256(payload, signature_hex=twin, public_key=es256_key.public_key())
+
+
+def test_receipt_digest_is_unchanged_by_malleation(es256_receipt):
+    """One signing act, one identity, whichever encoding of s arrives."""
+    twin = replace(es256_receipt, signature=malleate(es256_receipt.signature))
+    assert twin.signature != es256_receipt.signature
+    assert inference_receipt_digest(twin) == inference_receipt_digest(es256_receipt)
+
+
+def test_attestation_digest_is_unchanged_by_malleation(es256_attestation):
+    twin = replace(es256_attestation, signature=malleate(es256_attestation.signature))
+    assert twin.signature != es256_attestation.signature
+    assert (
+        inference_attestation_digest(twin)
+        == inference_attestation_digest(es256_attestation)
+    )
+
+
+def test_digest_still_moves_when_signed_content_changes(es256_receipt):
+    """Immunity to malleation must not become indifference to content.
+
+    Identity comes from the signed blocks, so changing one has to change the
+    digest. Otherwise the fix trades one collision for a worse one.
+    """
+    other = replace(
+        es256_receipt,
+        outcome_derived=replace(es256_receipt.outcome_derived, status="failed"),
+    )
+    assert inference_receipt_digest(other) != inference_receipt_digest(es256_receipt)


### PR DESCRIPTION
## What

`inference_receipt_digest` and `inference_attestation_digest` hashed the full wire bytes with the signature included. The docstring stated the intent: pin every receipt byte-for-byte, so that binding a session manifest to a hardware root transitively pins the receipts.

An ES256 signature is not byte-unique for one signing act. Given a valid `(r, s)` over P-256, `(r, n - s)` is also valid over the same payload and the same key, and `verify_es256` accepts it because it decodes the pair and re-encodes to DER before verifying.

Measured against this implementation:

```
malleated twin also verifies      200/200
digest over receipt incl. signature
  original  654f2e8b0a9ac7c068957ece475526c9cc5f8be3f1268eab04b9edd580782a47
  twin      10ce0f15af959452cef9720f734e1557be21f3a386c42631af209ad2fedea076
same signing act, same key, equal  False
```

So the byte-for-byte pin was never achievable, and taking identity from those bytes meant one signing act could produce two receipts that both verify and disagree about which receipt they are. The second copy requires no key: an observer in transit can compute it. Both digests are used as identities, `receiptDigest` in the session manifest and `subject_receipt_digest` in the crosscheck.

## The fix

Both digests now hash the module's existing `_receipt_signing_payload` and `_attestation_signing_payload`, which are JCS over the signed blocks with the signature excluded.

`vaara.audit.timeanchor._signed_payload_digest` has always worked this way, which is why `anchoredDigest` was never affected. This aligns the inference path with the rest of the tree.

## Tests

`tests/test_inference_digest_malleability.py`, four cases:

- the twin verifies, guarding the premise the other tests rest on
- the receipt digest does not move under malleation
- the attestation digest does not move under malleation
- the receipt digest still moves when signed content changes, so immunity to malleation did not become indifference to content

394 passed across the inference, attestation, session and crosscheck suites with no regressions.

## Compatibility

A `receiptDigest` or attestation digest recorded before this change will not match one computed after it. No signature is invalidated and verification behaviour is unchanged.

## Credit

Raised on the SCITT mailing list by Anton Sokolov, 2026-08-18, with a reproduction over 200 keys and a hardware-backed example. The finding above is this implementation checked against his report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated receipt and attestation digests to hash signed payloads without signature data.
  - Digest values now remain stable across equivalent ES256 signature encodings.

- **Compatibility**
  - Previously stored digests may differ from newly computed values.
  - Signature verification behavior remains unchanged.

- **Tests**
  - Added coverage confirming digest stability when signatures are re-encoded and sensitivity to changes in signed content.

- **Documentation**
  - Added an unreleased changelog entry describing the digest behavior and compatibility impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->