### PR TITLE
feat: detect source profiles on object keys, and ingest CAEP events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Declarative source profiles can detect on object keys. New `anyKeyStartsWith` operator tests whether the object at `path` carries any key with the given prefix. Every operator before this one read values only, and `resolve_path` splits on `.`, so a format whose discriminator is a URI-shaped key was impossible to express: the whole Security Event Token family (CAEP, RISC) and anything keyed by namespace URI. Implemented in the engine and in `tests/vectors/normalize_v0/_check_independent.py`, which reimplements the operators without importing Vaara, so a third party reproduces the same detection.
+- `caep-security-event` source profile: OpenID CAEP Security Event Tokens ingest as `decision-input`. The detector pins the CAEP namespace, so a RISC event does not match. Per-event members sit under the event-type URI key and cannot be lifted into advisory yet; the profile says so in its notes rather than implying coverage it does not have.
+- `test_every_normalize_input_has_an_expected_entry` guards the normalize corpus against silent gaps. `_check_independent.py` iterates `expected.json` and loads the input each key names, so an input with no expected entry was never exercised while the suite still reported every case matched. The ingest corpus already had a guard of this shape; normalize did not, and 14 inputs sat against 13 entries.
+
 ## [1.68.0] - 2026-08-17
 
 ### Added

--- a/src/vaara/attestation/_declarative.py
+++ b/src/vaara/attestation/_declarative.py
@@ -77,7 +77,7 @@ def _split_indices(segment: str) -> tuple[str, list[int]]:
     return key, indices
 
 
-_KNOWN_OPS = ("equals", "startsWith", "in", "exists")
+_KNOWN_OPS = ("equals", "startsWith", "in", "exists", "anyKeyStartsWith")
 
 
 def _validate_rule(rule: Any) -> None:
@@ -105,6 +105,16 @@ def _eval_rule(doc: Any, rule: dict[str, Any]) -> bool:
         return value in rule["in"]
     if "exists" in rule:
         return (value is not None) == bool(rule["exists"])
+    if "anyKeyStartsWith" in rule:
+        # Tests the object's KEYS rather than its value. Some formats put the
+        # discriminator in the key: a CAEP Security Event Token names its event
+        # type as a URI key under "events". resolve_path splits on ".", and
+        # those URIs contain dots, so no path can address them and every
+        # value-only operator is blind to the whole SET family.
+        prefix = rule["anyKeyStartsWith"]
+        if not isinstance(value, dict):
+            return False
+        return any(isinstance(k, str) and k.startswith(prefix) for k in value)
     raise ProfileSpecError(f"detect rule has no known operator: {rule!r}")
 
 

--- a/src/vaara/attestation/profiles/caep_security_event.json
+++ b/src/vaara/attestation/profiles/caep_security_event.json
@@ -1,0 +1,29 @@
+{
+  "sourceFormat": "caep-security-event",
+  "sourceTitle": "OpenID CAEP Security Event Token",
+  "priority": 55,
+  "detect": {
+    "all": [
+      {"path": "iss", "exists": true},
+      {"path": "jti", "exists": true},
+      {"path": "iat", "exists": true},
+      {"path": "events", "anyKeyStartsWith": "https://schemas.openid.net/secevent/caep/event-type/"}
+    ]
+  },
+  "evidencePlane": "decision-input",
+  "advisory": {
+    "issuer": "iss",
+    "eventId": "jti",
+    "issuedAt": "iat",
+    "audience": "aud",
+    "framework": {"const": "openid-caep-1.0"}
+  },
+  "missing": ["alg", "signature", "backLink", "receiptAsserted", "outcomeDerived"],
+  "notes": [
+    "a CAEP Security Event Token reports a change in session, credential, assurance or device state at an identity provider; it is a signal a relying party may act on, not a record of an action taken",
+    "the plane is decision-input: the event is evidence available before a decision, and asserts nothing about what was decided or executed",
+    "SET signing (RFC 8417 carries these as a signed JWT) is a separate envelope and is not modeled here, so alg, signature and receiptAsserted remain a separate signing event",
+    "per-event members (subject, initiating_entity, reason_admin, reason_user, event_timestamp) sit under a key that is the event-type URI; resolve_path splits on '.' and those URIs contain dots, so they cannot be lifted into advisory today. Detection reaches them via anyKeyStartsWith; lifting them needs key-addressable paths",
+    "the detector pins the CAEP namespace specifically, so a RISC event under https://schemas.openid.net/secevent/risc/event-type/ does not match"
+  ]
+}

--- a/tests/test_declarative_profile.py
+++ b/tests/test_declarative_profile.py
@@ -274,3 +274,100 @@ def test_ap2_checkout_receipt_not_claimed_as_payment_receipt():
         "order_id": "ord_789",
     }
     assert detect_format(checkout) != "ap2-payment-receipt"
+
+
+# --- anyKeyStartsWith: detecting on object keys ------------------------------
+#
+# Some formats put their discriminator in an object KEY rather than a value.
+# A CAEP Security Event Token carries its event type as a URI key:
+#
+#   {"events": {"https://schemas.openid.net/secevent/caep/event-type/
+#                session-revoked": {...}}}
+#
+# resolve_path splits on ".", and that key contains dots, so no path can reach
+# it. Every operator before this one tested values only, which left the whole
+# SET family (CAEP, RISC) and anything keyed by namespace URI impossible to
+# express declaratively. Found 2026-08-18 while writing the CAEP profile.
+
+
+def test_any_key_starts_with_matches_a_uri_keyed_event():
+    from vaara.attestation._declarative import compile_profile
+
+    profile = compile_profile({
+        "sourceFormat": "caep-test",
+        "sourceTitle": "CAEP test",
+        "detect": {"all": [
+            {"path": "events",
+             "anyKeyStartsWith": "https://schemas.openid.net/secevent/caep/event-type/"}
+        ]},
+    })
+    doc = {"events": {
+        "https://schemas.openid.net/secevent/caep/event-type/session-revoked": {}
+    }}
+    assert profile.detector(doc) is True
+
+
+def test_any_key_starts_with_rejects_a_different_namespace():
+    from vaara.attestation._declarative import compile_profile
+
+    profile = compile_profile({
+        "sourceFormat": "caep-test",
+        "sourceTitle": "CAEP test",
+        "detect": {"all": [
+            {"path": "events",
+             "anyKeyStartsWith": "https://schemas.openid.net/secevent/caep/event-type/"}
+        ]},
+    })
+    risc = {"events": {
+        "https://schemas.openid.net/secevent/risc/event-type/account-disabled": {}
+    }}
+    assert profile.detector(risc) is False
+
+
+def test_any_key_starts_with_on_a_missing_or_non_dict_path():
+    from vaara.attestation._declarative import compile_profile
+
+    profile = compile_profile({
+        "sourceFormat": "caep-test",
+        "sourceTitle": "CAEP test",
+        "detect": {"all": [{"path": "events", "anyKeyStartsWith": "https://"}]},
+    })
+    assert profile.detector({}) is False
+    assert profile.detector({"events": "not-an-object"}) is False
+    assert profile.detector({"events": []}) is False
+
+
+def test_any_key_starts_with_is_a_known_operator():
+    """A rule carrying only this operator must compile rather than be rejected
+    as operator-less."""
+    from vaara.attestation._declarative import compile_profile
+
+    compile_profile({
+        "sourceFormat": "k", "sourceTitle": "k",
+        "detect": {"all": [{"path": "events", "anyKeyStartsWith": "x"}]},
+    })
+
+
+def test_every_normalize_input_has_an_expected_entry():
+    """No input may sit in the corpus without being checked.
+
+    ``_check_independent.py`` iterates ``expected.json`` and loads the input
+    named by each key, so an input file with no expected entry is never
+    exercised and the suite still reports every case matched. On 2026-08-18 a
+    CAEP fixture was added and the checker reported 13 of 13 matched while
+    silently ignoring it: 14 inputs, 13 entries.
+
+    The ingest corpus already has a drift guard of this shape
+    (``test_corpus_tracks_the_full_input_registry``) and it caught the same
+    fixture immediately. This is that guard for normalize.
+    """
+    import json
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent / "vectors" / "normalize_v0"
+    inputs = {p.stem for p in (root / "inputs").glob("*.json")}
+    expected = set(json.loads((root / "expected.json").read_text()))
+    assert inputs == expected, (
+        f"inputs without an expected entry: {sorted(inputs - expected)}; "
+        f"expected entries without an input: {sorted(expected - inputs)}"
+    )

--- a/tests/vectors/ingest_v0/cases/caep_security_event.json
+++ b/tests/vectors/ingest_v0/cases/caep_security_event.json
@@ -1,0 +1,55 @@
+{
+  "evidence": {
+    "advisory": {
+      "audience": "https://sp.example.com/caep",
+      "eventId": "24c63fb56e5a2d77a6b512616ca9fa24",
+      "framework": "openid-caep-1.0",
+      "issuedAt": 1615305159,
+      "issuer": "https://idp.example.com/123456789/"
+    },
+    "evidencePlane": "decision-input",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "a CAEP Security Event Token reports a change in session, credential, assurance or device state at an identity provider; it is a signal a relying party may act on, not a record of an action taken",
+      "the plane is decision-input: the event is evidence available before a decision, and asserts nothing about what was decided or executed",
+      "SET signing (RFC 8417 carries these as a signed JWT) is a separate envelope and is not modeled here, so alg, signature and receiptAsserted remain a separate signing event",
+      "per-event members (subject, initiating_entity, reason_admin, reason_user, event_timestamp) sit under a key that is the event-type URI; resolve_path splits on '.' and those URIs contain dots, so they cannot be lifted into advisory today. Detection reaches them via anyKeyStartsWith; lifting them needs key-addressable paths",
+      "the detector pins the CAEP namespace specifically, so a RISC event under https://schemas.openid.net/secevent/risc/event-type/ does not match"
+    ],
+    "populated": [],
+    "recognized": true,
+    "sep2828": {},
+    "sourceFormat": "caep-security-event",
+    "sourceTitle": "OpenID CAEP Security Event Token"
+  },
+  "record": {
+    "alg": "HS256",
+    "completeness": {
+      "runningCount": 1,
+      "seq": 1
+    },
+    "evidenceRef": {
+      "canonicalization": "JCS",
+      "digest": "sha256:b7dc7deffc0dd1118a56e7afd0522bde1d7eebf7d5a4f3bfbdc6cc898b9f2b96",
+      "schema": "vaara.normalized-evidence/v0"
+    },
+    "ingestAsserted": {
+      "alg": "HS256",
+      "iat": "2026-06-23T00:00:00Z",
+      "iss": "did:web:vaara.io",
+      "nonce": "ingest-fixed-nonce-000000",
+      "secretVersion": "k1",
+      "sub": "sink"
+    },
+    "schema": "vaara.ingest/v0",
+    "signature": "9ca0d8fdc2c5a92af73015c91714c64957ae6a0fb3fdb9cb6b6bb0aa8e9452e5",
+    "sourceFormat": "caep-security-event",
+    "version": 0
+  }
+}

--- a/tests/vectors/ingest_v0/corpus.json
+++ b/tests/vectors/ingest_v0/corpus.json
@@ -4,6 +4,7 @@
     "agent_decision",
     "ap2_payment_receipt",
     "c2pa_manifest",
+    "caep_security_event",
     "sep2643_rar_denial",
     "sep2643_scope_denial",
     "sep2643_url_denial",
@@ -15,7 +16,7 @@
     "unknown",
     "x402_settlement"
   ],
-  "corpusDigest": "sha256:58038e9a690a0d528bbdcbe11d339a74b732d60de0d29ffef49da7d069e05ec1",
+  "corpusDigest": "sha256:83e52f6bcf8364144911a5be989c0f9ed27b1dd25bf8a427681c0644f449e21c",
   "fixed": {
     "iat": "2026-06-23T00:00:00Z",
     "iss": "did:web:vaara.io",
@@ -35,6 +36,10 @@
     "c2pa_manifest": {
       "evidenceDigest": "sha256:3d02ab1236af269f497797fe75f08ec772fc1080e66c424a03d53ab54fbe5cf7",
       "signature": "ffb1f8ab39b6436811fd8d969a679fdcb5ee83cfcdf8a2cf804913a9542ca604"
+    },
+    "caep_security_event": {
+      "evidenceDigest": "sha256:b7dc7deffc0dd1118a56e7afd0522bde1d7eebf7d5a4f3bfbdc6cc898b9f2b96",
+      "signature": "9ca0d8fdc2c5a92af73015c91714c64957ae6a0fb3fdb9cb6b6bb0aa8e9452e5"
     },
     "sep2643_rar_denial": {
       "evidenceDigest": "sha256:06e748273802ade556dac8d705c291af7dc6504ab15f25a31cd9ef102cfe245d",

--- a/tests/vectors/normalize_v0/_check_independent.py
+++ b/tests/vectors/normalize_v0/_check_independent.py
@@ -143,6 +143,14 @@ def _rule_ok(doc: Any, rule: dict[str, Any]) -> bool:
         return value in rule["in"]
     if "exists" in rule:
         return (value is not None) == bool(rule["exists"])
+    if "anyKeyStartsWith" in rule:
+        # Tests the object's keys rather than its value. A CAEP Security Event
+        # Token names its event type as a URI key under "events", and _resolve
+        # splits paths on ".", so those keys are unreachable by any path.
+        if not isinstance(value, dict):
+            return False
+        prefix = rule["anyKeyStartsWith"]
+        return any(isinstance(k, str) and k.startswith(prefix) for k in value)
     return False
 
 

--- a/tests/vectors/normalize_v0/expected.json
+++ b/tests/vectors/normalize_v0/expected.json
@@ -89,6 +89,35 @@
     "sourceFormat": "c2pa-manifest",
     "sourceTitle": "C2PA content provenance manifest"
   },
+  "caep_security_event": {
+    "advisory": {
+      "audience": "https://sp.example.com/caep",
+      "eventId": "24c63fb56e5a2d77a6b512616ca9fa24",
+      "framework": "openid-caep-1.0",
+      "issuedAt": 1615305159,
+      "issuer": "https://idp.example.com/123456789/"
+    },
+    "evidencePlane": "decision-input",
+    "missing": [
+      "alg",
+      "signature",
+      "backLink",
+      "receiptAsserted",
+      "outcomeDerived"
+    ],
+    "notes": [
+      "a CAEP Security Event Token reports a change in session, credential, assurance or device state at an identity provider; it is a signal a relying party may act on, not a record of an action taken",
+      "the plane is decision-input: the event is evidence available before a decision, and asserts nothing about what was decided or executed",
+      "SET signing (RFC 8417 carries these as a signed JWT) is a separate envelope and is not modeled here, so alg, signature and receiptAsserted remain a separate signing event",
+      "per-event members (subject, initiating_entity, reason_admin, reason_user, event_timestamp) sit under a key that is the event-type URI; resolve_path splits on '.' and those URIs contain dots, so they cannot be lifted into advisory today. Detection reaches them via anyKeyStartsWith; lifting them needs key-addressable paths",
+      "the detector pins the CAEP namespace specifically, so a RISC event under https://schemas.openid.net/secevent/risc/event-type/ does not match"
+    ],
+    "populated": [],
+    "recognized": true,
+    "sep2828": {},
+    "sourceFormat": "caep-security-event",
+    "sourceTitle": "OpenID CAEP Security Event Token"
+  },
   "sep2643_rar_denial": {
     "advisory": {
       "authorizationContextId": "authzctx_pay_9f2c",

--- a/tests/vectors/normalize_v0/inputs/caep_security_event.json
+++ b/tests/vectors/normalize_v0/inputs/caep_security_event.json
@@ -1,0 +1,33 @@
+{
+  "iss": "https://idp.example.com/123456789/",
+  "jti": "24c63fb56e5a2d77a6b512616ca9fa24",
+  "iat": 1615305159,
+  "aud": "https://sp.example.com/caep",
+  "events": {
+    "https://schemas.openid.net/secevent/caep/event-type/session-revoked": {
+      "subject": {
+        "session": {
+          "format": "opaque",
+          "id": "dMTlD|1600802906337.16|16008.16"
+        },
+        "user": {
+          "format": "iss_sub",
+          "iss": "https://idp.example.com/123456789/",
+          "sub": "99beb27c-c1c2-4955-882a-e0dc4996fcbc"
+        },
+        "tenant": {
+          "format": "opaque",
+          "id": "123456789"
+        }
+      },
+      "initiating_entity": "policy",
+      "reason_admin": {
+        "en": "Landspeed Policy Violation: C076E82F"
+      },
+      "reason_user": {
+        "en": "Access attempt from multiple regions."
+      },
+      "event_timestamp": 1615304991643
+    }
+  }
+}

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -102,9 +102,9 @@
     <div class="stat"><b>42</b><span>passed</span></div>
     <div class="stat"><b>0</b><span>failed</span></div>
     <div class="stat"><b>1</b><span>skipped</span></div>
-    <div class="stat"><b>45</b><span>cases</span></div>
+    <div class="stat"><b>46</b><span>cases</span></div>
   </div>
-  <p class="mono" style="color:var(--faint)">generated 2026-08-16T06:42:30Z</p>
+  <p class="mono" style="color:var(--faint)">generated 2026-08-18T14:44:10Z</p>
 
   <h2>Run it yourself</h2>
   <p>Nothing here needs Vaara installed. The checkers use the standard library


### PR DESCRIPTION
## Why

Declarative profile detection read values only, and `resolve_path` splits on `.`. A CAEP Security Event Token names its event type as a URI key:

```json
{"events": {"https://schemas.openid.net/secevent/caep/event-type/session-revoked": {...}}}
```

That key contains dots, so no path reaches it and no operator inspects keys. The same shape blocks RISC and anything keyed by namespace URI, which makes this a class of formats rather than one.

## What

**`anyKeyStartsWith`.** Tests whether the object at `path` carries any key with the given prefix.

Implemented twice on purpose: in the engine, and in `tests/vectors/normalize_v0/_check_independent.py`, which reimplements the operators and imports no Vaara. A detection rule only the engine understands would make the third-party reproduction claim false, and the checker caught exactly that during this change.

**`caep-security-event` profile.** CAEP events ingest as `decision-input`, which is what they are: a signal available before a decision, asserting nothing about what was decided or executed. The detector pins the CAEP namespace, so a RISC event under `.../risc/event-type/` does not match.

Stated limitation, in the profile's own notes rather than left implied: per-event members (`subject`, `initiating_entity`, `reason_admin`, `event_timestamp`) sit under the event-type URI key and cannot be lifted into advisory yet. Detection reaches them; lifting them needs key-addressable paths.

**A guard the normalize corpus was missing.** `_check_independent.py` iterates `expected.json` and loads the input each key names, so an input file with no expected entry was never exercised while the run still reported every case matched. Adding the CAEP fixture surfaced it: 14 inputs against 13 entries, reported as 13 of 13.

The ingest corpus already had a guard of this shape and caught the same fixture on the first run. `test_every_normalize_input_has_an_expected_entry` is that guard for normalize.

## Verification

```
normalize _check_independent.py   14/14 cases matched (0 skipped)
ingest    _check_independent.py   15/15 checks passed
pytest -k "normalize or ingest or declarative or profile or attest"   449 passed
```

## Note on scope

This registers a foreign format as a Vaara source, which is the 1.10.0 shape: adjacent formats become source formats. Nothing here is written for another project's repository, and no other specification changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting keys that start with a configured prefix.
  * Added recognition and normalization for CAEP Security Event Tokens, including event metadata and advisory fields.

* **Bug Fixes**
  * Improved handling of non-object values during declarative detection.

* **Tests**
  * Added coverage for CAEP events, prefix-based detection, and normalization corpus consistency.
  * Updated conformance results to reflect 46 cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->