### PR TITLE
fix(vcr): make the conformance desk answer, and take the rank off the badge

### DIFF
--- a/.github/workflows/conformance-desk.yml
+++ b/.github/workflows/conformance-desk.yml
@@ -37,9 +37,21 @@ concurrency:
 
 jobs:
   desk:
+    # The label alone was the guard until 2026-08-19, and it silently failed on
+    # the first real application. The issue form declares
+    # `labels: ["conformance-row"]`, but that label did not exist in the
+    # repository, so the issue arrived with no labels, this job was skipped, and
+    # a submitter who did nothing wrong got no answer at all. A guard whose
+    # failure mode is silence is the wrong guard for a desk that is supposed to
+    # answer within a minute. The title prefix is set by the form and is not
+    # something a stranger has to know about, so it catches the same issues
+    # without depending on repository state that can drift. Everything a run
+    # produces is still checked by scripts/vcr_row.py, so a wrong trigger costs
+    # one comment explaining why, never a bad row.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.issue.labels.*.name, 'conformance-row')
+      contains(github.event.issue.labels.*.name, 'conformance-row') ||
+      startsWith(github.event.issue.title, 'VCR:')
     runs-on: ubuntu-latest
     steps:
       - name: Check out main for the scripts, the suites and the history

--- a/.github/workflows/conformance-desk.yml
+++ b/.github/workflows/conformance-desk.yml
@@ -174,8 +174,7 @@ jobs:
           gh issue comment "${{ steps.issue.outputs.number }}" --body "$(cat <<EOF
           You are row #${ID} at https://vaara.io/conformance.html
 
-          Your badge, which carries your row number, the date and the commit
-          you ran at:
+          Your badge, which carries the date and the commit you ran at:
 
           \`\`\`
           [![Vaara Conformance Results row ${ID}](https://vaara.io/badge/${SLUG}.svg)](https://vaara.io/conformance.html)
@@ -188,6 +187,11 @@ jobs:
           https://vaara.io/badge/${SLUG}.json as JCS-canonical bytes, so
           \`curl -s <that url> | sha256sum\` checks either artifact against it
           without trusting us or installing anything.
+
+          Your row number is in the badge metadata and on the page, not on the
+          badge face. Rows are chained so the order exists, but a row is a
+          record of a run and not a placing, and row 1 and row 250 say the same
+          thing.
 
           The number is permanent and is never reissued, and so is the row.
           This records a run that happened, so it is not taken down later and

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg" alt="License"></a>
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://github.com/vaaraio/vaara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://github.com/vaaraio/vaara/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>
+  <a href="https://vaara.io/conformance.html"><img src="https://raw.githubusercontent.com/vaaraio/vaara/main/webpage/badge/conformance.svg" alt="Vaara Conformance: 43 suites, 42 passing"></a>
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
 </p>

--- a/scripts/render_conformance_page.py
+++ b/scripts/render_conformance_page.py
@@ -70,10 +70,11 @@ height="20" role="img" aria-label="{alt}">
     <rect x="{lw}" width="{mw}" height="20" fill="#78A08A"/>
     <rect width="{w}" height="20" fill="url(#s)"/>
   </g>
-  <g font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="11">
-    <text x="6" y="15" fill="#000" fill-opacity=".3" textLength="{lt}" \
+  <polygon points="12,5.5 17.5,15 6.5,15" fill="#78A08A"/>
+  <g font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="10">
+    <text x="24" y="15" fill="#000" fill-opacity=".3" textLength="{lt}" \
 lengthAdjust="spacingAndGlyphs">{label}</text>
-    <text x="6" y="14" fill="#fff" textLength="{lt}" \
+    <text x="24" y="14" fill="#fff" textLength="{lt}" \
 lengthAdjust="spacingAndGlyphs">{label}</text>
     <text x="{mx}" y="15" fill="#000" fill-opacity=".3" textLength="{mt}" \
 lengthAdjust="spacingAndGlyphs">{message}</text>
@@ -84,8 +85,69 @@ lengthAdjust="spacingAndGlyphs">{message}</text>
 """
 
 
+#: The project's own shield, as opposed to a listed party's badge. It states
+#: what the corpus is, never that anybody reproduced anything, which is the
+#: line that keeps it honest: the per-party badges say "reproduced" and are
+#: earned, this one says "43 suites" and is just a fact about the repository.
+#: Lives at a fixed name so the README can hotlink it and the URL never moves.
+CORPUS_BADGE = "conformance.svg"
+
+
 def esc(value: object) -> str:
     return html.escape(str(value), quote=True)
+
+
+def corpus_badge_svg(report: dict) -> str:
+    """The shield for our own README, pointing at the results page.
+
+    Deliberately not a party badge. There is no generic reproduction badge, for
+    the reason stated above ``BADGE_TEMPLATE``: a shared "reproduced" URL is
+    copyable by anyone who never ran anything. This one makes no claim on
+    anyone's behalf. It reports the size of the corpus and how much of it
+    passes, which is a property of the repository the reader is already looking
+    at, and it links to the page where every one of those verdicts recomputes.
+    """
+    totals = report["totals"]
+    label = "VAARA CONFORMANCE"
+    message = f"{totals['suites']} suites, {totals['passed']} passing"
+    lw = int(len(label) * 5.6) + 32
+    mw = int(len(message) * 6.2) + 12
+    alt = (f"Vaara conformance corpus: {totals['suites']} suites, "
+           f"{totals['passed']} passing")
+    return BADGE_TEMPLATE.format(
+        w=lw + mw,
+        lw=lw,
+        mw=mw,
+        lt=lw - 32,
+        mt=mw - 12,
+        mx=lw + 6,
+        label=esc(label),
+        message=esc(message),
+        alt=esc(alt),
+        row_id="",
+        slug="",
+        digest="",
+    ).replace(
+        # A corpus shield commits to no row, so it carries no row metadata to
+        # recompute. Empty elements would read as a row that hashes to nothing.
+        """  <metadata>
+    <vcr xmlns="https://vaara.io/ns/vcr/v1">
+      <row></row>
+      <digest></digest>
+      <over>https://vaara.io/badge/.json</over>
+      <recompute>sha256 of those bytes, which are JCS-canonical per RFC 8785</recompute>
+    </vcr>
+  </metadata>
+""",
+        """  <metadata>
+    <vcr xmlns="https://vaara.io/ns/vcr/v1">
+      <corpus>https://vaara.io/conformance.html</corpus>
+      <note>Corpus status, not a reproduction. This badge is not evidence \
+that any party ran anything.</note>
+    </vcr>
+  </metadata>
+""",
+    )
 
 
 def row_bytes(row: dict) -> bytes:
@@ -112,21 +174,33 @@ def row_digest(row: dict) -> str:
 def badge_svg(row: dict) -> str:
     """A badge that dates itself, so nobody has to police staleness.
 
-    The row number, the date and the short commit are baked into the pixels.
-    A badge earned two years ago reads as two years old wherever it is pasted,
-    without the badge ever calling home to say so.
+    The date and the short commit are baked into the pixels. A badge earned two
+    years ago reads as two years old wherever it is pasted, without the badge
+    ever calling home to say so.
+
+    THE ROW NUMBER IS NOT ON THE FACE, and that is deliberate. Rows are chained,
+    so an order exists and the number stays in the row, in the served bytes and
+    in the metadata above, where a reader needs it to find what this badge
+    commits to. On the face it stops being an index and becomes a placing. Row 1
+    and row 250 carry the identical claim, and only one of them reads like an
+    achievement. This table pays off on volume and on strangers walking in years
+    later, so a badge that quietly tells the fiftieth party their sticker is
+    worth less works against the thing it exists for. Decided 2026-08-19, when
+    the first application arrived from a party who had no idea a number was on
+    offer, which is fairly good evidence nobody is here for the number.
     """
-    label = f"VCR #{row['id']}"
+    label = "VAARA CONFORMANCE"
     message = f"reproduced {row.get('date', '')} {str(row.get('at_commit', ''))[:7]}"
-    # 6.2px per character at 11px Verdana, plus 6px padding either side.
-    lw = int(len(label) * 6.2) + 12
+    # 5.6px per character at 10px Verdana for the label, 6.2px at 11px for the
+    # message, plus the 24px the mark and its padding take on the left cap.
+    lw = int(len(label) * 5.6) + 32
     mw = int(len(message) * 6.2) + 12
     alt = f"Vaara Conformance Results row {row['id']}: {row.get('party', '')}"
     return BADGE_TEMPLATE.format(
         w=lw + mw,
         lw=lw,
         mw=mw,
-        lt=lw - 12,
+        lt=lw - 32,
         mt=mw - 12,
         mx=lw + 6,
         label=esc(label),
@@ -545,7 +619,7 @@ def main(argv: list[str]) -> int:
         strip = lambda s: "\n".join(  # noqa: E731
             ln for ln in s.splitlines() if "generated " not in ln
         )
-        stale_badges = badge_drift(repro)
+        stale_badges = badge_drift(repro, report=report)
         if strip(current) != strip(page) or stale_badges:
             detail = f" Badges out of sync: {', '.join(stale_badges)}." if stale_badges else ""
             print(
@@ -560,16 +634,20 @@ def main(argv: list[str]) -> int:
 
     out.write_text(page, encoding="utf-8")
     badges = write_badges(repro)
+    BADGE_DIR.mkdir(parents=True, exist_ok=True)
+    (BADGE_DIR / CORPUS_BADGE).write_text(corpus_badge_svg(report), encoding="utf-8")
     print(
         f"wrote {out} ({t_len(page)} bytes, {report['totals']['suites']} suites, "
-        f"{len(badges)} badges)"
+        f"{len(badges)} badges) and {CORPUS_BADGE}"
     )
     return 0
 
 
-def badge_drift(repro: dict, badge_dir: Path = BADGE_DIR) -> list[str]:
+def badge_drift(repro: dict, badge_dir: Path = BADGE_DIR, report: dict | None = None) -> list[str]:
     """Names of badge files that do not match the rows, in either direction."""
     wanted: dict[str, bytes] = {}
+    if report is not None:
+        wanted[CORPUS_BADGE] = corpus_badge_svg(report).encode("utf-8")
     for r in repro.get("reproductions", []):
         wanted[f"{r['slug']}.svg"] = badge_svg(r).encode("utf-8")
         wanted[f"{r['slug']}.json"] = row_bytes(r)
@@ -577,7 +655,12 @@ def badge_drift(repro: dict, badge_dir: Path = BADGE_DIR) -> list[str]:
     on_disk: set[str] = set()
     if badge_dir.exists():
         on_disk = {p.name for p in badge_dir.iterdir() if p.is_file()}
-    drift = sorted(on_disk - set(wanted))
+    extra = on_disk - set(wanted)
+    if report is None:
+        # Without a report there is nothing to check the corpus shield against,
+        # so its presence is not drift. Callers that hold a report get it graded.
+        extra -= {CORPUS_BADGE}
+    drift = sorted(extra)
     for name, blob in wanted.items():
         path = badge_dir / name
         if not path.exists() or path.read_bytes() != blob:

--- a/scripts/vcr_row.py
+++ b/scripts/vcr_row.py
@@ -114,6 +114,52 @@ def known_suites() -> set[str]:
     return {p.name for p in VECTORS.iterdir() if p.is_dir()} if VECTORS.exists() else set()
 
 
+#: What scripts/conformance_runner.py writes into the prefilled issue link after
+#: a whole-corpus run: `all 43 suites`. It says so rather than listing every
+#: name, both because the row reads better and because the names do not fit the
+#: 200-character field.
+WHOLE_CORPUS = re.compile(r"^all\s+(\d+)\s+suites$", re.IGNORECASE)
+
+
+def parse_suites(raw: str) -> list[str]:
+    """The suites a row claims, from either the tool's words or the party's.
+
+    Two accepted forms, and nothing else:
+
+    * ``all <N> suites``, exactly as the runner prints it, where N has to match
+      the corpus actually in this repository. A whole-corpus claim that names
+      the wrong size is a claim about some other run.
+    * a comma or newline separated list of suite directory names.
+
+    The first form existed on the printing side from 2026-08-17 and was never
+    taught to this validator, so the single path we tell people to walk was
+    refused here. Issue #587, the first real application, hit it. Kept narrow on
+    purpose: it accepts what our own tool emits and still refuses a hand-written
+    paragraph, because a row is quoted onto a public page and free prose in a
+    field with a fixed meaning is how that page stops meaning one thing.
+    """
+    known = known_suites()
+    text = raw.strip()
+    whole = WHOLE_CORPUS.match(text)
+    if whole:
+        claimed = int(whole.group(1))
+        if claimed != len(known):
+            raise Rejected(
+                f"This repository has {len(known)} suites, and the row claims a "
+                f"run over {claimed}. Rerun `python scripts/conformance_runner.py` "
+                "at the commit you are listing and use the link it prints."
+            )
+        return sorted(known)
+
+    names = [s.strip() for s in text.replace("\n", ",").split(",") if s.strip()]
+    if not names:
+        raise Rejected("Name at least one suite you ran.")
+    unknown = sorted(set(names) - known)
+    if unknown:
+        raise Rejected(f"These are not suites in this repository: {', '.join(unknown)}")
+    return names
+
+
 def validate(fields: dict, author: str) -> dict:
     """Return the row to publish, or raise Rejected with a readable reason."""
     consent = fields.get("consent") or []
@@ -157,13 +203,7 @@ def validate(fields: dict, author: str) -> dict:
     if not commit_exists(sha):
         raise Rejected(f"Commit `{sha}` is not in this repository.")
 
-    raw_suites = [s.strip() for s in str(fields.get("suites", "")).replace("\n", ",").split(",")]
-    suites = [s for s in raw_suites if s]
-    if not suites:
-        raise Rejected("Name at least one suite you ran.")
-    unknown = sorted(set(suites) - known_suites())
-    if unknown:
-        raise Rejected(f"These are not suites in this repository: {', '.join(unknown)}")
+    suites = parse_suites(str(fields.get("suites", "")))
 
     result = str(fields.get("result", "")).strip()
     if not result:

--- a/tests/test_vcr_row.py
+++ b/tests/test_vcr_row.py
@@ -120,6 +120,34 @@ def test_a_suite_that_does_not_exist_is_refused():
         row_from(form(suites="totally_made_up_v0"))
 
 
+def test_the_runners_own_whole_corpus_value_is_accepted():
+    """The desk has to accept what our own tool tells people to submit.
+
+    scripts/conformance_runner.py ends every full run by printing a prefilled
+    issue link carrying `suites=all <N> suites`, deliberately, so a whole-corpus
+    run says so instead of listing forty-three names. The validator only knew
+    directory names, so the one path we actively tell people to walk was refused
+    by our own gate. Found 2026-08-19 on the first real application, issue #587.
+    """
+    n = len(vcr.known_suites())
+    row = row_from(form(suites=f"all {n} suites"))
+    assert row["suites"] == sorted(vcr.known_suites())
+
+
+def test_a_whole_corpus_claim_has_to_match_the_corpus():
+    """`all 9 suites` against a 43-suite corpus is a claim about a different run."""
+    n = len(vcr.known_suites())
+    with pytest.raises(vcr.Rejected, match="suites"):
+        row_from(form(suites=f"all {n - 1} suites"))
+
+
+def test_prose_around_the_suites_is_still_refused():
+    """Liberal enough for the tool's output, not for a hand-written paragraph."""
+    n = len(vcr.known_suites())
+    with pytest.raises(vcr.Rejected, match="not suites"):
+        row_from(form(suites=f"all {n} suites (full default run, my own venv)"))
+
+
 def test_the_commit_has_to_be_in_this_repository():
     """A row nobody can rerun is an assertion. The SHA is what makes it checkable."""
     with pytest.raises(vcr.Rejected, match="not in this repository"):
@@ -168,15 +196,41 @@ def test_two_parties_with_the_same_name_get_different_badges():
     assert a["slug"] != b["slug"]
 
 
-def test_a_badge_carries_the_number_the_date_and_the_commit():
+def test_a_badge_dates_itself_without_phoning_home():
     """Baked into the pixels so the badge dates itself without phoning home."""
     svg = render.badge_svg(
         {"id": 7, "slug": "x", "date": "2026-08-14", "at_commit": HEAD, "party": "X"}
     )
-    assert "VCR #7" in svg
     assert "2026-08-14" in svg
     assert HEAD[:7] in svg
     assert "http://" not in svg.replace('xmlns="http://www.w3.org/2000/svg"', "")
+
+
+def test_the_badge_face_does_not_rank_the_holder():
+    """The row number is a chain index, never a placing.
+
+    Rows are chained, so an order exists and the number has to live in the row,
+    the served bytes and the metadata a reader recomputes against. Putting it on
+    the face turns that index into a standing: row 1 and row 250 are the
+    identical claim, and only one of them reads as an achievement. The table
+    pays off on volume and on strangers walking in years later, so a badge that
+    quietly tells the fiftieth party their sticker is worth less is working
+    against the thing it was built for.
+    """
+    import xml.etree.ElementTree as ET
+
+    svg = render.badge_svg(
+        {"id": 7, "slug": "x", "date": "2026-08-14", "at_commit": HEAD, "party": "X"}
+    )
+    root = ET.fromstring(svg)
+    ns = "{http://www.w3.org/2000/svg}"
+    face = " ".join((el.text or "") for el in root.iter(f"{ns}text"))
+    assert "#7" not in face
+    assert "7" not in face.replace("2026-08-14", "").replace(HEAD[:7], "")
+    assert "reproduced" in face
+
+    # It still has to be recoverable, or the badge stops pointing at a row.
+    assert root.find(".//{https://vaara.io/ns/vcr/v1}row").text == "7"
 
 
 def test_a_badge_commits_to_its_own_row(tmp_path):

--- a/webpage/badge/conformance.svg
+++ b/webpage/badge/conformance.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="269" height="20" role="img" aria-label="Vaara conformance corpus: 43 suites, 42 passing">
+  <title>Vaara conformance corpus: 43 suites, 42 passing</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <metadata>
+    <vcr xmlns="https://vaara.io/ns/vcr/v1">
+      <corpus>https://vaara.io/conformance.html</corpus>
+      <note>Corpus status, not a reproduction. This badge is not evidence that any party ran anything.</note>
+    </vcr>
+  </metadata>
+  <clipPath id="r"><rect width="269" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="127" height="20" fill="#1A2226"/>
+    <rect x="127" width="142" height="20" fill="#78A08A"/>
+    <rect width="269" height="20" fill="url(#s)"/>
+  </g>
+  <polygon points="12,5.5 17.5,15 6.5,15" fill="#78A08A"/>
+  <g font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="10">
+    <text x="24" y="15" fill="#000" fill-opacity=".3" textLength="95" lengthAdjust="spacingAndGlyphs">VAARA CONFORMANCE</text>
+    <text x="24" y="14" fill="#fff" textLength="95" lengthAdjust="spacingAndGlyphs">VAARA CONFORMANCE</text>
+    <text x="133" y="15" fill="#000" fill-opacity=".3" textLength="130" lengthAdjust="spacingAndGlyphs">43 suites, 42 passing</text>
+    <text x="133" y="14" fill="#1A2226" textLength="130" lengthAdjust="spacingAndGlyphs">43 suites, 42 passing</text>
+  </g>
+</svg>

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -104,7 +104,7 @@
     <div class="stat"><b>1</b><span>skipped</span></div>
     <div class="stat"><b>49</b><span>cases</span></div>
   </div>
-  <p class="mono" style="color:var(--faint)">generated 2026-08-19T09:26:25Z</p>
+  <p class="mono" style="color:var(--faint)">generated 2026-08-19T09:36:59Z</p>
 
   <h2>Run it yourself</h2>
   <p>Nothing here needs Vaara installed. The checkers use the standard library

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -104,7 +104,7 @@
     <div class="stat"><b>1</b><span>skipped</span></div>
     <div class="stat"><b>49</b><span>cases</span></div>
   </div>
-  <p class="mono" style="color:var(--faint)">generated 2026-08-18T16:20:31Z</p>
+  <p class="mono" style="color:var(--faint)">generated 2026-08-19T09:26:25Z</p>
 
   <h2>Run it yourself</h2>
   <p>Nothing here needs Vaara installed. The checkers use the standard library


### PR DESCRIPTION
The first self-service application to Vaara Conformance Results arrived on 19 August as issue #587 and got no answer at all. Nothing was wrong with the submission. The faults were ours, and each one was enough on its own to stop a row.

The desk workflow is guarded on a `conformance-row` label. The issue form declares that label, but it did not exist in the repository, so it was dropped on creation, the issue arrived unlabelled, and the job skipped. That failure is silent, which is the wrong behaviour for a desk that promises an answer in about a minute. The job now also fires on the title prefix the form sets, and the label has been created. Every run is still checked by `scripts/vcr_row.py`, so a wrong trigger costs one comment and never a bad row.

Since 17 August the runner has ended every full run by printing a prefilled issue link carrying `suites=all 43 suites`. That wording is deliberate: forty-three directory names do not fit a 200-character field. The validator only ever knew directory names, so it refused the exact value our own tool hands people. It now accepts that form when the count matches the corpus, and still refuses a hand-written paragraph.

The badge face no longer carries the row number. Rows are chained, so the number stays in the row, in the served JSON and in the SVG metadata, where a reader needs it to check what the badge commits to. On the face it reads as a placing rather than an index, and row 1 and row 250 carry the identical claim. The handover comment was updated to match.

The README gains a corpus shield, which is a different artefact from a party badge. It reports how many suites exist and how many pass, links to the results page, and states in its own metadata that it is not evidence that any party ran anything.

Full suite: 3115 passed, 26 skipped.