### PR TITLE
fix(vcr): let the desk publish the site it just wrote

### DIFF
--- a/.github/workflows/conformance-desk.yml
+++ b/.github/workflows/conformance-desk.yml
@@ -30,6 +30,13 @@ on:
 permissions:
   contents: write
   issues: write
+  # The last step dispatches pages.yml so the row this run just published is
+  # actually served. Dispatching a workflow needs `actions: write`, which was
+  # missing, so on row #1 the API returned 403, the site was never rebuilt, and
+  # the submitter got a comment congratulating him next to a badge URL that
+  # returned 404 for an hour and a half. The desk had otherwise worked end to
+  # end. Publishing is part of the handover, so the token has to carry it.
+  actions: write
 
 concurrency:
   group: conformance-desk


### PR DESCRIPTION
The desk's final step dispatches `pages.yml` so that the row it has just published is actually served. Dispatching a workflow needs `actions: write`, and the permissions block granted only `contents` and `issues`.

On row #1 that step returned 403. Everything before it succeeded: the row was validated, chained, written to the `vcr` branch and the badge was handed over in a comment. The site was never rebuilt, so the submitter received a comment naming his row alongside three badge URLs that returned 404. They were live once Pages was dispatched by hand.

Adding the one permission the last step needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated automated publishing permissions so the conformance site can be successfully published after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->