### PR TITLE
fix(vcr): white on a deeper green, and count failures rather than passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg" alt="License"></a>
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://github.com/vaaraio/vaara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://github.com/vaaraio/vaara/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>
-  <a href="https://vaara.io/conformance.html"><img src="https://raw.githubusercontent.com/vaaraio/vaara/main/webpage/badge/conformance.svg" alt="Vaara Conformance: 43 suites, 42 passing"></a>
+  <a href="https://vaara.io/conformance.html"><img src="https://raw.githubusercontent.com/vaaraio/vaara/main/webpage/badge/conformance.svg" alt="Vaara Conformance: 43 suites, 0 failing"></a>
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>
 </p>

--- a/scripts/render_conformance_page.py
+++ b/scripts/render_conformance_page.py
@@ -44,6 +44,15 @@ TITLE = "Vaara Conformance Results"
 # another set by an edit they never saw.
 FALLBACK_TERMS_VERSION = "unversioned"
 
+# COLOURS. The left cap is brand dark #1A2226 carrying the mark in brand green
+# #78A08A. The message side is a deeper green, #4A6E5C, rather than the brand
+# green itself, and that is a readability decision. White on brand green
+# measures 2.92:1, which fails WCAG AA for normal text at this size. Dark text
+# on brand green passes at 5.53:1 but reads as inverted beside every other
+# shield in a README row. #4A6E5C carries white at 5.71:1, so the badge looks
+# like an ordinary shield and stays legible. The brand green is still on the
+# badge, in the mark, where nothing has to be read off it.
+#
 # One badge per listed party, named for that party's slug. There is no generic
 # badge on purpose: a single shared URL is copyable by anyone who never ran
 # anything, and the copy is indistinguishable from the real thing. A per-party
@@ -67,7 +76,7 @@ height="20" role="img" aria-label="{alt}">
   <clipPath id="r"><rect width="{w}" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
     <rect width="{lw}" height="20" fill="#1A2226"/>
-    <rect x="{lw}" width="{mw}" height="20" fill="#78A08A"/>
+    <rect x="{lw}" width="{mw}" height="20" fill="#4A6E5C"/>
     <rect width="{w}" height="20" fill="url(#s)"/>
   </g>
   <polygon points="12,5.5 17.5,15 6.5,15" fill="#78A08A"/>
@@ -78,7 +87,7 @@ lengthAdjust="spacingAndGlyphs">{label}</text>
 lengthAdjust="spacingAndGlyphs">{label}</text>
     <text x="{mx}" y="15" fill="#000" fill-opacity=".3" textLength="{mt}" \
 lengthAdjust="spacingAndGlyphs">{message}</text>
-    <text x="{mx}" y="14" fill="#1A2226" textLength="{mt}" \
+    <text x="{mx}" y="14" fill="#fff" textLength="{mt}" \
 lengthAdjust="spacingAndGlyphs">{message}</text>
   </g>
 </svg>
@@ -109,11 +118,17 @@ def corpus_badge_svg(report: dict) -> str:
     """
     totals = report["totals"]
     label = "VAARA CONFORMANCE"
-    message = f"{totals['suites']} suites, {totals['passed']} passing"
+    # Counting passes against the suite total reads as a failure that is not
+    # there. The corpus has suites the aggregate runner cannot execute from a
+    # bare case directory, article12_fold_v0 being one: its checker validates a
+    # bundle zip. Those skip, and a "42 of 43 passing" badge invites a reader to
+    # assume the missing one is broken, on the maintainer's own README. Failures
+    # are the number that carries meaning here, and the honest one is zero.
+    message = f"{totals['suites']} suites, {totals['failed']} failing"
     lw = int(len(label) * 5.6) + 32
     mw = int(len(message) * 6.2) + 12
     alt = (f"Vaara conformance corpus: {totals['suites']} suites, "
-           f"{totals['passed']} passing")
+           f"{totals['failed']} failing")
     return BADGE_TEMPLATE.format(
         w=lw + mw,
         lw=lw,

--- a/webpage/badge/conformance.svg
+++ b/webpage/badge/conformance.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="269" height="20" role="img" aria-label="Vaara conformance corpus: 43 suites, 42 passing">
-  <title>Vaara conformance corpus: 43 suites, 42 passing</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="263" height="20" role="img" aria-label="Vaara conformance corpus: 43 suites, 0 failing">
+  <title>Vaara conformance corpus: 43 suites, 0 failing</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -10,17 +10,17 @@
       <note>Corpus status, not a reproduction. This badge is not evidence that any party ran anything.</note>
     </vcr>
   </metadata>
-  <clipPath id="r"><rect width="269" height="20" rx="3" fill="#fff"/></clipPath>
+  <clipPath id="r"><rect width="263" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
     <rect width="127" height="20" fill="#1A2226"/>
-    <rect x="127" width="142" height="20" fill="#78A08A"/>
-    <rect width="269" height="20" fill="url(#s)"/>
+    <rect x="127" width="136" height="20" fill="#4A6E5C"/>
+    <rect width="263" height="20" fill="url(#s)"/>
   </g>
   <polygon points="12,5.5 17.5,15 6.5,15" fill="#78A08A"/>
   <g font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="10">
     <text x="24" y="15" fill="#000" fill-opacity=".3" textLength="95" lengthAdjust="spacingAndGlyphs">VAARA CONFORMANCE</text>
     <text x="24" y="14" fill="#fff" textLength="95" lengthAdjust="spacingAndGlyphs">VAARA CONFORMANCE</text>
-    <text x="133" y="15" fill="#000" fill-opacity=".3" textLength="130" lengthAdjust="spacingAndGlyphs">43 suites, 42 passing</text>
-    <text x="133" y="14" fill="#1A2226" textLength="130" lengthAdjust="spacingAndGlyphs">43 suites, 42 passing</text>
+    <text x="133" y="15" fill="#000" fill-opacity=".3" textLength="124" lengthAdjust="spacingAndGlyphs">43 suites, 0 failing</text>
+    <text x="133" y="14" fill="#fff" textLength="124" lengthAdjust="spacingAndGlyphs">43 suites, 0 failing</text>
   </g>
 </svg>

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -104,7 +104,7 @@
     <div class="stat"><b>1</b><span>skipped</span></div>
     <div class="stat"><b>49</b><span>cases</span></div>
   </div>
-  <p class="mono" style="color:var(--faint)">generated 2026-08-19T09:36:59Z</p>
+  <p class="mono" style="color:var(--faint)">generated 2026-08-19T11:53:16Z</p>
 
   <h2>Run it yourself</h2>
   <p>Nothing here needs Vaara installed. The checkers use the standard library


### PR DESCRIPTION
Two readability fixes to the badges.

The message side was brand green `#78A08A` carrying dark text. White on that green measures 2.92:1, which fails WCAG AA for normal text at this size, and the dark text reads as inverted beside every other shield in a README row. `#4A6E5C` carries white at 5.71:1. Brand green stays on the badge, in the mark, where nothing has to be read off it. Geometry is untouched, so the shield still aligns with the rest of the badge row.

The corpus shield read `43 suites, 42 passing`, which invites a reader to assume one suite is broken, on the maintainer's own README. Nothing fails. The suite that does not run is `article12_fold_v0`, whose independent checker validates a produced Article 12 regulator package rather than a bare case directory, so the aggregate runner cannot reach it without the Vaara install it promises not to need. That suite is covered by `tests/test_article12_fold.py`, including a case that builds a package and runs the independent checker against it. The badge now reports failures, which is the number that carries meaning.