### PR TITLE
fix(attestation): a lens that did not run reports ok as null, not false

### DIFF
--- a/src/vaara/attestation/_bundle.py
+++ b/src/vaara/attestation/_bundle.py
@@ -72,10 +72,29 @@ class LensResult:
     """Result of one lens over the bundle.
 
     ``applicable`` is True when the bundle carried the evidence the lens
-    needs. ``ok`` is True only when the lens applied AND passed; a lens that
-    did not apply has ``applicable=False`` and ``ok=False`` and does not
-    count against the verdict. ``reason`` is a short human string for audit
-    logs.
+    needs. ``ok`` is True only when the lens applied AND passed, and a lens
+    that did not apply does not count against the verdict. ``reason`` is a
+    short human string for audit logs.
+
+    SERIALIZED ``ok`` IS ``None`` WHEN THE LENS DID NOT APPLY, and that is
+    the point of the field rather than a detail of it. The aggregation here
+    has always been correct: :func:`verify_evidence_bundle` counts a lens
+    only when ``applicable`` is true, so an inapplicable lens never produced
+    a failure. What the serialization did was emit ``ok: false`` beside
+    ``applicable: false``, which states a verdict on a check that never ran.
+    A consumer reading ``ok`` on its own, which is the field whose name
+    invites being read on its own, saw a failure everywhere nothing was
+    evaluated.
+
+    Two booleans can be half read and a single terminal value cannot, so the
+    absent case now serializes as null. Raised on the IETF SCITT list on
+    2026-08-19 in the CHAP thread, where the working group is settling a
+    NOT_EVALUATED state that is terminal and mutually exclusive with pass and
+    fail. This is the same distinction, and the argument was made there
+    against Vaara's own committed expectations rather than in the abstract.
+
+    The in-memory field stays a bool so callers that already branch on it are
+    unaffected; only the JSON crossing a trust boundary changes.
     """
 
     lens: str
@@ -84,11 +103,14 @@ class LensResult:
     reason: str
 
     def to_dict(self) -> dict[str, Any]:
-        """Plain-dict form for JSON output (CLI, logs)."""
+        """Plain-dict form for JSON output (CLI, logs).
+
+        ``ok`` is ``None`` for an inapplicable lens. See the class docstring.
+        """
         return {
             "lens": self.lens,
             "applicable": self.applicable,
-            "ok": self.ok,
+            "ok": self.ok if self.applicable else None,
             "reason": self.reason,
         }
 

--- a/tests/test_evidence_bundle.py
+++ b/tests/test_evidence_bundle.py
@@ -234,7 +234,14 @@ def test_vaara_reproduces_vector_verdict(case):
     verdict = verify_evidence_bundle(_bundle_from_json(case["bundle"]))
     assert verdict.ok is want["ok"]
     assert verdict.authenticity_established is want["authenticity_established"]
-    got = {r.lens: {"applicable": r.applicable, "ok": r.ok} for r in verdict.lenses}
+    # Compare what a caller actually receives. Reading r.ok off the dataclass
+    # bypasses to_dict, which is where an inapplicable lens reports ok as
+    # None, and that bypass is how the vectors and the reference drifted on
+    # this field in the first place.
+    got = {
+        r.lens: {k: v for k, v in r.to_dict().items() if k in ("applicable", "ok")}
+        for r in verdict.lenses
+    }
     assert got == want["lenses"]
 
 

--- a/tests/test_verify_bundle_cli.py
+++ b/tests/test_verify_bundle_cli.py
@@ -51,7 +51,12 @@ def test_loader_reproduces_vector_verdict(name):
     verdict = verify_evidence_bundle(evidence_bundle_from_json(doc))
     assert verdict.ok is want["ok"]
     assert verdict.authenticity_established is want["authenticity_established"]
-    got = {r.lens: {"applicable": r.applicable, "ok": r.ok} for r in verdict.lenses}
+    # Through to_dict, so this compares what a caller receives rather than the
+    # in-memory bool. See LensResult: an inapplicable lens serializes ok=None.
+    got = {
+        r.lens: {k: v for k, v in r.to_dict().items() if k in ("applicable", "ok")}
+        for r in verdict.lenses
+    }
     assert got == want["lenses"]
 
 

--- a/tests/vectors/build_bundle_v0/expected.json
+++ b/tests/vectors/build_bundle_v0/expected.json
@@ -24,7 +24,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": true
@@ -38,7 +38,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -46,15 +46,15 @@
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -64,7 +64,7 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": true,
@@ -76,15 +76,15 @@
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -98,7 +98,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -114,7 +114,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -124,23 +124,23 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": true,
@@ -158,7 +158,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -174,7 +174,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -184,15 +184,15 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": true,
@@ -204,7 +204,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -214,23 +214,23 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": true,

--- a/tests/vectors/bundle_doc_v0/expected.json
+++ b/tests/vectors/bundle_doc_v0/expected.json
@@ -24,7 +24,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": true
@@ -38,7 +38,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -46,15 +46,15 @@
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -64,7 +64,7 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": true,
@@ -76,15 +76,15 @@
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -98,7 +98,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -114,7 +114,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -124,23 +124,23 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": true,
@@ -158,7 +158,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -174,7 +174,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -184,15 +184,15 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": true,
@@ -204,7 +204,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -214,23 +214,23 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": true,

--- a/tests/vectors/evidence_bundle_v0/_check_independent.py
+++ b/tests/vectors/evidence_bundle_v0/_check_independent.py
@@ -174,7 +174,15 @@ def _verify_consistency(first_size, first_root, second_size, second_root, proof)
 
 
 def _lens(applicable: bool, ok: bool) -> dict:
-    return {"applicable": applicable, "ok": ok}
+    """An inapplicable lens reports ``ok`` as None, never as False.
+
+    False here would be a verdict on a check that never ran, and a consumer
+    reading ``ok`` alone would see a failure where nothing was evaluated. The
+    aggregation below counts a lens only when ``applicable`` is true, so the
+    verdict is unchanged either way; what changes is that the absent case can
+    no longer be misread as a refusal.
+    """
+    return {"applicable": applicable, "ok": ok if applicable else None}
 
 
 def _identity_lens(bundle: dict):
@@ -271,12 +279,18 @@ def _evaluate(bundle: dict) -> dict:
         "consistency": _consistency_lens(bundle),
         "revocation": _revocation_lens(bundle, keyid),
     }
-    authenticity = lenses["identity"]["ok"] or lenses["signature"]["ok"]
+    # bool() on each side, because an inapplicable lens now reports ok as
+    # None and ``None or None`` is None rather than False. Without this the
+    # aggregate leaks a null into authenticity_established and into the
+    # overall verdict, which would be the exact defect this change is fixing,
+    # one level up. Caught by running the checker against the regenerated
+    # vectors rather than by reading the diff.
+    authenticity = bool(lenses["identity"]["ok"]) or bool(lenses["signature"]["ok"])
     failures = [
         name for name, res in lenses.items() if res["applicable"] and not res["ok"]
     ]
     return {
-        "ok": authenticity and not failures,
+        "ok": bool(authenticity and not failures),
         "authenticity_established": authenticity,
         "lenses": lenses,
     }

--- a/tests/vectors/evidence_bundle_v0/_generate.py
+++ b/tests/vectors/evidence_bundle_v0/_generate.py
@@ -120,7 +120,12 @@ def _verdict_json(verdict: BundleVerdict) -> dict[str, object]:
         "ok": verdict.ok,
         "authenticity_established": verdict.authenticity_established,
         "lenses": {
-            r.lens: {"applicable": r.applicable, "ok": r.ok} for r in verdict.lenses
+            # Serialize through LensResult.to_dict so the committed vectors
+            # carry exactly what a caller sees, including ok=None for a lens
+            # that did not apply. Building the dict by hand here is what let
+            # the vectors and the reference drift on that field.
+            r.lens: {k: v for k, v in r.to_dict().items() if k in ("applicable", "ok")}
+            for r in verdict.lenses
         },
     }
 

--- a/tests/vectors/evidence_bundle_v0/cases.json
+++ b/tests/vectors/evidence_bundle_v0/cases.json
@@ -117,7 +117,7 @@
           },
           "signature": {
             "applicable": false,
-            "ok": false
+            "ok": null
           }
         },
         "ok": true
@@ -222,7 +222,7 @@
           },
           "consistency": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "identity": {
             "applicable": true,
@@ -238,7 +238,7 @@
           },
           "signature": {
             "applicable": false,
-            "ok": false
+            "ok": null
           }
         },
         "ok": false
@@ -336,7 +336,7 @@
           },
           "consistency": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "identity": {
             "applicable": true,
@@ -352,7 +352,7 @@
           },
           "signature": {
             "applicable": false,
-            "ok": false
+            "ok": null
           }
         },
         "ok": false
@@ -413,7 +413,7 @@
         "lenses": {
           "back_link": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "consistency": {
             "applicable": true,
@@ -425,15 +425,15 @@
           },
           "inclusion": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "revocation": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "signature": {
             "applicable": false,
-            "ok": false
+            "ok": null
           }
         },
         "ok": false
@@ -518,7 +518,7 @@
           },
           "consistency": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "identity": {
             "applicable": true,
@@ -526,15 +526,15 @@
           },
           "inclusion": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "revocation": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "signature": {
             "applicable": false,
-            "ok": false
+            "ok": null
           }
         },
         "ok": false
@@ -576,23 +576,23 @@
         "lenses": {
           "back_link": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "consistency": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "identity": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "inclusion": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "revocation": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "signature": {
             "applicable": true,
@@ -645,15 +645,15 @@
         "lenses": {
           "back_link": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "consistency": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "identity": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "inclusion": {
             "applicable": true,
@@ -665,7 +665,7 @@
           },
           "signature": {
             "applicable": false,
-            "ok": false
+            "ok": null
           }
         },
         "ok": false
@@ -707,23 +707,23 @@
         "lenses": {
           "back_link": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "consistency": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "identity": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "inclusion": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "revocation": {
             "applicable": false,
-            "ok": false
+            "ok": null
           },
           "signature": {
             "applicable": true,

--- a/tests/vectors/evidence_bundle_v0/expected.json
+++ b/tests/vectors/evidence_bundle_v0/expected.json
@@ -24,7 +24,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": true
@@ -38,7 +38,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -46,15 +46,15 @@
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -64,7 +64,7 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": true,
@@ -76,15 +76,15 @@
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -98,7 +98,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -114,7 +114,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -124,23 +124,23 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": true,
@@ -158,7 +158,7 @@
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": true,
@@ -174,7 +174,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -184,15 +184,15 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": true,
@@ -204,7 +204,7 @@
       },
       "signature": {
         "applicable": false,
-        "ok": false
+        "ok": null
       }
     },
     "ok": false
@@ -214,23 +214,23 @@
     "lenses": {
       "back_link": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "consistency": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "identity": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "inclusion": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "revocation": {
         "applicable": false,
-        "ok": false
+        "ok": null
       },
       "signature": {
         "applicable": true,

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -104,7 +104,7 @@
     <div class="stat"><b>1</b><span>skipped</span></div>
     <div class="stat"><b>49</b><span>cases</span></div>
   </div>
-  <p class="mono" style="color:var(--faint)">generated 2026-08-19T11:53:16Z</p>
+  <p class="mono" style="color:var(--faint)">generated 2026-08-19T14:08:29Z</p>
 
   <h2>Run it yourself</h2>
   <p>Nothing here needs Vaara installed. The checkers use the standard library


### PR DESCRIPTION
`verify_evidence_bundle` has always aggregated correctly. A lens counts toward the verdict only when `applicable` is true, so an inapplicable lens never produced a failure. What the serialization did was emit `ok: false` next to `applicable: false`, which states a verdict on a check that never ran. A consumer reading `ok` on its own, which is the field whose name invites being read on its own, saw a failure everywhere nothing had been evaluated.

This was raised on the IETF SCITT list on 19 August in the CHAP thread, where the working group is settling a NOT_EVALUATED state that is terminal and mutually exclusive with pass and fail. The argument was made there against Vaara's own committed expectations rather than in the abstract, so it is fixed here.

The in-memory field stays a bool, so callers that branch on it are unaffected. Only the JSON that crosses a trust boundary changes.

Three places built that JSON by hand instead of going through `LensResult.to_dict`, which is how the vectors and the reference drifted on this field in the first place. All three now go through it.

The vectors were edited in place rather than regenerated. Both generators mint fresh Merkle roots on every run, so a regenerate churns hashes that have nothing to do with this change and breaks fixtures other suites pin. The diff over `tests/vectors` touches the `ok` field and nothing else.

Full suite: 3115 passed, 26 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inapplicable checks are now serialized as `ok: null` instead of `false`, clearly distinguishing them from failed checks.
  * Overall verdicts and applicable check results remain unchanged.

* **Tests**
  * Updated verification scenarios and expected results to reflect the corrected serialized check status.

* **Documentation**
  * Clarified the serialized representation of inapplicable checks.
  * Refreshed the conformance page timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->