### PR TITLE
fix(vcr): let the desk and the refresh switch to the vcr branch over a dirty tree

### DIFF
--- a/.github/workflows/conformance-desk.yml
+++ b/.github/workflows/conformance-desk.yml
@@ -171,8 +171,14 @@ jobs:
           cp -r webpage/badge /tmp/vcr/vcr/badge
           git config user.name "vaara-desk"
           git config user.email "hello@vaara.io"
+          # -f because the working tree still holds the regenerated page and the
+          # rows carried over from vcr, and a plain checkout refuses to switch
+          # over them. Everything this job publishes was copied to /tmp/vcr
+          # above, so discarding the tree here loses nothing. Row #1 did not hit
+          # this: the branch did not exist yet, so it took the orphan path, which
+          # keeps the working tree. The next submission would have failed.
           if git ls-remote --exit-code --heads origin vcr >/dev/null 2>&1; then
-            git checkout vcr
+            git checkout -f vcr
           else
             git checkout --orphan vcr
             git rm -rf --cached . >/dev/null 2>&1 || true
@@ -276,8 +282,14 @@ jobs:
           cp -r webpage/badge /tmp/vcr/vcr/badge
           git config user.name "vaara-desk"
           git config user.email "hello@vaara.io"
+          # -f because the working tree still holds the regenerated page and the
+          # rows carried over from vcr, and a plain checkout refuses to switch
+          # over them. Everything this job publishes was copied to /tmp/vcr
+          # above, so discarding the tree here loses nothing. Row #1 did not hit
+          # this: the branch did not exist yet, so it took the orphan path, which
+          # keeps the working tree. The next submission would have failed.
           if git ls-remote --exit-code --heads origin vcr >/dev/null 2>&1; then
-            git checkout vcr
+            git checkout -f vcr
           else
             git checkout --orphan vcr
             git rm -rf --cached . >/dev/null 2>&1 || true

--- a/.github/workflows/downloads-badge.yml
+++ b/.github/workflows/downloads-badge.yml
@@ -35,6 +35,18 @@ jobs:
         with:
           ref: badges
 
+      # The badge geometry lives in scripts/render_conformance_page.py on main.
+      # This job used to carry a second renderer written in shell, and the two
+      # drifted: this one still put white on brand green at 2.92:1, the contrast
+      # failure the Python one fixed in August, and it forced the glyph width.
+      - name: Check out main for the badge renderer
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: .renderer
+          sparse-checkout: scripts/render_conformance_page.py
+          sparse-checkout-cone-mode: false
+
       - name: Compute installs and render self-hosted badge SVGs
         run: |
           set -euo pipefail
@@ -56,18 +68,10 @@ jobs:
           total=$(( pypi + npm ))
           echo "pypi=$pypi npm=$npm total=$total version=${version:-none}"
 
-          # Self-contained shields-style "flat" SVG, rendered in pure shell.
-          # textLength forces the text to fit the computed width, so we never need
-          # exact font glyph metrics. SVG attributes use single quotes so the outer
-          # double-quoted string can expand the shell vars. Inputs here are
-          # controlled (labels, a semver, a count), so no XML escaping is needed.
+          # One renderer for every shield the project publishes.
           render_badge() { # $1=label $2=message $3=hexcolor $4=outfile
-            local label="$1" message="$2" color="$3" out="$4" lw mw W lx mx ltl mtl
-            lw=$(awk -v n=${#label}   'BEGIN{print int(n*6.5)+10}')
-            mw=$(awk -v n=${#message} 'BEGIN{print int(n*6.5)+10}')
-            W=$((lw + mw)); lx=$((lw * 5)); mx=$((lw * 10 + mw * 5))
-            ltl=$(((lw - 10) * 10)); mtl=$(((mw - 10) * 10))
-            printf '%s' "<svg xmlns='http://www.w3.org/2000/svg' width='$W' height='20' role='img' aria-label='$label: $message'><title>$label: $message</title><linearGradient id='s' x2='0' y2='100%'><stop offset='0' stop-color='#bbb' stop-opacity='.1'/><stop offset='1' stop-opacity='.1'/></linearGradient><clipPath id='r'><rect width='$W' height='20' rx='3' fill='#fff'/></clipPath><g clip-path='url(#r)'><rect width='$lw' height='20' fill='#555'/><rect x='$lw' width='$mw' height='20' fill='#$color'/><rect width='$W' height='20' fill='url(#s)'/></g><g fill='#fff' text-anchor='middle' font-family='Verdana,Geneva,DejaVu Sans,sans-serif' text-rendering='geometricPrecision' font-size='110'><text aria-hidden='true' x='$lx' y='150' transform='scale(.1)' fill='#000' fill-opacity='.3' textLength='$ltl'>$label</text><text x='$lx' y='140' transform='scale(.1)' textLength='$ltl'>$label</text><text aria-hidden='true' x='$mx' y='150' transform='scale(.1)' fill='#000' fill-opacity='.3' textLength='$mtl'>$message</text><text x='$mx' y='140' transform='scale(.1)' textLength='$mtl'>$message</text></g></svg>" > "$out"
+            python3 .renderer/scripts/render_conformance_page.py \
+              --badge "$1" "$2" "#$3" "$4"
           }
 
           # Version badge: render whenever PyPI returns a version, independent of
@@ -92,9 +96,9 @@ jobs:
 
           msg=$(awk -v n="$total" 'BEGIN{ if (n>=1000) printf "%.1fk all-time", n/1000; else printf "%d all-time", n }')
           gen=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          printf '{"schemaVersion":1,"label":"downloads","message":"%s","total":%d,"color":"78A08A","generated":"%s"}\n' "$msg" "$total" "$gen" \
+          printf '{"schemaVersion":1,"label":"downloads","message":"%s","total":%d,"color":"4A6E5C","generated":"%s"}\n' "$msg" "$total" "$gen" \
             > installs.json
-          render_badge "downloads" "$msg" "78A08A" downloads.svg
+          render_badge "downloads" "$msg" "4A6E5C" downloads.svg
           cat installs.json
 
       - name: Commit if changed

--- a/scripts/render_conformance_page.py
+++ b/scripts/render_conformance_page.py
@@ -91,8 +91,7 @@ height="20" role="img" aria-label="{alt}">
     <rect x="{lw}" width="{mw}" height="20" fill="{mcolor}"/>
     <rect width="{w}" height="20" fill="url(#s)"/>
   </g>
-  <polygon points="12,5 18,15 6,15" fill="#78A08A"/>
-  <g fill="#fff" text-anchor="middle" \
+{mark}  <g fill="#fff" text-anchor="middle" \
 font-family="Verdana,Geneva,DejaVu Sans,sans-serif" \
 text-rendering="geometricPrecision" font-size="110">
     <g transform="scale(.1)">
@@ -162,6 +161,15 @@ _FAIL = "#B03A2E"
 #: instead of by hex, which broke them the first time this colour moved.
 _LABEL = "#45565E"
 
+#: The mark. It fills the shields.io logo slot, which every badge carrying a
+#: logo uses: x=5, 14 wide, centred in the 20px height. Inside that slot it
+#: keeps the wordmark's own 1.2:1 hill (points 32,22 44,42 20,42 on the site),
+#: so 14 by 11.6 rather than the 13 by 13 that first stood in for it and read
+#: as a pine. The conformance badge always carries it. The downloads shield
+#: makes no conformance claim, so it carries no mark and takes the ordinary
+#: shields left padding, which keeps the mark a signal instead of decoration.
+_MARK = '  <polygon points="12,4.2 19,15.8 5,15.8" fill="#78A08A"/>\n'
+
 
 def text_width(s: str) -> float:
     """Natural rendered width of ``s`` at 10px Verdana, in px."""
@@ -178,6 +186,60 @@ CORPUS_BADGE = "conformance.svg"
 
 def esc(value: object) -> str:
     return html.escape(str(value), quote=True)
+
+
+#: The row metadata every badge carries by default. A badge that commits to no
+#: row swaps this out, because empty elements read as a row hashing to nothing.
+_ROW_METADATA = """  <metadata>
+    <vcr xmlns="https://vaara.io/ns/vcr/v1">
+      <row></row>
+      <digest></digest>
+      <over>https://vaara.io/badge/.json</over>
+      <recompute>sha256 of those bytes, which are JCS-canonical per RFC 8785</recompute>
+    </vcr>
+  </metadata>
+"""
+
+
+def plain_badge_svg(label: str, message: str, color: str, alt: str | None = None) -> str:
+    """A shield in the Vaara colourway that commits to no conformance claim.
+
+    The downloads and version shields used to be rendered by a second
+    implementation, written in shell inside downloads-badge.yml. The two drifted:
+    that one still carried white on brand green #78A08A at 2.92:1, the contrast
+    failure this file fixed in August, and it forced the glyph width the same way
+    the badges here used to. One renderer means a colour or geometry decision
+    reaches every shield the project publishes.
+    """
+    lwid = text_width(label)
+    mwid = text_width(message)
+    lw = round(_PAD + lwid + _PAD)
+    mw = round(_PAD + mwid + _PAD)
+    return BADGE_TEMPLATE.format(
+        w=lw + mw,
+        lw=lw,
+        mw=mw,
+        mcolor=color,
+        lcolor=_LABEL,
+        mark="",
+        lcx=round((_PAD + lwid / 2) * 10),
+        mcx=round((lw + _PAD + mwid / 2) * 10),
+        label=esc(label),
+        message=esc(message),
+        alt=esc(alt or f"{label}: {message}"),
+        row_id="",
+        slug="",
+        digest="",
+    ).replace(
+        _ROW_METADATA,
+        """  <metadata>
+    <vcr xmlns="https://vaara.io/ns/vcr/v1">
+      <note>Project status. This badge is not evidence that any party ran \
+anything.</note>
+    </vcr>
+  </metadata>
+""",
+    )
 
 
 def corpus_badge_svg(report: dict) -> str:
@@ -212,6 +274,7 @@ def corpus_badge_svg(report: dict) -> str:
         mw=mw,
         mcolor=_OK if not totals["failed"] else _FAIL,
         lcolor=_LABEL,
+        mark=_MARK,
         lcx=round((_LOGO_SPAN + lwid / 2) * 10),
         mcx=round((lw + _PAD + mwid / 2) * 10),
         label=esc(label),
@@ -298,6 +361,7 @@ def badge_svg(row: dict) -> str:
         # the corpus, so it never turns red.
         mcolor=_OK,
         lcolor=_LABEL,
+        mark=_MARK,
         lcx=round((_LOGO_SPAN + lwid / 2) * 10),
         mcx=round((lw + _PAD + mwid / 2) * 10),
         label=esc(label),
@@ -702,6 +766,20 @@ def main(argv: list[str]) -> int:
     if not argv:
         print(__doc__)
         return 2
+
+    # Used by downloads-badge.yml so the project publishes one badge geometry
+    # rather than two implementations that drift apart.
+    if argv[0] == "--badge":
+        if len(argv) != 5:
+            print("usage: --badge LABEL MESSAGE COLOR OUT", file=sys.stderr)
+            return 2
+        _, label, message, color, out_path = argv
+        Path(out_path).write_text(
+            plain_badge_svg(label, message, color), encoding="utf-8"
+        )
+        print(f"wrote {out_path} ({label}: {message})")
+        return 0
+
     report_path = Path(argv[0])
     check = "--check" in argv
     out = Path(argv[1]) if len(argv) > 1 and not argv[1].startswith("-") else DEFAULT_OUT

--- a/scripts/render_conformance_page.py
+++ b/scripts/render_conformance_page.py
@@ -44,8 +44,19 @@ TITLE = "Vaara Conformance Results"
 # another set by an edit they never saw.
 FALLBACK_TERMS_VERSION = "unversioned"
 
-# COLOURS. The left cap is brand dark #1A2226 carrying the mark in brand green
-# #78A08A. The message side is a deeper green, #4A6E5C, rather than the brand
+# COLOURS. The left cap is #45565E carrying the mark in brand green
+# #78A08A. Brand dark #1A2226 sat there first and it swallowed the gloss: every
+# shields.io badge lays a #bbb gradient at 10% opacity over both plates, and on
+# a near-black plate there is nothing for it to lift, so the badge read flat
+# beside the CI and Scorecard shields in the same row. shields uses #555 at
+# luminance 0.0908; #45565E is 0.0873 in the brand hue, so the gloss reads the
+# same and white still carries 7.65:1.
+#
+# The mark is 12 by 10, the 1.2:1 proportion of the wordmark's own hill
+# (points 32,22 44,42 20,42 on the site). A 13 by 13 triangle stood in for it
+# first, and at 1:1 in brand green it reads as a pine rather than a hill.
+#
+# The message side is a deeper green, #4A6E5C, rather than the brand
 # green itself, and that is a readability decision. White on brand green
 # measures 2.92:1, which fails WCAG AA for normal text at this size. Dark text
 # on brand green passes at 5.53:1 but reads as inverted beside every other
@@ -76,11 +87,11 @@ height="20" role="img" aria-label="{alt}">
   </metadata>
   <clipPath id="r"><rect width="{w}" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
-    <rect width="{lw}" height="20" fill="#1A2226"/>
+    <rect width="{lw}" height="20" fill="{lcolor}"/>
     <rect x="{lw}" width="{mw}" height="20" fill="{mcolor}"/>
     <rect width="{w}" height="20" fill="url(#s)"/>
   </g>
-  <polygon points="12,3.5 18.5,16.5 5.5,16.5" fill="#78A08A"/>
+  <polygon points="12,5 18,15 6,15" fill="#78A08A"/>
   <g fill="#fff" text-anchor="middle" \
 font-family="Verdana,Geneva,DejaVu Sans,sans-serif" \
 text-rendering="geometricPrecision" font-size="110">
@@ -133,8 +144,8 @@ _VERDANA_10 = {
 #: runs uniformly narrow by 1.085 and 1.092, so one constant corrects it.
 _VERDANA_CAL = 1.09
 
-#: Where the label plate ends and its text begins. The mark occupies the
-#: shields.io logo slot, a 14px box centred in the 20px height.
+#: Where the label plate ends and its text begins. The mark sits in the
+#: shields.io logo slot ahead of it, centred in the 20px height.
 _LOGO_SPAN = 24.0
 #: Padding either side of a text run. shields.io pads a 37px label into a 47px
 #: plate and a 51px message into a 61px plate, so 5px per side.
@@ -146,6 +157,10 @@ _PAD = 5.0
 #: instead of reading it would be misled.
 _OK = "#4A6E5C"
 _FAIL = "#B03A2E"
+
+#: The label plate, carrying the mark. Named so the tests locate it by meaning
+#: instead of by hex, which broke them the first time this colour moved.
+_LABEL = "#45565E"
 
 
 def text_width(s: str) -> float:
@@ -196,6 +211,7 @@ def corpus_badge_svg(report: dict) -> str:
         lw=lw,
         mw=mw,
         mcolor=_OK if not totals["failed"] else _FAIL,
+        lcolor=_LABEL,
         lcx=round((_LOGO_SPAN + lwid / 2) * 10),
         mcx=round((lw + _PAD + mwid / 2) * 10),
         label=esc(label),
@@ -281,6 +297,7 @@ def badge_svg(row: dict) -> str:
         # A party badge records that a run happened. It carries no verdict on
         # the corpus, so it never turns red.
         mcolor=_OK,
+        lcolor=_LABEL,
         lcx=round((_LOGO_SPAN + lwid / 2) * 10),
         mcx=round((lw + _PAD + mwid / 2) * 10),
         label=esc(label),

--- a/scripts/render_conformance_page.py
+++ b/scripts/render_conformance_page.py
@@ -176,7 +176,7 @@ def corpus_badge_svg(report: dict) -> str:
     at, and it links to the page where every one of those verdicts recomputes.
     """
     totals = report["totals"]
-    label = "VAARA CONFORMANCE"
+    label = "Vaara Conformance"
     # Counting passes against the suite total reads as a failure that is not
     # there. The corpus has suites the aggregate runner cannot execute from a
     # bare case directory, article12_fold_v0 being one: its checker validates a
@@ -266,7 +266,7 @@ def badge_svg(row: dict) -> str:
     the first application arrived from a party who had no idea a number was on
     offer, which is fairly good evidence nobody is here for the number.
     """
-    label = "VAARA CONFORMANCE"
+    label = "Vaara Conformance"
     message = f"reproduced {row.get('date', '')} {str(row.get('at_commit', ''))[:7]}"
     lwid = text_width(label)
     mwid = text_width(message)

--- a/tests/test_conformance_page.py
+++ b/tests/test_conformance_page.py
@@ -227,7 +227,10 @@ def test_the_mark_is_centred_in_the_plate():
 
 def test_text_centres_sit_inside_their_own_plates():
     svg = renderer().corpus_badge_svg({"totals": {"suites": 43, "failed": 0}})
-    plate = float(re.search(r'<rect width="([0-9.]+)" height="20" fill="#1A2226"', svg).group(1))
+    module = renderer()
+    svg = module.corpus_badge_svg({"totals": {"suites": 43, "failed": 0}})
+    plate = float(re.search(
+        rf'<rect width="([0-9.]+)" height="20" fill="{module._LABEL}"', svg).group(1))
     # x is at ten times scale, to match the scale(.1) the text group carries.
     label_cx, message_cx = (int(x) / 10 for x in re.findall(r'<text x="(\d+)" y="140"', svg))
     assert 0 < label_cx < plate, "the label is centred outside its own plate"

--- a/webpage/badge/conformance.svg
+++ b/webpage/badge/conformance.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="267" height="20" role="img" aria-label="Vaara conformance corpus: 43 suites, 0 failing">
+<svg xmlns="http://www.w3.org/2000/svg" width="248" height="20" role="img" aria-label="Vaara conformance corpus: 43 suites, 0 failing">
   <title>Vaara conformance corpus: 43 suites, 0 failing</title>
   <filter id="blur"><feGaussianBlur stdDeviation="16"/></filter>
   <linearGradient id="s" x2="0" y2="100%">
@@ -11,27 +11,27 @@
       <note>Corpus status, not a reproduction. This badge is not evidence that any party ran anything.</note>
     </vcr>
   </metadata>
-  <clipPath id="r"><rect width="267" height="20" rx="3" fill="#fff"/></clipPath>
+  <clipPath id="r"><rect width="248" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
-    <rect width="156" height="20" fill="#1A2226"/>
-    <rect x="156" width="111" height="20" fill="#4A6E5C"/>
-    <rect width="267" height="20" fill="url(#s)"/>
+    <rect width="137" height="20" fill="#1A2226"/>
+    <rect x="137" width="111" height="20" fill="#4A6E5C"/>
+    <rect width="248" height="20" fill="url(#s)"/>
   </g>
   <polygon points="12,3.5 18.5,16.5 5.5,16.5" fill="#78A08A"/>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <g transform="scale(.1)">
       <g aria-hidden="true" fill="#010101">
-        <text x="874" y="150" fill-opacity=".8" filter="url(#blur)">VAARA CONFORMANCE</text>
-        <text x="874" y="150" fill-opacity=".3">VAARA CONFORMANCE</text>
+        <text x="782" y="150" fill-opacity=".8" filter="url(#blur)">Vaara Conformance</text>
+        <text x="782" y="150" fill-opacity=".3">Vaara Conformance</text>
       </g>
-      <text x="874" y="140">VAARA CONFORMANCE</text>
+      <text x="782" y="140">Vaara Conformance</text>
     </g>
     <g transform="scale(.1)">
       <g aria-hidden="true" fill="#010101">
-        <text x="2116" y="150" fill-opacity=".8" filter="url(#blur)">43 suites, 0 failing</text>
-        <text x="2116" y="150" fill-opacity=".3">43 suites, 0 failing</text>
+        <text x="1926" y="150" fill-opacity=".8" filter="url(#blur)">43 suites, 0 failing</text>
+        <text x="1926" y="150" fill-opacity=".3">43 suites, 0 failing</text>
       </g>
-      <text x="2116" y="140">43 suites, 0 failing</text>
+      <text x="1926" y="140">43 suites, 0 failing</text>
     </g>
   </g>
 </svg>

--- a/webpage/badge/conformance.svg
+++ b/webpage/badge/conformance.svg
@@ -13,11 +13,11 @@
   </metadata>
   <clipPath id="r"><rect width="248" height="20" rx="3" fill="#fff"/></clipPath>
   <g clip-path="url(#r)">
-    <rect width="137" height="20" fill="#1A2226"/>
+    <rect width="137" height="20" fill="#45565E"/>
     <rect x="137" width="111" height="20" fill="#4A6E5C"/>
     <rect width="248" height="20" fill="url(#s)"/>
   </g>
-  <polygon points="12,3.5 18.5,16.5 5.5,16.5" fill="#78A08A"/>
+  <polygon points="12,5 18,15 6,15" fill="#78A08A"/>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <g transform="scale(.1)">
       <g aria-hidden="true" fill="#010101">

--- a/webpage/badge/conformance.svg
+++ b/webpage/badge/conformance.svg
@@ -17,7 +17,7 @@
     <rect x="137" width="111" height="20" fill="#4A6E5C"/>
     <rect width="248" height="20" fill="url(#s)"/>
   </g>
-  <polygon points="12,5 18,15 6,15" fill="#78A08A"/>
+  <polygon points="12,4.2 19,15.8 5,15.8" fill="#78A08A"/>
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <g transform="scale(.1)">
       <g aria-hidden="true" fill="#010101">


### PR DESCRIPTION
Both jobs render the page and carry the rows over from vcr before switching to
that branch to publish, so the working tree holds modified copies of
conformance/reproductions.json and webpage/conformance.html at the moment
`git checkout vcr` runs. Git refuses to switch across them and the job stops
one step from publishing.

Row #1 did not hit this. The vcr branch did not exist on 2026-08-19, so the
desk took the `git checkout --orphan` path, which keeps the working tree. The
first push-triggered refresh found it on 2026-08-20, and the next submission
to the desk would have found it the same way.

Everything either job publishes is copied to /tmp/vcr before the switch, so
discarding the tree costs nothing and `-f` is the whole fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved badge rendering with consistent styling, sizing, colors, casing, and optional visual marks.
  * Added support for generating standard badges through the rendering workflow.
  * Updated the downloads badge with refreshed coloring and presentation.

* **Bug Fixes**
  * Publication workflows now reliably discard outdated branch contents before replacing them.

* **Tests**
  * Updated badge layout validation to remain accurate when styling colors change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->