### PR TITLE
fix(vcr): the results page gets the Resin's theme toggle and home control

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ It also states what a passing check does not establish: that the key belongs to 
 
 The explorer on the same page reads the public transparency log straight from your browser. Look a trail head up by digest, or paste a public key to see everything published under it. No account and no sign-in, because the key is the identity. Publishing to that log is opt-in and off by default (`vaara trail publish-head`), so an absence there means nothing was published rather than nothing happened.
 
+### See who else has checked it
+
+[vaara.io/conformance.html](https://vaara.io/conformance.html) is the results page. It carries every suite and its verdict, and every party other than the maintainer who ran the checkers and reported what they found in public. Rows are chained, each holding the digest of the row before it, so removing or reordering one breaks every digest after it and the break is visible to anyone. The maintainer cannot take a row down either. A run that disagrees with ours is a row too, with the reason stated, and there is no blacklist.
+
+The aggregate runner grades every suite at once, and grades another implementation's vectors the same way:
+
+```bash
+python scripts/conformance_runner.py                                 # grade the reference corpus
+python scripts/conformance_runner.py --vectors-dir ./your_vectors    # grade your own
+```
+
+It prints a prefilled link at the end of every run, so asking for a row takes one click. The named, versioned rule set, what a pass does and does not establish, and the full suite list are in [docs/conformance-profile.md](docs/conformance-profile.md).
+
 <details>
 <summary><b>Prefer the explicit pipeline?</b></summary>
 
@@ -104,15 +117,6 @@ python tests/vectors/external_evidence_v0/_check_independent.py
 It re-derives every verdict from the receipt bytes and the public key alone. The output shows the property the trail is built for: a receipt dropped from inside a declared boundary is a provable gap from the held set, with no issuer access and no external witness.
 
 For the whole loop in one runnable file, produce a signed record, verify it yourself, then watch a single forged byte get caught, see [examples/prove-it-yourself/](examples/prove-it-yourself/). The logs-versus-evidence argument behind it is in [docs/logs-vs-evidence.md](docs/logs-vs-evidence.md).
-
-The aggregate runner grades every suite at once, and grades another implementation's vectors the same way:
-
-```bash
-python scripts/conformance_runner.py                                 # grade the reference corpus
-python scripts/conformance_runner.py --vectors-dir ./your_vectors    # grade your own
-```
-
-The named, versioned rule set, what a pass does and does not establish, and the full suite list are in [docs/conformance-profile.md](docs/conformance-profile.md).
 </details>
 
 <details>

--- a/scripts/render_conformance_page.py
+++ b/scripts/render_conformance_page.py
@@ -587,7 +587,15 @@ def render(report: dict, repro: dict) -> str:
     --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
     --sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
   }}
-  html[data-theme="dark"], html:not([data-theme]) {{}}
+  /* Light is the default across every Vaara surface. The dark grammar is the
+     same set of tokens under data-theme, the same as verify.html and
+     index.html, so the three pages cannot drift apart. */
+  html[data-theme="dark"] {{
+    color-scheme: dark;
+    --bg:#0F1417; --panel:#1A2226; --panel-2:#151D20; --line:rgba(123,156,138,.16);
+    --ink:#DEE4E1; --muted:#8B9792; --faint:#5E6A66;
+    --tri:#78A08A; --tri-bright:#93B8A3; --warn:#D98B8B;
+  }}
   @media (prefers-color-scheme: dark) {{
     html:not([data-theme]) {{
       color-scheme: dark;
@@ -649,12 +657,36 @@ def render(report: dict, repro: dict) -> str:
   pre code{{background:none;padding:0}}
   footer{{margin-top:64px;padding-top:20px;border-top:1px solid var(--line);
          color:var(--faint);font-size:12.5px}}
+  .nav-jump{{position:fixed;top:14px;left:16px;z-index:10;display:inline-flex;
+    background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}}
+  .nav-jump a{{font-family:var(--mono);font-size:11px;letter-spacing:.18em;
+    text-transform:uppercase;color:var(--faint);padding:4px 11px;border-radius:999px;
+    text-decoration:none;border:0}}
+  .nav-jump a:hover{{color:var(--tri);background:var(--panel-2)}}
+  .theme-toggle{{position:fixed;top:14px;right:16px;z-index:10;display:inline-flex;
+    gap:2px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}}
+  .theme-toggle button{{appearance:none;background:none;border:0;cursor:pointer;margin:0;
+    font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--faint);padding:4px 11px;border-radius:999px}}
+  .theme-toggle button[aria-pressed="true"]{{color:var(--tri);background:var(--panel-2)}}
+  .theme-toggle button:hover{{color:var(--tri)}}
 </style>
+<script>
+  // Apply the stored theme before first paint, the same as index.html and
+  // verify.html. Without this the page renders in the OS colourway and snaps
+  // to the saved choice when the body script runs.
+  (function(){{ try {{ var t = localStorage.getItem('vaara-theme');
+    if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
+  }} catch(e){{}} }})();
+</script>
 </head>
 <body>
+<nav class="nav-jump"><a href="/">Home</a></nav>
+<div class="theme-toggle" role="group" aria-label="Color theme">
+  <button type="button" data-set-theme="light" aria-pressed="true">light</button>
+  <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
+</div>
 <div class="wrap">
-  <a class="back" href="/">&larr; vaara.io</a>
-
   <p class="kicker">Vaara Conformance Results</p>
   <h1>Every suite, every verdict, and everyone who checked it themselves.</h1>
 
@@ -757,6 +789,34 @@ python scripts/vcr_chain.py            # nothing removed from the table</code></
     pull request. Vaara is AGPL-3.0-or-later.
   </footer>
 </div>
+<script>
+(function(){{
+  var root = document.documentElement;
+  var btns = document.querySelectorAll('.theme-toggle [data-set-theme]');
+  function apply(theme){{
+    root.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
+    btns.forEach(function(b){{
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-set-theme") === theme));
+    }});
+    try {{ localStorage.setItem("vaara-theme", theme); }} catch(e) {{}}
+  }}
+  // No stored choice: leave data-theme off so the OS decides, and show which
+  // side the OS landed on so the toggle is not lying about the current state.
+  function reflectAuto(){{
+    root.removeAttribute("data-theme");
+    var dark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    btns.forEach(function(b){{
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-set-theme") === (dark ? "dark" : "light")));
+    }});
+  }}
+  btns.forEach(function(b){{
+    b.addEventListener("click", function(){{ apply(b.getAttribute("data-set-theme")); }});
+  }});
+  var saved = null;
+  try {{ saved = localStorage.getItem("vaara-theme"); }} catch(e) {{}}
+  if (saved === "dark" || saved === "light") apply(saved); else reflectAuto();
+}})();
+</script>
 </body>
 </html>
 """

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -21,7 +21,15 @@
     --mono:ui-monospace,'SFMono-Regular','JetBrains Mono',Menlo,Consolas,monospace;
     --sans:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;
   }
-  html[data-theme="dark"], html:not([data-theme]) {}
+  /* Light is the default across every Vaara surface. The dark grammar is the
+     same set of tokens under data-theme, the same as verify.html and
+     index.html, so the three pages cannot drift apart. */
+  html[data-theme="dark"] {
+    color-scheme: dark;
+    --bg:#0F1417; --panel:#1A2226; --panel-2:#151D20; --line:rgba(123,156,138,.16);
+    --ink:#DEE4E1; --muted:#8B9792; --faint:#5E6A66;
+    --tri:#78A08A; --tri-bright:#93B8A3; --warn:#D98B8B;
+  }
   @media (prefers-color-scheme: dark) {
     html:not([data-theme]) {
       color-scheme: dark;
@@ -83,12 +91,36 @@
   pre code{background:none;padding:0}
   footer{margin-top:64px;padding-top:20px;border-top:1px solid var(--line);
          color:var(--faint);font-size:12.5px}
+  .nav-jump{position:fixed;top:14px;left:16px;z-index:10;display:inline-flex;
+    background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}
+  .nav-jump a{font-family:var(--mono);font-size:11px;letter-spacing:.18em;
+    text-transform:uppercase;color:var(--faint);padding:4px 11px;border-radius:999px;
+    text-decoration:none;border:0}
+  .nav-jump a:hover{color:var(--tri);background:var(--panel-2)}
+  .theme-toggle{position:fixed;top:14px;right:16px;z-index:10;display:inline-flex;
+    gap:2px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}
+  .theme-toggle button{appearance:none;background:none;border:0;cursor:pointer;margin:0;
+    font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;
+    color:var(--faint);padding:4px 11px;border-radius:999px}
+  .theme-toggle button[aria-pressed="true"]{color:var(--tri);background:var(--panel-2)}
+  .theme-toggle button:hover{color:var(--tri)}
 </style>
+<script>
+  // Apply the stored theme before first paint, the same as index.html and
+  // verify.html. Without this the page renders in the OS colourway and snaps
+  // to the saved choice when the body script runs.
+  (function(){ try { var t = localStorage.getItem('vaara-theme');
+    if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
+  } catch(e){} })();
+</script>
 </head>
 <body>
+<nav class="nav-jump"><a href="/">Home</a></nav>
+<div class="theme-toggle" role="group" aria-label="Color theme">
+  <button type="button" data-set-theme="light" aria-pressed="true">light</button>
+  <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
+</div>
 <div class="wrap">
-  <a class="back" href="/">&larr; vaara.io</a>
-
   <p class="kicker">Vaara Conformance Results</p>
   <h1>Every suite, every verdict, and everyone who checked it themselves.</h1>
 
@@ -233,5 +265,33 @@ python scripts/vcr_chain.py            # nothing removed from the table</code></
     pull request. Vaara is AGPL-3.0-or-later.
   </footer>
 </div>
+<script>
+(function(){
+  var root = document.documentElement;
+  var btns = document.querySelectorAll('.theme-toggle [data-set-theme]');
+  function apply(theme){
+    root.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
+    btns.forEach(function(b){
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-set-theme") === theme));
+    });
+    try { localStorage.setItem("vaara-theme", theme); } catch(e) {}
+  }
+  // No stored choice: leave data-theme off so the OS decides, and show which
+  // side the OS landed on so the toggle is not lying about the current state.
+  function reflectAuto(){
+    root.removeAttribute("data-theme");
+    var dark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    btns.forEach(function(b){
+      b.setAttribute("aria-pressed", String(b.getAttribute("data-set-theme") === (dark ? "dark" : "light")));
+    });
+  }
+  btns.forEach(function(b){
+    b.addEventListener("click", function(){ apply(b.getAttribute("data-set-theme")); });
+  });
+  var saved = null;
+  try { saved = localStorage.getItem("vaara-theme"); } catch(e) {}
+  if (saved === "dark" || saved === "light") apply(saved); else reflectAuto();
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
The page followed the OS colour scheme already, but `html[data-theme="dark"]` was an empty rule, so an explicit choice did nothing and no toggle existed to make one.

It now carries the same dark tokens, the same light and dark pills, the same fixed Home pill and the same `vaara-theme` localStorage key as `verify.html` and `index.html`. That includes the pre-paint script, without which the page renders in the OS colourway and then snaps to the saved choice when the body script runs. The small `vaara.io` back link above the h1 is replaced by the Home pill.

README: the results page had a badge at the top and passing mentions inside a collapsed block, while the Resin had a section of its own. It has a section now, carrying the chained-rows property and what happens to a run that disagrees. The runner commands moved up into it, so the collapsed block no longer repeats them.