### PR TITLE
chore(citation): pin the citation metadata for the Zenodo archive

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,40 @@
+{
+  "title": "Vaara: Accountable Autonomy for AI agents",
+  "description": "<p>Vaara is a runtime execution layer for AI agents. It gates tool calls against a policy, scores each one, and writes the decision, the call and the outcome into a hash-chained, tamper-evident record that a third party can verify offline without the operator's keys and without running Vaara's code.</p><p>The repository publishes a conformance corpus of 43 suites. Every suite ships an independent checker that imports no Vaara code and recomputes its verdicts from the bytes of its own case files, so a reproduction can disagree and show its work. Independent reproductions are recorded at https://vaara.io/conformance.html on a chained table whose rows cannot be removed or reordered without breaking every digest after them.</p><p>The receipt format is specified in the IETF Internet-Draft draft-sirkkavaara-vaara-receipt.</p>",
+  "upload_type": "software",
+  "license": "AGPL-3.0-or-later",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Sirkkavaara, Henri"
+    }
+  ],
+  "keywords": [
+    "AI agents",
+    "agent governance",
+    "audit trail",
+    "tamper-evident logging",
+    "conformance vectors",
+    "independent verification",
+    "EU AI Act",
+    "provenance",
+    "transparency log"
+  ],
+  "related_identifiers": [
+    {
+      "identifier": "https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://vaara.io/conformance.html",
+      "relation": "references",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://github.com/vaaraio/vaara",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    }
+  ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,5 +21,5 @@ references:
         given-names: Henri
     institution:
       name: Internet Engineering Task Force (IETF)
-    number: draft-sirkkavaara-vaara-receipt-04
+    number: draft-sirkkavaara-vaara-receipt
     url: https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/


### PR DESCRIPTION
`CITATION.cff` cited `draft-sirkkavaara-vaara-receipt-04` while the published draft is at -07. The revision number is dropped rather than bumped, because the datatracker series URL already resolves to the current revision and a pinned number goes stale on every post. A normative reference inside another document still pins a revision; this file states which specification the software implements.

`.zenodo.json` did not exist, so the record would have been built from the GitHub repository description. It now carries the title, the description, the licence, the keywords, and related identifiers pointing at the Internet-Draft and the conformance results page, so the DOI carries its own citation links.

The repository is enabled for Zenodo, so the next tagged release is archived and minted a DOI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project metadata for software archiving and citation.
  * Updated the IETF draft reference in the citation information to use the version-independent draft identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->