### PR TITLE
release: 1.70.0, the corpus becomes citable and every shield comes from one renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,21 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.70.0] - 2026-08-20
+
+### Added
+
+- The repository is archived by Zenodo, so every tagged release from this one on is preserved and minted a DOI. `.zenodo.json` carries the record's title, description, licence, keywords and related identifiers pointing at the IETF Internet-Draft and the conformance results page, so the DOI arrives with its citation links already attached. Zenodo is operated by CERN as an OpenAIRE service, which puts the record in the EOSC graph. `CITATION.cff` drops the pinned draft revision, because the datatracker series URL resolves to the current one and a pinned number goes stale on every post.
+
+### Fixed
+
+- Badge geometry matches shields.io. The label was sized by one flat constant, 5.6px per character, and pinned there with `textLength` and `lengthAdjust="spacingAndGlyphs"`. Verdana capitals run near 7px, so the label wanted about 120px, got 95, and every glyph was squeezed to fit. A per-character width table sizes the plate now and nothing pins the text. The table is calibrated against shields.io's own published `textLength` values and matches within 0.5%.
+- The corpus shield turns red when a suite fails. It carried one hardcoded green, so "43 suites, 3 failing" rendered in the same colour as a clean corpus.
+- The corpus shield tracks the corpus. It regenerated only when somebody filed a conformance row, so adding a suite left the published count stale until the next submission. A push to main touching `tests/vectors` or either rendering script now re-renders the page and every badge.
+- The conformance desk and the refresh job can switch to the `vcr` branch over a dirty working tree. Both render before switching, so `git checkout vcr` aborted one step from publishing. Row #1 did not hit this because the branch did not exist yet and the orphan path keeps the tree.
+- One renderer produces every shield the project publishes. The downloads and version badges came from a second implementation written in shell, which still put white on brand green at 2.92:1 and forced the glyph width the same way.
+- The results page carries the light and dark toggle, the home control and the wordmark, matching index.html and verify.html. Its `html[data-theme="dark"]` rule was empty, so an explicit choice did nothing. All three surfaces switched the wordmark on `data-theme` alone, so an OS-dark machine with nothing saved served the light wordmark onto a dark background.
+
 ## [1.68.0] - 2026-08-17
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.69.0"
+appVersion: "1.70.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.69.0, Helm chart 0.1.0.
+Vaara 1.70.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.69.0",
+  "version": "1.70.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.69.0"
+version = "1.70.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.69.0",
+  "version": "1.70.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.69.0",
+"version": "1.70.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.69.0",
+  "version": "1.70.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.69.0",
+"version": "1.70.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.69.0"
+__version__ = "1.70.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Cuts 1.70.0 from the four fixes merged since v1.69.0 plus the Zenodo citation
metadata.

The repository is archived by Zenodo from this release on, so each tag is
preserved and minted a DOI, and Zenodo also mints a concept DOI that always
resolves to the newest version. `.zenodo.json` carries the record's title,
description, licence, keywords and related identifiers pointing at
`draft-sirkkavaara-vaara-receipt` and the conformance results page. Zenodo runs
as an OpenAIRE service operated by CERN, so the record enters the EOSC graph.

Badge geometry matches shields.io. `lw = int(len(label) * 5.6) + 32` sized the
plate and `textLength` with `lengthAdjust="spacingAndGlyphs"` forced the text
into it. Verdana capitals run near 7px, so the label wanted about 120px and was
given 95. A per-character width table replaces the constant, calibrated against
shields.io's own published `textLength` values to within 0.5%.

The corpus shield turns red on a failure, where it previously carried one
hardcoded green. It regenerates on a push to main touching `tests/vectors`,
where it previously waited for somebody to file a conformance row.

The conformance desk and the refresh job can now switch to the `vcr` branch
over a dirty tree. Row #1 survived only because the branch did not exist and
the run took the orphan path; the next submission would have failed.

One renderer produces every shield. The results page gained the light and dark
toggle, the home control and the wordmark, and all three web surfaces stopped
serving the light wordmark onto a dark background.

Full suite 3119 passed, 26 skipped. Conformance 43 of 43 with `--with-vaara`.
