### PR TITLE
release: 1.74.0, the timestamp authority stops seeing what the receipt prints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.74.0] - 2026-08-21
+
+### Added
+
+- Blinded time anchors, methods `rfc3161-blinded` and `rfc3161-eidas-qualified-blinded`. An unblinded anchor sends the timestamping authority exactly the value the receipt then publishes as `anchoredDigest`. An authority keeps a request log, every entry in it sits behind a customer account, and a log that is sold, breached or produced under compulsion lets whoever holds it match its entries against any corpus of published receipts. That reveals which receipts a named customer anchored and when, and no signature has to break for it to work.
+
+  A blinded anchor sends `sha256("vaara/anchor-blind/v1" || salt || anchoredDigest)` instead and carries the 32-byte salt as `anchorSalt`. `anchoredDigest` still names the Section 2.1 signed payload, so the receipt binding does not move and the attested time is untouched.
+
+- `blinded_anchor_digest()` and `new_anchor_salt()` in `vaara.audit.timeanchor`, and a `blind` keyword on `SelfHostedTSA.anchor_receipt` and `QualifiedTSA.anchor_receipt`. `salt` can be pinned so a generator reproduces an anchor byte for byte; production leaves it unset, because two anchors under one salt are linkable to each other.
+
+- `VAARA_ANCHOR_BLIND=1` turns blinding on for the server's qualified anchorer. Off by default, since it changes the anchor's `method` and a consumer pinned to `rfc3161-eidas-qualified` should not start seeing a new one without the operator asking.
+
+- SPEC.md Section 4.1 states the rule and its limit. A verifier must recompute the imprint from `anchoredDigest` and `anchorSalt`, must reject a blinded anchor whose salt is absent or is not 32 bytes of hex, and must reject an unblinded method that carries a salt, because a verifier that ignores the member would read a blinded anchor as a plain one.
+
+  The limit is stated rather than left to be inferred. Blinding stops a party holding only the authority's log from matching that log against receipts it was not given. It does not make the anchor unlinkable to anyone holding the receipt, since the salt travels with the receipt so a holder can verify. It does not hide the fact, timing or volume of anchoring from the authority, which sees each request as it happens.
+
+### Changed
+
+- The receipt evidence page renders `rfc3161-eidas-qualified-blinded` through the same path as `rfc3161-eidas-qualified`. Without that, a blinded qualified anchor dropped to the generic branch and stopped reading as qualified on the page a relying party is shown.
+
 ## [1.73.0] - 2026-08-21
 
 ### Added

--- a/SPEC.md
+++ b/SPEC.md
@@ -132,6 +132,43 @@ Registered methods (the registry is open; a profile MAY register more):
 | `rfc3161-eidas-qualified` | An RFC 3161 token from a *qualified* TSA under eIDAS. | A qualified trust service provider. Adds legal / court-admissible weight; this is the only thing the qualification adds over `rfc3161`. |
 | `ledger` | A commitment of the anchored digest to a public ledger; the block time bounds existence. | Self-producible; trust-minimized, no TSA. |
 | `scitt` | A transparency-log inclusion proof: the anchored digest is appended to a SCITT-compatible Merkle transparency log, and the entry carries the inclusion proof (sibling hashes) and the log's root hash at the time of append. The verifier recomputes the root from leaf + proof alone — no key, no operator to trust. The entry carries `logId` (base64 of the log identity digest), `leafIndex`, `treeSize`, `inclusionProof` (array of base64 sibling hashes), and `rootHash` (base64 Merkle root). | Self-hostable via the in-process transparency log (producer: `vaara.audit.scitt_anchor`), or against a remote SCITT log (e.g. Sigstore Rekor). |
+| `rfc3161-blinded` | `rfc3161`, with the authority shown a salted digest instead of the anchored digest. The entry additionally carries `anchorSalt` (64 lowercase hex characters, 32 bytes). See Section 4.1. | Same as `rfc3161`. |
+| `rfc3161-eidas-qualified-blinded` | `rfc3161-eidas-qualified`, blinded as above. The qualified time is unaffected. | Same as `rfc3161-eidas-qualified`. |
+
+### 4.1 Blinded anchors
+
+An unblinded anchor sends the timestamping authority exactly the value the
+receipt then publishes as `anchoredDigest`. An authority keeps a request log,
+every entry in it sits behind a customer account, and a log that is sold,
+breached or produced under compulsion lets whoever holds it match its entries
+against any corpus of published receipts. That match reveals which receipts a
+named customer anchored and when, without breaking any signature.
+
+A blinded anchor closes that match. The producer draws a fresh 32-byte salt,
+sends the authority
+
+```
+sha256( "vaara/anchor-blind/v1" || salt || anchoredDigest_bytes )
+```
+
+and carries the salt in the anchor entry as `anchorSalt`. `anchoredDigest`
+still names the Section 2.1 signed payload, so the receipt binding is unchanged.
+
+A producer using a blinded method MUST draw the salt from a cryptographic
+random source and MUST NOT reuse a salt across anchors, since two anchors under
+one salt are linkable to each other. A verifier MUST recompute the imprint from
+`anchoredDigest` and `anchorSalt` and MUST reject a blinded anchor whose
+`anchorSalt` is absent or is not 32 bytes of hex. A verifier MUST reject an
+unblinded method that carries `anchorSalt`, because a verifier that ignores the
+member would read a blinded anchor as a plain one.
+
+**What this does and does not buy.** It stops a party holding only the
+authority's log from matching that log against receipts it was not given. It
+does not make the anchor unlinkable to anyone holding the receipt: the salt
+travels with the receipt precisely so a holder can verify, and any holder can
+therefore recompute the imprint and find the log entry. It also does not hide
+the fact, timing or volume of anchoring from the authority itself, which sees
+the request as it happens.
 
 A receipt MAY carry several anchors of different methods. The technical anchor
 (`rfc3161`, `scitt`) and the legal anchor (`rfc3161-eidas-qualified`) are

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.73.0"
+appVersion: "1.74.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.73.0, Helm chart 0.1.0.
+Vaara 1.74.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.73.0",
+  "version": "1.74.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.73.0"
+version = "1.74.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.73.0",
+  "version": "1.74.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.73.0",
+"version": "1.74.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.73.0",
+  "version": "1.74.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.73.0",
+"version": "1.74.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.73.0"
+__version__ = "1.74.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/audit/receipt_anchor.py
+++ b/src/vaara/audit/receipt_anchor.py
@@ -37,10 +37,24 @@ from vaara.audit.timeanchor import (
     _signed_payload_digest,
     _urllib_transport,
     anchored_digest,
+    blinded_anchor_digest,
     build_timestamp_request,
     extract_token_from_response,
+    new_anchor_salt,
     verify_timestamp_token,
 )
+
+#: The blinded sibling of each method. Blinding changes only what the TSA is
+#: shown, so it gets its own method name rather than an optional field on the
+#: existing ones: a verifier that did not know about the salt would otherwise
+#: read a blinded anchor as a plain one and report a digest mismatch, which is
+#: a confusing failure for a correct anchor. An unknown method is a clean one.
+_BLINDED_METHOD = {
+    "rfc3161": "rfc3161-blinded",
+    "rfc3161-eidas-qualified": "rfc3161-eidas-qualified-blinded",
+}
+_PLAIN_METHODS = frozenset(_BLINDED_METHOD)
+_BLIND_METHODS = frozenset(_BLINDED_METHOD.values())
 
 # _SIGNED_BLOCKS, _signed_payload_digest and anchored_digest moved to
 # vaara.audit.timeanchor so anchor methods that are not RFC 3161 can reach
@@ -165,15 +179,29 @@ class SelfHostedTSA:
         return cms.ContentInfo(
             {"content_type": "signed_data", "content": signed_data}).dump()
 
-    def anchor_receipt(self, receipt: dict) -> dict[str, Any]:
-        """Produce a SPEC.md Section 4 ``timestampAnchors`` entry for ``receipt``."""
+    def anchor_receipt(self, receipt: dict, *, blind: bool = False,
+                       salt: Optional[bytes] = None) -> dict[str, Any]:
+        """Produce a SPEC.md Section 4 ``timestampAnchors`` entry for ``receipt``.
+
+        With ``blind`` the authority is shown a salted digest instead of the one
+        the receipt publishes, so its log cannot be matched against a corpus of
+        published receipts. ``salt`` exists so a vector generator can reproduce
+        an anchor byte for byte; production leaves it unset.
+        """
         raw = _signed_payload_digest(receipt)
-        return {
+        entry: dict[str, Any] = {
             "method": "rfc3161",
             "anchoredDigest": "sha256:" + raw.hex(),
-            "token": base64.b64encode(self.issue_token(raw)).decode("ascii"),
-            "authority": self.authority,
         }
+        imprint = raw
+        if blind:
+            salt = new_anchor_salt() if salt is None else salt
+            imprint = blinded_anchor_digest(raw, salt)
+            entry["method"] = _BLINDED_METHOD["rfc3161"]
+            entry["anchorSalt"] = bytes(salt).hex()
+        entry["token"] = base64.b64encode(self.issue_token(imprint)).decode("ascii")
+        entry["authority"] = self.authority
+        return entry
 
 
 class QualifiedTSA:
@@ -223,10 +251,22 @@ class QualifiedTSA:
         self._issuer_pin = trusted_issuer_cert
         self._transport = transport or _urllib_transport
 
-    def anchor_receipt(self, receipt: dict) -> dict[str, Any]:
-        """Fetch, pin-verify, and return a qualified anchor for ``receipt``."""
+    def anchor_receipt(self, receipt: dict, *, blind: bool = False,
+                       salt: Optional[bytes] = None) -> dict[str, Any]:
+        """Fetch, pin-verify, and return a qualified anchor for ``receipt``.
+
+        ``blind`` matters more here than on the self-hosted path. A qualified
+        TSA is a third party with a customer account behind every request, so
+        its log is the one that can be sold, breached or subpoenaed. Blinding
+        leaves the qualified time intact and stops the log from being matched
+        against published receipts.
+        """
         raw = _signed_payload_digest(receipt)
-        request = build_timestamp_request(raw)
+        imprint = raw
+        if blind:
+            salt = new_anchor_salt() if salt is None else salt
+            imprint = blinded_anchor_digest(raw, salt)
+        request = build_timestamp_request(imprint)
         try:
             response = self._transport(self.tsa_url, request, self.timeout)
         except Exception as exc:  # network, TLS, HTTP error
@@ -235,16 +275,20 @@ class QualifiedTSA:
         token = extract_token_from_response(response)
         # Refuse before recording: the anchor must never carry a token whose
         # signer fails the pin (exact signer certificate and/or issuing CA).
-        verify_timestamp_token(token, raw, trusted_signer_cert=self._pin,
+        verify_timestamp_token(token, imprint, trusted_signer_cert=self._pin,
                                trusted_issuer_cert=self._issuer_pin)
         authority = self.authority or self._token_signer_cn(token)
-        return {
+        entry: dict[str, Any] = {
             "method": "rfc3161-eidas-qualified",
             "anchoredDigest": "sha256:" + raw.hex(),
-            "token": base64.b64encode(token).decode("ascii"),
-            "authority": authority,
-            "tsaUrl": self.tsa_url,
         }
+        if blind:
+            entry["method"] = _BLINDED_METHOD["rfc3161-eidas-qualified"]
+            entry["anchorSalt"] = bytes(salt).hex()  # type: ignore[arg-type]
+        entry["token"] = base64.b64encode(token).decode("ascii")
+        entry["authority"] = authority
+        entry["tsaUrl"] = self.tsa_url
+        return entry
 
     def _token_signer_cn(self, token: bytes) -> str:
         from asn1crypto import cms as _cms
@@ -272,21 +316,41 @@ def verify_receipt_anchor(
     certificate you hold out of band to require the token's signer to be that
     exact certificate before the time is treated as independently anchored.
     """
-    if anchor.get("method") not in ("rfc3161", "rfc3161-eidas-qualified"):
-        raise TimeAnchorError(f"not an rfc3161 anchor: method={anchor.get('method')!r}")
+    method = anchor.get("method")
+    if method not in _PLAIN_METHODS | _BLIND_METHODS:
+        raise TimeAnchorError(f"not an rfc3161 anchor: method={method!r}")
     expected = "sha256:" + _signed_payload_digest(receipt).hex()
     if anchor.get("anchoredDigest") != expected:
         raise TimeAnchorError(
             "anchoredDigest does not match the receipt's signed payload")
+    payload = bytes.fromhex(expected.split(":", 1)[1])
+
+    raw_salt = anchor.get("anchorSalt")
+    if method in _BLIND_METHODS:
+        if not isinstance(raw_salt, str):
+            raise TimeAnchorError("a blinded anchor must carry anchorSalt")
+        try:
+            salt = bytes.fromhex(raw_salt)
+        except ValueError as exc:
+            raise TimeAnchorError("anchorSalt is not hex") from exc
+        imprint = blinded_anchor_digest(payload, salt)
+    else:
+        # A salt sitting on an unblinded method would be ignored, and a verifier
+        # that ignores it reads a blinded anchor as a plain one. Refuse instead.
+        if raw_salt is not None:
+            raise TimeAnchorError(
+                f"anchorSalt present on unblinded method {method!r}")
+        imprint = payload
+
     try:
         token_der = base64.b64decode(anchor["token"])
     except Exception as exc:
         raise TimeAnchorError(f"anchor token is not valid base64: {exc}") from exc
     return verify_timestamp_token(
-        token_der, bytes.fromhex(expected.split(":", 1)[1]),
+        token_der, imprint,
         hash_algorithm="sha256", trusted_signer_cert=trusted_signer_cert,
         trusted_issuer_cert=trusted_issuer_cert)
 
 
 __all__ = ["QualifiedTSA", "SelfHostedTSA", "anchored_digest",
-           "verify_receipt_anchor"]
+           "blinded_anchor_digest", "new_anchor_salt", "verify_receipt_anchor"]

--- a/src/vaara/audit/receipt_page.py
+++ b/src/vaara/audit/receipt_page.py
@@ -132,7 +132,12 @@ def render_receipt_page(receipt: dict, *, title: str | None = None) -> str:
             status, detail, verified = _scitt_detail(receipt, anchor)
             checked = ("inclusion proof re-checked by recomputation" if verified
                        else "status as recorded, not re-checked here")
-        elif method == "rfc3161-eidas-qualified":
+        elif method in ("rfc3161-eidas-qualified",
+                        "rfc3161-eidas-qualified-blinded"):
+            # The blinded method is the same qualified token over a salted
+            # digest (SPEC.md 4.1). It renders the same way, or a blinded
+            # anchor would drop to the generic branch and stop reading as
+            # qualified on the page a relying party is shown.
             status, detail, rechecked = _qualified_detail(receipt, anchor)
             checked = ("digest binding re-checked offline; the QTSP pin needs "
                        "the certificate held out of band, not re-checked here"

--- a/src/vaara/audit/timeanchor.py
+++ b/src/vaara/audit/timeanchor.py
@@ -89,6 +89,47 @@ def anchored_digest(receipt: dict) -> str:
     return "sha256:" + _signed_payload_digest(receipt).hex()
 
 
+#: Domain separation for the blinded anchor methods, so a blinded imprint can
+#: never collide with a digest computed for any other purpose in this tree.
+ANCHOR_BLIND_LABEL = b"vaara/anchor-blind/v1"
+
+#: Salt width. 32 bytes because a salt narrow enough to enumerate is not a salt.
+SALT_LEN = 32
+
+
+def new_anchor_salt() -> bytes:
+    """A fresh blinding salt from the system CSPRNG."""
+    return secrets.token_bytes(SALT_LEN)
+
+
+def blinded_anchor_digest(payload_digest: bytes, salt: bytes) -> bytes:
+    """What a blinded anchor sends the TSA instead of the receipt's own digest.
+
+    An unblinded anchor hands the authority exactly the value the receipt then
+    publishes in ``anchoredDigest``. A TSA keeps a log, every request in it sits
+    behind a customer account, and a log that is sold, breached or subpoenaed
+    lets whoever holds it match its entries against any corpus of published
+    receipts. Anchoring ``sha256(label || salt || payload_digest)`` and carrying
+    the salt in the anchor removes that match: the value the TSA holds appears
+    nowhere else.
+
+    The property is narrow and stated that way on purpose. Anyone given the
+    receipt holds the salt too and can still link it to the log entry, because
+    that is exactly what verification requires. What changes is that the log
+    alone is no longer enough.
+    """
+    if not isinstance(salt, (bytes, bytearray)) or len(salt) != SALT_LEN:
+        raise TimeAnchorError(
+            f"anchor salt must be {SALT_LEN} bytes, got "
+            f"{len(salt) if isinstance(salt, (bytes, bytearray)) else type(salt).__name__}"
+        )
+    if not isinstance(payload_digest, (bytes, bytearray)) or len(payload_digest) != 32:
+        raise TimeAnchorError("payload digest must be a 32-byte sha256 digest")
+    return hashlib.sha256(
+        ANCHOR_BLIND_LABEL + bytes(salt) + bytes(payload_digest)
+    ).digest()
+
+
 def _require_deps() -> None:
     if not _HAS_DEPS:
         raise TimeAnchorError(_INSTALL_HINT)
@@ -492,9 +533,14 @@ def verify_anchor_over_records(anchor: TimeAnchor, record_hashes: list[str]) -> 
 
 
 __all__ = [
+    "ANCHOR_BLIND_LABEL",
+    "SALT_LEN",
     "TimeAnchor",
     "TimeAnchorError",
     "RFC3161TimeAnchorClient",
+    "anchored_digest",
+    "blinded_anchor_digest",
+    "new_anchor_salt",
     "build_timestamp_request",
     "extract_token_from_response",
     "verify_timestamp_token",

--- a/src/vaara/server/anchor.py
+++ b/src/vaara/server/anchor.py
@@ -13,6 +13,12 @@ The QTSP's issuing CA is pinned. In production, pin it from the EU trusted list
 the helper falls back to trust-on-first-use (``VAARA_ANCHOR_ALLOW_TOFU=1``): one
 probe of the endpoint to learn the CA. TOFU is a conscious opt-in; without it
 and without a CA cert, anchoring refuses with ``AnchorNotConfigured``.
+
+``VAARA_ANCHOR_BLIND=1`` salts the digest sent to the QTSP (SPEC.md Section 4.1)
+and emits ``rfc3161-eidas-qualified-blinded``. The QTSP is a third party keeping
+a request log with an account behind every entry, and unblinded that log records
+the exact digest the receipt publishes. Off by default because it changes the
+anchor's ``method``.
 """
 
 from __future__ import annotations
@@ -33,6 +39,20 @@ if TYPE_CHECKING:
 
 def _tofu_allowed() -> bool:
     return (os.environ.get("VAARA_ANCHOR_ALLOW_TOFU") or "").strip().lower() in {
+        "1", "true", "yes", "on"
+    }
+
+
+def _blind_enabled() -> bool:
+    """Whether to salt the digest sent to the QTSP (SPEC.md Section 4.1).
+
+    Off by default, because it changes the anchor's ``method`` and a consumer
+    pinned to ``rfc3161-eidas-qualified`` should not start seeing a new one
+    without the operator asking. Worth turning on: the QTSP is a third party
+    holding a request log with an account behind every entry, and unblinded it
+    logs the exact digest the receipt publishes.
+    """
+    return (os.environ.get("VAARA_ANCHOR_BLIND") or "").strip().lower() in {
         "1", "true", "yes", "on"
     }
 
@@ -85,6 +105,7 @@ class Anchorer:
         self,
         tsa_url: Optional[str] = None,
         ca_cert: Optional[bytes] = None,
+        blind: Optional[bool] = None,
     ) -> None:
         # No provider is baked in. The operator names their own QTSP, or
         # anchoring refuses (see _ensure). Choosing a provider for everyone is
@@ -92,6 +113,7 @@ class Anchorer:
         self.tsa_url = (
             tsa_url or os.environ.get("VAARA_ANCHOR_TSA_URL", "").strip() or None
         )
+        self.blind = _blind_enabled() if blind is None else blind
         self._ca = ca_cert
         if self._ca is None:
             path = os.environ.get("VAARA_ANCHOR_CA_CERT", "").strip()
@@ -130,8 +152,13 @@ class Anchorer:
             return self._qtsa
 
     def anchor(self, receipt: dict) -> dict[str, Any]:
-        """Return an ``rfc3161-eidas-qualified`` anchor for ``receipt``."""
-        return self._ensure().anchor_receipt(receipt)
+        """Return a qualified anchor for ``receipt``.
+
+        ``rfc3161-eidas-qualified``, or ``rfc3161-eidas-qualified-blinded`` when
+        ``VAARA_ANCHOR_BLIND`` is set. Blinding changes only what the QTSP is
+        shown; the attested time and its legal weight are unaffected.
+        """
+        return self._ensure().anchor_receipt(receipt, blind=self.blind)
 
     def attested_time(self, receipt: dict, anchor: dict) -> str:
         """ISO-8601 UTC time the pinned QTSP attested, verified against the pin."""

--- a/tests/test_receipt_anchor_blinded.py
+++ b/tests/test_receipt_anchor_blinded.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Blinded anchors: what the TSA sees stops matching what the receipt publishes.
+
+An unblinded anchor sends the TSA exactly the digest the receipt then prints in
+`anchoredDigest`. A TSA keeps a log, a log has a customer account behind every
+request, and a log that is sold or subpoenaed lets the holder match its entries
+against any corpus of published receipts.
+
+Blinding sends `sha256(label || salt || payload_digest)` instead and carries the
+salt in the anchor. A party holding the receipt still verifies, because the salt
+is right there. A party holding only the log sees a value that appears nowhere
+else, so it cannot match the log against receipts it was not given.
+
+That is the whole claim and it is deliberately narrow. Anyone handed the receipt
+can still link it to the log entry, which is what verification requires.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("asn1crypto")  # the 'timeanchor' extra; skip when absent
+
+from vaara.audit.receipt_anchor import (  # noqa: E402
+    SelfHostedTSA,
+    verify_receipt_anchor,
+)
+from vaara.audit.timeanchor import (  # noqa: E402
+    ANCHOR_BLIND_LABEL,
+    SALT_LEN,
+    TimeAnchorError,
+    anchored_digest,
+    blinded_anchor_digest,
+    new_anchor_salt,
+)
+
+VECTOR = (Path(__file__).resolve().parents[1]
+          / "tests/vectors/x402_settlement_v0/generic/step1/receipt.json")
+
+
+@pytest.fixture
+def receipt() -> dict:
+    return json.loads(VECTOR.read_text())
+
+
+def _token_imprint(anchor: dict) -> bytes:
+    """The digest the TSA actually attested, read straight out of the token."""
+    from asn1crypto import cms, core, tsp
+
+    content = cms.ContentInfo.load(base64.b64decode(anchor["token"]))["content"]
+    tst_bytes = content["encap_content_info"]["content"].cast(core.OctetString).native
+    return tsp.TSTInfo.load(tst_bytes)["message_imprint"]["hashed_message"].native
+
+
+def _payload_digest(receipt: dict) -> bytes:
+    return bytes.fromhex(anchored_digest(receipt).split(":", 1)[1])
+
+
+# --- the salt ---------------------------------------------------------------
+
+
+def test_a_salt_is_fresh_every_time():
+    assert len({new_anchor_salt() for _ in range(16)}) == 16
+    assert all(len(new_anchor_salt()) == SALT_LEN for _ in range(4))
+
+
+def test_the_blinded_digest_is_domain_separated(receipt: dict):
+    salt = new_anchor_salt()
+    payload = _payload_digest(receipt)
+    assert blinded_anchor_digest(payload, salt) == hashlib.sha256(
+        ANCHOR_BLIND_LABEL + salt + payload
+    ).digest()
+
+
+def test_a_wrong_length_salt_is_refused(receipt: dict):
+    for bad in (b"", bytes(16), bytes(64)):
+        with pytest.raises(TimeAnchorError):
+            blinded_anchor_digest(_payload_digest(receipt), bad)
+
+
+# --- the leak this closes ---------------------------------------------------
+
+
+def test_an_unblinded_anchor_sends_the_tsa_the_published_digest(receipt: dict):
+    """The behaviour being fixed, pinned so it cannot come back unnoticed."""
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt)
+    assert _token_imprint(anchor) == _payload_digest(receipt)
+    assert anchor["anchoredDigest"] == anchored_digest(receipt)
+
+
+def test_a_blinded_anchor_sends_the_tsa_something_else(receipt: dict):
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True)
+    imprint = _token_imprint(anchor)
+    assert imprint != _payload_digest(receipt)
+    assert imprint.hex() not in json.dumps(anchor)
+    # The receipt binding is unchanged: anchoredDigest still names the payload.
+    assert anchor["anchoredDigest"] == anchored_digest(receipt)
+
+
+def test_two_blinded_anchors_over_one_receipt_do_not_look_alike(receipt: dict):
+    tsa = SelfHostedTSA.create()
+    first = tsa.anchor_receipt(receipt, blind=True)
+    second = tsa.anchor_receipt(receipt, blind=True)
+    assert _token_imprint(first) != _token_imprint(second)
+    assert first["anchorSalt"] != second["anchorSalt"]
+
+
+def test_the_holder_can_still_link_the_anchor_to_its_token(receipt: dict):
+    """The narrow limit, asserted so the docs cannot drift into overclaiming."""
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True)
+    salt = bytes.fromhex(anchor["anchorSalt"])
+    assert _token_imprint(anchor) == blinded_anchor_digest(
+        _payload_digest(receipt), salt
+    )
+
+
+# --- shape and verification -------------------------------------------------
+
+
+def test_blinded_anchor_has_the_spec_shape_and_verifies(receipt: dict):
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True)
+    assert set(anchor) == {
+        "method", "anchoredDigest", "anchorSalt", "token", "authority",
+    }
+    assert anchor["method"] == "rfc3161-blinded"
+    assert len(anchor["anchorSalt"]) == 2 * SALT_LEN
+    attested = verify_receipt_anchor(receipt, anchor)
+    assert attested.tzinfo is not None
+
+
+def test_a_pinned_salt_reproduces_the_anchor(receipt: dict):
+    """A generator needs to pin the salt; production never should."""
+    salt = bytes(range(SALT_LEN))
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True, salt=salt)
+    assert anchor["anchorSalt"] == salt.hex()
+    assert verify_receipt_anchor(receipt, anchor) is not None
+
+
+def test_unblinded_anchors_still_verify_unchanged(receipt: dict):
+    """Existing anchors keep working; this release adds a method, it moves none."""
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt)
+    assert anchor["method"] == "rfc3161"
+    assert "anchorSalt" not in anchor
+    assert verify_receipt_anchor(receipt, anchor) is not None
+
+
+# --- what must not verify ---------------------------------------------------
+
+
+def test_a_blinded_anchor_without_its_salt_does_not_verify(receipt: dict):
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True)
+    stripped = {k: v for k, v in anchor.items() if k != "anchorSalt"}
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(receipt, stripped)
+
+
+def test_a_blinded_anchor_with_the_wrong_salt_does_not_verify(receipt: dict):
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True)
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(receipt, dict(anchor, anchorSalt=bytes(SALT_LEN).hex()))
+
+
+@pytest.mark.parametrize("bad", ["", "zz", "ab", "ff" * 16, "ff" * 64])
+def test_a_malformed_salt_does_not_verify(receipt: dict, bad: str):
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True)
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(receipt, dict(anchor, anchorSalt=bad))
+
+
+def test_an_unblinded_method_carrying_a_salt_is_refused(receipt: dict):
+    """Otherwise a verifier that ignores the field reads a blinded anchor as plain."""
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt)
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(receipt, dict(anchor, anchorSalt=new_anchor_salt().hex()))
+
+
+def test_a_blinded_anchor_over_a_tampered_receipt_does_not_verify(receipt: dict):
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True)
+    tampered = dict(receipt, version=receipt["version"] + 1)
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(tampered, anchor)
+
+
+def test_a_blinded_anchor_with_a_forged_token_does_not_verify(receipt: dict):
+    anchor = SelfHostedTSA.create().anchor_receipt(receipt, blind=True)
+    forged = SelfHostedTSA.create().issue_token(bytes(32))
+    swapped = dict(anchor, token=base64.b64encode(forged).decode())
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(receipt, swapped)
+
+
+# --- the qualified path -----------------------------------------------------
+
+
+def _qtsp(tsa):
+    """A fake QTSP endpoint: TimeStampReq DER in, TimeStampResp DER out."""
+    from asn1crypto import cms, tsp
+
+    def transport(url: str, der_request: bytes, timeout: float) -> bytes:
+        req = tsp.TimeStampReq.load(der_request)
+        token = tsa.issue_token(req["message_imprint"]["hashed_message"].native)
+        return tsp.TimeStampResp({
+            "status": tsp.PKIStatusInfo({"status": "granted"}),
+            "time_stamp_token": cms.ContentInfo.load(token),
+        }).dump()
+
+    return transport
+
+
+def test_a_blinded_qualified_anchor_keeps_its_pin_and_its_time(receipt, tmp_path):
+    from vaara.audit.receipt_anchor import QualifiedTSA
+
+    tsa = SelfHostedTSA.create("EU Test QTSP")
+    tsa.save(tmp_path)
+    pin = (tmp_path / "tsa_cert.pem").read_bytes()
+    qtsa = QualifiedTSA("https://qtsp.example/tsr", trusted_signer_cert=pin,
+                        transport=_qtsp(tsa))
+
+    anchor = qtsa.anchor_receipt(receipt, blind=True)
+    assert anchor["method"] == "rfc3161-eidas-qualified-blinded"
+    assert set(anchor) == {"method", "anchoredDigest", "anchorSalt", "token",
+                           "authority", "tsaUrl"}
+    # The QTSP was shown the salted value, not the one the receipt publishes.
+    assert _token_imprint(anchor) != _payload_digest(receipt)
+    attested = verify_receipt_anchor(receipt, anchor, trusted_signer_cert=pin)
+    assert attested.tzinfo is not None
+
+
+def test_a_blinded_qualified_anchor_still_renders_as_qualified(receipt, tmp_path):
+    """Otherwise the evidence page silently demotes it to a generic anchor."""
+    from vaara.audit.receipt_anchor import QualifiedTSA
+    from vaara.audit.receipt_page import render_receipt_page
+
+    tsa = SelfHostedTSA.create("EU Test QTSP")
+    tsa.save(tmp_path)
+    pin = (tmp_path / "tsa_cert.pem").read_bytes()
+    qtsa = QualifiedTSA("https://qtsp.example/tsr", trusted_signer_cert=pin,
+                        transport=_qtsp(tsa))
+
+    anchored = dict(receipt)
+    anchored["timestampAnchors"] = [qtsa.anchor_receipt(receipt, blind=True)]
+    page = render_receipt_page(anchored)
+    assert "rfc3161-eidas-qualified-blinded" in page
+    assert "status as recorded, not re-checked here" not in page
+
+
+def test_the_server_anchorer_reads_the_blind_switch(monkeypatch):
+    """Construction does no network I/O, so this only reads the switch."""
+    from vaara.server.anchor import Anchorer
+
+    url = "https://qtsp.example/tsr"
+    monkeypatch.delenv("VAARA_ANCHOR_BLIND", raising=False)
+    assert Anchorer(tsa_url=url).blind is False
+    monkeypatch.setenv("VAARA_ANCHOR_BLIND", "1")
+    assert Anchorer(tsa_url=url).blind is True
+    # An explicit argument still wins over the environment.
+    assert Anchorer(tsa_url=url, blind=False).blind is False
+
+
+def test_the_unblinded_token_does_not_pass_as_blinded(receipt: dict):
+    """Relabelling a plain anchor as blinded must fail: the imprint is the wrong one."""
+    tsa = SelfHostedTSA.create()
+    plain = tsa.anchor_receipt(receipt)
+    relabelled = dict(
+        plain, method="rfc3161-blinded", anchorSalt=new_anchor_salt().hex()
+    )
+    with pytest.raises(TimeAnchorError):
+        verify_receipt_anchor(receipt, relabelled)


### PR DESCRIPTION
Cuts 1.74.0: two new anchor methods that stop a timestamp authority's log from
being matched against published receipts.

## The leak

An unblinded anchor sends the timestamping authority exactly the value the
receipt then publishes as `anchoredDigest`.

An authority keeps a request log. Every entry in it sits behind a customer
account. A log that is sold, breached or produced under compulsion lets whoever
holds it match its entries against any corpus of published receipts, and learn
which receipts a named customer anchored and when.

No signature has to break for that to work. The two values are simply the same
value, one held privately by a third party and one printed in the document.

## The fix

Two methods, `rfc3161-blinded` and `rfc3161-eidas-qualified-blinded`. The
producer draws a fresh 32-byte salt and sends the authority:

```
sha256( "vaara/anchor-blind/v1" || salt || anchoredDigest_bytes )
```

The salt rides in the anchor as `anchorSalt`. `anchoredDigest` still names the
Section 2.1 signed payload, so the receipt binding does not move, and the
attested time and its legal weight are untouched.

## Why new method names instead of an optional field

A verifier that did not know about the salt would compute the imprint the old
way and report a digest mismatch on an anchor that is perfectly correct.
Rejecting an unrecognised method says what actually happened.

Existing anchors are unchanged and still verify. Nothing moves.

## Rules a verifier follows

- Recompute the imprint from `anchoredDigest` and `anchorSalt`.
- Reject a blinded anchor whose salt is absent, is not hex, or is not 32 bytes.
- Reject an unblinded method that carries `anchorSalt`, because a verifier that
  ignores the member reads a blinded anchor as a plain one.

## Limits, stated rather than implied

Section 4.1 says these in the document:

- Blinding stops a party holding **only the authority's log** from matching that
  log against receipts it was not given.
- It does **not** make the anchor unlinkable to anyone holding the receipt. The
  salt travels with the receipt precisely so a holder can verify, so any holder
  can recompute the imprint and find the log entry.
- It does **not** hide the fact, timing or volume of anchoring from the
  authority, which sees each request as it happens.

## Surface

`blinded_anchor_digest()` and `new_anchor_salt()` in `vaara.audit.timeanchor`.
A `blind` keyword on `SelfHostedTSA.anchor_receipt` and
`QualifiedTSA.anchor_receipt`, with an optional `salt` so a generator reproduces
an anchor byte for byte. Production leaves `salt` unset: two anchors under one
salt are linkable to each other.

`VAARA_ANCHOR_BLIND=1` turns blinding on for the server's qualified anchorer.
Off by default, since it changes the `method` a consumer may be pinned to.

The receipt evidence page renders the blinded qualified method through the same
path as the unblinded one. Without that it dropped to the generic branch and
stopped reading as qualified on the page a relying party is shown.

## Checks

The corpus pins the behaviour being fixed as well as the fix, so an unblinded
anchor sending the published digest cannot come back unnoticed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional blinding for RFC 3161 and qualified timestamp anchors, helping prevent external log matching while preserving receipt verification.
  * Added configurable salts, including reproducible pinned salts for testing or controlled workflows.
  * Added an environment setting to enable blinding for qualified server anchors.

* **Bug Fixes**
  * Blinded qualified anchors now use the correct verification and evidence display flow.

* **Documentation**
  * Documented verification rules, salt validation, and the privacy limitations of anchor blinding.
  * Updated release version to 1.74.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->