### PR TITLE
fix(conformance): a Windows clone is not a disagreement with the spec

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Line-ending policy. Vaara pins bytes, not lines.
+#
+# Default: normalise text to LF in the repository and check it out as LF on
+# every platform, including Windows. This project's digests, goldens and CI all
+# assume LF, so a working tree that differs from the object store is a bug.
+* text=auto eol=lf
+
+# The SEP-2828 conformance corpus is byte-pinned. Every file has a SHA-256 in
+# MANIFEST.json, and one corpusDigest covers the whole set, so the corpus
+# version names an exact byte set that anyone can recompute.
+#
+# Git's line-ending translation breaks that. Git for Windows installs with
+# core.autocrlf=true by default, which rewrites LF to CRLF on checkout and
+# changes every digest in the corpus. The clone then reports the published
+# corpus as unverified, through no fault of the emitter or the corpus.
+#
+# -text means never translate, in either direction: what is in the object store
+# lands on disk verbatim. That is the same promise the manifest makes.
+conformance/sep2828/** -text
+
+# The conformance-statement goldens pin rendered output against that corpus.
+tests/vectors/conformance_statement_v0/** -text
+
+# Binaries: never translate, never diff as text.
+*.png binary
+*.jpg binary
+*.ico binary
+*.mp4 binary
+*.zip binary
+*.bin binary
+*.joblib binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
   The wording on the page, in `conformance/reproductions.json` and in the issue form now says what a chain gives, and states the residual: a row added after the last witnessing carries only the chain until the next head is published. `terms_version` is bumped to `2026-08-21`; the row already listed keeps the terms it agreed to.
 
+- A Windows clone made the SEP-2828 conformance corpus read as a disagreement with the spec. Git for Windows installs with `core.autocrlf=true`, which rewrites LF to CRLF on checkout. The corpus is pinned byte for byte, so all 32 file digests and the `corpusDigest` fail while no content changes at all. `vaara conformance-statement` called that NON-CONFORMING, and the `conformance_statement_v0` suite reported 0 of 5 scenarios matching, which reads as the implementation contradicting the published corpus. It is a checkout artefact and says nothing about conformance. Emek Can Dogru found it on 2026-08-21, before it reached a row.
+
+  Corpus integrity is now graded as the precondition it is. It asks whether the published byte set is present, not whether an implementation agrees with SEP-2828, so a corpus that does not verify grades `unproved` rather than `false`. It still gates: only `proved` yields CONFORMS, so a corpus that does not verify can never produce a pass. A mismatched file is re-hashed with the line-ending translation undone, which proves whether its content is the published content, and the cause is named instead of printing 32 bare digest mismatches. The `conformance_statement_v0` suite exits 77 (SKIP) with that reason rather than failing, because it cannot compare goldens against a corpus that is not the published one. Only a difference that is provably newlines-only goes quiet; real tampering still fails loudly.
+
+  Statement `schemaVersion` is 3, adding `corpus.lineEndingMismatches` and `corpus.lineEndingsOnly`. The verdict for a byte-exact corpus is unchanged.
+
 ### Added
+
+- A root `.gitattributes`. The byte-pinned corpus and its goldens are checked out verbatim on every platform, and the rest of the tree normalises to LF, so a fresh clone on Windows holds the published bytes.
 
 - `scripts/vcr_publish_head.py` records the current chain head in a public transparency log the maintainer does not operate, so a rewritten chain reaches a head that matches no witnessed entry. It publishes one digest and a signature over it, nothing else, and prints what leaves the machine before it does anything.
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -72,7 +72,7 @@ translation undone and names line endings as the cause. A statement built
 against a corpus in this state grades UNPROVED rather than
 NON-CONFORMING, because the published bytes were not present to check
 against, which is not the same as an implementation disagreeing with the
-spec. None of it is a verdict about your emitter.
+spec.
 
 ## Claiming conformance
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -49,6 +49,31 @@ python record_conformance_v0/_check_independent.py
 python record_set_v0/_check_independent.py
 ```
 
+## Windows and line endings
+
+This corpus is pinned byte for byte, so line-ending translation breaks it.
+Git for Windows installs with `core.autocrlf=true`, which rewrites LF to
+CRLF on checkout. Every digest in `MANIFEST.json` then fails, and so does
+the `corpusDigest`, while no content has changed at all.
+
+The repository ships a `.gitattributes` that checks this directory out
+verbatim on every platform, so a fresh clone is already correct. A clone
+made before that was added can be repaired in place:
+
+```
+git config core.autocrlf false
+git rm --cached -r .
+git reset --hard
+```
+
+The tooling tells this apart from real damage rather than reporting it as
+a conformance problem. `run.py --verify-manifest` re-hashes with the
+translation undone and names line endings as the cause. A statement built
+against a corpus in this state grades UNPROVED rather than
+NON-CONFORMING, because the published bytes were not present to check
+against, which is not the same as an implementation disagreeing with the
+spec. None of it is a verdict about your emitter.
+
 ## Claiming conformance
 
 Your implementation conforms to a corpus version when, for every fixture,

--- a/conformance/sep2828/run.py
+++ b/conformance/sep2828/run.py
@@ -95,22 +95,62 @@ def run_suites(manifest: dict[str, Any]) -> int:
     return 0
 
 
+def is_line_ending_only(path: Path, want: str) -> bool:
+    """Does this file match the manifest once its line endings are undone?
+
+    Exact, not a guess: undo the CRLF (and lone-CR) translation a checkout can
+    apply, re-hash, and compare. A match proves the content is byte for byte the
+    published content and only the newlines were rewritten.
+
+    This never makes the check pass. The manifest stays byte-exact; this only
+    tells the two very different causes of a mismatch apart.
+    """
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return False
+    if b"\r" not in raw:
+        return False
+    normalised = raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return "sha256:" + hashlib.sha256(normalised).hexdigest() == want
+
+
 def verify_manifest(manifest: dict[str, Any]) -> int:
     want: dict[str, str] = manifest["files"]
     got = file_digests(HERE, manifest["suites"])
     problems: list[str] = []
+    line_endings: list[str] = []
     for rel in sorted(set(want) | set(got)):
         if rel not in got:
             problems.append(f"missing file: {rel}")
         elif rel not in want:
             problems.append(f"unexpected file: {rel}")
         elif want[rel] != got[rel]:
-            problems.append(f"digest mismatch: {rel}")
+            if is_line_ending_only(HERE / rel, want[rel]):
+                line_endings.append(rel)
+                problems.append(f"line endings changed, content intact: {rel}")
+            else:
+                problems.append(f"digest mismatch: {rel}")
     want_corpus = manifest["corpusDigest"]
     got_corpus = corpus_digest(got)
     if want_corpus != got_corpus:
         problems.append(f"corpusDigest mismatch: manifest {want_corpus} != computed {got_corpus}")
     if problems:
+        # Every mismatch is a line-ending rewrite: say so once, loudly, instead
+        # of printing the same fact once per file and letting it read as damage.
+        if line_endings and len(line_endings) == len(problems) - 1:
+            print("MANIFEST verification FAILED: line endings, not content.\n")
+            print(f"  All {len(line_endings)} fixture files carry the published content "
+                  "byte for byte\n  once their line endings are undone.\n")
+            print("  Cause: this clone translated LF to CRLF. Git for Windows installs")
+            print("  with core.autocrlf=true, and this corpus is pinned byte for byte,")
+            print("  so the translation breaks every digest without changing content.\n")
+            print("  Fix:")
+            print("    git config core.autocrlf false")
+            print("    git rm --cached -r .")
+            print("    git reset --hard\n")
+            print("  This says nothing about SEP-2828 conformance. Re-run after the fix.")
+            return 1
         print("MANIFEST verification FAILED:")
         for line in problems:
             print(f"  {line}")

--- a/docs/conformance-profile.md
+++ b/docs/conformance-profile.md
@@ -44,6 +44,16 @@ when their dependency is absent rather than failing the run. None of these is
 Vaara. The point of the profile is that you run standard public crypto, never
 the producer's stack.
 
+On Windows, check that Git did not rewrite the line endings. The SEP-2828
+corpus is pinned byte for byte, and Git for Windows installs with
+`core.autocrlf=true`, which converts LF to CRLF on checkout and breaks every
+digest without changing any content. The repository's `.gitattributes` prevents
+this on a fresh clone. An older clone is repaired with `git config
+core.autocrlf false`, then `git rm --cached -r .` and `git reset --hard`. The
+`conformance_statement_v0` suite detects the case and reports SKIP with that
+reason, so it is never counted as a failed suite or a disagreement with the
+spec.
+
 ## The one command
 
 Grade the reference corpus from a clean checkout:

--- a/src/vaara/attestation/_conformance_statement.py
+++ b/src/vaara/attestation/_conformance_statement.py
@@ -29,9 +29,19 @@ Every part grades to one of three states rather than a boolean:
 A boolean cannot tell a reader whether a check failed or was never reached, and
 those call for different repairs. ``unproved`` is only ever produced by an
 explicit execution state the runner recorded (a suite it could not place, a
-record file it could not read), never inferred from a primary check that failed.
-Where a run mixes states, the worst one wins: a check that ran and failed
-outranks one that never ran.
+record file it could not read, a corpus whose bytes are not the published set),
+never inferred from a primary check that failed. Where a run mixes states, the
+worst one wins: a check that ran and failed outranks one that never ran.
+
+Corpus integrity is a precondition and grades ``unproved`` when it fails, never
+``false``. It asks whether the published byte set is present, not whether any
+implementation agrees with the spec, so a corpus that does not verify means the
+self-test measured something other than the published corpus and the run
+established nothing. A common cause is entirely benign and local: a Windows
+clone with Git's ``core.autocrlf`` on rewrites every fixture's line endings,
+which breaks every digest without changing a single byte of content. The
+statement detects that case exactly, by re-hashing with the translation undone,
+and names it rather than reporting a disagreement that no check observed.
 
 Deterministic and keyless. There is no clock: an ``as_of`` date is echoed
 verbatim when the caller supplies one and is never read from the system, so the
@@ -54,7 +64,10 @@ from vaara.attestation._record_set_conformance import check_record_set
 from vaara.attestation._record_set_findings import SetFinding
 
 STATEMENT_SCHEMA = "sep2828-conformance-statement"
-STATEMENT_SCHEMA_VERSION = 2
+#: v3 adds ``corpus.lineEndingMismatches`` / ``corpus.lineEndingsOnly`` and
+#: grades an unverified corpus ``unproved`` rather than ``false``. Additive for
+#: readers; the verdict for a byte-exact corpus is unchanged.
+STATEMENT_SCHEMA_VERSION = 3
 
 #: The check ran and the property holds.
 PROVED = "proved"
@@ -98,11 +111,39 @@ class CorpusIntegrity:
     file_count: int
     verified: bool
     problems: tuple[str, ...]
+    #: Files that differ from the manifest only by line endings. Their content
+    #: is the published content; the checkout rewrote the newlines.
+    line_ending_mismatches: tuple[str, ...] = ()
 
     @property
     def grade(self) -> str:
-        """Corpus integrity is always reachable: the bytes are here or they are not."""
-        return PROVED if self.verified else FALSE
+        """``PROVED`` when the bytes match, ``UNPROVED`` when they do not.
+
+        Corpus integrity is a precondition, not a conformance claim. It answers
+        "am I holding the published byte set", and nothing about whether an
+        implementation agrees with SEP-2828. When the bytes on disk are not the
+        published set, the self-test ran against something else, so the run
+        established nothing about conformance to the published corpus.
+
+        That is ``UNPROVED``, not ``FALSE``. Grading it ``FALSE`` would fold a
+        local checkout problem into a verdict that reads as a disagreement with
+        the spec, which is a claim no part of the run observed. The most common
+        cause is exactly that benign: a Windows clone with Git's
+        ``core.autocrlf`` on, which rewrites every fixture's line endings and so
+        breaks every digest while changing no content at all.
+
+        ``UNPROVED`` still gates. A statement conforms only when every in-scope
+        check grades ``PROVED``, so a tampered or mangled corpus can never yield
+        a pass; it yields "cannot tell", which is the honest answer.
+        """
+        return PROVED if self.verified else UNPROVED
+
+    @property
+    def line_endings_only(self) -> bool:
+        """True when line endings explain every problem found."""
+        return bool(self.line_ending_mismatches) and len(self.line_ending_mismatches) == len(
+            [p for p in self.problems if not p.startswith("corpusDigest mismatch")]
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -114,6 +155,8 @@ class CorpusIntegrity:
             "verified": self.verified,
             "grade": self.grade,
             "problems": list(self.problems),
+            "lineEndingMismatches": list(self.line_ending_mismatches),
+            "lineEndingsOnly": self.line_endings_only,
         }
 
 
@@ -301,6 +344,27 @@ def _corpus_digest(files: dict[str, str]) -> str:
     return "sha256:" + hashlib.sha256(blob).hexdigest()
 
 
+def _is_line_ending_only(path: Path, want: str) -> bool:
+    """Does this file match the manifest once its line endings are undone?
+
+    Exact, not a guess: undo the CRLF (and lone-CR) translation a checkout can
+    apply and re-hash. A match means the content is byte for byte the published
+    content and only the newlines were rewritten, which is a property of the
+    working tree rather than of the corpus.
+
+    Never used to pass the integrity check. The digest stays byte-exact; this
+    only lets the statement say which of the two very different things happened.
+    """
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return False
+    if b"\r" not in raw:
+        return False
+    normalised = raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
+    return "sha256:" + hashlib.sha256(normalised).hexdigest() == want
+
+
 def verify_corpus_integrity(corpus_dir: Path, manifest: dict[str, Any]) -> CorpusIntegrity:
     """Confirm the corpus bytes on disk match what its manifest pins.
 
@@ -314,13 +378,21 @@ def verify_corpus_integrity(corpus_dir: Path, manifest: dict[str, Any]) -> Corpu
     got = _file_digests(corpus_dir, suites)
 
     problems: list[str] = []
+    line_endings: list[str] = []
     for rel in sorted(set(want) | set(got)):
         if rel not in got:
             problems.append(f"missing file: {rel}")
         elif rel not in want:
             problems.append(f"unexpected file: {rel}")
         elif want[rel] != got[rel]:
-            problems.append(f"digest mismatch: {rel}")
+            # Separate "this file was changed" from "this checkout rewrote the
+            # newlines". They look identical to a digest and call for opposite
+            # responses, so the statement must not report them with one word.
+            if _is_line_ending_only(corpus_dir / rel, want[rel]):
+                line_endings.append(rel)
+                problems.append(f"line endings changed, content intact: {rel}")
+            else:
+                problems.append(f"digest mismatch: {rel}")
 
     want_corpus = str(manifest.get("corpusDigest", ""))
     got_corpus = _corpus_digest(got)
@@ -335,6 +407,7 @@ def verify_corpus_integrity(corpus_dir: Path, manifest: dict[str, Any]) -> Corpu
         file_count=len(got),
         verified=not problems,
         problems=tuple(problems),
+        line_ending_mismatches=tuple(line_endings),
     )
 
 
@@ -543,9 +616,19 @@ def render_conformance_statement(statement: ConformanceStatement) -> str:
             "and the corpusDigest recomputes."
         )
     else:
-        lines.append(f"NOT verified: {len(c.problems)} problem(s) with the corpus bytes.")
-        for p in c.problems:
-            lines.append(f"- {_safe(p)}")
+        if c.line_endings_only:
+            _render_line_ending_diagnosis(c, lines)
+        else:
+            lines.append(f"NOT verified: {len(c.problems)} problem(s) with the corpus bytes.")
+            for p in c.problems:
+                lines.append(f"- {_safe(p)}")
+            if c.line_ending_mismatches:
+                lines.append("")
+                lines.append(
+                    f"Of these, {len(c.line_ending_mismatches)} differ by line endings "
+                    "only and their content is intact; see the note on "
+                    "`core.autocrlf` in the corpus README."
+                )
     lines.append("")
 
     st = statement.self_test
@@ -556,6 +639,15 @@ def render_conformance_statement(statement: ConformanceStatement) -> str:
         f"This implementation's keyless conformance check {state} "
         f"{st.reproduced} of {st.cases} recorded verdicts."
     )
+    if not c.verified:
+        # Cuts the mirror-image misreading: a clean self-test over bytes that
+        # were never pinned is not a pass against the published corpus either.
+        lines.append("")
+        lines.append(
+            "Read this against the corpus integrity section above: these cases "
+            "came from the files on disk, which did not match the published "
+            "manifest, so the count is not a claim about the published corpus."
+        )
     lines.append("")
     for s in st.suites:
         if not s.runnable:
@@ -576,6 +668,43 @@ def render_conformance_statement(statement: ConformanceStatement) -> str:
     lines.append(_HOW)
     lines.append("")
     return "\n".join(lines)
+
+
+def _render_line_ending_diagnosis(c: CorpusIntegrity, lines: list[str]) -> None:
+    """Say plainly that the checkout rewrote the newlines and nothing else.
+
+    Every one of these files carries the published content. Listing them one by
+    one would repeat a single fact many times and bury it; the count and the
+    cause are what a reader needs, and both are stated exactly.
+    """
+    n = len(c.line_ending_mismatches)
+    lines.append(
+        f"NOT verified: all {n} fixture file{_s(n)} differ from `MANIFEST.json` "
+        "by line endings only, so the corpusDigest does not recompute either. "
+        "The content is the published content, byte for byte, once the newlines "
+        "are undone."
+    )
+    lines.append("")
+    lines.append(
+        "This is a checkout artefact, not a problem with the corpus or with any "
+        "emitter. Git for Windows installs with `core.autocrlf=true`, which "
+        "rewrites LF to CRLF on checkout. The corpus is pinned byte for byte, so "
+        "that translation breaks every digest while changing no content."
+    )
+    lines.append("")
+    lines.append("To check out the corpus verbatim:")
+    lines.append("")
+    lines.append("```")
+    lines.append("git config core.autocrlf false")
+    lines.append("git rm --cached -r .")
+    lines.append("git reset --hard")
+    lines.append("```")
+    lines.append("")
+    lines.append(
+        "Nothing above is a disagreement with SEP-2828. This statement is "
+        "UNPROVED because the published bytes were not present to check "
+        "against, not because a check ran and failed."
+    )
 
 
 def _render_records(r: RecordsResult, lines: list[str]) -> None:

--- a/tests/test_conformance_statement.py
+++ b/tests/test_conformance_statement.py
@@ -221,6 +221,160 @@ def test_extra_file_in_corpus_is_an_integrity_problem(tmp_path):
     assert any("unexpected file" in p for p in statement.corpus.problems)
 
 
+# ── Windows checkout (CRLF) ───────────────────────────────────────────────────
+#
+# Git for Windows installs with core.autocrlf=true, so a plain clone rewrites
+# every fixture's line endings. The corpus is pinned byte for byte, so that
+# breaks all 32 digests without changing a byte of content. Before the fix the
+# statement called that NON-CONFORMING, which reads as "this emitter disagrees
+# with SEP-2828" and is the kind of thing that gets filed as a permanent public
+# conformance row. It is not a disagreement. It is a checkout artefact.
+
+
+def _to_crlf(corpus: Path) -> int:
+    """Do to the corpus what a core.autocrlf=true checkout does."""
+    n = 0
+    for path in sorted(corpus.rglob("*")):
+        if not path.is_file() or "__pycache__" in path.parts:
+            continue
+        raw = path.read_bytes()
+        if b"\r" in raw or b"\n" not in raw or b"\0" in raw:
+            continue
+        path.write_bytes(raw.replace(b"\n", b"\r\n"))
+        n += 1
+    return n
+
+
+def test_windows_checkout_is_unproved_not_a_disagreement(tmp_path):
+    corpus = _copy_corpus(tmp_path / "corpus")
+    assert _to_crlf(corpus) > 0
+    statement = build_conformance_statement(corpus)
+
+    # The implementation still agrees with the spec on every recorded case:
+    # CRLF changes the bytes on disk, not what the records mean.
+    assert statement.self_test.conforms
+    assert statement.self_test.reproduced == statement.self_test.cases
+
+    # So the run establishes nothing, rather than contradicting the spec.
+    assert statement.corpus.grade == "unproved"
+    assert statement.grade == "unproved"
+    assert statement.corpus.line_endings_only
+
+    page = render_conformance_statement(statement)
+    assert "**Statement: UNPROVED**" in page
+    assert "NON-CONFORMING" not in page  # the false-disagreement regression
+    assert "core.autocrlf" in page  # and it names the actual cause
+
+
+def test_mangled_corpus_still_cannot_yield_a_pass(tmp_path):
+    """UNPROVED gates exactly as hard as FALSE did. It is honest, not lenient."""
+    corpus = _copy_corpus(tmp_path / "corpus")
+    _to_crlf(corpus)
+    statement = build_conformance_statement(corpus)
+    assert not statement.conforms
+    assert not statement.corpus.verified
+    rc = main(["conformance-statement", "--corpus", str(corpus)])
+    assert rc == 1
+
+
+def test_line_ending_detection_is_exact_not_a_guess(tmp_path):
+    """A real content edit is never excused as a line-ending artefact.
+
+    The check re-hashes with the translation undone, so only a file whose
+    content is byte for byte the published content can qualify.
+    """
+    corpus = _copy_corpus(tmp_path / "corpus")
+    victim = corpus / "record_set_v0" / "sets" / "clean" / "r1.json"
+    doc = json.loads(victim.read_text())
+    doc["alg"] = "HS256-tampered"
+    victim.write_bytes(json.dumps(doc, indent=2).encode() + b"\r\n")  # CRLF *and* edited
+    statement = build_conformance_statement(corpus)
+    assert not statement.corpus.line_ending_mismatches
+    assert any("digest mismatch" in p for p in statement.corpus.problems)
+    assert not statement.corpus.line_endings_only
+
+
+def test_mangling_plus_tampering_does_not_hide_the_tampering(tmp_path):
+    corpus = _copy_corpus(tmp_path / "corpus")
+    _to_crlf(corpus)
+    victim = corpus / "record_set_v0" / "sets" / "clean" / "r2.json"
+    victim.write_bytes(b'{"not": "the published record"}')
+    statement = build_conformance_statement(corpus)
+    assert not statement.corpus.line_endings_only  # one file is genuinely changed
+    page = render_conformance_statement(statement)
+    assert "digest mismatch: record_set_v0/sets/clean/r2.json" in page
+
+
+def test_standalone_runner_names_line_endings(tmp_path):
+    """The Vaara-free path a third party runs must say the same thing."""
+    corpus = _copy_corpus(tmp_path / "corpus")
+    _to_crlf(corpus)
+    proc = subprocess.run([sys.executable, "run.py", "--verify-manifest"],
+                          cwd=corpus, capture_output=True, text=True)
+    assert proc.returncode == 1
+    assert "line endings, not content" in proc.stdout
+    assert "core.autocrlf" in proc.stdout
+    assert "says nothing about SEP-2828 conformance" in proc.stdout
+
+
+def test_vectors_checker_skips_a_mangled_clone_instead_of_failing(tmp_path):
+    """The symptom a stranger actually reports, and the one that becomes a row.
+
+    This suite compares committed goldens against a fresh derivation from the
+    corpus. On a CRLF clone the derivation runs over bytes that are not the
+    published corpus, so every scenario mismatched and the suite reported 0/5.
+    That reads as Vaara disagreeing with its own vectors and is exactly the kind
+    of thing that gets filed as a permanent public conformance row.
+
+    It must skip with a reason instead. Exit 77 is the profile runner's SKIP
+    contract, and the runner takes the last stderr line as the reason.
+    """
+    shutil.copytree(CORPUS, tmp_path / "conformance" / "sep2828")
+    dst = tmp_path / "tests" / "vectors" / "conformance_statement_v0"
+    shutil.copytree(VECTORS, dst)
+    assert _to_crlf(tmp_path / "conformance") > 0
+
+    proc = subprocess.run([sys.executable, str(dst / "_check_independent.py")],
+                          capture_output=True, text=True)
+    assert proc.returncode == 77, proc.stdout + proc.stderr
+    assert proc.stderr.strip().splitlines()[-1].startswith("SKIP: ")
+    assert "core.autocrlf" in proc.stderr
+    assert "Not a conformance result" in proc.stderr
+    # It must not read as a disagreement.
+    assert "statements match the independent derivation" not in proc.stdout
+
+
+def test_vectors_checker_still_fails_on_real_corpus_tampering(tmp_path):
+    """Only a provably newlines-only difference goes quiet. Tampering stays loud."""
+    shutil.copytree(CORPUS, tmp_path / "conformance" / "sep2828")
+    dst = tmp_path / "tests" / "vectors" / "conformance_statement_v0"
+    shutil.copytree(VECTORS, dst)
+    victim = (tmp_path / "conformance" / "sep2828" / "record_set_v0" / "sets"
+              / "clean" / "r1.json")
+    victim.write_bytes(b'{"tampered": true}')
+
+    proc = subprocess.run([sys.executable, str(dst / "_check_independent.py")],
+                          capture_output=True, text=True)
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "SKIP" not in proc.stderr
+
+
+def test_gitattributes_checks_the_corpus_out_verbatim():
+    """The root fix: git must never translate the byte-pinned corpus.
+
+    Asserts the effective attribute rather than the file's text, so the guard
+    survives any reshuffle of .gitattributes that keeps the promise.
+    """
+    if not (REPO / ".gitattributes").is_file():
+        pytest.fail(".gitattributes is missing; the corpus is unpinned on Windows")
+    probe = "conformance/sep2828/record_set_v0/sets/clean/r1.json"
+    proc = subprocess.run(["git", "check-attr", "text", "--", probe],
+                          cwd=REPO, capture_output=True, text=True)
+    if proc.returncode != 0:
+        pytest.skip("git unavailable")
+    assert proc.stdout.strip().endswith("text: unset"), proc.stdout
+
+
 # ── CLI ───────────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_docs_cli_flags_exist.py
+++ b/tests/test_docs_cli_flags_exist.py
@@ -47,6 +47,11 @@ NOT_OURS = {
     "--create-namespace",  # helm install
     "--namespace",         # helm, kubectl
     "--from-file",         # kubectl create secret generic
+    # git, in docs/conformance-profile.md. Repairing a Windows clone whose
+    # line endings were rewritten is a git operation, so the commands that
+    # undo it belong to git.
+    "--cached",  # git rm --cached -r .
+    "--hard",    # git reset --hard
 }
 
 

--- a/tests/vectors/conformance_statement_v0/README.md
+++ b/tests/vectors/conformance_statement_v0/README.md
@@ -50,6 +50,23 @@ The `clean` and `flawed` records are byte copies of the `proper_pair` and
 `mixed_nonconforming` sets from the `record_set_v0` vectors, so their set
 verdict is already independently fixed there.
 
+## Corpus integrity is a precondition
+
+Corpus integrity asks whether the published byte set is present, not whether
+any implementation agrees with SEP-2828. When it fails, the self-test measured
+something other than the published corpus, so the run establishes nothing and
+the statement grades `unproved` rather than `false`. It still gates: only
+`proved` yields CONFORMS, so a corpus that does not verify can never produce a
+pass.
+
+The common cause is local and harmless. Git for Windows installs with
+`core.autocrlf=true` and rewrites every fixture's line endings on checkout,
+which breaks all 32 digests without changing a byte of content. Both this
+checker and `vaara conformance-statement` detect that exactly, by re-hashing
+with the translation undone, and name it instead of reporting a disagreement
+no check observed. This checker exits 77 (SKIP) in that case, because it
+cannot compare goldens against a corpus that is not the published one.
+
 ## Verifying
 
 ```

--- a/tests/vectors/conformance_statement_v0/_check_independent.py
+++ b/tests/vectors/conformance_statement_v0/_check_independent.py
@@ -77,11 +77,30 @@ def _corpus_digest(files):
     return "sha256:" + hashlib.sha256(("\n".join(lines) + "\n").encode("utf-8")).hexdigest()
 
 
+def _line_ending_only(rel, want):
+    """Does this file match the manifest once its line endings are undone?
+
+    Exact, not a guess: undo the CRLF (and lone-CR) rewrite a checkout can apply
+    and re-hash. A match proves the content is byte for byte the published
+    content. Never used to pass a check, only to tell two causes apart.
+    """
+    try:
+        raw = (CORPUS / rel).read_bytes()
+    except OSError:
+        return False
+    if b"\r" not in raw:
+        return False
+    return "sha256:" + hashlib.sha256(
+        raw.replace(b"\r\n", b"\n").replace(b"\r", b"\n")).hexdigest() == want
+
+
 def corpus_facts():
     """Recompute the corpus identity and integrity from the bytes on disk."""
     manifest = json.loads((CORPUS / "MANIFEST.json").read_text())
     files = _file_digests(manifest["suites"])
     verified = files == manifest["files"] and _corpus_digest(files) == manifest["corpusDigest"]
+    mismatched = [r for r, d in files.items() if manifest["files"].get(r) not in (None, d)]
+    same_set = set(files) == set(manifest["files"])
     return {
         "name": manifest["corpus"],
         "version": manifest["version"],
@@ -89,6 +108,10 @@ def corpus_facts():
         "fileCount": len(files),
         "verified": verified,
         "suites": list(manifest["suites"]),
+        # True only when every difference is provably a line-ending rewrite.
+        "lineEndingsOnly": bool(mismatched) and same_set and all(
+            _line_ending_only(r, manifest["files"][r]) for r in mismatched),
+        "mismatchCount": len(mismatched),
     }
 
 
@@ -244,8 +267,40 @@ def parse_page(text):
 # ── Cross-check ───────────────────────────────────────────────────────────────
 
 
+#: The conventional automake skip code the profile runner reports as SKIP.
+SKIP_EXIT_CODE = 77
+
+
 def main() -> int:
     corpus = corpus_facts()
+
+    # Precondition: this suite compares committed goldens against a fresh
+    # derivation from the published corpus. If the working tree is not that
+    # corpus, no comparison here can mean anything, and every scenario would
+    # report a mismatch that looks like Vaara disagreeing with its own vectors.
+    #
+    # A checkout that rewrote the line endings is the common cause and is
+    # provably content-identical, so the suite skips with the reason instead of
+    # failing. Any other integrity failure still fails loudly: only a difference
+    # we can prove is newlines-only goes quiet.
+    if corpus["lineEndingsOnly"]:
+        # The profile runner takes the last stderr line as the skip reason, so
+        # the whole diagnosis goes to stderr with "SKIP: " last.
+        print(
+            f"All {corpus['mismatchCount']} corpus fixture files differ from "
+            "MANIFEST.json by line endings only. Their content is the published "
+            "content byte for byte.\n"
+            "Cause: this clone translated LF to CRLF. Git for Windows installs "
+            "with core.autocrlf=true, and the corpus is pinned byte for byte.\n"
+            "Fix: git config core.autocrlf false && git rm --cached -r . && "
+            "git reset --hard\n",
+            file=sys.stderr,
+        )
+        print("SKIP: this clone rewrote the corpus line endings, so the published "
+              "bytes are not present to check against. Not a conformance result.",
+              file=sys.stderr)
+        return SKIP_EXIT_CODE
+
     reproduces_all, per_suite = self_test_facts(corpus["suites"])
     expected = json.loads((HERE / "expected.json").read_text())
     failures = 0
@@ -253,7 +308,11 @@ def main() -> int:
     for scenario in sorted(SCENARIO_RECORDS):
         rec = records_facts(scenario)
         # Grade every in-scope check independently, then fold worst-first.
-        corpus_grade = PROVED if corpus["verified"] else FALSE
+        # Corpus integrity is a precondition, so a corpus that does not verify
+        # is UNPROVED, not FALSE: the published bytes were not there to check
+        # against, which is not the same as an implementation disagreeing with
+        # the spec. It still gates, because only PROVED yields CONFORMS.
+        corpus_grade = PROVED if corpus["verified"] else UNPROVED
         selftest_grade = PROVED if reproduces_all else FALSE
         grades = [corpus_grade, selftest_grade]
         if rec is not None:

--- a/tests/vectors/conformance_statement_v0/expected.json
+++ b/tests/vectors/conformance_statement_v0/expected.json
@@ -6,6 +6,8 @@
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
       "grade": "proved",
+      "lineEndingMismatches": [],
+      "lineEndingsOnly": false,
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
@@ -23,7 +25,7 @@
       "unreadable": []
     },
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 2,
+    "schemaVersion": 3,
     "selfTest": {
       "cases": 17,
       "conforms": true,
@@ -56,6 +58,8 @@
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
       "grade": "proved",
+      "lineEndingMismatches": [],
+      "lineEndingsOnly": false,
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
@@ -82,7 +86,7 @@
       "unreadable": []
     },
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 2,
+    "schemaVersion": 3,
     "selfTest": {
       "cases": 17,
       "conforms": true,
@@ -115,6 +119,8 @@
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
       "grade": "proved",
+      "lineEndingMismatches": [],
+      "lineEndingsOnly": false,
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
@@ -139,7 +145,7 @@
       "unreadable": []
     },
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 2,
+    "schemaVersion": 3,
     "selfTest": {
       "cases": 17,
       "conforms": true,
@@ -172,6 +178,8 @@
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
       "grade": "proved",
+      "lineEndingMismatches": [],
+      "lineEndingsOnly": false,
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
@@ -181,7 +189,7 @@
     "grade": "proved",
     "records": null,
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 2,
+    "schemaVersion": 3,
     "selfTest": {
       "cases": 17,
       "conforms": true,
@@ -214,6 +222,8 @@
       "corpusDigest": "sha256:0baa437da95d6ffb6bda3185d657385b7738c79daba77819acc0c6280ac0ed7a",
       "fileCount": 32,
       "grade": "proved",
+      "lineEndingMismatches": [],
+      "lineEndingsOnly": false,
       "name": "sep2828-execution-record-conformance",
       "problems": [],
       "spec": "SEP-2828",
@@ -236,7 +246,7 @@
       ]
     },
     "schema": "sep2828-conformance-statement",
-    "schemaVersion": 2,
+    "schemaVersion": 3,
     "selfTest": {
       "cases": 17,
       "conforms": true,


### PR DESCRIPTION
A Windows clone made the SEP-2828 conformance corpus read as a disagreement with the spec. Found by Emek Can Dogru on 2026-08-21, before it reached a row.

## What happens

Git for Windows installs with `core.autocrlf=true`, which rewrites LF to CRLF on checkout. The corpus is pinned byte for byte, so all 32 file digests and the `corpusDigest` fail while no content changes at all.

Reproduced on a corpus converted to CRLF the way a checkout does:

- `vaara conformance-statement` printed NON-CONFORMING with 32 bare `digest mismatch` lines.
- `conformance_statement_v0` reported 0 of 5 scenarios matching.
- The suites themselves still passed 10/10 and 7/7, and the self-test still reproduced 17 of 17 recorded verdicts.

So the check that asks whether the implementation agrees with the spec passed, and the check that asks whether the published bytes are present failed. The statement reported the second as though it were the first.

## What changed

Corpus integrity is now graded as the precondition it is. It asks whether the published byte set is present, not whether an implementation agrees with SEP-2828. When it fails, the self-test measured something other than the published corpus, so the run establishes nothing and the statement grades `unproved` rather than `false`. It still gates: only `proved` yields CONFORMS, so a corpus that does not verify can never produce a pass. A mangled clone gets "cannot tell", and exit code 1 is unchanged.

A mismatched file is re-hashed with the line-ending translation undone. A match proves the content is byte for byte the published content, which separates the two causes of a mismatch exactly. This never makes a check pass; the digests stay byte-exact.

`conformance_statement_v0` exits 77 (SKIP) with that reason. This suite compares committed goldens against a fresh derivation from the corpus, so on a mangled clone it can never match and would always report 0 of 5. It now skips, and the profile runner surfaces the reason:

```
SKIP  conformance_statement_v0  (this clone rewrote the corpus line endings, so the
                                 published bytes are not present to check against.
                                 Not a conformance result.)
```

Only a difference that is provably newlines-only goes quiet. Real tampering still fails loudly, and a test covers that.

A root `.gitattributes` checks the byte-pinned corpus and its goldens out verbatim on every platform, and normalises the rest of the tree to LF. A fresh clone on Windows now holds the published bytes. An older clone is repaired with:

```
git config core.autocrlf false
git rm --cached -r .
git reset --hard
```

## Compatibility

`schemaVersion` goes to 3, adding `corpus.lineEndingMismatches` and `corpus.lineEndingsOnly`. Additive for readers. The verdict for a byte-exact corpus is unchanged, and `corpusDigest` is unchanged at `sha256:0baa437d...`. The `flawed` and `duplicate` scenarios still report NON-CONFORMING, so real record-level disagreements were not weakened.

## Verification

- 46 tests in `tests/test_conformance_statement.py`, 8 of them new, covering the CRLF path, the exactness of the detection, mangling plus tampering together, the standalone runner, the suite skip, and the `.gitattributes` attribute itself.
- Clean tree unchanged: corpus 32/32 files match, 5/5 statements match the independent derivation, profile runner PASS.
- Both documented repair paths and both diagnostics checked against a corpus converted to CRLF.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Windows CRLF and other line-ending conversions in the SEP-2828 conformance corpus.
  * Line-ending-only mismatches now receive clear diagnostics and are marked as unproved or skipped rather than mistaken for tampering.
  * Genuine corpus modifications continue to fail integrity verification.

* **Documentation**
  * Added guidance for preventing, detecting, and repairing line-ending changes across platforms.
  * Updated conformance output and schema documentation with line-ending diagnostics and remediation instructions.

* **Tests**
  * Added coverage for Windows checkouts, integrity reporting, command-line messaging, and skip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->