### PR TITLE
release: 1.75.0, a Windows clone is not a disagreement and a row says what kind it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.75.0] - 2026-08-22
+
 ### Fixed
 
 - The Vaara Conformance Results terms said the maintainer cannot remove a row because rows are chained. A chain makes a break detectable to someone holding an earlier head. It does not make removal impossible when one operator controls both the file and the published page, who could rewrite the chain and republish it consistently. The claim was wrong, and it sat in the consent form a party agrees through, which is worse than sitting in marketing. Iman Schrock raised it on the SCITT list on 2026-08-21 before filing a row, and he was right to hold it.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.74.0",
+  "version": "1.75.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.74.0"
+appVersion: "1.75.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.74.0, Helm chart 0.1.0.
+Vaara 1.75.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.74.0",
+  "version": "1.75.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.74.0"
+version = "1.75.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.74.0",
+  "version": "1.75.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.74.0",
+"version": "1.75.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.74.0",
+  "version": "1.75.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.74.0",
+"version": "1.75.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.74.0"
+__version__ = "1.75.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Two things a stranger runs into before anyone reads their result.

## A Windows clone is not a disagreement with the spec

Git for Windows installs with `core.autocrlf=true`, which rewrites LF to CRLF on checkout. The SEP-2828 corpus is pinned byte for byte, so all 32 file digests and the `corpusDigest` fail while no content changes at all.

Reproduced on a corpus converted the way a checkout does it:

- `vaara conformance-statement` printed NON-CONFORMING with 32 bare `digest mismatch` lines
- `conformance_statement_v0` reported 0 of 5 scenarios matching
- the suites themselves still passed 10 of 10 and 8 of 8, and the self-test reproduced 17 of 17

So the check asking whether the implementation agrees with the spec passed, and the check asking whether the published bytes are present failed. The statement reported the second as though it were the first.

Corpus integrity is now graded as the precondition it is. It asks whether the published byte set is present, not whether an implementation agrees with SEP-2828, so a corpus that does not verify grades `unproved` rather than `false`. It still gates, because only `proved` yields CONFORMS, so a mangled or tampered corpus can never produce a pass.

A mismatched file is re-hashed with the line-ending translation undone. A match proves the content is byte for byte the published content, which separates the two causes of a mismatch exactly, and never makes a check pass. `conformance_statement_v0` exits 77 (SKIP) with that reason rather than failing, because it compares committed goldens against a fresh derivation and cannot do that against a corpus that is not the published one. Only a provably newlines-only difference goes quiet; real tampering still fails.

A root `.gitattributes` checks the byte-pinned corpus and its goldens out verbatim on every platform.

`schemaVersion` goes to 3, adding `corpus.lineEndingMismatches` and `corpus.lineEndingsOnly`. The verdict for a byte-exact corpus is unchanged, `corpusDigest` is unchanged, and the `flawed` and `duplicate` scenarios still report NON-CONFORMING.

## A row says what kind of run it was

What a run establishes is a property of who wrote the verifier and who wrote the vectors, not of how well it went. The three kinds are not degrees of one another:

| Kind | What it establishes |
|---|---|
| Reproduction: the author's checkers over the author's vectors | The artefact runs and is byte-stable somewhere other than the author's machine. Nothing about the specification text |
| Independent implementation from the text, run against the author's vectors | Something about the text, because a second reader had to decide what the sentences meant |
| Independent implementation run against independently constructed vectors | Something about both |

A row that does not name its kind reads as the first, because that is the weakest claim available. The row stores a stable key rather than the form's prose, so rewording the dropdown cannot restate what a published row claimed. Rows listed before the field existed carry no kind and are never edited to add one, so the page states the rule instead of backfilling them. `terms_version` is bumped to `2026-08-22`, and rows already listed keep the terms they agreed to.

The loss this prevents happens where a result gets filed. A row outlives the message that explains it, so a register that cannot tell a reproduction from an independent implementation gets cited for the second while holding the first, by someone who is not lying.

## Also

The conformance desk went red on every rejected submission. A rejection leaves the row output empty, and Actions expands a step's `env` block before it applies the step's `if`, so `fromJSON('')` failed the whole workflow template. The submitter still got their comment, which is posted earlier, but the run failed and the steps after it never ran.

## Credit

Emek Can Doğru found the Windows trap and reported the desk failure. Joel Hillier proposed the kind field. Iman Schrock scoped his own row that way before anyone asked him to. All three on the SCITT list on 2026-08-21.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the product and associated packages to version 1.75.0.
  * Added the 1.75.0 entry to the changelog, dated August 22, 2026.
  * Updated supported-platform documentation to reflect the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->