### PR TITLE
fix(vcr): read the corpus size at the commit a row is scoped to

### DIFF
--- a/scripts/vcr_row.py
+++ b/scripts/vcr_row.py
@@ -137,7 +137,50 @@ def commit_exists(sha: str) -> bool:
         return False
 
 
-def known_suites() -> set[str]:
+#: Path to the vector directory as git spells it, for `git ls-tree`.
+VECTORS_IN_TREE = "tests/vectors"
+
+
+def known_suites(at_commit: str | None = None) -> set[str]:
+    """The suite names, at a commit if one is given, else in the working tree.
+
+    Resolving against the working tree was the only behaviour until 2026-08-25,
+    and it made an honest historical row impossible to file. A row is scoped to
+    the commit it ran at, which is the whole reason the field exists, so a run
+    over the 44 suites that existed at 62a7080 was being measured against the 46
+    on the branch today and refused. The rejection then told the submitter to
+    rerun at the commit they were listing and use the link it prints, which is
+    exactly what they had done: the runner at that commit prints `all 44
+    suites`, and this function refused it. The instruction contradicted itself.
+
+    Naming the suites individually is not a way round it either. FIELD_LIMITS
+    caps `suites` at 200 characters and the 44 names come to 802, which the
+    comment on WHOLE_CORPUS below already says.
+
+    So the only path through was to relabel a 44-suite run as 46, and Iman
+    Schrock refused to do that and said so on issue #618. He was right. A
+    register built to record what people actually got must never be the reason
+    somebody restates their run.
+    """
+    if at_commit:
+        try:
+            out = subprocess.run(
+                ["git", "ls-tree", "--name-only", f"{at_commit}:{VECTORS_IN_TREE}"],
+                cwd=REPO,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            names = {line.strip().rstrip("/") for line in out.splitlines() if line.strip()}
+            if names:
+                return names
+            # An empty listing means the path did not exist at that commit.
+            # Fall through rather than accept a row against nothing.
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            # A shallow clone cannot see the tree at an old commit. Better to
+            # fall back to the working tree than to refuse a row for a reason
+            # that is about our checkout depth and not about their run.
+            pass
     return {p.name for p in VECTORS.iterdir() if p.is_dir()} if VECTORS.exists() else set()
 
 
@@ -148,14 +191,14 @@ def known_suites() -> set[str]:
 WHOLE_CORPUS = re.compile(r"^all\s+(\d+)\s+suites$", re.IGNORECASE)
 
 
-def parse_suites(raw: str) -> list[str]:
+def parse_suites(raw: str, at_commit: str | None = None) -> list[str]:
     """The suites a row claims, from either the tool's words or the party's.
 
     Two accepted forms, and nothing else:
 
     * ``all <N> suites``, exactly as the runner prints it, where N has to match
-      the corpus actually in this repository. A whole-corpus claim that names
-      the wrong size is a claim about some other run.
+      the corpus AT THE COMMIT THE ROW IS SCOPED TO. A whole-corpus claim that
+      names the wrong size for that commit is a claim about some other run.
     * a comma or newline separated list of suite directory names.
 
     The first form existed on the printing side from 2026-08-17 and was never
@@ -165,15 +208,16 @@ def parse_suites(raw: str) -> list[str]:
     paragraph, because a row is quoted onto a public page and free prose in a
     field with a fixed meaning is how that page stops meaning one thing.
     """
-    known = known_suites()
+    known = known_suites(at_commit)
     text = raw.strip()
     whole = WHOLE_CORPUS.match(text)
     if whole:
         claimed = int(whole.group(1))
         if claimed != len(known):
+            where = f"at commit {at_commit[:9]}" if at_commit else "in this repository"
             raise Rejected(
-                f"This repository has {len(known)} suites, and the row claims a "
-                f"run over {claimed}. Rerun `python scripts/conformance_runner.py` "
+                f"The corpus {where} has {len(known)} suites, and the row claims "
+                f"a run over {claimed}. Rerun `python scripts/conformance_runner.py` "
                 "at the commit you are listing and use the link it prints."
             )
         return sorted(known)
@@ -183,7 +227,8 @@ def parse_suites(raw: str) -> list[str]:
         raise Rejected("Name at least one suite you ran.")
     unknown = sorted(set(names) - known)
     if unknown:
-        raise Rejected(f"These are not suites in this repository: {', '.join(unknown)}")
+        where = f"suites at commit {at_commit[:9]}" if at_commit else "suites in this repository"
+        raise Rejected(f"These are not {where}: {', '.join(unknown)}")
     return names
 
 
@@ -253,7 +298,9 @@ def validate(fields: dict, author: str) -> dict:
     if not commit_exists(sha):
         raise Rejected(f"Commit `{sha}` is not in this repository.")
 
-    suites = parse_suites(str(fields.get("suites", "")))
+    # `sha` is validated above, so the suite check can be scoped to the commit
+    # the row is actually about rather than to whatever is on the branch today.
+    suites = parse_suites(str(fields.get("suites", "")), sha)
 
     result = str(fields.get("result", "")).strip()
     if not result:

--- a/tests/test_vcr_row.py
+++ b/tests/test_vcr_row.py
@@ -196,6 +196,50 @@ def test_a_whole_corpus_claim_has_to_match_the_corpus():
         row_from(form(suites=f"all {n - 1} suites"))
 
 
+#: A commit whose corpus is smaller than the one on the branch today. Iman
+#: Schrock ran here, and the runner at this commit prints `all 44 suites`.
+HISTORICAL_COMMIT = "62a7080b7c854173c7d6b8ee51ce4dd724d59227"
+
+
+def _has_commit(sha: str) -> bool:
+    return subprocess.run(
+        ["git", "cat-file", "-e", f"{sha}^{{commit}}"],
+        cwd=ROOT, capture_output=True,
+    ).returncode == 0
+
+
+@pytest.mark.skipif(
+    not _has_commit(HISTORICAL_COMMIT),
+    reason="shallow clone cannot see the tree at that commit",
+)
+def test_the_corpus_size_is_read_at_the_commit_the_row_is_scoped_to():
+    """A row over 44 suites at a 44-suite commit is not a claim about 46.
+
+    Issue #618, 2026-08-24. The corpus grew from 44 to 46, this validator
+    resolved the count against the working tree, and an honest row became
+    impossible to file. `all 44 suites` was refused for not being 46, and the
+    rejection told the submitter to rerun at the commit they were listing and
+    use the link it prints, which is exactly what produced the 44. Naming the
+    suites instead does not help either: the field caps at 200 characters and
+    the 44 names come to 802. The only remaining path was to relabel the run as
+    46, and Iman Schrock refused to do that, correctly.
+    """
+    at_commit = vcr.known_suites(HISTORICAL_COMMIT)
+    today = vcr.known_suites()
+    assert at_commit, "no suites resolved at the historical commit"
+    assert len(at_commit) < len(today), (
+        "this test needs a commit whose corpus is smaller than today's; "
+        f"got {len(at_commit)} then and {len(today)} now"
+    )
+
+    row = row_from(form(suites=f"all {len(at_commit)} suites", commit=HISTORICAL_COMMIT))
+    assert row["suites"] == sorted(at_commit)
+
+    # And today's count is the wrong claim for that commit, in both directions.
+    with pytest.raises(vcr.Rejected, match="suites"):
+        row_from(form(suites=f"all {len(today)} suites", commit=HISTORICAL_COMMIT))
+
+
 def test_prose_around_the_suites_is_still_refused():
     """Liberal enough for the tool's output, not for a hand-written paragraph."""
     n = len(vcr.known_suites())


### PR DESCRIPTION
Closes the reason a row filed on 24 August could not go up.

## What was wrong

`scripts/vcr_row.py` resolved the suite count against the working tree. A row carries `at_commit` precisely because it is scoped to the commit it ran at, so measuring it against whatever is on the branch today makes an honest historical row impossible to file once the corpus grows.

The corpus went from 44 to 46. A run at `62a7080` over the 44 suites that existed there was refused for not being 46. The rejection then said:

> Rerun `python scripts/conformance_runner.py` at the commit you are listing and use the link it prints.

That is what produced the 44. The instruction contradicted itself.

Naming the suites individually was not an escape either. `FIELD_LIMITS["suites"]` caps at 200 characters and the 44 names come to 802, which the comment above `WHOLE_CORPUS` already said.

So the only path through was to relabel a 44-suite run as 46. That is a false statement about the run, and the submitter refused to make it. He was right to. A page built to record what people actually got must never be the reason somebody restates their run.

## What changed

`known_suites()` takes an optional commit and reads the tree there with `git ls-tree`. `validate()` passes the SHA it has already checked, so the suite check is scoped to the same commit as the rest of the row. The rejection text now names which commit it measured against.

A shallow clone that cannot see the old tree falls back to the working tree. Refusing a row for a reason that is about our checkout depth rather than about their run would be the same class of defect.

## Verified

The submission that could not be filed now validates, with all 44 suites resolved at its own commit and the scoping preserved as written:

```
Iman, 62a7080          -> 44 suites
Emek, a209864e         -> 46 suites
working tree           -> 46 suites
```

A regression test pins it, and it skips rather than fails on a clone too shallow to see the commit. Full file: 40 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suite validation now uses the commit associated with each record, preventing historical entries from being checked against the current suite list.
  * Improved handling for repositories with limited history or unavailable commit trees by falling back safely when needed.

* **Tests**
  * Added coverage confirming historical suite counts and validation behave correctly for past commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->