### PR TITLE
docs(sep): stop asserting what a third party's verifier does

### DIFF
--- a/docs/sep/sep-server-execution-record.md
+++ b/docs/sep/sep-server-execution-record.md
@@ -680,10 +680,12 @@ decision-only escalate, the two replay-rejection cases (substituted attestation
 back-link and substituted pairing nonce, both failing Check A), a substituted
 decision under a shared attestation (Check A passes, Check B fails), the
 equal-`decidedAt` supersession tie reported as ambiguous, and the no-SEP-2787
-fallback request-envelope binding (with its replayed-envelope substitution). An
-independent consumer verifier (Rul1an/Assay) reproduces the Check-A subset today
-and the Check-B and supersession cases as it adopts the digest and ordering
-model.
+fallback request-envelope binding (with its replayed-envelope substitution).
+
+Runs of these vectors by parties other than the author are recorded at
+<https://vaara.io/conformance.html>, on terms that are the same for everyone and
+that each runner agrees to before a row is published. This page states no claim
+about any third-party implementation on its own account.
 
 Conformance traceability, mapping each MUST / MUST NOT and SHOULD / SHOULD NOT in
 the Specification to a conformance check ID, is maintained with the living


### PR DESCRIPTION
The Test Vectors section claimed a named external verifier "reproduces the Check-A subset today". A page of ours is the wrong place to assert the current behaviour of somebody else's software. We cannot keep such a claim true, and it had already gone stale.

Replaced with a pointer to the results page, where runs by parties other than the author are recorded on terms that are the same for everyone and that each runner agrees to before publication. The section now makes no claim about any third-party implementation on its own account.

Checked: this was the only public occurrence. It is not in the Internet-Draft, not in SPEC.md, and not elsewhere under docs/ or src/.

Reported in #617.