### PR TITLE
fix(tests): guard the blind-switch test on the server extra

### DIFF
--- a/tests/test_receipt_anchor_blinded.py
+++ b/tests/test_receipt_anchor_blinded.py
@@ -251,8 +251,19 @@ def test_a_blinded_qualified_anchor_still_renders_as_qualified(receipt, tmp_path
 
 
 def test_the_server_anchorer_reads_the_blind_switch(monkeypatch):
-    """Construction does no network I/O, so this only reads the switch."""
-    from vaara.server.anchor import Anchorer
+    """Construction does no network I/O, so this only reads the switch.
+
+    Guarded because `vaara.server.anchor` imports the app, which needs fastapi.
+    Without the guard this fails rather than skips on any checkout that has the
+    signing extras and not the server extra, which is exactly what the "Signing
+    extras" CI job installs. Main has been red on that job since 2026-08-21,
+    when the blind switch shipped in v1.74.0, through four releases, and it did
+    not show up locally because a development venv has fastapi.
+    """
+    try:
+        from vaara.server.anchor import Anchorer
+    except ImportError:
+        pytest.skip("server extra not installed (pip install 'vaara[server]')")
 
     url = "https://qtsp.example/tsr"
     monkeypatch.delenv("VAARA_ANCHOR_BLIND", raising=False)


### PR DESCRIPTION
Main has been red since 2026-08-21, across four releases, and it is one line of test setup.

## What is wrong

`test_the_server_anchorer_reads_the_blind_switch` imports `vaara.server.anchor`, which imports the app, which imports fastapi. The "Signing extras" CI job installs the attestation, scitt, timeanchor, pq and yaml extras and deliberately not the server extra, so the import raises there:

```
src/vaara/server/app.py:18: ModuleNotFoundError: No module named 'fastapi'
```

The test failed rather than skipped. It shipped with the blind switch in v1.74.0 on 21 August, which is exactly when that job went red, and it never showed up locally because a development venv has fastapi installed.

## Fix

Guarded the same way `tests/test_v040_per_tenant_threshold.py` already guards the server extra, so the pattern is the one this repo already uses rather than a new one.

## Verified both directions

- fastapi present: `tests/test_receipt_anchor_blinded.py` 24 passed
- fastapi genuinely unimportable: 1 skipped, with the stated reason

Worth noting separately: the job that caught this is doing its job. It exists to fail when signing-critical code goes unexecuted, and a test that errors on a missing optional dependency is the same class of hole it was written to close.