### PR TITLE
release: 1.76.0, the results register is readable by machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.76.0] - 2026-08-25
+
 ### Added
 
 - The conformance results page ships structured data. The corpus is described as a `Dataset` that carries its concept DOI, its license and the live suite totals. Every listed reproduction becomes a `Report` credited to the party who made the claim, with a link to their own public record and the sha256 of the row it commits to. Every row also gets a stable anchor, so a single run can be cited on its own.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.75.0"
+appVersion: "1.76.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.75.0, Helm chart 0.1.0.
+Vaara 1.76.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.75.0"
+version = "1.76.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.75.0",
+  "version": "1.76.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.75.0",
+"version": "1.76.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.75.0",
+  "version": "1.76.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.75.0",
+"version": "1.76.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.75.0"
+__version__ = "1.76.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Five named third parties have reproduced the conformance corpus and said so in public. A crawler or a model arriving at that page saw a rendered table and had to guess what the columns meant, so none of it accrued.

## The conformance page

The corpus is described as a `Dataset` carrying its concept DOI, its license and the live suite totals. Every listed reproduction becomes a `Report` credited to the party who made the claim, with a link to their own public record and the sha256 of the row it commits to. Every row also gets a stable anchor, so a single run can be cited on its own.

The whole block is generated from the same two inputs as the visible table, so the two cannot disagree. `--check` compares them on every run.

Nothing in the block is typed as a review, a rating or a certification, because the page spends three paragraphs saying it is none of those. No party is typed as a person or a company either: the register records a party name and does not record which of the two it is, and the listed parties are a mix of both plus a pseudonym. Tests hold both rules. Another one feeds a party name containing `</script>` through the renderer and checks the block still parses.

## The explorer

`webpage/verify.html` carried a title in its head and nothing more. It now has a description, a canonical URL, link preview tags and structured data, including a `WebApplication` node for the verifier and a `HowTo` whose closing step is the page's own sentence about what a passing signature does not establish.

## The files that could not see the rows

Rows land on the unprotected `vcr` branch and the site is built from main, so `llms.txt`, `sitemap.xml` and the register itself all described rows they had no access to. `llms.txt` did not mention the results register at all. The sitemap reported the conformance page unchanged since 2026-08-15 under `changefreq weekly`, while three rows had landed in that window.

`scripts/stamp_site.py` fills all three from the rows actually being published, and the Pages job runs it right after the overlay. Sitemap dates come from git, or from the `vcr` branch for the page published from it. `https://vaara.io/conformance.json` is new and serves the whole register as one file; single rows were already served as canonical bytes under `/badge/<slug>.json`, while the table as a whole was only reachable by scraping the page.

The `llms.txt` section is generated rather than typed, for the same reason the results page is. A hand-maintained list of other people's names is wrong the day after the next row lands.

## Checks that ran

- 97 tests across the four affected files, all passing
- The renderer run against the five live `vcr` rows: the block parses, and each row digest matches the bytes served at `/badge/<slug>.json` today
- The publish-time stamp simulated against those same rows: five in the register, all five parties reaching `llms.txt`, conformance `lastmod` resolving to the `vcr` tip date

## What this release carries

The wheel and the npm package are unchanged in behaviour. Everything above is
the published site, the renderer that generates it and the script that stamps
it, so the version exists to give the change a name and a date in the history
rather than to move code on PyPI.
