### PR TITLE
release: 1.77.0, a fourth kind of run, and the form that could not offer it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.77.0] - 2026-08-25
+
+### Added
+
+- A fourth kind of run for the conformance register. Tiago Pinto reproduced a published class digest from the prose describing it, without running the author's verifier and without writing a second implementation, and said on the SCITT list that it fitted none of the three kinds the register offered. He was right.
+
+  `construction_reproduction` sits second, above `reproduction` and below an independent implementation. A reproduction asks whether the artefact runs somewhere other than the author's machine. A construction reproduction asks whether the description was sufficient to derive the published value at all, which is a question about the text and is answerable with no code on either side. Filed as a reproduction it would have recorded a claim about prose as a claim about an artefact, in a row nobody can edit afterwards.
+
+  The unstated-kind rule is untouched. A row with no kind still reads as the weakest, and rows listed before the field existed are still never edited to add one.
+
+### Fixed
+
+- Nothing bound the conformance issue form's dropdown to the register's own table of kinds. A kind added to the table had no way to be chosen, and a reworded option would have parsed as the weakest kind, filing a quieter claim than the submitter picked. Both failed silently, in a row that cannot be edited afterwards. A test now binds the two one to one and in order, and reads the form without PyYAML, which ships in the `yaml` extra, so the guard runs on every job instead of skipping wherever that extra is absent.
+
+- `parse_kind` matched the `reproduction` prefix before anything else, so the fourth kind's wording, which carries that word, would have fallen through to the weakest kind. The construction prefix is now checked first and a test pins the ordering.
+
 ## [1.76.0] - 2026-08-25
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.76.0",
+  "version": "1.77.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.76.0"
+appVersion: "1.77.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.76.0, Helm chart 0.1.0.
+Vaara 1.77.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.76.0",
+  "version": "1.77.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.76.0"
+version = "1.77.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.76.0",
+  "version": "1.77.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.76.0",
+"version": "1.77.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.76.0",
+  "version": "1.77.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.76.0",
+"version": "1.77.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.76.0"
+__version__ = "1.77.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Tiago Pinto reproduced a published class digest from the prose describing it, without running the author's verifier and without writing a second implementation, and said on the SCITT list that it fitted none of the three kinds the register offered. He was right.

## The fourth kind

`construction_reproduction` sits second, above `reproduction` and below an independent implementation, in the register's table, in the page's prose, in the issue form and in the terms paragraph.

A reproduction asks whether the artefact runs somewhere other than the author's machine. A construction reproduction asks whether the description was sufficient to derive the published value at all. That is a question about the text, and it is answerable with no code on either side.

Filed as a reproduction it would have recorded a claim about prose as a claim about an artefact, in a row nobody can edit afterwards.

The unstated-kind rule is untouched. A row with no kind still reads as the weakest, and rows listed before the field existed are still never edited to add one.

## Two silent failures closed with it

Nothing bound the issue form's dropdown to the register's own table of kinds. A kind added to the table had no way to be chosen, and a reworded option would have parsed as the weakest kind and filed a quieter claim than the submitter picked. A test now binds the two one to one and in order.

That test reads the form without PyYAML, which ships in the `yaml` extra. Importing it would have errored the test out on every job that does not install that extra, which is the fault #622 fixed. A guard that skips on most runs is not a guard.

`parse_kind` matched the `reproduction` prefix before anything else, so the fourth kind's wording, which carries that word, would have fallen through to the weakest kind. The construction prefix is checked first now, and a test pins the ordering against three phrasings.

## Checked

- Full suite green on the branch, 17 of 17 required checks
- The form guard mutation-tested against both failures it exists to catch: a reworded option that stops parsing, and a kind added to the table with no matching option
- `webpage/conformance.html` regenerated, so the committed page carries the new terms paragraph
