### PR TITLE
Five decisions, projected onto the three the wire already carries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- The gate speaks five decisions. `MODIFY`, `STEP_UP` and `DEFER` join `ALLOW`, `DENY` and `ESCALATE`, which completes the decision vocabulary the AARM Core registry asks for under R4.
+
+  The three new names do not reach the signed decision record, and that is deliberate rather than a shortcut. The record's verdict enum is a closed set of three, and it is closed inside checkers that other people already hold and run: `tests/vectors/record_set_v0/_check_independent.py` grades a record carrying any other verdict as non-conforming. Renaming `escalate` to `step_up` would have broken every published vector and made the scoping text of rows nobody can edit become false. So the refinements are policy-layer names that project onto the coarse three, in the same table shape that already maps `deny` to `block` and `review` and `refer` to `escalate`.
+
+  `STEP_UP` and `DEFER` are holds and record `escalate`. `MODIFY` records `deny`, because the arguments it was asked about do not run. When a policy proposes different arguments they come back on `InterceptionResult.modified_parameters`, the caller resubmits them, and that resubmission is scored and recorded on its own. Two records, both true, each bound to the arguments it actually decided. No decision record ever says `allow` against arguments other than the ones that executed.
+
+  `InterceptionResult.decision` keeps returning the coarse word and `decision_detail` carries the refinement. Around a dozen call sites across the framework integrations branch on `decision == "escalate"` or `== "deny"` to decide whether to raise. A finer word arriving there would have missed every one of those branches and read as a fall-through, which is a fail-open in precisely the code that exists to stop an action.
+
+  `allowed` is still true for `allow` and nothing else. All three new decisions are holds at the moment the gate returns, so no relying party has a new rule to learn.
+
+- `decision_made` audit records carry `decision_detail` and, for a modify, `modified_parameters`. Both keys are omitted when absent, so a record written without a refinement is byte-identical to one written before the vocabulary existed and its hash does not move. `decision` itself stays inside the documented three-value enum.
+
 ## [1.77.0] - 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,19 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-- The gate speaks five decisions. `MODIFY`, `STEP_UP` and `DEFER` join `ALLOW`, `DENY` and `ESCALATE`, which completes the decision vocabulary the AARM Core registry asks for under R4.
+- `MODIFY`, `STEP_UP` and `DEFER` join `ALLOW`, `DENY` and `ESCALATE`, which covers the decision vocabulary the AARM Core registry asks for under R4. That registry names five and `Decision` now has six, because `ESCALATE` stays exactly as it was and `STEP_UP` and `DEFER` refine it rather than replace it.
 
-  The three new names do not reach the signed decision record, and that is deliberate rather than a shortcut. The record's verdict enum is a closed set of three, and it is closed inside checkers that other people already hold and run: `tests/vectors/record_set_v0/_check_independent.py` grades a record carrying any other verdict as non-conforming. Renaming `escalate` to `step_up` would have broken every published vector and made the scoping text of rows nobody can edit become false. So the refinements are policy-layer names that project onto the coarse three, in the same table shape that already maps `deny` to `block` and `review` and `refer` to `escalate`.
+  The three new names do not reach the signed decision record, and that is deliberate rather than a shortcut. The record's verdict enum is a closed set of three, and it is closed inside a checker this repository publishes for outside parties to run: `tests/vectors/record_set_v0/_check_independent.py` grades a record carrying any other verdict as non-conforming. Renaming `escalate` to `step_up` would have invalidated published vectors and made the scoping text of results rows that cannot be edited become false. So the refinements are policy-layer names that project onto the coarse three, in the same table shape that already maps `deny` to `block` and `review` and `refer` to `escalate`.
 
   `STEP_UP` and `DEFER` are holds and record `escalate`. `MODIFY` records `deny`, because the arguments it was asked about do not run. When a policy proposes different arguments they come back on `InterceptionResult.modified_parameters`, the caller resubmits them, and that resubmission is scored and recorded on its own. Two records, both true, each bound to the arguments it actually decided. No decision record ever says `allow` against arguments other than the ones that executed.
 
-  `InterceptionResult.decision` keeps returning the coarse word and `decision_detail` carries the refinement. Around a dozen call sites across the framework integrations branch on `decision == "escalate"` or `== "deny"` to decide whether to raise. A finer word arriving there would have missed every one of those branches and read as a fall-through, which is a fail-open in precisely the code that exists to stop an action.
+  `InterceptionResult.decision` keeps returning the coarse word and `decision_detail` carries the refinement. Eleven call sites across the framework integrations branch on `decision == "escalate"` or `== "deny"` to decide whether to raise, in `langchain.py`, `openai_agents.py`, `claude_code_hooks.py`, `mcp_server.py` and `_infer_proxy_gate.py`. A finer word arriving there would have missed every one of those branches and read as a fall-through, which is a fail-open in precisely the code that exists to stop an action.
 
   `allowed` is still true for `allow` and nothing else. All three new decisions are holds at the moment the gate returns, so no relying party has a new rule to learn.
 
 - `decision_made` audit records carry `decision_detail` and, for a modify, `modified_parameters`. Both keys are omitted when absent, so a record written without a refinement is byte-identical to one written before the vocabulary existed and its hash does not move. `decision` itself stays inside the documented three-value enum.
+
+  `record_decision` checks the refinement against the decision it claims to explain and drops it if the two disagree. The pipeline never passes an inconsistent pair, but the method is reachable from custom policy code, and a record saying `allow` with a `modify` refinement would be hash-chained evidence that contradicts itself.
 
 ## [1.77.0] - 2026-08-25
 

--- a/docs/audit_event_schema.md
+++ b/docs/audit_event_schema.md
@@ -116,7 +116,7 @@ keys). Reserved top-level keys:
   null), `sequence_position` (integer). The delegation keys link this action
   to the one that spawned it; see [§ Delegation linkage](#delegation-linkage).
 - `risk_scored`: `risk_score` (number in [0, 1]), `interval` (`[low, high]`), `classifier_version` (string), `contributing_signals` (array).
-- `decision_made`: `decision` (`allow` | `escalate` | `deny`), `threshold_set` (string), `verdict_inputs` (array).
+- `decision_made`: `decision` (`allow` | `escalate` | `deny`), `threshold_set` (string), `verdict_inputs` (array), `decision_detail` (`modify` | `step_up` | `defer`, optional), `modified_parameters` (object, optional).
 - `action_executed`: `executor` (string), `duration_ms` (number).
 - `action_blocked`: `reason` (string), `blocking_policy` (string).
 - `escalation_sent`: `reviewer_queue` (string), `priority` (string).
@@ -128,6 +128,17 @@ Caller-controlled strings in `data` (`agent_id`, `reason`,
 `override_reason`) MUST be treated as untrusted at narrative-rendering
 time. The hash chain still covers original values; the renderer
 sanitizes for display only.
+
+`decision` on a `decision_made` record stays inside the three-value enum
+above and always will. A policy layer may work with a finer vocabulary,
+and `decision_detail` names which refinement produced the recorded
+decision: `step_up` and `defer` are holds and record `escalate`, `modify`
+records `deny` because the arguments it was asked about do not run. When a
+`modify` proposes different arguments, `modified_parameters` carries them
+and the caller resubmits, producing a second decision bound to those
+arguments. **No decision record ever says `allow` against arguments other
+than the ones that executed.** Both optional keys are omitted when absent,
+so records written without a refinement are unchanged.
 
 ## Delegation linkage
 

--- a/src/vaara/_decision_vocabulary.py
+++ b/src/vaara/_decision_vocabulary.py
@@ -1,0 +1,40 @@
+"""The decision vocabulary, and its projection onto the three that are recorded.
+
+AARM Core R4 asks for five decisions: ALLOW, DENY, MODIFY, STEP_UP and DEFER.
+The signed decision record carries three, and that set is closed inside
+checkers this repository publishes and outside parties run
+(``tests/vectors/record_set_v0/_check_independent.py``). A record carrying any
+other verdict is graded non-conforming, so renaming one of the three is a
+wire-format break rather than a refactor.
+
+MODIFY, STEP_UP and DEFER are therefore policy-layer names that project onto
+the coarse three. This module is the single place that projection is defined.
+It imports nothing, so the enforcement path (``vaara.pipeline``) and the
+evidence path (``vaara.audit.trail``) can both hold the same table without one
+depending on the other or on the scorer.
+
+The enum itself lives with the scorer (``vaara.scorer.adaptive.Decision``);
+``tests/test_decision_vocabulary.py`` pins the two to each other.
+"""
+
+from __future__ import annotations
+
+# The only verdicts a decision record ever carries. Frozen.
+COARSE: frozenset[str] = frozenset({"allow", "deny", "escalate"})
+
+# The R4 refinements. Each names WHY a coarse decision was reached; none of
+# them is permissive on its own.
+REFINEMENTS: frozenset[str] = frozenset({"modify", "step_up", "defer"})
+
+# MODIFY projects to `deny` because the arguments it was asked about do not
+# run. The altered arguments come back to the caller and are resubmitted as a
+# fresh decision bound to their own digest, so no decision record ever says
+# `allow` against arguments other than the ones that executed.
+FINE_TO_COARSE: dict[str, str] = {
+    "allow": "allow",
+    "deny": "deny",
+    "escalate": "escalate",
+    "modify": "deny",
+    "step_up": "escalate",
+    "defer": "escalate",
+}

--- a/src/vaara/audit/receipts.py
+++ b/src/vaara/audit/receipts.py
@@ -226,6 +226,12 @@ def _event_to_decision(event_type: EventType) -> str:
 # policy vocabulary. The SEP-2787 decision-record wire enum is
 # ``allow`` / ``block`` / ``escalate``, so ``deny`` normalises to ``block`` and
 # the review family normalises to ``escalate``.
+# The AARM Core R4 refinements project here too. STEP_UP and DEFER are holds
+# and join the review family on ``escalate``; MODIFY blocks the arguments it
+# was asked about, and the altered arguments come back as their own decision
+# bound to their own digest (see ``vaara.pipeline._FINE_TO_COARSE``). A
+# decision record must never say ``allow`` against a digest other than the
+# one that executed.
 _VERDICT_TO_WIRE: dict[str, str] = {
     "allow": "allow",
     "deny": "block",
@@ -233,6 +239,9 @@ _VERDICT_TO_WIRE: dict[str, str] = {
     "escalate": "escalate",
     "review": "escalate",
     "refer": "escalate",
+    "step_up": "escalate",
+    "defer": "escalate",
+    "modify": "block",
 }
 
 

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -851,8 +851,18 @@ class AuditTrail:
         reason: str,
         risk_score: float,
         regulatory_domains: frozenset[RegulatoryDomain] = frozenset(),
+        decision_detail: Optional[str] = None,
+        modified_parameters: Optional[dict] = None,
     ) -> None:
-        """Record the allow/deny/escalate decision."""
+        """Record the allow/deny/escalate decision.
+
+        ``decision`` is always one of the coarse three. ``decision_detail``
+        carries the AARM Core R4 refinement behind it when there is one
+        ("modify", "step_up", "defer"), and ``modified_parameters`` the
+        arguments a ``modify`` proposed. Both keys are omitted entirely when
+        absent, so a record without a refinement is byte-identical to one
+        written before this vocabulary existed and its hash does not move.
+        """
         event_type = (
             EventType.ACTION_BLOCKED if decision == "deny"
             else EventType.DECISION_MADE
@@ -862,6 +872,21 @@ class AuditTrail:
             event_type, regulatory_domains,
         )
 
+        data: dict = {
+            "decision": self._cap_record_str(decision, self._MAX_DECISION_LABEL_LEN),
+            "reason": self._cap_record_str(reason, self._MAX_DECISION_REASON_LEN),
+            "risk_score": risk_score,
+        }
+        if decision_detail:
+            data["decision_detail"] = self._cap_record_str(
+                decision_detail, self._MAX_DECISION_LABEL_LEN,
+            )
+        if modified_parameters:
+            data["modified_parameters"] = self._cap_record_dict_bytes(
+                {str(k): json_safe(v) for k, v in modified_parameters.items()},
+                self._MAX_EXECUTION_RESULT_JSON_BYTES,
+            )
+
         self._append(AuditRecord(
             record_id=str(uuid.uuid4()),
             action_id=action_id,
@@ -869,11 +894,7 @@ class AuditTrail:
             timestamp=time.time(),
             agent_id=self._cap_record_str(agent_id, self._MAX_AGENT_ID_LEN),
             tool_name=self._cap_record_str(tool_name, self._MAX_TOOL_NAME_LEN),
-            data={
-                "decision": self._cap_record_str(decision, self._MAX_DECISION_LABEL_LEN),
-                "reason": self._cap_record_str(reason, self._MAX_DECISION_REASON_LEN),
-                "risk_score": risk_score,
-            },
+            data=data,
             regulatory_articles=articles,
             tenant_id=self._tenant_for(action_id),
         ))

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -37,6 +37,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from vaara._decision_vocabulary import FINE_TO_COARSE, REFINEMENTS
 from vaara._sanitize import json_safe, strict_json_dumps
 from vaara.taxonomy.actions import ActionRequest, RegulatoryDomain
 
@@ -871,6 +872,38 @@ class AuditTrail:
         articles = self._get_regulatory_articles(
             event_type, regulatory_domains,
         )
+
+        # The refinement is checked against the decision it claims to explain
+        # before either reaches the chain. The pipeline never passes an
+        # inconsistent pair, but record_decision is reachable from custom
+        # policy code, and a record saying `allow` with a `modify` refinement
+        # would be hash-chained evidence that contradicts itself. That is the
+        # exact failure the coarse/fine split exists to prevent, so an
+        # unrecognised or mismatched refinement is dropped with a warning
+        # rather than recorded: `decision` is the authoritative field and it
+        # stays true either way.
+        if decision_detail:
+            claimed = str(decision_detail).strip().lower()
+            projects_to = FINE_TO_COARSE.get(claimed)
+            if claimed not in REFINEMENTS or projects_to != decision:
+                logger.warning(
+                    "record_decision: decision_detail=%r does not refine "
+                    "decision=%r for action_id=%s; recording the decision "
+                    "without it",
+                    decision_detail, decision, action_id,
+                )
+                decision_detail = None
+                modified_parameters = None
+
+        # Proposed arguments only mean something alongside a modify. Anywhere
+        # else they are arguments nobody decided on.
+        if modified_parameters and decision_detail != "modify":
+            logger.warning(
+                "record_decision: modified_parameters supplied with "
+                "decision_detail=%r for action_id=%s; dropping them",
+                decision_detail, action_id,
+            )
+            modified_parameters = None
 
         data: dict = {
             "decision": self._cap_record_str(decision, self._MAX_DECISION_LABEL_LEN),

--- a/src/vaara/pipeline.py
+++ b/src/vaara/pipeline.py
@@ -42,6 +42,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Sequence
 
+from vaara._decision_vocabulary import FINE_TO_COARSE
 from vaara._sanitize import json_safe
 from pathlib import Path
 
@@ -120,37 +121,20 @@ _MAX_OVERRIDE_REASON_LEN = 8192
 _MAX_DECISION_LABEL_LEN = 64
 
 
-# The decision vocabulary, and the projection that keeps it from reaching
-# places that only understand three words.
+# The projection from the policy vocabulary onto the three words that are
+# recorded (see vaara._decision_vocabulary for the table and why it exists).
 #
-# AARM Core R4 asks for five decisions. The signed decision record can carry
-# three: published conformance checkers hold a closed verdict set and grade
-# anything else non-conforming, and independent parties already run those
-# checkers. So MODIFY, STEP_UP and DEFER are policy-layer names that project
-# onto the coarse three here, at the pipeline boundary.
-#
-# Projecting HERE rather than downstream is deliberate. Roughly a dozen call
-# sites across the integrations branch on `result.decision == "escalate"` or
-# `== "deny"` to decide whether to raise. A fine-grained name flowing out of
-# intercept() would miss every one of those branches and read as a fall-
-# through, which is a fail-OPEN in exactly the code paths that exist to stop
-# an action. `InterceptionResult.decision` therefore keeps returning the
-# coarse word and `decision_detail` carries the refinement for callers that
-# know to look.
-#
-# MODIFY maps to `deny` because the arguments it was asked about must not
-# run. The altered arguments come back to the caller in
-# `modified_parameters` and are resubmitted as a fresh intercept with its own
-# decision bound to its own digest. A decision record must never say `allow`
-# against arguments other than the ones that executed.
-_FINE_TO_COARSE: dict[str, str] = {
-    "allow": "allow",
-    "deny": "deny",
-    "escalate": "escalate",
-    "modify": "deny",
-    "step_up": "escalate",
-    "defer": "escalate",
-}
+# Projecting HERE, at the pipeline boundary rather than downstream, is
+# deliberate. Eleven call sites across the integrations branch on
+# `result.decision == "escalate"` or `== "deny"` to decide whether to raise:
+# langchain.py:173,181,353,361, openai_agents.py:152,159,272,278,
+# claude_code_hooks.py:376, mcp_server.py:658, _infer_proxy_gate.py:104. A
+# fine-grained name flowing out of intercept() would miss every one of those
+# branches and read as a fall-through, which is a fail-OPEN in exactly the
+# code paths that exist to stop an action. `InterceptionResult.decision`
+# therefore keeps returning the coarse word and `decision_detail` carries the
+# refinement for callers that know to look.
+_FINE_TO_COARSE = FINE_TO_COARSE
 
 # JSON-serialized bytes for a gate-proposed argument set. Same amplification
 # concern as _MAX_PARAMS_JSON_BYTES: this value is scorer-controlled, lands

--- a/src/vaara/pipeline.py
+++ b/src/vaara/pipeline.py
@@ -120,6 +120,44 @@ _MAX_OVERRIDE_REASON_LEN = 8192
 _MAX_DECISION_LABEL_LEN = 64
 
 
+# The decision vocabulary, and the projection that keeps it from reaching
+# places that only understand three words.
+#
+# AARM Core R4 asks for five decisions. The signed decision record can carry
+# three: published conformance checkers hold a closed verdict set and grade
+# anything else non-conforming, and independent parties already run those
+# checkers. So MODIFY, STEP_UP and DEFER are policy-layer names that project
+# onto the coarse three here, at the pipeline boundary.
+#
+# Projecting HERE rather than downstream is deliberate. Roughly a dozen call
+# sites across the integrations branch on `result.decision == "escalate"` or
+# `== "deny"` to decide whether to raise. A fine-grained name flowing out of
+# intercept() would miss every one of those branches and read as a fall-
+# through, which is a fail-OPEN in exactly the code paths that exist to stop
+# an action. `InterceptionResult.decision` therefore keeps returning the
+# coarse word and `decision_detail` carries the refinement for callers that
+# know to look.
+#
+# MODIFY maps to `deny` because the arguments it was asked about must not
+# run. The altered arguments come back to the caller in
+# `modified_parameters` and are resubmitted as a fresh intercept with its own
+# decision bound to its own digest. A decision record must never say `allow`
+# against arguments other than the ones that executed.
+_FINE_TO_COARSE: dict[str, str] = {
+    "allow": "allow",
+    "deny": "deny",
+    "escalate": "escalate",
+    "modify": "deny",
+    "step_up": "escalate",
+    "defer": "escalate",
+}
+
+# JSON-serialized bytes for a gate-proposed argument set. Same amplification
+# concern as _MAX_PARAMS_JSON_BYTES: this value is scorer-controlled, lands
+# on the hash chain, and goes back to the caller.
+_MAX_MODIFIED_PARAMS_JSON_BYTES = 64 * 1024
+
+
 def _cap_str(value: Any, max_len: int, field_name: str) -> str:
     """Truncate a caller-supplied string to max_len with a TRUNCATED marker.
 
@@ -215,13 +253,22 @@ class InterceptionResult:
     """Result of intercepting an action request."""
     allowed: bool
     action_id: str              # For tracking outcome later
-    decision: str               # "allow", "deny", "escalate"
+    decision: str               # "allow", "deny", "escalate" — always coarse
     risk_score: float           # Point estimate
     risk_interval: tuple[float, float]  # Conformal (lower, upper)
     reason: str
     action_type: ActionType
     signals: dict[str, float]   # Contributing risk signals
     evaluation_ms: float
+    # The AARM Core R4 refinement behind `decision`, when there is one:
+    # "modify", "step_up" or "defer". None when the decision was already
+    # one of the coarse three. `decision` stays coarse so existing callers
+    # keep working; read this when the finer answer matters.
+    decision_detail: Optional[str] = None
+    # Only set alongside decision_detail == "modify": the arguments the gate
+    # is willing to permit. The original call is denied. Resubmit these
+    # through intercept() to get a decision bound to them.
+    modified_parameters: Optional[dict] = None
 
 
 class InterceptionPipeline:
@@ -569,13 +616,45 @@ class InterceptionPipeline:
             decision_str = raw_decision.strip().lower()
         else:
             decision_str = "deny"
-        if decision_str not in ("allow", "deny", "escalate"):
+        if decision_str not in _FINE_TO_COARSE:
             logger.warning(
                 "Scorer returned unknown action=%r for action_id=%s; "
                 "failing closed to 'deny'",
                 raw_decision, action_id,
             )
             decision_str = "deny"
+
+        # 6a. Project the R4 refinements onto the coarse three. `decision_str`
+        # stays coarse from here down, so every downstream branch, audit
+        # record and integration sees a vocabulary it already understands.
+        decision_detail: Optional[str] = None
+        modified_parameters: Optional[dict] = None
+        coarse = _FINE_TO_COARSE[decision_str]
+        if coarse != decision_str:
+            decision_detail = decision_str
+            decision_str = coarse
+
+        if decision_detail == "modify":
+            # A modify that carries no modification is malformed. Fall back to
+            # a plain deny rather than a deny the caller cannot act on: the
+            # action is already blocked either way, and claiming a refinement
+            # the scorer did not supply would put a false detail on the chain.
+            raw_modified = scorer_result.get("modified_parameters")
+            if isinstance(raw_modified, dict) and raw_modified:
+                modified_parameters = _cap_dict_bytes(
+                    _json_safe_dict(raw_modified),
+                    _MAX_MODIFIED_PARAMS_JSON_BYTES,
+                    "modified_parameters",
+                )
+            else:
+                logger.warning(
+                    "Scorer returned action='modify' without usable "
+                    "modified_parameters (%r) for action_id=%s; recording a "
+                    "plain deny",
+                    type(raw_modified).__name__, action_id,
+                )
+                decision_detail = None
+
         allowed = decision_str == "allow"
         reason = scorer_result.get("reason", "")
         if not isinstance(reason, str):
@@ -592,6 +671,11 @@ class InterceptionPipeline:
         if attenuation_reason is not None:
             decision_str = "deny"
             allowed = False
+            # Attenuation outranks whatever the scorer proposed. A refinement
+            # left in place here would describe a decision that no longer
+            # applies, and a modification the caller must not retry.
+            decision_detail = None
+            modified_parameters = None
             reason = _cap_str(
                 f"privilege attenuation violation ({attenuation_reason})"
                 + (f"; {reason}" if reason else ""),
@@ -619,13 +703,21 @@ class InterceptionPipeline:
             if prior is not None:
                 decision_str = "allow"
                 allowed = True
+                # The recorded decision is now `allow`; a leftover step_up or
+                # defer detail would contradict the word next to it.
+                decision_detail = None
                 reason = _cap_str(
                     f"auto-allowed by prior approval "
                     f"(action_id={prior.action_id}, {prior.timestamp})",
                     _MAX_DECISION_REASON_LEN, "reason",
                 )
 
-        # 8. Record the decision in audit
+        # 8. Record the decision in audit. `decision` stays inside the
+        # documented allow/escalate/deny enum; the refinement and any
+        # proposed arguments ride along as additional keys, which the 1.0
+        # data-payload schema explicitly permits (consumers MUST accept
+        # unknown keys). A record with no refinement gains no keys, so
+        # every existing record hashes exactly as it did before.
         self.trail.record_decision(
             action_id=action_id,
             agent_id=agent_id,
@@ -634,6 +726,8 @@ class InterceptionPipeline:
             reason=reason,
             risk_score=point_estimate,
             regulatory_domains=action_type.regulatory_domains,
+            decision_detail=decision_detail,
+            modified_parameters=modified_parameters,
         )
 
         if decision_str == "escalate":
@@ -744,6 +838,8 @@ class InterceptionPipeline:
             action_type=action_type,
             signals=signals,
             evaluation_ms=elapsed_ms,
+            decision_detail=decision_detail,
+            modified_parameters=modified_parameters,
         )
 
     def report_outcome(

--- a/src/vaara/scorer/adaptive.py
+++ b/src/vaara/scorer/adaptive.py
@@ -74,10 +74,28 @@ def _coerce_optional_unit_float(value: Any) -> Optional[float]:
 # ── Decision types ────────────────────────────────────────────────────────
 
 class Decision(str, Enum):
-    """Scorer decision — allow, deny, or escalate for human review."""
+    """Scorer decision.
+
+    ALLOW, DENY and ESCALATE are the coarse vocabulary and they are frozen.
+    Published conformance checkers hold a closed verdict set (see
+    ``tests/vectors/record_set_v0/_check_independent.py``) and grade any
+    other value non-conforming, and independent parties already run those
+    checkers against pinned commits. Renaming one of these three is a
+    wire-format break dressed up as a refactor.
+
+    MODIFY, STEP_UP and DEFER are the AARM Core R4 refinements. They are
+    policy-layer names: each projects onto one of the coarse three at the
+    pipeline boundary (``vaara.pipeline._FINE_TO_COARSE``) and again at the
+    receipt boundary (``vaara.audit.receipts._VERDICT_TO_WIRE``). None of
+    them is permissive on its own, which is what keeps ``allowed`` a
+    single-meaning bool for every existing relying party.
+    """
     ALLOW = "allow"
     DENY = "deny"
     ESCALATE = "escalate"  # Human review required
+    MODIFY = "modify"      # Only with altered arguments; blocks, then retry
+    STEP_UP = "step_up"    # Only after stronger authentication; a hold
+    DEFER = "defer"        # Not now, possibly later; a hold
 
 
 @dataclass
@@ -133,7 +151,14 @@ class RiskAssessment:
                 )
 
     def to_backend_decision(self) -> dict:
-        """Convert to a plain decision dict (allowed/action/reason/backend)."""
+        """Convert to a plain decision dict (allowed/action/reason/backend).
+
+        ``allowed`` is True for ALLOW and nothing else, including the three
+        R4 refinements: MODIFY, STEP_UP and DEFER are all holds at the moment
+        the gate returns. The pipeline re-derives this bool from the decision
+        string anyway (see ``vaara.pipeline`` step 6) and does not trust the
+        value here, so the two must not be allowed to drift apart.
+        """
         return {
             "allowed": self.decision == Decision.ALLOW,
             "action": self.decision.value,

--- a/tests/test_decision_vocabulary.py
+++ b/tests/test_decision_vocabulary.py
@@ -1,0 +1,258 @@
+"""The five-light decision vocabulary and its projection onto the wire.
+
+AARM Core R4 asks for ALLOW, DENY, MODIFY, STEP_UP and DEFER. The signed
+decision record cannot carry five: published conformance checkers hold a
+closed set of ``{allow, block, escalate}`` and grade anything else
+non-conforming, and six independent parties already run those checkers.
+
+So the refinements live in the policy layer and project down. These tests pin
+both halves: the new names exist and behave, and nothing that reaches the
+chain or an existing integration changed shape.
+"""
+
+import pytest
+
+from vaara.audit.receipts import _verdict_to_wire
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.pipeline import _FINE_TO_COARSE, InterceptionPipeline
+from vaara.scorer.adaptive import Decision, RiskAssessment
+
+
+class _FixedScorer:
+    """Scorer stub returning one fixed decision dict."""
+
+    def __init__(self, action: str, **extra) -> None:
+        self._payload = {
+            "action": action,
+            "reason": f"stub {action}",
+            "raw_result": {
+                "point_estimate": 0.5,
+                "conformal_interval": [0.4, 0.6],
+                "signals": {},
+            },
+            **extra,
+        }
+
+    def evaluate(self, context):
+        return dict(self._payload)
+
+
+def _pipeline(scorer):
+    backend = SQLiteAuditBackend(":memory:")
+    trail = backend.load_trail()
+    trail._on_record = backend.write_record
+    return InterceptionPipeline(trail=trail, scorer=scorer)
+
+
+def _decision_record(pipeline, action_id):
+    for record in pipeline.trail.get_action_trail(action_id):
+        if "decision" in (record.data or {}):
+            return record
+    raise AssertionError("no decision record on the trail")
+
+
+# ── The enum ──────────────────────────────────────────────────────────────
+
+def test_the_three_published_values_are_unchanged():
+    """These strings are on other people's disks. They do not move."""
+    assert Decision.ALLOW.value == "allow"
+    assert Decision.DENY.value == "deny"
+    assert Decision.ESCALATE.value == "escalate"
+
+
+def test_r4_refinements_exist():
+    assert Decision.MODIFY.value == "modify"
+    assert Decision.STEP_UP.value == "step_up"
+    assert Decision.DEFER.value == "defer"
+
+
+def test_enum_has_exactly_six_members():
+    assert len(Decision) == 6
+
+
+@pytest.mark.parametrize("decision", list(Decision))
+def test_allowed_is_true_for_allow_and_nothing_else(decision):
+    """The one rule every relying party already knows, kept intact."""
+    assessment = RiskAssessment(
+        action_name="t", agent_id="a", point_estimate=0.5,
+        conformal_lower=0.4, conformal_upper=0.6, decision=decision,
+        signals={}, mwu_weights={}, threshold_allow=0.4, threshold_deny=0.7,
+        sequence_risk=0.0, calibration_size=0,
+    )
+    backend = assessment.to_backend_decision()
+    assert backend["allowed"] is (decision is Decision.ALLOW)
+    assert backend["action"] == decision.value
+
+
+# ── The projection ────────────────────────────────────────────────────────
+
+def test_coarse_names_project_to_themselves():
+    assert _FINE_TO_COARSE["allow"] == "allow"
+    assert _FINE_TO_COARSE["deny"] == "deny"
+    assert _FINE_TO_COARSE["escalate"] == "escalate"
+
+
+def test_refinements_project_onto_the_coarse_three():
+    assert _FINE_TO_COARSE["step_up"] == "escalate"
+    assert _FINE_TO_COARSE["defer"] == "escalate"
+    assert _FINE_TO_COARSE["modify"] == "deny"
+
+
+def test_every_enum_member_has_a_projection():
+    for decision in Decision:
+        assert decision.value in _FINE_TO_COARSE
+
+
+def test_wire_projection_covers_the_refinements():
+    """receipts._VERDICT_TO_WIRE is the second, independent projection."""
+    assert _verdict_to_wire("step_up") == "escalate"
+    assert _verdict_to_wire("defer") == "escalate"
+    assert _verdict_to_wire("modify") == "block"
+    # And the ones that were already there.
+    assert _verdict_to_wire("deny") == "block"
+    assert _verdict_to_wire("escalate") == "escalate"
+    assert _verdict_to_wire("allow") == "allow"
+
+
+# ── Through the pipeline ──────────────────────────────────────────────────
+
+def test_step_up_holds_the_action_and_reads_as_escalate():
+    pipeline = _pipeline(_FixedScorer("step_up"))
+    result = pipeline.intercept(agent_id="a", tool_name="tx.sign")
+
+    assert result.allowed is False
+    assert result.decision == "escalate"      # what old integrations see
+    assert result.decision_detail == "step_up"  # what R4 asks for
+
+
+def test_defer_holds_the_action_and_reads_as_escalate():
+    pipeline = _pipeline(_FixedScorer("defer"))
+    result = pipeline.intercept(agent_id="a", tool_name="tx.sign")
+
+    assert result.allowed is False
+    assert result.decision == "escalate"
+    assert result.decision_detail == "defer"
+
+
+def test_modify_blocks_the_original_and_hands_back_the_change():
+    pipeline = _pipeline(_FixedScorer(
+        "modify", modified_parameters={"amount": 5000},
+    ))
+    result = pipeline.intercept(
+        agent_id="a", tool_name="tx.transfer", parameters={"amount": 50000},
+    )
+
+    assert result.allowed is False
+    assert result.decision == "deny"          # the original never runs
+    assert result.decision_detail == "modify"
+    assert result.modified_parameters == {"amount": 5000}
+
+
+def test_modify_without_a_modification_fails_closed_to_plain_deny():
+    """A scorer saying 'modify' but supplying nothing is malformed."""
+    pipeline = _pipeline(_FixedScorer("modify"))
+    result = pipeline.intercept(agent_id="a", tool_name="tx.transfer")
+
+    assert result.allowed is False
+    assert result.decision == "deny"
+    assert result.decision_detail is None
+    assert result.modified_parameters is None
+
+
+def test_modify_with_a_non_dict_modification_fails_closed():
+    pipeline = _pipeline(_FixedScorer("modify", modified_parameters=["nope"]))
+    result = pipeline.intercept(agent_id="a", tool_name="tx.transfer")
+
+    assert result.decision == "deny"
+    assert result.decision_detail is None
+
+
+def test_unknown_decision_still_fails_closed():
+    """Regression: the fail-closed invariant predates this vocabulary."""
+    pipeline = _pipeline(_FixedScorer("maybe"))
+    result = pipeline.intercept(agent_id="a", tool_name="tx.sign")
+
+    assert result.allowed is False
+    assert result.decision == "deny"
+    assert result.decision_detail is None
+
+
+def test_plain_decisions_carry_no_detail():
+    pipeline = _pipeline(_FixedScorer("allow"))
+    result = pipeline.intercept(agent_id="a", tool_name="data.read")
+
+    assert result.allowed is True
+    assert result.decision == "allow"
+    assert result.decision_detail is None
+
+
+# ── What lands on the chain ───────────────────────────────────────────────
+
+def test_the_chain_records_the_coarse_decision():
+    """data.decision stays inside the documented allow/escalate/deny enum."""
+    pipeline = _pipeline(_FixedScorer("step_up"))
+    result = pipeline.intercept(agent_id="a", tool_name="tx.sign")
+
+    record = _decision_record(pipeline, result.action_id)
+    assert record.data["decision"] == "escalate"
+
+
+def test_the_chain_also_records_the_refinement():
+    """Unknown keys are permitted by the 1.0 schema, so the detail is evidence."""
+    pipeline = _pipeline(_FixedScorer("defer"))
+    result = pipeline.intercept(agent_id="a", tool_name="tx.sign")
+
+    record = _decision_record(pipeline, result.action_id)
+    assert record.data["decision_detail"] == "defer"
+
+
+def test_a_plain_decision_record_gains_no_new_keys():
+    """Existing records must stay byte-identical, or every hash moves."""
+    pipeline = _pipeline(_FixedScorer("allow"))
+    result = pipeline.intercept(agent_id="a", tool_name="data.read")
+
+    record = _decision_record(pipeline, result.action_id)
+    assert set(record.data) == {"decision", "reason", "risk_score"}
+
+
+def test_modify_records_what_it_proposed():
+    pipeline = _pipeline(_FixedScorer(
+        "modify", modified_parameters={"amount": 5000},
+    ))
+    result = pipeline.intercept(
+        agent_id="a", tool_name="tx.transfer", parameters={"amount": 50000},
+    )
+
+    record = _decision_record(pipeline, result.action_id)
+    assert record.data["decision"] == "deny"
+    assert record.data["decision_detail"] == "modify"
+    assert record.data["modified_parameters"] == {"amount": 5000}
+
+
+# ── The re-decision loop, which is the point of shape (a) ─────────────────
+
+def test_the_retry_is_a_separate_decision_bound_to_its_own_arguments():
+    """No approval is ever bound to arguments other than the ones that ran."""
+    scorer = _FixedScorer("modify", modified_parameters={"amount": 5000})
+    pipeline = _pipeline(scorer)
+
+    first = pipeline.intercept(
+        agent_id="a", tool_name="tx.transfer", parameters={"amount": 50000},
+    )
+    assert first.allowed is False
+
+    # The caller resubmits what the gate proposed. Fresh scorer verdict.
+    pipeline.scorer = _FixedScorer("allow")
+    second = pipeline.intercept(
+        agent_id="a", tool_name="tx.transfer",
+        parameters=first.modified_parameters,
+        parent_action_id=first.action_id,
+    )
+
+    assert second.allowed is True
+    assert second.action_id != first.action_id
+
+    blocked = _decision_record(pipeline, first.action_id)
+    permitted = _decision_record(pipeline, second.action_id)
+    assert blocked.data["decision"] == "deny"
+    assert permitted.data["decision"] == "allow"

--- a/tests/test_decision_vocabulary.py
+++ b/tests/test_decision_vocabulary.py
@@ -233,6 +233,72 @@ def test_modify_records_what_it_proposed():
 
 # ── The re-decision loop, which is the point of shape (a) ─────────────────
 
+def test_the_trail_refuses_a_refinement_that_contradicts_its_decision():
+    """record_decision is reachable from custom policy code, not just here."""
+    pipeline = _pipeline(_FixedScorer("allow"))
+    pipeline.trail.record_decision(
+        action_id="a-1", agent_id="a", tool_name="tx.transfer",
+        decision="allow", reason="", risk_score=0.1,
+        decision_detail="modify", modified_parameters={"amount": 1},
+    )
+
+    record = _decision_record(pipeline, "a-1")
+    assert record.data["decision"] == "allow"
+    assert "decision_detail" not in record.data
+    assert "modified_parameters" not in record.data
+
+
+def test_the_trail_refuses_an_unknown_refinement():
+    pipeline = _pipeline(_FixedScorer("allow"))
+    pipeline.trail.record_decision(
+        action_id="a-2", agent_id="a", tool_name="tx.sign",
+        decision="escalate", reason="", risk_score=0.5,
+        decision_detail="probably",
+    )
+
+    record = _decision_record(pipeline, "a-2")
+    assert record.data["decision"] == "escalate"
+    assert "decision_detail" not in record.data
+
+
+def test_the_trail_refuses_a_coarse_word_as_a_refinement():
+    """`escalate` explains nothing about `escalate`."""
+    pipeline = _pipeline(_FixedScorer("allow"))
+    pipeline.trail.record_decision(
+        action_id="a-3", agent_id="a", tool_name="tx.sign",
+        decision="escalate", reason="", risk_score=0.5,
+        decision_detail="escalate",
+    )
+
+    assert "decision_detail" not in _decision_record(pipeline, "a-3").data
+
+
+def test_the_trail_drops_proposed_arguments_without_a_modify():
+    pipeline = _pipeline(_FixedScorer("allow"))
+    pipeline.trail.record_decision(
+        action_id="a-4", agent_id="a", tool_name="tx.sign",
+        decision="escalate", reason="", risk_score=0.5,
+        decision_detail="step_up", modified_parameters={"amount": 1},
+    )
+
+    record = _decision_record(pipeline, "a-4")
+    assert record.data["decision_detail"] == "step_up"
+    assert "modified_parameters" not in record.data
+
+
+def test_the_trail_keeps_a_consistent_refinement():
+    pipeline = _pipeline(_FixedScorer("allow"))
+    pipeline.trail.record_decision(
+        action_id="a-5", agent_id="a", tool_name="tx.transfer",
+        decision="deny", reason="", risk_score=0.9,
+        decision_detail="modify", modified_parameters={"amount": 5000},
+    )
+
+    record = _decision_record(pipeline, "a-5")
+    assert record.data["decision_detail"] == "modify"
+    assert record.data["modified_parameters"] == {"amount": 5000}
+
+
 def test_the_retry_is_a_separate_decision_bound_to_its_own_arguments():
     """No approval is ever bound to arguments other than the ones that ran."""
     scorer = _FixedScorer("modify", modified_parameters={"amount": 5000})

--- a/tests/test_decision_vocabulary.py
+++ b/tests/test_decision_vocabulary.py
@@ -99,7 +99,9 @@ def test_refinements_project_onto_the_coarse_three():
 
 
 def test_every_enum_member_has_a_projection():
-    for decision in Decision:
+    # list(Decision) rather than iterating the class directly: CodeQL does not
+    # model EnumMeta.__iter__ and reports py/non-iterable-in-for-loop.
+    for decision in list(Decision):
         assert decision.value in _FINE_TO_COARSE
 
 


### PR DESCRIPTION
AARM Core R4 asks for five decisions: `ALLOW`, `DENY`, `MODIFY`, `STEP_UP`, `DEFER`. Vaara had three.

## Why this is not a rename

The signed decision record's verdict enum is a closed set of three, and it is closed inside checkers that other people already hold and run. `tests/vectors/record_set_v0/_check_independent.py` grades a record carrying any other verdict as non-conforming. Renaming `escalate` to `step_up` would have invalidated published vectors and made the scoping text of results rows nobody can edit become false.

So the refinements are policy-layer names that project onto the coarse three, in the same table shape that already maps `deny` to `block` and `review` and `refer` to `escalate`.

| Policy decision | Recorded | Why |
|---|---|---|
| `step_up` | `escalate` | a hold, pending stronger authentication |
| `defer` | `escalate` | a hold, possibly permitted later |
| `modify` | `deny` | the arguments it was asked about do not run |

## What modify does

When a policy proposes different arguments they come back on `InterceptionResult.modified_parameters`. The caller resubmits, and that resubmission is scored and recorded on its own. Two records, both true, each bound to the arguments it actually decided.

No decision record ever says `allow` against arguments other than the ones that executed.

A `modify` that carries no usable modification is malformed and falls back to a plain deny rather than putting a refinement on the chain that the scorer did not supply.

## Where the projection happens, and why it matters

At the pipeline boundary, not downstream. Around a dozen call sites across the framework integrations branch on `result.decision == "escalate"` or `== "deny"` to decide whether to raise. A finer word arriving there would have missed every one of those branches and read as a fall-through, which is a fail-open in precisely the code that exists to stop an action.

`InterceptionResult.decision` keeps returning the coarse word. `decision_detail` carries the refinement for callers that know to look. No integration needed editing.

`allowed` is still true for `allow` and nothing else. All three new decisions are holds at the moment the gate returns.

## Audit records

`decision_made` records gain `decision_detail` and, for a modify, `modified_parameters`. Both keys are omitted when absent, so a record written without a refinement is byte-identical to one written before the vocabulary existed and its hash does not move. `decision` itself stays inside the documented three-value enum, and the 1.0 data-payload schema already requires consumers to accept unknown keys.

## Verification

- 3412 passed, 26 skipped
- 46 conformance suites: 45 passed, 0 failed, 1 skipped, unchanged
- ruff clean
- 25 new tests in `tests/test_decision_vocabulary.py`, including the fail-closed paths and the re-decision loop

## Not in this change

The conformance lane that would pin the projection as a published vector suite. A vector suite is permanent once outside parties pin it, so it goes out on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refined policy decisions for modifying arguments, requesting additional approval, or deferring execution.
  * Exposed decision details and replacement parameters in interception results.
  * Added optional audit information for decision details and modified parameters.

* **Bug Fixes**
  * Invalid or incomplete modifications now fail safely as denials.
  * Preserved backward-compatible audit serialization and coarse decision reporting.

* **Documentation**
  * Updated audit schema and changelog with decision mappings and resubmission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->