### PR TITLE
A gate that offers five decisions has to answer a question the claim does not: when the policy said something finer than allow, deny or escalate, what did the permanent record end up saying. MODIFY, STEP_UP and DEFER join the vocabulary and none of them reach the signed record, because the record's verdict enum is a closed set of three and it is closed inside a checker this repository publishes for outside parties to run. The refinements project onto the coarse three instead, in the table shape that already maps deny to block. No decision record ever says allow against arguments other than the ones that executed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.78.0] - 2026-08-27
+
 ### Added
 
 - `MODIFY`, `STEP_UP` and `DEFER` join `ALLOW`, `DENY` and `ESCALATE`, which covers the decision vocabulary the AARM Core registry asks for under R4. That registry names five and `Decision` now has six, because `ESCALATE` stays exactly as it was and `STEP_UP` and `DEFER` refine it rather than replace it.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.77.0"
+appVersion: "1.78.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.77.0, Helm chart 0.1.0.
+Vaara 1.78.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.77.0"
+version = "1.78.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.77.0",
+  "version": "1.78.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.77.0",
+"version": "1.78.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.77.0",
+  "version": "1.78.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.77.0",
+"version": "1.78.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.77.0"
+__version__ = "1.78.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Five commits since 1.77.0. Two of them widen what a record can rest on, one anchors the log itself, and the corpus grows from 46 suites to 48.

## Five decisions, projected onto the three the wire already carries

`MODIFY`, `STEP_UP` and `DEFER` join `ALLOW`, `DENY` and `ESCALATE`, which covers the decision vocabulary the AARM Core registry asks for under R4.

None of the three new names reaches the signed decision record. That is deliberate. The record's verdict enum is a closed set of three, and it is closed inside a checker this repository publishes for outside parties to run, so renaming `escalate` to `step_up` would have invalidated published vectors and made the scoping text of results rows that cannot be edited become false.

`STEP_UP` and `DEFER` are holds and record `escalate`. `MODIFY` records `deny`, because the arguments it was asked about do not run. When a policy proposes different arguments they come back on `InterceptionResult.modified_parameters`, the caller resubmits, and that resubmission is scored and recorded on its own. Two records, both true, each bound to the arguments it actually decided.

Eleven call sites across the framework integrations branch on `decision == "escalate"` or `== "deny"` to decide whether to raise. A finer word arriving there would have missed every one of those branches and read as a fall-through, which is a fail-open in precisely the code that exists to stop an action.

## A grant can carry a qualified attestation of attributes

Every actor claim on a record today is self-asserted. `asserted.iss` and `.sub` are strings the issuer writes about itself, and a verifier can check the signature and recompute the args commitment without ever being able to check that the issuer is the organisation it names.

A qualified electronic attestation of attributes is an eIDAS trust service. A supervised, audited provider attests an attribute of a subject, and an organisation cannot issue one about itself by construction, so that one claim comes to rest on a public register rather than on the producer's word.

`mandate` is optional and adds nothing to the signed preimage when absent, so a grant minted without one signs exactly the bytes it signed before the field existed. Every published grant vector still verifies. Resolving the provider against the EU trusted lists is the next piece and is not in this release.

## A trail head, published where a stranger can check it only ever grew

HCS-27 anchors an append-only log to a Hedera Consensus Service topic by publishing periodic Merkle checkpoints, and it states plainly that it does not define log entry schemas. HCS-27 supplies the commitment that a log only ever grew. Vaara supplies the record saying a specific act was permitted, by whom, under what scope.

There is no Merkle implementation in the new module, because `vaara.attestation.transparency_log` already was one and is byte-identical to the HCS-27 Merkle v1 profile. Established by running the upstream `standards-sdk/src/hcs-27/merkle.ts` against it, not by reading it:

- Roots agree for every tree size 0 to 64, and at every power-of-two boundary to 1025. No mismatches.
- 110 Vaara proofs verify unmodified in the upstream `verifyInclusionProof` and `verifyConsistencyProof`.
- Both checkpoint messages and all eight proofs pass the upstream zod schemas.

`ensure_ascii=False` is load-bearing. The leaf preimage is JCS, and Python's default escapes every umlaut to `\uXXXX`, yielding a leaf hash no other implementation reproduces. Finnish text makes that a certainty rather than an edge case.

The entry carries identity and `recordHash`, not the payload and not the compliance attribution. Both stay committed through `recordHash`, so anyone holding the record can still prove what was in it while a public topic carries neither.

Two limits are recorded rather than routed around. `metadata.type` is typed as a single literal upstream, so a standard that delegates entry schemas to consuming profiles gives a second profile no way to name itself. HCS-1 overflow inscription is not implemented, because a checkpoint measures 461 bytes against Hedera's 1024-byte cap.

## The corpus grows from 46 suites to 48

`decision_vocabulary_v0`, thirteen cases. Eight are what Vaara produces, generated by driving the real pipeline rather than written to match the checker. Four are committed as non-conforming: the refinement used as the verdict itself, `allow` standing beside a `modify`, a retry claiming a modify as its parent while carrying the arguments that modify refused, and a decision reason edited after the fact. The fifth adversarial case is a modify nobody retried, which is advisory and still conforms, because a caller is allowed to give up.

A corpus where nothing ever fails says nothing about whether the checker can tell.

`hcs27_checkpoint_v0`, seven hash-chained records. Seven is not a power of two, so the tree is lopsided and the two constructions diverge in shape while agreeing on the root. The checker builds every primitive the opposite way round from the way Vaara builds it: the root by recursive top-down split, the inclusion proof by the RFC 9162 bit walk, the record hash re-implemented from the documented field list. Producer and checker share no code and no method.

Both checkers import no Vaara.

## Documentation

Walking the EU trusted lists on 2026-08-26 finds two granted EAA/Q services, Microsec (HU) and IDnow Trust Services AB (SE), where a walk three weeks earlier found one. The Portuguese list did not respond, so two is a floor rather than a ceiling. The count moved inside three weeks, so the document now says to re-walk before repeating any count.

The qualified attestation spec also gains a state of implementation section, because the design had been settled for a while and none of it was built.

## Verification

- 3471 tests pass, 26 skipped.
- 47 passed, 0 failed, 1 skipped, 88 cases across 48 suites.
- No breaking change. Every published vector from earlier releases still verifies.
