### PR TITLE
A checkpoint on a live topic, and a checker that needs nothing to read it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ scitt = ["cbor2>=5.4", "cryptography>=41.0"]
 proxy = ["fastapi>=0.110", "uvicorn>=0.29", "httpx>=0.27"]
 llm-proxy = ["fastapi>=0.110", "uvicorn>=0.29", "httpx[http2]>=0.27"]
 pq = ["dilithium-py>=1.4.0"]
+# Only scripts/hcs27_publish.py needs this. vaara.audit.hcs27 builds and
+# verifies checkpoints with the standard library alone, so a machine with no
+# SDK and no Hedera account can still do everything except submit.
+hedera = ["hiero-sdk-python>=0.2.10"]
 pdf = ["reportlab>=4.0"]
 bedrock = ["boto3>=1.34"]
 azure-content-safety = ["azure-ai-contentsafety>=1.0"]

--- a/scripts/demo_mcp_guardian.py
+++ b/scripts/demo_mcp_guardian.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Vaara as the guardian in front of an MCP agent, anchored to Hedera.
+
+The demo this exists to give: an agent asks to do a series of things, Vaara
+decides each one, the decisions become a hash-chained trail, and the head of
+that trail is committed to a public Hedera topic as an HCS-27 checkpoint.
+A stranger then reads the topic and checks what the agent was allowed to do,
+without installing Vaara and without trusting anyone who ran it.
+
+    scripts/demo_mcp_guardian.py --topic-id 0.0.NNNNN
+
+Run it with `--offline` to do everything except the ledger submit, which is
+the version that works on a machine with no account.
+
+Why this composes with HCS-27 rather than duplicating it
+---------------------------------------------------------
+The Hedera Agent Kit already governs value movement: spend caps, recipient
+allowlists, time windows, enforced by smart contract. Its own tracker (issue
+#1001, open since July) says even that is unfinished, and it has no notion of
+tool scope, argument content, or a decision reason.
+
+Vaara governs the act. Most of what an agent does is not a payment, and a
+transaction history cannot record a tool call that was refused, because a
+refused call never becomes a transaction. That absence is the whole problem:
+the actions worth auditing are exactly the ones that left no trace on chain.
+
+So the checkpoint commits to decisions, including the denials, and HCS-27
+supplies the append-only commitment underneath. The two do not overlap.
+
+Chaining
+--------
+Every checkpoint after the first carries `prev`, the last accepted
+(treeSize, rootHashB64u). That state lives in `.shared/hedera/` and is not in
+the repository, because it is per-deployment and not per-checkout. Losing it
+does not lose the trail; it means the next checkpoint has to be re-linked by
+reading the last one back off the topic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+STATE = REPO / ".shared" / "hedera" / "checkpoint-state.json"
+
+#: What an agent connected through an MCP proxy actually asks for. Ordinary
+#: work first, then the ones that should not go through.
+#:
+#: Every name here is checked against `create_default_registry()`, which knows
+#: 23 action types. That check is not cosmetic: an unregistered name classifies
+#: as `unknown` with a local blast radius and scores LOW, so a demo built on a
+#: made-up tool name would show Vaara waving through the very thing it exists
+#: to catch. The first draft of this file did exactly that with a plausible
+#: looking `id.credential.issue`, which is not an action Vaara knows.
+CALLS: list[tuple[str, dict[str, Any]]] = [
+    ("data.read", {"resource": "customer_records", "count": 25}),
+    ("data.read", {"table": "orders", "filter": "status=open"}),
+    ("tx.transfer", {"amount": 25.0, "currency": "EUR", "to": "supplier_a"}),
+    ("data.export", {"resource": "customer_records", "destination": "s3://vendor-bucket", "count": 50000}),
+    ("tx.transfer", {"amount": 250000.0, "currency": "EUR", "to": "unknown_account"}),
+    ("id.grant_permission", {"subject": "contractor_9", "scope": "admin", "role": "root"}),
+    ("data.read", {"resource": "public_catalogue", "count": 3}),
+]
+
+AGENT = "mcp-agent-demo"
+
+
+def _load_state(topic_id: str) -> dict[str, Any]:
+    if not STATE.exists():
+        return {}
+    return json.loads(STATE.read_text(encoding="utf-8")).get(topic_id, {})
+
+
+def _save_state(topic_id: str, tree_size: int, root_b64u: str) -> None:
+    all_state = {}
+    if STATE.exists():
+        all_state = json.loads(STATE.read_text(encoding="utf-8"))
+    all_state[topic_id] = {"treeSize": tree_size, "rootHashB64u": root_b64u}
+    STATE.parent.mkdir(parents=True, exist_ok=True)
+    STATE.write_text(json.dumps(all_state, indent=2) + "\n", encoding="utf-8")
+
+
+def run_agent(db_path: Path) -> tuple[Any, list[Any]]:
+    """Drive the real pipeline against a trail that survives between runs.
+
+    The trail is deliberately persistent. An in-memory trail would make every
+    run produce a fresh log of the same length, and successive checkpoints
+    would then publish different roots at the same ``treeSize``: a log that was
+    replaced rather than extended, which is precisely the failure
+    ``hcs27_mirror_check.py`` exists to catch. It caught this script's first
+    version doing it.
+    """
+    from vaara.audit.sqlite_backend import SQLiteAuditBackend
+    from vaara.pipeline import InterceptionPipeline
+
+    from vaara.taxonomy.actions import create_default_registry
+
+    registry = create_default_registry()
+    unknown = [t for t, _ in CALLS if registry.classify(t, {}).name == "unknown"]
+    if unknown:
+        raise SystemExit(
+            "refusing to run: these tool names are not in the taxonomy and would "
+            f"classify as 'unknown', which scores low and allows: {sorted(set(unknown))}"
+        )
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    trail = SQLiteAuditBackend(str(db_path)).load_trail()
+    pipeline = InterceptionPipeline(trail=trail)
+
+    before = len(trail.snapshot())
+    print(f"trail before this run: {before} records ({db_path.name})\n")
+    print("The agent asks. Vaara answers.\n")
+    print(f"  {'TOOL':<26} {'DECISION':<10} {'DETAIL':<10} WHY")
+    print(f"  {'-' * 26} {'-' * 10} {'-' * 10} {'-' * 34}")
+
+    for tool, params in CALLS:
+        result = pipeline.intercept(
+            agent_id=AGENT, tool_name=tool, parameters=params, session_id="demo-1"
+        )
+        detail = getattr(result, "decision_detail", None) or ""
+        reason = (getattr(result, "reason", "") or "")[:34]
+        mark = "ok " if result.allowed else "STOP"
+        print(f"  {mark} {tool:<22} {result.decision:<10} {detail:<10} {reason}")
+
+    return trail, trail.snapshot()
+
+
+def build_checkpoint(records: list[Any], topic_id: str, memo: str) -> tuple[dict, list, bytes]:
+    from vaara.audit.hcs27 import checkpoint_for_records
+
+    prev = _load_state(topic_id)
+    prev_size = prev.get("treeSize")
+    prev_root = None
+    if prev_size is not None:
+        import base64
+
+        padding = "=" * (-len(prev["rootHashB64u"]) % 4)
+        prev_root = base64.urlsafe_b64decode(prev["rootHashB64u"] + padding)
+
+    return checkpoint_for_records(
+        records,
+        registry="vaara",
+        log_id="mcp-guardian",
+        prev_tree_size=prev_size,
+        prev_root_hash=prev_root,
+        memo=memo,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--topic-id", default="0.0.10245892")
+    parser.add_argument(
+        "--reset", action="store_true",
+        help="delete the persistent demo trail and start the log over",
+    )
+    parser.add_argument("--network", default="testnet")
+    parser.add_argument(
+        "--offline", action="store_true", help="do everything except the ledger submit"
+    )
+    args = parser.parse_args()
+
+    if args.reset:
+        for f in (REPO / ".shared" / "hedera").glob("mcp-guardian-trail.db*"):
+            f.unlink()
+        print("reset: removed the persistent demo trail\n")
+
+    print("=" * 72)
+    print("VAARA AS MCP GUARDIAN, ANCHORED TO HEDERA")
+    print("=" * 72)
+    print()
+
+    db_path = REPO / ".shared" / "hedera" / "mcp-guardian-trail.db"
+    trail, records = run_agent(db_path)
+
+    print()
+    print(f"  trail: {len(records)} records, chain intact: {trail.chain_intact}")
+    print()
+
+    memo = f"vaara mcp guardian, {len(records)} records"
+    message, entries, root = build_checkpoint(records, args.topic_id, memo)
+
+    from vaara.audit.hcs27 import b64u, message_bytes
+
+    payload = message_bytes(message)
+    root_b64u = b64u(root)
+
+    print("-" * 72)
+    print("CHECKPOINT")
+    print("-" * 72)
+    print(f"  entries    {len(entries)}")
+    print(f"  treeSize   {message['metadata']['root']['treeSize']}")
+    print(f"  root       {root_b64u}")
+    prev = message["metadata"].get("prev")
+    print(f"  prev       {prev['treeSize'] + ' / ' + prev['rootHashB64u'] if prev else 'genesis'}")
+    print(f"  bytes      {len(payload)}")
+    print()
+
+    if args.offline:
+        print("OFFLINE: not submitted. The bytes that would go on the ledger:")
+        print()
+        print(payload.decode("utf-8"))
+        return 0
+
+    import importlib.util as u
+
+    spec = u.spec_from_file_location("pub", str(REPO / "scripts" / "hcs27_publish.py"))
+    pub = u.module_from_spec(spec)
+    spec.loader.exec_module(pub)
+
+    from hiero_sdk_python import TopicId, TopicMessageSubmitTransaction
+
+    client, _key, network, operator = pub._client()
+    receipt = TopicMessageSubmitTransaction(
+        topic_id=TopicId.from_string(args.topic_id), message=payload
+    ).execute(client)
+
+    print("-" * 72)
+    print("SUBMITTED")
+    print("-" * 72)
+    print(f"  network    {network}")
+    print(f"  topic      {args.topic_id}")
+    print(f"  sequence   {getattr(receipt, 'topic_sequence_number', None)}")
+    print()
+
+    _save_state(args.topic_id, len(entries), root_b64u)
+
+    entries_path = REPO / ".shared" / "hedera" / f"entries-{args.topic_id}.json"
+    entries_path.parent.mkdir(parents=True, exist_ok=True)
+    entries_path.write_text(
+        json.dumps(entries, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    print("Anyone can now check this, with no Vaara and no Hedera SDK:")
+    print()
+    print(f"  scripts/hcs27_mirror_check.py --topic-id {args.topic_id} \\")
+    print(f"      --network {network} --entries {entries_path}")
+    print()
+    print(f"  https://{network}.mirrornode.hedera.com/api/v1/topics/{args.topic_id}/messages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hcs27_mirror_check.py
+++ b/scripts/hcs27_mirror_check.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Read a Vaara checkpoint back off a Hedera topic and check it, importing nothing.
+
+This is the half that has to convince someone who trusts neither Vaara nor the
+party that published the checkpoint. It imports **no Vaara code and no Hedera
+SDK**. Standard library only, over the public mirror-node REST API, which needs
+no account, no key and no install.
+
+    scripts/hcs27_mirror_check.py --topic-id 0.0.NNNNN
+
+What it proves, stated narrowly
+-------------------------------
+1. A message exists on that topic, at a consensus timestamp the network agreed.
+2. It parses as an HCS-27 `op=register` checkpoint.
+3. The root it publishes recomputes from the entries held locally, by a Merkle
+   construction built the opposite way round from the one that produced it:
+   recursive top-down split, where Vaara folds bottom up.
+4. Successive checkpoints on the topic chain: each `prev` equals the previous
+   message's `(treeSize, rootHashB64u)`, and the tree never shrinks.
+
+What it does not prove
+----------------------
+That the entries describe anything true. A checkpoint commits to a log. It says
+nothing about whether any record inside it describes a permitted act, and
+HCS-27 does not define log entry schemas. Checking the records themselves is
+`tests/vectors/hcs27_checkpoint_v0/_check_independent.py`, which recomputes the
+hash chain.
+
+**And it does not prove append-only growth between checkpoints.** `prev`
+chaining only asserts that a checkpoint names its predecessor correctly; a
+publisher who discards a log and starts a new one still produces a chain that
+links. Two cases are caught here, a shrinking tree and a tree that stayed the
+same size while its root moved, because both are visible from the checkpoints
+alone. The general case is not: proving that the earlier tree is a prefix of
+the later one needs an RFC 9162 consistency proof, which HCS-27 serves
+off-ledger rather than in the checkpoint. The vector carries one and
+`_check_independent.py` verifies it. A verifier who needs that guarantee
+between two live checkpoints has to ask the log operator for the proof.
+
+Canonicalisation is done here with `json.dumps(sort_keys=True,
+ensure_ascii=False, separators=(",", ":"))`, which reproduces JCS exactly for
+the fixed ASCII-keyed entry shape and needs no dependency. The independence
+claim of this script is about the network read-back. The independent JCS
+implementation is exercised by the vector checker, which uses `rfc8785`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_ENTRIES = REPO / "tests" / "vectors" / "hcs27_checkpoint_v0" / "entries.json"
+
+MIRROR = {
+    "testnet": "https://testnet.mirrornode.hedera.com",
+    "previewnet": "https://previewnet.mirrornode.hedera.com",
+    "mainnet": "https://mainnet.mirrornode.hedera.com",
+}
+
+
+# --- RFC 9162, built top-down, the opposite of the way Vaara builds it -------
+
+def _hash_leaf(data: bytes) -> bytes:
+    return hashlib.sha256(b"\x00" + data).digest()
+
+
+def _hash_node(left: bytes, right: bytes) -> bytes:
+    return hashlib.sha256(b"\x01" + left + right).digest()
+
+
+def _largest_power_of_two_lt(n: int) -> int:
+    k = 1
+    while k * 2 < n:
+        k *= 2
+    return k
+
+
+def merkle_root(canonical_entries: list[bytes]) -> bytes:
+    if not canonical_entries:
+        return hashlib.sha256(b"").digest()
+    if len(canonical_entries) == 1:
+        return _hash_leaf(canonical_entries[0])
+    k = _largest_power_of_two_lt(len(canonical_entries))
+    return _hash_node(
+        merkle_root(canonical_entries[:k]), merkle_root(canonical_entries[k:])
+    )
+
+
+def jcs(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+# --- mirror node -------------------------------------------------------------
+
+def fetch_messages(network: str, topic_id: str, limit: int) -> list[dict[str, Any]]:
+    base = MIRROR[network]
+    url = f"{base}/api/v1/topics/{topic_id}/messages?limit={limit}&order=asc"
+    out: list[dict[str, Any]] = []
+    while url:
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                page = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                print(
+                    f"  topic {topic_id} has no messages on {network}, "
+                    f"or does not exist",
+                    file=sys.stderr,
+                )
+                return []
+            raise
+        out.extend(page.get("messages", []))
+        nxt = (page.get("links") or {}).get("next")
+        url = f"{base}{nxt}" if nxt else None
+        if len(out) >= limit:
+            break
+    return out
+
+
+def decode_message(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """Decode one mirror-node message into a checkpoint, or None if it is not one."""
+    chunk = raw.get("chunk_info")
+    if chunk and chunk.get("total", 1) > 1:
+        # A Vaara checkpoint is a few hundred bytes and never chunks. A chunked
+        # message on this topic came from something else, and silently
+        # reassembling it would be guessing at another producer's framing.
+        return None
+    try:
+        payload = base64.b64decode(raw["message"])
+        return json.loads(payload.decode("utf-8"))
+    except Exception:
+        return None
+
+
+# --- checks ------------------------------------------------------------------
+
+def check_topic(
+    network: str, topic_id: str, entries: list[dict[str, Any]], limit: int
+) -> int:
+    print(f"topic     {topic_id} on {network}")
+    print(f"mirror    {MIRROR[network]}")
+    print()
+
+    messages = fetch_messages(network, topic_id, limit)
+    if not messages:
+        print("FAIL: no messages on the topic")
+        return 1
+
+    local_root = b64u(merkle_root([jcs(e) for e in entries]))
+    print(f"local entries      {len(entries)}")
+    print(f"local root         {local_root}")
+    print()
+
+    checkpoints: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for raw in messages:
+        decoded = decode_message(raw)
+        if not decoded:
+            continue
+        if decoded.get("p") != "hcs-27" or decoded.get("op") != "register":
+            continue
+        checkpoints.append((raw, decoded))
+
+    if not checkpoints:
+        print(f"FAIL: {len(messages)} message(s) on the topic, none an hcs-27 register")
+        return 1
+
+    failures = 0
+    matched_root = False
+
+    # One topic may legitimately carry several independent logs. HCS-27 gives
+    # each a `stream.log_id`, so `prev` chains within a log and says nothing
+    # across logs. Chaining per topic would report a false break the moment a
+    # second stream shares the topic, which is exactly what happened the first
+    # time this checker ran against a real one.
+    prev_by_log: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for raw, message in checkpoints:
+        metadata = message.get("metadata") or {}
+        root = metadata.get("root") or {}
+        stream = metadata.get("stream") or {}
+        seq = raw.get("sequence_number")
+        ts = raw.get("consensus_timestamp")
+        tree_size = root.get("treeSize")
+        root_hash = root.get("rootHashB64u")
+        log_key = (str(stream.get("registry")), str(stream.get("log_id")))
+        prev_seen = prev_by_log.get(log_key)
+
+        print(f"seq {seq}  consensus {ts}")
+        print(f"  log        {log_key[0]} / {log_key[1]}")
+        print(f"  registry   {(metadata.get('stream') or {}).get('registry')}")
+        print(f"  profile    {metadata.get('vaaraProfile', '(none)')}")
+        print(f"  leaf       {(metadata.get('log') or {}).get('leaf')}")
+        print(f"  treeSize   {tree_size}")
+        print(f"  root       {root_hash}")
+
+        # Structural rules HCS-27 states, checked rather than assumed.
+        if not isinstance(tree_size, str) or not tree_size.isdigit():
+            print("  FAIL: treeSize is not a canonical decimal string")
+            failures += 1
+        if not isinstance(root_hash, str) or "=" in root_hash or "+" in root_hash:
+            print("  FAIL: rootHashB64u is not unpadded base64url")
+            failures += 1
+
+        # The chain between successive checkpoints on this topic.
+        prev = metadata.get("prev")
+        if prev_seen is not None:
+            if not prev:
+                print("  FAIL: non-genesis checkpoint carries no prev")
+                failures += 1
+            elif (
+                prev.get("treeSize") != prev_seen["treeSize"]
+                or prev.get("rootHashB64u") != prev_seen["rootHashB64u"]
+            ):
+                print(
+                    f"  FAIL: prev does not match the previous checkpoint "
+                    f"({prev.get('treeSize')}, {prev.get('rootHashB64u')})"
+                )
+                failures += 1
+            elif int(tree_size) < int(prev_seen["treeSize"]):
+                print("  FAIL: the log shrank")
+                failures += 1
+            elif (
+                tree_size == prev_seen["treeSize"]
+                and root_hash != prev_seen["rootHashB64u"]
+            ):
+                # Same size, different root. The log did not grow, it was
+                # replaced. `prev` chaining cannot catch this on its own,
+                # because the new checkpoint honestly names the old one; only
+                # comparing the pair says the contents changed underneath.
+                print(
+                    "  FAIL: same treeSize as the previous checkpoint but a "
+                    "different root, so this log was replaced, not extended"
+                )
+                failures += 1
+            else:
+                print("  ok: prev chains to the previous checkpoint in this log")
+        else:
+            print("  first checkpoint seen for this log")
+
+        if root_hash == local_root and tree_size == str(len(entries)):
+            print("  ok: root recomputes from the local entries")
+            matched_root = True
+
+        prev_by_log[log_key] = {"treeSize": tree_size, "rootHashB64u": root_hash}
+        print()
+
+    if not matched_root:
+        print(
+            f"FAIL: no checkpoint on the topic publishes the root of the "
+            f"{len(entries)} local entries"
+        )
+        failures += 1
+
+    if failures:
+        print(f"FAIL: {failures} problem(s) across {len(checkpoints)} checkpoint(s)")
+        return 1
+
+    print(
+        f"PASS: {len(checkpoints)} checkpoint(s) read off the ledger, "
+        f"root recomputed independently, chain intact"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--topic-id", required=True, help="e.g. 0.0.12345")
+    parser.add_argument("--network", default="testnet", choices=sorted(MIRROR))
+    parser.add_argument(
+        "--entries",
+        default=str(DEFAULT_ENTRIES),
+        help="entries the published root should commit to (default: the committed vector)",
+    )
+    parser.add_argument("--limit", type=int, default=100)
+    args = parser.parse_args()
+
+    entries = json.loads(Path(args.entries).read_text(encoding="utf-8"))
+    return check_topic(args.network, args.topic_id, entries, args.limit)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hcs27_publish.py
+++ b/scripts/hcs27_publish.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Create an HCS-27 checkpoint topic and submit a Vaara checkpoint to it.
+
+This is the network half of `vaara.audit.hcs27`. The module itself is stdlib
+only and never touches a network; everything that speaks to Hedera lives here,
+behind the `hedera` extra, so a checkpoint can still be built and verified on a
+machine that has no SDK and no account.
+
+    pip install 'vaara[hedera]'
+
+Credentials are never written, logged or echoed. They come from the
+environment, or from an env file that is not in the repository:
+
+    HEDERA_ACCOUNT_ID    operator account, e.g. 0.0.12345      (public)
+    HEDERA_PRIVATE_KEY   operator key, DER or hex               (SECRET)
+    HEDERA_NETWORK       testnet (default), previewnet, mainnet
+
+The default env file is `.shared/hedera/testnet.env`, under the one gitignored
+root, so a key put there cannot reach a commit. A real environment variable
+always wins over the file, and the file is refused if its permissions let
+anyone but the owner read it.
+
+Two steps, deliberately separate, because they have very different costs. A
+topic is created once and lives forever. Messages are submitted against it many
+times.
+
+    scripts/hcs27_publish.py create-topic
+    scripts/hcs27_publish.py submit --topic-id 0.0.NNNNN
+
+What gets submitted
+-------------------
+By default, the checkpoint from the committed conformance vector
+`tests/vectors/hcs27_checkpoint_v0/`. That is the useful thing to publish
+first: the root on the ledger can then be checked against entries any stranger
+can download from the repository, so the claim "this root commits to these
+seven records" is checkable by someone who trusts neither of us.
+
+`--from-checkpoint` takes any checkpoint message JSON instead, which is what a
+real trail run will pass.
+
+On the admin key
+----------------
+The topic is created with the operator key as admin key, so it can be updated
+or deleted later. Pass `--immutable` to create a topic with no admin key at
+all, which nobody can ever change or remove. That is the right choice for a
+production checkpoint stream and the wrong one for a first experiment, so it is
+opt-in.
+
+HIP-991 custom fees are not set here. The SDK supports them
+(`set_custom_fees`, `set_fee_schedule_key`, `set_fee_exempt_keys`) and the fee
+schedule key cannot be added after creation, so a topic intended to carry fees
+later has to be created with one from the start. That is a commercial decision
+rather than a technical default, so this script does not quietly make it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+VECTOR = REPO / "tests" / "vectors" / "hcs27_checkpoint_v0"
+DEFAULT_ENV_FILE = REPO / ".shared" / "hedera" / "testnet.env"
+
+NETWORKS = ("testnet", "previewnet", "mainnet")
+
+CREDENTIAL_KEYS = (
+    "HEDERA_ACCOUNT_ID",
+    "HEDERA_PRIVATE_KEY",
+    "HEDERA_NETWORK",
+    "HEDERA_KEY_TYPE",
+)
+
+#: A raw 32-byte key is ambiguous: the SDK's own warning says there is no way
+#: to tell an Ed25519 seed from an ECDSA scalar, so it tries Ed25519 first and
+#: silently succeeds either way. Signing with the wrong curve produces a key
+#: that parses, an account that does not match, and an error at submit time
+#: that names neither. Say which curve it is.
+KEY_TYPES = ("ed25519", "ecdsa", "auto")
+
+
+def _fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    """Read KEY=value lines, without ever putting a value in a message.
+
+    A real environment variable wins over the file, so an operator can override
+    a stored key for one run without editing anything.
+    """
+    if not path.exists():
+        return {}
+
+    mode = path.stat().st_mode & 0o077
+    if mode:
+        _fail(
+            f"{path} is readable or writable by others (mode {oct(path.stat().st_mode & 0o777)}). "
+            f"Run: chmod 600 {path}"
+        )
+
+    values: dict[str, str] = {}
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            _fail(f"{path}:{lineno} is not a KEY=value line")
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        if key not in CREDENTIAL_KEYS:
+            _fail(
+                f"{path}:{lineno} sets {key!r}, which is not one of "
+                f"{', '.join(CREDENTIAL_KEYS)}"
+            )
+        values[key] = value.strip().strip("'\"")
+    return values
+
+
+def _client(env_file: Path | None = None) -> Any:
+    """Build an operator-bound client, or explain exactly what is missing."""
+    try:
+        from hiero_sdk_python import AccountId, Client, Network, PrivateKey
+    except ImportError:
+        _fail(
+            "the hiero-sdk-python package is not installed. "
+            "Install the extra with: pip install 'vaara[hedera]'"
+        )
+
+    path = env_file if env_file is not None else DEFAULT_ENV_FILE
+    from_file = _load_env_file(path)
+
+    def _get(key: str, default: str = "") -> str:
+        return (os.environ.get(key) or from_file.get(key) or default).strip()
+
+    account_id = _get("HEDERA_ACCOUNT_ID")
+    private_key = _get("HEDERA_PRIVATE_KEY")
+    network = _get("HEDERA_NETWORK", "testnet") or "testnet"
+
+    if not account_id:
+        _fail(
+            "HEDERA_ACCOUNT_ID is not set. Export it, or put it in "
+            f"{path} as HEDERA_ACCOUNT_ID=0.0.12345"
+        )
+    if not private_key:
+        _fail(f"HEDERA_PRIVATE_KEY is not set. Export it, or put it in {path}")
+    if network not in NETWORKS:
+        _fail(f"HEDERA_NETWORK must be one of {', '.join(NETWORKS)}, got {network!r}")
+
+    key_type = (_get("HEDERA_KEY_TYPE", "ed25519") or "ed25519").lower()
+    if key_type not in KEY_TYPES:
+        _fail(f"HEDERA_KEY_TYPE must be one of {', '.join(KEY_TYPES)}, got {key_type!r}")
+
+    parser = {
+        "ed25519": PrivateKey.from_string_ed25519,
+        "ecdsa": PrivateKey.from_string_ecdsa,
+        "auto": PrivateKey.from_string,
+    }[key_type]
+
+    try:
+        key = parser(private_key)
+    except Exception:
+        # Deliberately does not include the exception text, which some parsers
+        # render with the offending key material in it.
+        _fail(
+            f"HEDERA_PRIVATE_KEY could not be parsed as a {key_type} private key. "
+            f"If the account was created with the other curve, set HEDERA_KEY_TYPE."
+        )
+
+    client = Client(Network(network=network))
+    client.set_operator(AccountId.from_string(account_id), key)
+    return client, key, network, account_id
+
+
+def cmd_create_topic(args: argparse.Namespace) -> int:
+    from hiero_sdk_python import TopicCreateTransaction
+
+    client, key, network, account_id = _client(args.env_file and Path(args.env_file))
+
+    tx = TopicCreateTransaction().set_memo(args.memo)
+    if not args.immutable:
+        tx = tx.set_admin_key(key.public_key())
+    if args.submit_key:
+        tx = tx.set_submit_key(key.public_key())
+
+    receipt = tx.execute(client)
+    topic_id = str(receipt.topic_id)
+
+    print(f"network   {network}")
+    print(f"operator  {account_id}")
+    print(f"topic     {topic_id}")
+    print(f"memo      {args.memo}")
+    print(f"admin key {'none, this topic is immutable' if args.immutable else 'operator'}")
+    print(f"submit    {'operator key only' if args.submit_key else 'open to anyone'}")
+    print()
+    print("Next:")
+    print(f"  scripts/hcs27_publish.py submit --topic-id {topic_id}")
+    return 0
+
+
+def _load_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
+    if args.from_checkpoint:
+        return json.loads(Path(args.from_checkpoint).read_text(encoding="utf-8"))
+    checkpoints = json.loads((VECTOR / "checkpoints.json").read_text(encoding="utf-8"))
+    return checkpoints["current"]
+
+
+def cmd_submit(args: argparse.Namespace) -> int:
+    checkpoint = _load_checkpoint(args)
+
+    # Exact submitted bytes. json.dumps with these settings is what
+    # vaara.audit.hcs27.message_bytes emits, and the digest on the wire has to
+    # be the digest anyone recomputing from the vector gets.
+    payload = json.dumps(checkpoint, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    if len(payload) > 1024:
+        _fail(f"message is {len(payload)} bytes, over Hedera's 1024-byte cap")
+
+    root = checkpoint["metadata"]["root"]
+
+    # Before the client, so a dry run needs no SDK, no key and no network. It
+    # is the step you use to see the exact bytes before anything is spent.
+    if args.dry_run:
+        print("DRY RUN, nothing submitted")
+        print(f"topic      {args.topic_id}")
+        print(f"bytes      {len(payload)}")
+        print(f"treeSize   {root['treeSize']}")
+        print(f"root       {root['rootHashB64u']}")
+        print()
+        print(payload.decode("utf-8"))
+        return 0
+
+    from hiero_sdk_python import TopicId, TopicMessageSubmitTransaction
+
+    client, _key, network, account_id = _client(args.env_file and Path(args.env_file))
+
+    receipt = (
+        TopicMessageSubmitTransaction(
+            topic_id=TopicId.from_string(args.topic_id), message=payload
+        )
+    ).execute(client)
+
+    sequence = getattr(receipt, "topic_sequence_number", None)
+
+    print(f"network    {network}")
+    print(f"operator   {account_id}")
+    print(f"topic      {args.topic_id}")
+    print(f"bytes      {len(payload)}")
+    print(f"treeSize   {root['treeSize']}")
+    print(f"root       {root['rootHashB64u']}")
+    print(f"sequence   {sequence}")
+    print()
+    print("Read it back with a checker that imports neither Vaara nor the SDK:")
+    print(
+        f"  scripts/hcs27_mirror_check.py --topic-id {args.topic_id} "
+        f"--network {network}"
+    )
+
+    if args.receipt:
+        out = Path(args.receipt)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps(
+                {
+                    "network": network,
+                    "topicId": args.topic_id,
+                    "sequenceNumber": sequence,
+                    "messageBytes": len(payload),
+                    "treeSize": root["treeSize"],
+                    "rootHashB64u": root["rootHashB64u"],
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"\nreceipt written to {out}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create-topic", help="create a checkpoint topic, once")
+    create.add_argument(
+        "--memo",
+        default="vaara trail checkpoints, HCS-27",
+        help="topic memo, 100 bytes max",
+    )
+    create.add_argument(
+        "--immutable",
+        action="store_true",
+        help="create with no admin key, so the topic can never be changed or deleted",
+    )
+    create.add_argument(
+        "--submit-key",
+        action="store_true",
+        help="restrict submission to the operator key (default: anyone may submit)",
+    )
+    create.set_defaults(func=cmd_create_topic)
+
+    submit = sub.add_parser("submit", help="submit a checkpoint message")
+    submit.add_argument("--topic-id", required=True, help="e.g. 0.0.12345")
+    submit.add_argument(
+        "--from-checkpoint",
+        help="path to a checkpoint message JSON (default: the committed vector)",
+    )
+    submit.add_argument(
+        "--receipt", help="write a JSON receipt of the submission to this path"
+    )
+    submit.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the exact bytes and stop, touching no network and no credentials",
+    )
+    submit.set_defaults(func=cmd_submit)
+
+    for p_ in (create, submit):
+        p_.add_argument(
+            "--env-file",
+            help=f"credentials file (default: {DEFAULT_ENV_FILE})",
+        )
+
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
v1.78.0 shipped the HCS-27 module. It could build a checkpoint and nothing could put one on a network or read one back. Three scripts close that.

The split between them is the whole design. Everything that needs an account lives in one file. The file that verifies needs no account, no key, and no install.

| Script | Needs | Does |
|---|---|---|
| `hcs27_publish.py` | `vaara[hedera]` + a key | creates a topic, submits a checkpoint |
| `hcs27_mirror_check.py` | **nothing** | reads the topic back and recomputes the root |
| `demo_mcp_guardian.py` | both | drives the real pipeline, checkpoints the head |

`vaara.audit.hcs27` stays standard-library-only. That it pulls in zero third-party modules is asserted in the change, not assumed.

## Verified on testnet

```
topic   0.0.10246161
seq 1   treeSize 25   jO3dANmhRo8VwKAdXDzz8YjpLNQS1uflNjTTjtd8E7A   genesis
seq 2   treeSize 50   1bwozkB4bbR6TBn2TYODTGdAY4Dz2JO5us_W8iLhERs   prev -> 25
```

The log grew and the second checkpoint chains to the first. `hcs27_mirror_check.py` recomputes both roots from the public mirror node by recursive top-down split, which is the opposite construction to the bottom-up fold that produced them.

Measured fees, read from the mirror node transaction endpoint rather than a published table: topic create 0.258 HBAR, checkpoint submit 0.005 HBAR, transfer leg 0.00129 HBAR and linear in recipients, so batching gives no discount.

## Three defects found by running this against a real network

**A raw 32-byte private key is ambiguous.** The SDK's own warning says an Ed25519 seed cannot be told apart from an ECDSA scalar, so `from_string` tries Ed25519 first and succeeds either way. That yields a key that parses and a failure at submit time that names neither cause. `HEDERA_KEY_TYPE` now picks the parser explicitly and defaults to `ed25519`.

**One topic may carry several logs.** HCS-27 gives each a `stream.log_id`, so `prev` chains within a log and says nothing across logs. The first version chained per topic and reported a false break the moment a second stream shared a topic, which is what happened on the first real run.

**`prev` chaining does not prove append-only growth.** A publisher that discards a log and starts another still produces a chain that links correctly. Two cases are now caught from the checkpoints alone: a shrinking tree, and a tree that kept its size while its root moved. The general case needs an RFC 9162 consistency proof, which HCS-27 serves off-ledger, and the file states that rather than leaving it to be found later.

That last check immediately failed the demo itself, which was rebuilding a fresh trail on every run and republishing a different root at the same `treeSize`. The demo trail is now persistent so the log genuinely grows.

## One more thing the demo refuses to do

It will not start if any tool name is missing from the taxonomy. An unregistered name classifies as `unknown` with a local blast radius and scores low enough to be allowed, so a demo written against a plausible but non-existent tool would show the gate waving through exactly what it exists to stop. The first draft did that with `id.credential.issue`, which Vaara does not know. The real action is `id.grant_permission`, and it escalates.

## Credentials

From the environment, or an env file under the one gitignored root. Never echoed, and stripped out of parse errors. The script refuses an env file that group or others can read.

## Verification

- 3471 tests pass, 26 skipped.
- 48 conformance suites unchanged.
- `ruff` clean across `scripts/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional Hedera integration for publishing and anchoring checkpoints.
  - Added a demo workflow that runs tool calls, creates checkpoints, and supports offline execution.
  - Added checkpoint publishing for Hedera testnet, previewnet, and mainnet, including topic creation, dry runs, and receipts.
  - Added an independent mirror-node checker to validate checkpoint integrity, message chains, and tree consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->