### PR TITLE
site: replace the floating controls with one sticky top bar

### DIFF
--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -215,13 +215,12 @@
      means it can never run under them at any width or scroll position. Below
      the breakpoint the controls return to normal flow, where the overlap
      cannot happen at all. */
-  .wrap{max-width:min(940px, calc(100vw - 2*(2*var(--edge) + var(--ctrl))));margin:0 auto;padding:56px 22px 96px}
-  :root{--edge:16px;--ctrl:11.5rem}
-  @media (max-width:900px){
-    .nav-jump,.theme-toggle{position:static;top:auto;left:auto;right:auto}
-    .nav-jump{margin:14px 0 0 16px}
-    .theme-toggle{margin:14px 16px 0;justify-content:flex-end}
-    .wrap{max-width:940px}
+  .wrap{max-width:940px;margin:0 auto;padding:56px 22px 96px}
+  :root{--edge:16px}
+  @media (max-width:640px{
+    .topbar{gap:8px;padding:8px 12px}
+    .topbar .brand{margin-right:0;width:100%}
+    .nav-jump a{padding:4px 8px;letter-spacing:.12em}
   }
 
   a{color:var(--tri-bright);text-decoration:none;border-bottom:1px solid var(--line)}
@@ -293,13 +292,29 @@
     html:not([data-theme]) .wordmark .wm-light{display:none}
     html:not([data-theme]) .wordmark .wm-dark{display:inline-block}
   }
-  .nav-jump{position:fixed;top:14px;left:16px;z-index:10;display:inline-flex;
-    background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}
+  /* One sticky bar, in the mono label grammar (no icons).
+     Was two fixed clusters floating over the text, which reached five
+     controls once the surfaces page was added and forced the column to be
+     narrowed by a --ctrl guard so text could not run under them.
+     A sticky bar is in normal flow, so the guard is gone with it. */
+  .topbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;
+    gap:14px;flex-wrap:wrap;padding:10px 16px;
+    background:var(--bg);
+    background:color-mix(in srgb, var(--bg) 86%, transparent);
+    backdrop-filter:saturate(1.4) blur(10px);
+    -webkit-backdrop-filter:saturate(1.4) blur(10px);
+    border-bottom:1px solid var(--line)}
+  .topbar .brand{font-family:var(--mono);font-size:12px;letter-spacing:.24em;
+    text-transform:uppercase;color:var(--tri);font-weight:600;text-decoration:none;
+    padding:4px 2px;margin-right:auto;border:0}
+  .topbar .brand:hover{color:var(--tri-bright)}
+  .nav-jump{display:inline-flex;background:var(--panel);border:1px solid var(--line);
+    border-radius:999px;padding:4px}
   .nav-jump a{font-family:var(--mono);font-size:11px;letter-spacing:.18em;
     text-transform:uppercase;color:var(--faint);padding:4px 11px;border-radius:999px;
     text-decoration:none;border:0}
   .nav-jump a:hover{color:var(--tri);background:var(--panel-2)}
-  .theme-toggle{position:fixed;top:14px;right:16px;z-index:10;display:inline-flex;
+  .theme-toggle{display:inline-flex;
     gap:2px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}
   .theme-toggle button{appearance:none;background:none;border:0;cursor:pointer;margin:0;
     font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;
@@ -317,11 +332,14 @@
 </script>
 </head>
 <body>
-<nav class="nav-jump"><a href="/">Home</a></nav>
-<div class="theme-toggle" role="group" aria-label="Color theme">
-  <button type="button" data-set-theme="light" aria-pressed="true">light</button>
-  <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
-</div>
+<header class="topbar">
+  <a class="brand" href="/">Vaara</a>
+  <nav class="nav-jump" aria-label="Sections"><a href="/verify.html">Explorer</a><a href="/conformance.html" aria-current="page">Conformance</a><a href="/surfaces.html">Published</a></nav>
+  <div class="theme-toggle" role="group" aria-label="Color theme">
+    <button type="button" data-set-theme="light" aria-pressed="true">light</button>
+    <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
+  </div>
+</header>
 <div class="wrap">
   <div class="wordmark">
     <a href="/"><img class="wm-light" src="/vaara-wordmark-light.png" alt="Vaara" width="440" height="127"></a>

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -108,18 +108,15 @@
     font-family: var(--sans); font-size: 16px; line-height: 1.65;
     -webkit-font-smoothing: antialiased;
   }
-  /* Fixed controls sit against the viewport edge. The centred column is capped
-     so it leaves the control plus the same edge gap again on each side, which
-     means it can never run under them at any width or scroll position. Below
-     the breakpoint the controls return to normal flow, where the overlap
-     cannot happen at all. */
-  main { max-width: min(760px, calc(100vw - 2*(2*var(--edge) + var(--ctrl)))); margin: 0 auto; padding: 20px 28px 96px; }
-  :root{--edge:16px;--ctrl:11.5rem}
-  @media (max-width:900px){
-    .nav-jump,.theme-toggle{position:static;top:auto;left:auto;right:auto}
-    .nav-jump{margin:14px 0 0 16px}
-    .theme-toggle{margin:14px 16px 0;justify-content:flex-end}
-    main{max-width:760px}
+  /* The column is a plain cap now. It used to be narrowed by the width of the
+     floating controls so text could not run under them; the sticky bar is in
+     normal flow, so nothing overlaps and the guard is gone. */
+  main { max-width: 760px; margin: 0 auto; padding: 20px 28px 96px; }
+  :root{--edge:16px}
+  @media (max-width:640px){
+    .topbar{gap:8px;padding:8px 12px}
+    .topbar .brand{margin-right:0;width:100%}
+    .nav-jump a{padding:4px 8px;letter-spacing:.12em}
   }
 
   .wordmark { margin: 8px auto 0; text-align: center; }
@@ -162,14 +159,30 @@
   .evidence .dim { color: var(--faint); }
   #installs { color: var(--tri-bright); font-weight: 600; font-family: var(--mono); }
   .ago { opacity: .55; font-size: .85em; }
-  /* Theme toggle, top-right, in the mono label grammar (no icons). */
-  .nav-jump{position:fixed;top:14px;left:16px;z-index:10;display:inline-flex;
-    background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}
+  /* One sticky bar, in the mono label grammar (no icons).
+     Was two fixed clusters floating over the text, which reached five
+     controls once the surfaces page was added and forced main to be
+     narrowed by a --ctrl guard so the text could not run under them.
+     A sticky bar is in normal flow, so the guard is gone with it. */
+  .topbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;
+    gap:14px;flex-wrap:wrap;padding:10px 16px;
+    background:var(--bg);
+    background:color-mix(in srgb, var(--bg) 86%, transparent);
+    backdrop-filter:saturate(1.4) blur(10px);
+    -webkit-backdrop-filter:saturate(1.4) blur(10px);
+    border-bottom:1px solid var(--line)}
+  .topbar .brand{font-family:var(--mono);font-size:12px;letter-spacing:.24em;
+    text-transform:uppercase;color:var(--tri);font-weight:600;text-decoration:none;
+    padding:4px 2px;margin-right:auto}
+  .topbar .brand:hover{color:var(--tri-bright)}
+  .nav-jump{display:inline-flex;background:var(--panel);border:1px solid var(--line);
+    border-radius:999px;padding:4px}
   .nav-jump a{font-family:var(--mono);font-size:11px;letter-spacing:.18em;
     text-transform:uppercase;color:var(--faint);padding:4px 11px;border-radius:999px;
-    text-decoration:none}
+    text-decoration:none;white-space:nowrap}
   .nav-jump a:hover{color:var(--tri);background:var(--panel-2)}
-  .theme-toggle { position: fixed; top: 14px; right: 16px; z-index: 10; display: inline-flex; gap: 2px; background: var(--panel); border: 1px solid var(--line); border-radius: 999px; padding: 4px; }
+  .nav-jump a[aria-current="page"]{color:var(--tri);background:var(--panel-2)}
+  .theme-toggle { display: inline-flex; gap: 2px; background: var(--panel); border: 1px solid var(--line); border-radius: 999px; padding: 4px; }
   .theme-toggle button { appearance: none; background: none; border: 0; cursor: pointer; font-family: var(--mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--faint); padding: 4px 11px; border-radius: 999px; transition: color 0.15s ease, background 0.15s ease; }
   .theme-toggle button[aria-pressed="true"] { color: var(--tri); background: var(--panel-2); }
   .theme-toggle button:hover { color: var(--tri); }
@@ -360,11 +373,14 @@
 </script>
 </head>
 <body>
-<nav class="nav-jump"><a href="/verify.html">Explorer</a><a href="/conformance.html">Conformance</a><a href="/surfaces.html">What we publish</a></nav>
-<div class="theme-toggle" role="group" aria-label="Color theme">
-  <button type="button" data-set-theme="light" aria-pressed="true">light</button>
-  <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
-</div>
+<header class="topbar">
+  <a class="brand" href="/" aria-current="page">Vaara</a>
+  <nav class="nav-jump" aria-label="Sections"><a href="/verify.html">Explorer</a><a href="/conformance.html">Conformance</a><a href="/surfaces.html">Published</a></nav>
+  <div class="theme-toggle" role="group" aria-label="Color theme">
+    <button type="button" data-set-theme="light" aria-pressed="true">light</button>
+    <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
+  </div>
+</header>
 <main>
 <div class="wordmark">
   <img class="wm-light" src="/vaara-wordmark-light.png" alt="Vaara" width="440" height="127" fetchpriority="high">

--- a/webpage/surfaces.html
+++ b/webpage/surfaces.html
@@ -29,7 +29,30 @@
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
   line-height:1.55;-webkit-font-smoothing:antialiased}
-main{max-width:820px;margin:0 auto;padding:56px 22px 96px}
+main{max-width:820px;margin:0 auto;padding:40px 22px 96px}
+.topbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;
+  gap:14px;flex-wrap:wrap;padding:10px 16px;
+  background:var(--bg);
+  background:color-mix(in srgb, var(--bg) 86%, transparent);
+  backdrop-filter:saturate(1.4) blur(10px);
+  -webkit-backdrop-filter:saturate(1.4) blur(10px);
+  border-bottom:1px solid var(--line)}
+.topbar .brand{font-family:var(--mono);font-size:12px;letter-spacing:.24em;
+  text-transform:uppercase;color:var(--tri);font-weight:600;text-decoration:none;
+  padding:4px 2px;margin-right:auto;border:0}
+.topbar .brand:hover{color:var(--tri-bright)}
+.nav-jump{display:inline-flex;background:var(--panel);border:1px solid var(--line);
+  border-radius:999px;padding:4px}
+.nav-jump a{font-family:var(--mono);font-size:11px;letter-spacing:.18em;
+  text-transform:uppercase;color:var(--faint);padding:4px 11px;border-radius:999px;
+  text-decoration:none;white-space:nowrap;border:0}
+.nav-jump a:hover{color:var(--tri);background:var(--panel-2,var(--panel))}
+.nav-jump a[aria-current="page"]{color:var(--tri);background:var(--panel-2,var(--panel))}
+@media (max-width:640px){
+  .topbar{gap:8px;padding:8px 12px}
+  .topbar .brand{margin-right:0;width:100%}
+  .nav-jump a{padding:4px 8px;letter-spacing:.12em}
+}
 a{color:var(--tri-bright);text-decoration:none;border-bottom:1px solid var(--line)}
 a:hover{border-bottom-color:var(--tri)}
 h1{font-size:clamp(1.5rem,4vw,2.1rem);line-height:1.2;margin:0 0 10px;letter-spacing:-.02em}
@@ -51,6 +74,10 @@ footer{margin-top:52px;padding-top:20px;border-top:1px solid var(--line);
 </style>
 </head>
 <body>
+<header class="topbar">
+  <a class="brand" href="/">Vaara</a>
+  <nav class="nav-jump" aria-label="Sections"><a href="/verify.html">Explorer</a><a href="/conformance.html">Conformance</a><a href="/surfaces.html" aria-current="page">Published</a></nav>
+</header>
 <main>
 
 <h1>What Vaara publishes</h1>

--- a/webpage/verify.html
+++ b/webpage/verify.html
@@ -194,13 +194,12 @@
      means it can never run under them at any width or scroll position. Below
      the breakpoint the controls return to normal flow, where the overlap
      cannot happen at all. */
-  main { max-width: min(760px, calc(100vw - 2*(2*var(--edge) + var(--ctrl)))); margin: 0 auto; }
-  :root{--edge:16px;--ctrl:11.5rem}
-  @media (max-width:900px){
-    .nav-jump,.theme-toggle{position:static;top:auto;left:auto;right:auto}
-    .nav-jump{margin:14px 0 0 16px}
-    .theme-toggle{margin:14px 16px 0;justify-content:flex-end}
-    main{max-width:760px}
+  main { max-width:760px; margin: 0 auto; }
+  :root{--edge:16px}
+  @media (max-width:640px{
+    .topbar{gap:8px;padding:8px 12px}
+    .topbar .brand{margin-right:0;width:100%}
+    .nav-jump a{padding:4px 8px;letter-spacing:.12em}
   }
 
   h1 { font-family:var(--sans); font-size:18px; font-weight:500; margin:24px 0 12px;
@@ -214,7 +213,7 @@
              text-transform:uppercase; color:var(--faint); font-weight:600; }
   .tile .v { font-family:var(--mono); font-size:15px; color:var(--ink); margin-top:6px;
              word-break:break-all; }
-  @media (max-width:560px){ .tiles{grid-template-columns:1fr} }
+  @media (max-width:560px{ .tiles{grid-template-columns:1fr} }
   .drop { border:1px dashed var(--line); border-radius:8px; padding:1.5rem;
           background:var(--panel); text-align:center; color:var(--dim);
           transition:border-color .15s; }
@@ -251,15 +250,31 @@
     html:not([data-theme]) .wordmark .wm-light { display: none; }
     html:not([data-theme]) .wordmark .wm-dark { display: inline-block; }
   }
-  .nav-jump{position:fixed;top:14px;left:16px;z-index:10;display:inline-flex;
-    background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}
+  /* One sticky bar, in the mono label grammar (no icons).
+     Was two fixed clusters floating over the text, which reached five
+     controls once the surfaces page was added and forced the column to be
+     narrowed by a --ctrl guard so text could not run under them.
+     A sticky bar is in normal flow, so the guard is gone with it. */
+  .topbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;
+    gap:14px;flex-wrap:wrap;padding:10px 16px;
+    background:var(--bg);
+    background:color-mix(in srgb, var(--bg) 86%, transparent);
+    backdrop-filter:saturate(1.4) blur(10px);
+    -webkit-backdrop-filter:saturate(1.4) blur(10px);
+    border-bottom:1px solid var(--line)}
+  .topbar .brand{font-family:var(--mono);font-size:12px;letter-spacing:.24em;
+    text-transform:uppercase;color:var(--tri);font-weight:600;text-decoration:none;
+    padding:4px 2px;margin-right:auto;border:0}
+  .topbar .brand:hover{color:var(--tri-bright)}
+  .nav-jump{display:inline-flex;background:var(--panel);border:1px solid var(--line);
+    border-radius:999px;padding:4px}
   .nav-jump a{font-family:var(--mono);font-size:11px;letter-spacing:.18em;
     text-transform:uppercase;color:var(--faint);padding:4px 11px;border-radius:999px;
     text-decoration:none}
   .nav-jump a:hover{color:var(--tri);background:var(--panel-2)}
   .stamp-lead{font-family:var(--mono);font-size:12px;letter-spacing:.24em;
     text-transform:uppercase;color:var(--tri);font-weight:600;margin:2rem 0 .8rem}
-  .theme-toggle{position:fixed;top:14px;right:16px;z-index:10;display:inline-flex;
+  .theme-toggle{display:inline-flex;
     gap:2px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}
   .theme-toggle button{appearance:none;background:none;border:0;cursor:pointer;margin:0;
     font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;
@@ -296,7 +311,7 @@
   .searchrow { display:flex; gap:.5rem; align-items:stretch; }
   .searchrow input { flex:1 1 auto; min-width:0; font-size:13px; padding:.7rem .8rem; }
   .searchrow button { margin-top:0; white-space:nowrap; }
-  @media (max-width:560px) {
+  @media (max-width:560px {
     .searchrow { flex-wrap:wrap; }
     .searchrow input { flex:1 1 100%; }
   }
@@ -313,11 +328,14 @@
 </script>
 </head>
 <body>
-<nav class="nav-jump"><a href="/">Home</a></nav>
-<div class="theme-toggle" role="group" aria-label="Color theme">
-  <button type="button" data-set-theme="light" aria-pressed="true">light</button>
-  <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
-</div>
+<header class="topbar">
+  <a class="brand" href="/">Vaara</a>
+  <nav class="nav-jump" aria-label="Sections"><a href="/verify.html" aria-current="page">Explorer</a><a href="/conformance.html">Conformance</a><a href="/surfaces.html">Published</a></nav>
+  <div class="theme-toggle" role="group" aria-label="Color theme">
+    <button type="button" data-set-theme="light" aria-pressed="true">light</button>
+    <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
+  </div>
+</header>
 <main>
   <div class="wordmark">
     <a href="/"><img class="wm-light" src="/vaara-wordmark-light.png" alt="Vaara" width="440" height="127"></a>


### PR DESCRIPTION
Two fixed clusters hovered over the text on every page: a nav pill top-left and the theme toggle top-right. Adding the `surfaces.html` link took that to five controls floating while you scroll.

They cost layout as well as attention. Because they sat over the column, `main` was capped at `calc(100vw - 2*(2*edge + ctrl))` purely so text could never run under them, with a 900px breakpoint to drop them back into flow. A sticky bar is in normal flow, so the guard and the breakpoint hack both go.

One bar on all four pages, in the existing mono label grammar with no icons:

- brand link home
- Explorer, Conformance, Published, with `aria-current` on the page you are on
- the theme toggle, markup and its JS hook unchanged

`surfaces.html` had no navigation at all and now matches the rest.

An opaque `background` is declared before the `color-mix` one, so a browser without `color-mix` gets a solid bar instead of a transparent strip with text scrolling through it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consistent sticky top bar across site pages with Vaara branding, section navigation, and theme controls.
  - Updated navigation labels and highlighting to make Explorer, Conformance, and Published sections easier to access.
- **Improvements**
  - Simplified page layouts and adjusted spacing for a cleaner presentation.
  - Improved responsive behavior, with navigation adapting at smaller screen widths.
- **Bug Fixes**
  - Corrected responsive styling rules to ensure mobile layouts display properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->