### PR TITLE
site: give the published page the same wordmark as the other subpages

### DIFF
--- a/webpage/surfaces.html
+++ b/webpage/surfaces.html
@@ -41,7 +41,22 @@ html[data-theme="dark"]{
 *{box-sizing:border-box}
 body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
   line-height:1.55;-webkit-font-smoothing:antialiased}
-main{max-width:820px;margin:0 auto;padding:40px 22px 96px}
+main{max-width:820px;margin:0 auto;padding:28px 22px 96px}
+/* Same wordmark block as the explorer and conformance pages, so the three
+   subpages open the same way. Two images swapped by theme rather than one
+   recoloured, which is how the rest of the site already does it. */
+.wordmark{margin:8px auto 0;text-align:center}
+.wordmark a{border:0}
+.wordmark img{width:min(60vw,440px);height:auto;display:inline-block}
+.wordmark .wm-dark{display:none}
+html[data-theme="dark"] .wordmark .wm-light{display:none}
+html[data-theme="dark"] .wordmark .wm-dark{display:inline-block}
+@media (prefers-color-scheme:dark){
+  html:not([data-theme]) .wordmark .wm-light{display:none}
+  html:not([data-theme]) .wordmark .wm-dark{display:inline-block}
+}
+.stance{font-family:var(--mono);font-size:12px;letter-spacing:.22em;
+  text-transform:uppercase;color:var(--tri);text-align:center;margin:10px 0 34px}
 /* One glass bar. Mark on the left, links on the true centre, one sun/moon
    on the right. grid 1fr auto 1fr so the links stay centred on the viewport
    whatever the side cells weigh. No wordmark text: the mark is the mark. */
@@ -113,6 +128,11 @@ footer{margin-top:52px;padding-top:20px;border-top:1px solid var(--line);
   </div>
 </header>
 <main>
+  <div class="wordmark">
+    <a href="/"><img class="wm-light" src="/vaara-wordmark-light.png" alt="Vaara" width="440" height="127"></a>
+    <a href="/"><img class="wm-dark" src="/vaara-wordmark-dark.png" alt="Vaara" width="440" height="127"></a>
+  </div>
+  <p class="stance">Accountable Autonomy</p>
 
 <h1>What Vaara publishes</h1>
 <p class="lede">Every surface in one line each, with a link to the thing itself. Nothing here asks you to take a claim on trust. Each item is either a record held by someone else or a file you can recompute.</p>


### PR DESCRIPTION
`surfaces.html` opened straight onto its `h1`, while `verify.html` and `conformance.html` both open with the wordmark and the Accountable Autonomy line. Noticed by Henri: the published page did not match the other two.

Same block as the others, including the two-image light/dark swap rather than one recoloured image, both linking home. Top padding drops from 40px to 28px so the wordmark sits at the same height as on the other two pages.