### PR TITLE
site: take the padding off body on the explorer page

### DIFF
--- a/webpage/verify.html
+++ b/webpage/verify.html
@@ -186,15 +186,20 @@
     }
   }
   * { box-sizing: border-box; }
+  /* No padding on body. The sticky bar is a child of body, so padding here
+     inset it from the viewport edges and pushed it down from the top, which
+     left gaps either side of the bar with content scrolling through them.
+     The padding belongs on the column, which is how index.html already does
+     it. */
   body { margin:0; background:var(--bg); color:var(--ink);
          font-family:var(--sans); font-size:16px; line-height:1.65;
-         -webkit-font-smoothing:antialiased; padding:20px 28px 96px; }
+         -webkit-font-smoothing:antialiased; }
   /* Fixed controls sit against the viewport edge. The centred column is capped
      so it leaves the control plus the same edge gap again on each side, which
      means it can never run under them at any width or scroll position. Below
      the breakpoint the controls return to normal flow, where the overlap
      cannot happen at all. */
-  main { max-width:760px; margin: 0 auto; }
+  main { max-width:760px; margin: 0 auto; padding:20px 28px 96px; }
   :root{--edge:16px}
   @media (max-width:640px{
     .topbar{gap:8px;padding:8px 12px}


### PR DESCRIPTION
`verify.html` was the only page carrying padding on `body` rather than on its column:

```css
body { ... padding:20px 28px 96px; }
main { max-width:760px; margin: 0 auto; }
```

The sticky bar is a child of `body`, so that padding inset it 28px from each viewport edge and pushed it 20px down from the top. Once it stuck there were gaps down both sides of the bar with content scrolling through them, which is what Henri spotted.

`index.html` and `conformance.html` both keep `body` at zero padding and put it on `main` and `.wrap` respectively. This moves the same declaration onto `main` so the bar reaches the viewport edges on all four pages. No other rule changes.