### PR TITLE
vcr: add a prior-art field, and move the top bar into the generator

### DIFF
--- a/.github/ISSUE_TEMPLATE/conformance-row.yml
+++ b/.github/ISSUE_TEMPLATE/conformance-row.yml
@@ -68,7 +68,8 @@ body:
       description: >
         What your run establishes, which is a property of who wrote the
         verifier and who wrote the vectors, not of how well it went. These are
-        not degrees of the same thing. A row that does not name its kind reads
+        not degrees of the same thing. Naming one is required, so a new row
+        cannot arrive without a kind. Rows filed before this field existed read
         as the first one, because that is the weakest claim available.
       options:
         - "Reproduction: the author's checkers over the author's vectors"
@@ -100,6 +101,19 @@ body:
       placeholder: "https://mailarchive.ietf.org/arch/msg/..."
     validations:
       required: true
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Prior art
+      description: >
+        Optional. If the phenomenon your run turns on is already on the public
+        record, cite it here, and say what is new to this register rather than
+        what is new to the world. A row that names its prior art is stronger
+        than one that does not, because a reader can tell the difference
+        between finding something and being the first to raise it here.
+      placeholder: "draft-example-00 Section 6.2.1, or a paper, or a prior issue"
+    validations:
+      required: false
   - type: markdown
     attributes:
       value: |

--- a/scripts/render_conformance_page.py
+++ b/scripts/render_conformance_page.py
@@ -495,7 +495,7 @@ CERTIFICATE_TEMPLATE = """<!doctype html>
     <dt>At commit</dt><dd>{at_commit}</dd>
     <dt>Date</dt><dd>{date}</dd>
     <dt>Row digest</dt><dd>{digest}</dd>
-    <dt>Record</dt><dd>{record}</dd>
+    <dt>Record</dt><dd>{record}</dd>{prior_art_row}
     <dt>Terms</dt><dd>{terms_version}</dd>
   </dl>
 
@@ -540,6 +540,12 @@ def certificate_html(row: dict) -> str:
         date=esc(row.get("date", "")),
         digest=esc(row_digest(row)),
         record=esc(row.get("record", "")),
+        # Optional and omitted entirely when absent, so a row that cites no
+        # prior art does not display an empty field asserting there is none.
+        prior_art_row=(
+            "\n    <dt>Prior art</dt><dd>%s</dd>" % esc(row["prior_art"])
+            if row.get("prior_art") else ""
+        ),
         terms_version=esc(row.get("terms_version", "unversioned")),
     )
 
@@ -969,19 +975,11 @@ def render(report: dict, repro: dict) -> str:
   *{{box-sizing:border-box}}
   body{{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
        line-height:1.55;-webkit-font-smoothing:antialiased}}
-  /* Fixed controls sit against the viewport edge. The centred column is capped
-     so it leaves the control plus the same edge gap again on each side, which
-     means it can never run under them at any width or scroll position. Below
-     the breakpoint the controls return to normal flow, where the overlap
-     cannot happen at all. */
-  .wrap{{max-width:min(940px, calc(100vw - 2*(2*var(--edge) + var(--ctrl))));margin:0 auto;padding:56px 22px 96px}}
-  :root{{--edge:16px;--ctrl:11.5rem}}
-  @media (max-width:900px){{
-    .nav-jump,.theme-toggle{{position:static;top:auto;left:auto;right:auto}}
-    .nav-jump{{margin:14px 0 0 16px}}
-    .theme-toggle{{margin:14px 16px 0;justify-content:flex-end}}
-    .wrap{{max-width:940px}}
-  }}
+  /* The column is a plain cap. It used to be narrowed by the width of the
+     floating controls so text could not run under them; the sticky bar is in
+     normal flow, so the guard is gone. */
+  .wrap{{max-width:940px;margin:0 auto;padding:40px 22px 96px}}
+  :root{{--edge:16px}}
 
   a{{color:var(--tri-bright);text-decoration:none;border-bottom:1px solid var(--line)}}
   a:hover{{border-bottom-color:var(--tri)}}
@@ -1052,19 +1050,48 @@ def render(report: dict, repro: dict) -> str:
     html:not([data-theme]) .wordmark .wm-light{{display:none}}
     html:not([data-theme]) .wordmark .wm-dark{{display:inline-block}}
   }}
-  .nav-jump{{position:fixed;top:14px;left:16px;z-index:10;display:inline-flex;
-    background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}}
+  /* One glass bar. Mark on the left, links on the true centre, one sun/moon
+     on the right. grid 1fr auto 1fr so the links stay centred on the viewport
+     whatever the side cells weigh. No wordmark text: the mark is the mark. */
+  .topbar{{position:sticky;top:0;z-index:20;display:grid;
+    grid-template-columns:1fr auto 1fr;align-items:center;gap:12px;padding:9px 18px;
+    background:var(--bg);
+    background:color-mix(in srgb, var(--bg) 58%, transparent);
+    backdrop-filter:saturate(1.7) blur(18px);
+    -webkit-backdrop-filter:saturate(1.7) blur(18px);
+    border-bottom:1px solid var(--line)}}
+  .topbar .mark{{justify-self:start;display:inline-flex;align-items:center;border:0;
+    line-height:0;padding:3px;border-radius:9px}}
+  .topbar .mark img{{width:24px;height:24px;display:block}}
+  .topbar .mark:hover{{background:var(--panel)}}
+  .nav-jump{{justify-self:center;display:inline-flex;background:var(--panel);
+    border:1px solid var(--line);border-radius:999px;padding:4px}}
   .nav-jump a{{font-family:var(--mono);font-size:11px;letter-spacing:.18em;
-    text-transform:uppercase;color:var(--faint);padding:4px 11px;border-radius:999px;
-    text-decoration:none;border:0}}
+    text-transform:uppercase;color:var(--faint);padding:4px 12px;border-radius:999px;
+    text-decoration:none;white-space:nowrap;border:0}}
   .nav-jump a:hover{{color:var(--tri);background:var(--panel-2)}}
-  .theme-toggle{{position:fixed;top:14px;right:16px;z-index:10;display:inline-flex;
-    gap:2px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}}
-  .theme-toggle button{{appearance:none;background:none;border:0;cursor:pointer;margin:0;
-    font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;
-    color:var(--faint);padding:4px 11px;border-radius:999px}}
-  .theme-toggle button[aria-pressed="true"]{{color:var(--tri);background:var(--panel-2)}}
+  .nav-jump a[aria-current="page"]{{color:var(--tri);background:var(--panel-2)}}
+  .theme-toggle{{justify-self:end;display:inline-flex}}
+  .theme-toggle button{{appearance:none;background:var(--panel);border:1px solid var(--line);
+    border-radius:999px;cursor:pointer;margin:0;width:32px;height:32px;padding:0;
+    display:inline-flex;align-items:center;justify-content:center;color:var(--faint);
+    transition:color .15s ease,background .15s ease}}
   .theme-toggle button:hover{{color:var(--tri)}}
+  .theme-toggle button:focus-visible{{outline:2px solid var(--tri);outline-offset:2px}}
+  .theme-toggle svg{{width:16px;height:16px;display:block}}
+  /* Icon shows the mode you are about to get. Swapped in CSS, not JS, so it is
+     correct on first paint and cannot desync from the theme. */
+  .theme-toggle .i-sun{{display:none}}
+  html[data-theme="dark"] .theme-toggle .i-moon{{display:none}}
+  html[data-theme="dark"] .theme-toggle .i-sun{{display:block}}
+  @media (prefers-color-scheme:dark){{
+    html:not([data-theme]) .theme-toggle .i-moon{{display:none}}
+    html:not([data-theme]) .theme-toggle .i-sun{{display:block}}
+  }}
+  @media (max-width:640px){{
+    .topbar{{padding:8px 12px;gap:8px}}
+    .nav-jump a{{padding:4px 9px;letter-spacing:.10em;font-size:10px}}
+  }}
 </style>
 <script>
   // Apply the stored theme before first paint, the same as index.html and
@@ -1076,11 +1103,13 @@ def render(report: dict, repro: dict) -> str:
 </script>
 </head>
 <body>
-<nav class="nav-jump"><a href="/">Home</a></nav>
-<div class="theme-toggle" role="group" aria-label="Color theme">
-  <button type="button" data-set-theme="light" aria-pressed="true">light</button>
-  <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
-</div>
+<header class="topbar">
+  <a class="mark" href="/" aria-label="Vaara home"><img src="/favicon.svg" alt="Vaara" width="24" height="24"></a>
+  <nav class="nav-jump" aria-label="Sections"><a href="/verify.html">Explorer</a><a href="/conformance.html" aria-current="page">Conformance</a><a href="/surfaces.html">Published</a></nav>
+  <div class="theme-toggle">
+    <button type="button" id="themeBtn" aria-label="Switch to dark theme"><svg class="i-moon" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15.2 11.4A6.8 6.8 0 0 1 6.6 2.8a7 7 0 1 0 8.6 8.6z"/></svg><svg class="i-sun" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><circle cx="9" cy="9" r="3.4"/><path d="M9 1.4v1.7M9 14.9v1.7M1.4 9h1.7M14.9 9h1.7M3.6 3.6l1.2 1.2M13.2 13.2l1.2 1.2M14.4 3.6l-1.2 1.2M4.8 13.2l-1.2 1.2"/></svg></button>
+  </div>
+</header>
 <div class="wrap">
   <div class="wordmark">
     <a href="/"><img class="wm-light" src="/vaara-wordmark-light.png" alt="Vaara" width="440" height="127"></a>
@@ -1230,26 +1259,25 @@ python scripts/vcr_chain.py            # nothing removed from the table</code></
 <script>
 (function(){{
   var root = document.documentElement;
-  var btns = document.querySelectorAll('.theme-toggle [data-set-theme]');
-  function apply(theme){{
+  var meta = document.querySelector('meta[name="theme-color"]');
+  var btn  = document.getElementById("themeBtn");
+  var COLORS = {{ light: "#ececec", dark: "#0F1417" }};
+  function current(){{
+    var t = root.getAttribute("data-theme");
+    if (t) return t;
+    return (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "light";
+  }}
+  function label(){{
+    if (btn) btn.setAttribute("aria-label", current() === "dark" ? "Switch to light theme" : "Switch to dark theme");
+  }}
+  function apply(theme) {{
     root.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
-    btns.forEach(function(b){{
-      b.setAttribute("aria-pressed", String(b.getAttribute("data-set-theme") === theme));
-    }});
+    if (meta) meta.setAttribute("content", COLORS[theme] || COLORS.light);
     try {{ localStorage.setItem("vaara-theme", theme); }} catch(e) {{}}
+    label();
   }}
-  // No stored choice: leave data-theme off so the OS decides, and show which
-  // side the OS landed on so the toggle is not lying about the current state.
-  function reflectAuto(){{
-    root.removeAttribute("data-theme");
-    var dark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-    btns.forEach(function(b){{
-      b.setAttribute("aria-pressed", String(b.getAttribute("data-set-theme") === (dark ? "dark" : "light")));
-    }});
-  }}
-  btns.forEach(function(b){{
-    b.addEventListener("click", function(){{ apply(b.getAttribute("data-set-theme")); }});
-  }});
+  function reflectAuto(){{ root.removeAttribute("data-theme"); label(); }}
+  if (btn) btn.addEventListener("click", function(){{ apply(current() === "dark" ? "light" : "dark"); }});
   var saved = null;
   try {{ saved = localStorage.getItem("vaara-theme"); }} catch(e) {{}}
   if (saved === "dark" || saved === "light") apply(saved); else reflectAuto();

--- a/scripts/vcr_row.py
+++ b/scripts/vcr_row.py
@@ -43,6 +43,7 @@ LIMITS = {
     "result": 300,
     "their_scoping": 600,
     "record": 400,
+    "prior_art": 400,
 }
 
 FIELDS = {
@@ -54,6 +55,7 @@ FIELDS = {
     "Kind of run": "kind",
     "Your own scoping": "their_scoping",
     "Link to where you reported it": "record",
+    "Prior art": "prior_art",
 }
 
 #: What a run establishes is a property of who wrote the verifier and who wrote
@@ -322,7 +324,7 @@ def validate(fields: dict, author: str) -> dict:
     if not result:
         raise Rejected("The result is required.")
 
-    return {
+    row = {
         "party": party,
         "affiliation": str(fields.get("affiliation", "")).strip(),
         "suites": suites,
@@ -333,6 +335,13 @@ def validate(fields: dict, author: str) -> dict:
         "record": record,
         "submitted_by": author,
     }
+    # Only carried when the submitter gave one. Adding an empty key to every
+    # row would change the JCS bytes of rows that say nothing new, and the
+    # digest is supposed to move only when the content does.
+    prior_art = str(fields.get("prior_art", "")).strip()
+    if prior_art:
+        row["prior_art"] = prior_art
+    return row
 
 
 def row_digest(row: dict) -> str:

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -47,7 +47,7 @@
       "url": "https://vaara.io/conformance.html",
       "name": "Vaara Conformance Results",
       "description": "Every Vaara conformance suite, its verdict, and every independent party who reproduced the vectors and said so in public. Generated from the runner's own report.",
-      "dateModified": "2026-08-26T16:32:22Z",
+      "dateModified": "2026-08-29T10:01:07Z",
       "inLanguage": "en",
       "isPartOf": {
         "@id": "https://vaara.io/#website"
@@ -96,7 +96,7 @@
       "alternateName": "Vaara conformance corpus",
       "description": "Committed case files for every Vaara conformance suite. Each suite ships an independent checker that imports no Vaara code and recomputes its verdicts from the bytes of its own cases, so a stranger can disagree with an expected result and show their work. The vectors are Vaara's own and no ratification body stands behind them.",
       "url": "https://vaara.io/conformance.html",
-      "dateModified": "2026-08-26T16:32:22Z",
+      "dateModified": "2026-08-29T10:01:07Z",
       "identifier": "https://doi.org/10.5281/zenodo.22027975",
       "sameAs": [
         "https://doi.org/10.5281/zenodo.22027975",
@@ -210,18 +210,11 @@
   *{box-sizing:border-box}
   body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);
        line-height:1.55;-webkit-font-smoothing:antialiased}
-  /* Fixed controls sit against the viewport edge. The centred column is capped
-     so it leaves the control plus the same edge gap again on each side, which
-     means it can never run under them at any width or scroll position. Below
-     the breakpoint the controls return to normal flow, where the overlap
-     cannot happen at all. */
-  .wrap{max-width:940px;margin:0 auto;padding:56px 22px 96px}
+  /* The column is a plain cap. It used to be narrowed by the width of the
+     floating controls so text could not run under them; the sticky bar is in
+     normal flow, so the guard is gone. */
+  .wrap{max-width:940px;margin:0 auto;padding:40px 22px 96px}
   :root{--edge:16px}
-  @media (max-width:640px{
-    .topbar{gap:8px;padding:8px 12px}
-    .topbar .brand{margin-right:0;width:100%}
-    .nav-jump a{padding:4px 8px;letter-spacing:.12em}
-  }
 
   a{color:var(--tri-bright);text-decoration:none;border-bottom:1px solid var(--line)}
   a:hover{border-bottom-color:var(--tri)}
@@ -292,35 +285,48 @@
     html:not([data-theme]) .wordmark .wm-light{display:none}
     html:not([data-theme]) .wordmark .wm-dark{display:inline-block}
   }
-  /* One sticky bar, in the mono label grammar (no icons).
-     Was two fixed clusters floating over the text, which reached five
-     controls once the surfaces page was added and forced the column to be
-     narrowed by a --ctrl guard so text could not run under them.
-     A sticky bar is in normal flow, so the guard is gone with it. */
-  .topbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;
-    gap:14px;flex-wrap:wrap;padding:10px 16px;
+  /* One glass bar. Mark on the left, links on the true centre, one sun/moon
+     on the right. grid 1fr auto 1fr so the links stay centred on the viewport
+     whatever the side cells weigh. No wordmark text: the mark is the mark. */
+  .topbar{position:sticky;top:0;z-index:20;display:grid;
+    grid-template-columns:1fr auto 1fr;align-items:center;gap:12px;padding:9px 18px;
     background:var(--bg);
-    background:color-mix(in srgb, var(--bg) 86%, transparent);
-    backdrop-filter:saturate(1.4) blur(10px);
-    -webkit-backdrop-filter:saturate(1.4) blur(10px);
+    background:color-mix(in srgb, var(--bg) 58%, transparent);
+    backdrop-filter:saturate(1.7) blur(18px);
+    -webkit-backdrop-filter:saturate(1.7) blur(18px);
     border-bottom:1px solid var(--line)}
-  .topbar .brand{font-family:var(--mono);font-size:12px;letter-spacing:.24em;
-    text-transform:uppercase;color:var(--tri);font-weight:600;text-decoration:none;
-    padding:4px 2px;margin-right:auto;border:0}
-  .topbar .brand:hover{color:var(--tri-bright)}
-  .nav-jump{display:inline-flex;background:var(--panel);border:1px solid var(--line);
-    border-radius:999px;padding:4px}
+  .topbar .mark{justify-self:start;display:inline-flex;align-items:center;border:0;
+    line-height:0;padding:3px;border-radius:9px}
+  .topbar .mark img{width:24px;height:24px;display:block}
+  .topbar .mark:hover{background:var(--panel)}
+  .nav-jump{justify-self:center;display:inline-flex;background:var(--panel);
+    border:1px solid var(--line);border-radius:999px;padding:4px}
   .nav-jump a{font-family:var(--mono);font-size:11px;letter-spacing:.18em;
-    text-transform:uppercase;color:var(--faint);padding:4px 11px;border-radius:999px;
-    text-decoration:none;border:0}
+    text-transform:uppercase;color:var(--faint);padding:4px 12px;border-radius:999px;
+    text-decoration:none;white-space:nowrap;border:0}
   .nav-jump a:hover{color:var(--tri);background:var(--panel-2)}
-  .theme-toggle{display:inline-flex;
-    gap:2px;background:var(--panel);border:1px solid var(--line);border-radius:999px;padding:4px}
-  .theme-toggle button{appearance:none;background:none;border:0;cursor:pointer;margin:0;
-    font-family:var(--mono);font-size:11px;letter-spacing:.18em;text-transform:uppercase;
-    color:var(--faint);padding:4px 11px;border-radius:999px}
-  .theme-toggle button[aria-pressed="true"]{color:var(--tri);background:var(--panel-2)}
+  .nav-jump a[aria-current="page"]{color:var(--tri);background:var(--panel-2)}
+  .theme-toggle{justify-self:end;display:inline-flex}
+  .theme-toggle button{appearance:none;background:var(--panel);border:1px solid var(--line);
+    border-radius:999px;cursor:pointer;margin:0;width:32px;height:32px;padding:0;
+    display:inline-flex;align-items:center;justify-content:center;color:var(--faint);
+    transition:color .15s ease,background .15s ease}
   .theme-toggle button:hover{color:var(--tri)}
+  .theme-toggle button:focus-visible{outline:2px solid var(--tri);outline-offset:2px}
+  .theme-toggle svg{width:16px;height:16px;display:block}
+  /* Icon shows the mode you are about to get. Swapped in CSS, not JS, so it is
+     correct on first paint and cannot desync from the theme. */
+  .theme-toggle .i-sun{display:none}
+  html[data-theme="dark"] .theme-toggle .i-moon{display:none}
+  html[data-theme="dark"] .theme-toggle .i-sun{display:block}
+  @media (prefers-color-scheme:dark){
+    html:not([data-theme]) .theme-toggle .i-moon{display:none}
+    html:not([data-theme]) .theme-toggle .i-sun{display:block}
+  }
+  @media (max-width:640px){
+    .topbar{padding:8px 12px;gap:8px}
+    .nav-jump a{padding:4px 9px;letter-spacing:.10em;font-size:10px}
+  }
 </style>
 <script>
   // Apply the stored theme before first paint, the same as index.html and
@@ -333,11 +339,10 @@
 </head>
 <body>
 <header class="topbar">
-  <a class="brand" href="/">Vaara</a>
+  <a class="mark" href="/" aria-label="Vaara home"><img src="/favicon.svg" alt="Vaara" width="24" height="24"></a>
   <nav class="nav-jump" aria-label="Sections"><a href="/verify.html">Explorer</a><a href="/conformance.html" aria-current="page">Conformance</a><a href="/surfaces.html">Published</a></nav>
-  <div class="theme-toggle" role="group" aria-label="Color theme">
-    <button type="button" data-set-theme="light" aria-pressed="true">light</button>
-    <button type="button" data-set-theme="dark" aria-pressed="false">dark</button>
+  <div class="theme-toggle">
+    <button type="button" id="themeBtn" aria-label="Switch to dark theme"><svg class="i-moon" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15.2 11.4A6.8 6.8 0 0 1 6.6 2.8a7 7 0 1 0 8.6 8.6z"/></svg><svg class="i-sun" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" aria-hidden="true"><circle cx="9" cy="9" r="3.4"/><path d="M9 1.4v1.7M9 14.9v1.7M1.4 9h1.7M14.9 9h1.7M3.6 3.6l1.2 1.2M13.2 13.2l1.2 1.2M14.4 3.6l-1.2 1.2M4.8 13.2l-1.2 1.2"/></svg></button>
   </div>
 </header>
 <div class="wrap">
@@ -361,7 +366,7 @@
     <div class="stat"><b>1</b><span>skipped</span></div>
     <div class="stat"><b>88</b><span>cases</span></div>
   </div>
-  <p class="mono" style="color:var(--faint)">generated 2026-08-26T16:32:22Z</p>
+  <p class="mono" style="color:var(--faint)">generated 2026-08-29T10:01:07Z</p>
 
   <h2>Run it yourself</h2>
   <p>Nothing here needs Vaara installed. The checkers use the standard library
@@ -536,26 +541,25 @@ python scripts/vcr_chain.py            # nothing removed from the table</code></
 <script>
 (function(){
   var root = document.documentElement;
-  var btns = document.querySelectorAll('.theme-toggle [data-set-theme]');
-  function apply(theme){
+  var meta = document.querySelector('meta[name="theme-color"]');
+  var btn  = document.getElementById("themeBtn");
+  var COLORS = { light: "#ececec", dark: "#0F1417" };
+  function current(){
+    var t = root.getAttribute("data-theme");
+    if (t) return t;
+    return (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) ? "dark" : "light";
+  }
+  function label(){
+    if (btn) btn.setAttribute("aria-label", current() === "dark" ? "Switch to light theme" : "Switch to dark theme");
+  }
+  function apply(theme) {
     root.setAttribute("data-theme", theme === "dark" ? "dark" : "light");
-    btns.forEach(function(b){
-      b.setAttribute("aria-pressed", String(b.getAttribute("data-set-theme") === theme));
-    });
+    if (meta) meta.setAttribute("content", COLORS[theme] || COLORS.light);
     try { localStorage.setItem("vaara-theme", theme); } catch(e) {}
+    label();
   }
-  // No stored choice: leave data-theme off so the OS decides, and show which
-  // side the OS landed on so the toggle is not lying about the current state.
-  function reflectAuto(){
-    root.removeAttribute("data-theme");
-    var dark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-    btns.forEach(function(b){
-      b.setAttribute("aria-pressed", String(b.getAttribute("data-set-theme") === (dark ? "dark" : "light")));
-    });
-  }
-  btns.forEach(function(b){
-    b.addEventListener("click", function(){ apply(b.getAttribute("data-set-theme")); });
-  });
+  function reflectAuto(){ root.removeAttribute("data-theme"); label(); }
+  if (btn) btn.addEventListener("click", function(){ apply(current() === "dark" ? "light" : "dark"); });
   var saved = null;
   try { saved = localStorage.getItem("vaara-theme"); } catch(e) {}
   if (saved === "dark" || saved === "light") apply(saved); else reflectAuto();


### PR DESCRIPTION
Three changes, all from the same reading of the classification circulated for the interop report.

**Prior art.** Every row now carries an optional prior-art field, so a row can say what is new to this register rather than what is new to the world. The intake form had nine fields and none of them was that. Carried through vcr_row.py and rendered on the badge only when the submitter gave one. Omitted entirely when absent, because writing an empty key into every row would change the JCS bytes of rows that say nothing new, and a row digest should move only when its content does.

**Kind.** The form's description said a row that does not name its kind reads as the first one. The field is required, so that cannot happen through the form. Reworded to say what is true: naming one is required, and rows filed before the field existed read as the weakest.

**Top bar.** webpage/conformance.html is generated by render_conformance_page.py, so the bar added by hand in #642 and #643 left the committed page stale against its own generator, which test_page_matches_a_fresh_run caught. The bar now lives in the template and the page is regenerated from it. Without this the next desk run would overwrite the new bar with the old floating controls.

245 conformance and VCR tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Prior art” field to conformance submissions, with support for displaying cited prior art on certificates.
  * Clarified that selecting a “Kind of run” is required and explained how older submissions are interpreted.
  * Added a sticky top navigation bar with section links and a streamlined light/dark theme toggle.

* **Style**
  * Improved page spacing, navigation states, responsive behavior, and theme-color updates for a more consistent browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->