### PR TITLE
feat(hedera): publish checkpoints to a live topic, and check them back off it with nothing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ scitt = ["cbor2>=5.4", "cryptography>=41.0"]
 proxy = ["fastapi>=0.110", "uvicorn>=0.29", "httpx>=0.27"]
 llm-proxy = ["fastapi>=0.110", "uvicorn>=0.29", "httpx[http2]>=0.27"]
 pq = ["dilithium-py>=1.4.0"]
+# Only scripts/hcs27_publish.py needs this. vaara.audit.hcs27 builds and
+# verifies checkpoints with the standard library alone, so a machine with no
+# SDK and no Hedera account can still do everything except submit.
+hedera = ["hiero-sdk-python>=0.2.10"]
 pdf = ["reportlab>=4.0"]
 bedrock = ["boto3>=1.34"]
 azure-content-safety = ["azure-ai-contentsafety>=1.0"]

--- a/scripts/demo_mcp_guardian.py
+++ b/scripts/demo_mcp_guardian.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Vaara as the guardian in front of an MCP agent, anchored to Hedera.
+
+The demo this exists to give: an agent asks to do a series of things, Vaara
+decides each one, the decisions become a hash-chained trail, and the head of
+that trail is committed to a public Hedera topic as an HCS-27 checkpoint.
+A stranger then reads the topic and checks what the agent was allowed to do,
+without installing Vaara and without trusting anyone who ran it.
+
+    scripts/demo_mcp_guardian.py --topic-id 0.0.NNNNN
+
+Run it with `--offline` to do everything except the ledger submit, which is
+the version that works on a machine with no account.
+
+Why this composes with HCS-27 rather than duplicating it
+---------------------------------------------------------
+The Hedera Agent Kit already governs value movement: spend caps, recipient
+allowlists, time windows, enforced by smart contract. Its own tracker (issue
+#1001, open since July) says even that is unfinished, and it has no notion of
+tool scope, argument content, or a decision reason.
+
+Vaara governs the act. Most of what an agent does is not a payment, and a
+transaction history cannot record a tool call that was refused, because a
+refused call never becomes a transaction. That absence is the whole problem:
+the actions worth auditing are exactly the ones that left no trace on chain.
+
+So the checkpoint commits to decisions, including the denials, and HCS-27
+supplies the append-only commitment underneath. The two do not overlap.
+
+Chaining
+--------
+Every checkpoint after the first carries `prev`, the last accepted
+(treeSize, rootHashB64u). That state lives in `.shared/hedera/` and is not in
+the repository, because it is per-deployment and not per-checkout. Losing it
+does not lose the trail; it means the next checkpoint has to be re-linked by
+reading the last one back off the topic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "src"))
+
+STATE = REPO / ".shared" / "hedera" / "checkpoint-state.json"
+
+#: What an agent connected through an MCP proxy actually asks for. Ordinary
+#: work first, then the ones that should not go through.
+#:
+#: Every name here is checked against `create_default_registry()`, which knows
+#: 23 action types. That check is not cosmetic: an unregistered name classifies
+#: as `unknown` with a local blast radius and scores LOW, so a demo built on a
+#: made-up tool name would show Vaara waving through the very thing it exists
+#: to catch. The first draft of this file did exactly that with a plausible
+#: looking `id.credential.issue`, which is not an action Vaara knows.
+CALLS: list[tuple[str, dict[str, Any]]] = [
+    ("data.read", {"resource": "customer_records", "count": 25}),
+    ("data.read", {"table": "orders", "filter": "status=open"}),
+    ("tx.transfer", {"amount": 25.0, "currency": "EUR", "to": "supplier_a"}),
+    ("data.export", {"resource": "customer_records", "destination": "s3://vendor-bucket", "count": 50000}),
+    ("tx.transfer", {"amount": 250000.0, "currency": "EUR", "to": "unknown_account"}),
+    ("id.grant_permission", {"subject": "contractor_9", "scope": "admin", "role": "root"}),
+    ("data.read", {"resource": "public_catalogue", "count": 3}),
+]
+
+AGENT = "mcp-agent-demo"
+
+
+def _load_state(topic_id: str) -> dict[str, Any]:
+    if not STATE.exists():
+        return {}
+    return json.loads(STATE.read_text(encoding="utf-8")).get(topic_id, {})
+
+
+def _save_state(topic_id: str, tree_size: int, root_b64u: str) -> None:
+    all_state = {}
+    if STATE.exists():
+        all_state = json.loads(STATE.read_text(encoding="utf-8"))
+    all_state[topic_id] = {"treeSize": tree_size, "rootHashB64u": root_b64u}
+    STATE.parent.mkdir(parents=True, exist_ok=True)
+    STATE.write_text(json.dumps(all_state, indent=2) + "\n", encoding="utf-8")
+
+
+def run_agent(db_path: Path) -> tuple[Any, list[Any]]:
+    """Drive the real pipeline against a trail that survives between runs.
+
+    The trail is deliberately persistent. An in-memory trail would make every
+    run produce a fresh log of the same length, and successive checkpoints
+    would then publish different roots at the same ``treeSize``: a log that was
+    replaced rather than extended, which is precisely the failure
+    ``hcs27_mirror_check.py`` exists to catch. It caught this script's first
+    version doing it.
+    """
+    from vaara.audit.sqlite_backend import SQLiteAuditBackend
+    from vaara.pipeline import InterceptionPipeline
+
+    from vaara.taxonomy.actions import create_default_registry
+
+    registry = create_default_registry()
+    unknown = [t for t, _ in CALLS if registry.classify(t, {}).name == "unknown"]
+    if unknown:
+        raise SystemExit(
+            "refusing to run: these tool names are not in the taxonomy and would "
+            f"classify as 'unknown', which scores low and allows: {sorted(set(unknown))}"
+        )
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    trail = SQLiteAuditBackend(str(db_path)).load_trail()
+    pipeline = InterceptionPipeline(trail=trail)
+
+    before = len(trail.snapshot())
+    print(f"trail before this run: {before} records ({db_path.name})\n")
+    print("The agent asks. Vaara answers.\n")
+    print(f"  {'TOOL':<26} {'DECISION':<10} {'DETAIL':<10} WHY")
+    print(f"  {'-' * 26} {'-' * 10} {'-' * 10} {'-' * 34}")
+
+    for tool, params in CALLS:
+        result = pipeline.intercept(
+            agent_id=AGENT, tool_name=tool, parameters=params, session_id="demo-1"
+        )
+        detail = getattr(result, "decision_detail", None) or ""
+        reason = (getattr(result, "reason", "") or "")[:34]
+        mark = "ok " if result.allowed else "STOP"
+        print(f"  {mark} {tool:<22} {result.decision:<10} {detail:<10} {reason}")
+
+    return trail, trail.snapshot()
+
+
+def build_checkpoint(records: list[Any], topic_id: str, memo: str) -> tuple[dict, list, bytes]:
+    from vaara.audit.hcs27 import checkpoint_for_records
+
+    prev = _load_state(topic_id)
+    prev_size = prev.get("treeSize")
+    prev_root = None
+    if prev_size is not None:
+        import base64
+
+        padding = "=" * (-len(prev["rootHashB64u"]) % 4)
+        prev_root = base64.urlsafe_b64decode(prev["rootHashB64u"] + padding)
+
+    return checkpoint_for_records(
+        records,
+        registry="vaara",
+        log_id="mcp-guardian",
+        prev_tree_size=prev_size,
+        prev_root_hash=prev_root,
+        memo=memo,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--topic-id", default="0.0.10245892")
+    parser.add_argument(
+        "--reset", action="store_true",
+        help="delete the persistent demo trail and start the log over",
+    )
+    parser.add_argument("--network", default="testnet")
+    parser.add_argument(
+        "--offline", action="store_true", help="do everything except the ledger submit"
+    )
+    args = parser.parse_args()
+
+    if args.reset:
+        for f in (REPO / ".shared" / "hedera").glob("mcp-guardian-trail.db*"):
+            f.unlink()
+        print("reset: removed the persistent demo trail\n")
+
+    print("=" * 72)
+    print("VAARA AS MCP GUARDIAN, ANCHORED TO HEDERA")
+    print("=" * 72)
+    print()
+
+    db_path = REPO / ".shared" / "hedera" / "mcp-guardian-trail.db"
+    trail, records = run_agent(db_path)
+
+    print()
+    print(f"  trail: {len(records)} records, chain intact: {trail.chain_intact}")
+    print()
+
+    memo = f"vaara mcp guardian, {len(records)} records"
+    message, entries, root = build_checkpoint(records, args.topic_id, memo)
+
+    from vaara.audit.hcs27 import b64u, message_bytes
+
+    payload = message_bytes(message)
+    root_b64u = b64u(root)
+
+    print("-" * 72)
+    print("CHECKPOINT")
+    print("-" * 72)
+    print(f"  entries    {len(entries)}")
+    print(f"  treeSize   {message['metadata']['root']['treeSize']}")
+    print(f"  root       {root_b64u}")
+    prev = message["metadata"].get("prev")
+    print(f"  prev       {prev['treeSize'] + ' / ' + prev['rootHashB64u'] if prev else 'genesis'}")
+    print(f"  bytes      {len(payload)}")
+    print()
+
+    if args.offline:
+        print("OFFLINE: not submitted. The bytes that would go on the ledger:")
+        print()
+        print(payload.decode("utf-8"))
+        return 0
+
+    import importlib.util as u
+
+    spec = u.spec_from_file_location("pub", str(REPO / "scripts" / "hcs27_publish.py"))
+    pub = u.module_from_spec(spec)
+    spec.loader.exec_module(pub)
+
+    from hiero_sdk_python import TopicId, TopicMessageSubmitTransaction
+
+    client, _key, network, operator = pub._client()
+    receipt = TopicMessageSubmitTransaction(
+        topic_id=TopicId.from_string(args.topic_id), message=payload
+    ).execute(client)
+
+    print("-" * 72)
+    print("SUBMITTED")
+    print("-" * 72)
+    print(f"  network    {network}")
+    print(f"  topic      {args.topic_id}")
+    print(f"  sequence   {getattr(receipt, 'topic_sequence_number', None)}")
+    print()
+
+    _save_state(args.topic_id, len(entries), root_b64u)
+
+    entries_path = REPO / ".shared" / "hedera" / f"entries-{args.topic_id}.json"
+    entries_path.parent.mkdir(parents=True, exist_ok=True)
+    entries_path.write_text(
+        json.dumps(entries, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    print("Anyone can now check this, with no Vaara and no Hedera SDK:")
+    print()
+    print(f"  scripts/hcs27_mirror_check.py --topic-id {args.topic_id} \\")
+    print(f"      --network {network} --entries {entries_path}")
+    print()
+    print(f"  https://{network}.mirrornode.hedera.com/api/v1/topics/{args.topic_id}/messages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hcs27_mirror_check.py
+++ b/scripts/hcs27_mirror_check.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Read a Vaara checkpoint back off a Hedera topic and check it, importing nothing.
+
+This is the half that has to convince someone who trusts neither Vaara nor the
+party that published the checkpoint. It imports **no Vaara code and no Hedera
+SDK**. Standard library only, over the public mirror-node REST API, which needs
+no account, no key and no install.
+
+    scripts/hcs27_mirror_check.py --topic-id 0.0.NNNNN
+
+What it proves, stated narrowly
+-------------------------------
+1. A message exists on that topic, at a consensus timestamp the network agreed.
+2. It parses as an HCS-27 `op=register` checkpoint.
+3. The root it publishes recomputes from the entries held locally, by a Merkle
+   construction built the opposite way round from the one that produced it:
+   recursive top-down split, where Vaara folds bottom up.
+4. Successive checkpoints on the topic chain: each `prev` equals the previous
+   message's `(treeSize, rootHashB64u)`, and the tree never shrinks.
+
+What it does not prove
+----------------------
+That the entries describe anything true. A checkpoint commits to a log. It says
+nothing about whether any record inside it describes a permitted act, and
+HCS-27 does not define log entry schemas. Checking the records themselves is
+`tests/vectors/hcs27_checkpoint_v0/_check_independent.py`, which recomputes the
+hash chain.
+
+**And it does not prove append-only growth between checkpoints.** `prev`
+chaining only asserts that a checkpoint names its predecessor correctly; a
+publisher who discards a log and starts a new one still produces a chain that
+links. Two cases are caught here, a shrinking tree and a tree that stayed the
+same size while its root moved, because both are visible from the checkpoints
+alone. The general case is not: proving that the earlier tree is a prefix of
+the later one needs an RFC 9162 consistency proof, which HCS-27 serves
+off-ledger rather than in the checkpoint. The vector carries one and
+`_check_independent.py` verifies it. A verifier who needs that guarantee
+between two live checkpoints has to ask the log operator for the proof.
+
+Canonicalisation is done here with `json.dumps(sort_keys=True,
+ensure_ascii=False, separators=(",", ":"))`, which reproduces JCS exactly for
+the fixed ASCII-keyed entry shape and needs no dependency. The independence
+claim of this script is about the network read-back. The independent JCS
+implementation is exercised by the vector checker, which uses `rfc8785`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULT_ENTRIES = REPO / "tests" / "vectors" / "hcs27_checkpoint_v0" / "entries.json"
+
+MIRROR = {
+    "testnet": "https://testnet.mirrornode.hedera.com",
+    "previewnet": "https://previewnet.mirrornode.hedera.com",
+    "mainnet": "https://mainnet.mirrornode.hedera.com",
+}
+
+
+# --- RFC 9162, built top-down, the opposite of the way Vaara builds it -------
+
+def _hash_leaf(data: bytes) -> bytes:
+    return hashlib.sha256(b"\x00" + data).digest()
+
+
+def _hash_node(left: bytes, right: bytes) -> bytes:
+    return hashlib.sha256(b"\x01" + left + right).digest()
+
+
+def _largest_power_of_two_lt(n: int) -> int:
+    k = 1
+    while k * 2 < n:
+        k *= 2
+    return k
+
+
+def merkle_root(canonical_entries: list[bytes]) -> bytes:
+    if not canonical_entries:
+        return hashlib.sha256(b"").digest()
+    if len(canonical_entries) == 1:
+        return _hash_leaf(canonical_entries[0])
+    k = _largest_power_of_two_lt(len(canonical_entries))
+    return _hash_node(
+        merkle_root(canonical_entries[:k]), merkle_root(canonical_entries[k:])
+    )
+
+
+def jcs(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, ensure_ascii=False, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def b64u(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+# --- mirror node -------------------------------------------------------------
+
+def fetch_messages(network: str, topic_id: str, limit: int) -> list[dict[str, Any]]:
+    base = MIRROR[network]
+    url = f"{base}/api/v1/topics/{topic_id}/messages?limit={limit}&order=asc"
+    out: list[dict[str, Any]] = []
+    while url:
+        req = urllib.request.Request(url, headers={"Accept": "application/json"})
+        try:
+            with urllib.request.urlopen(req, timeout=30) as response:
+                page = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                print(
+                    f"  topic {topic_id} has no messages on {network}, "
+                    f"or does not exist",
+                    file=sys.stderr,
+                )
+                return []
+            raise
+        out.extend(page.get("messages", []))
+        nxt = (page.get("links") or {}).get("next")
+        url = f"{base}{nxt}" if nxt else None
+        if len(out) >= limit:
+            break
+    return out
+
+
+def decode_message(raw: dict[str, Any]) -> dict[str, Any] | None:
+    """Decode one mirror-node message into a checkpoint, or None if it is not one."""
+    chunk = raw.get("chunk_info")
+    if chunk and chunk.get("total", 1) > 1:
+        # A Vaara checkpoint is a few hundred bytes and never chunks. A chunked
+        # message on this topic came from something else, and silently
+        # reassembling it would be guessing at another producer's framing.
+        return None
+    try:
+        payload = base64.b64decode(raw["message"])
+        return json.loads(payload.decode("utf-8"))
+    except Exception:
+        return None
+
+
+# --- checks ------------------------------------------------------------------
+
+def check_topic(
+    network: str, topic_id: str, entries: list[dict[str, Any]], limit: int
+) -> int:
+    print(f"topic     {topic_id} on {network}")
+    print(f"mirror    {MIRROR[network]}")
+    print()
+
+    messages = fetch_messages(network, topic_id, limit)
+    if not messages:
+        print("FAIL: no messages on the topic")
+        return 1
+
+    local_root = b64u(merkle_root([jcs(e) for e in entries]))
+    print(f"local entries      {len(entries)}")
+    print(f"local root         {local_root}")
+    print()
+
+    checkpoints: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for raw in messages:
+        decoded = decode_message(raw)
+        if not decoded:
+            continue
+        if decoded.get("p") != "hcs-27" or decoded.get("op") != "register":
+            continue
+        checkpoints.append((raw, decoded))
+
+    if not checkpoints:
+        print(f"FAIL: {len(messages)} message(s) on the topic, none an hcs-27 register")
+        return 1
+
+    failures = 0
+    matched_root = False
+
+    # One topic may legitimately carry several independent logs. HCS-27 gives
+    # each a `stream.log_id`, so `prev` chains within a log and says nothing
+    # across logs. Chaining per topic would report a false break the moment a
+    # second stream shares the topic, which is exactly what happened the first
+    # time this checker ran against a real one.
+    prev_by_log: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for raw, message in checkpoints:
+        metadata = message.get("metadata") or {}
+        root = metadata.get("root") or {}
+        stream = metadata.get("stream") or {}
+        seq = raw.get("sequence_number")
+        ts = raw.get("consensus_timestamp")
+        tree_size = root.get("treeSize")
+        root_hash = root.get("rootHashB64u")
+        log_key = (str(stream.get("registry")), str(stream.get("log_id")))
+        prev_seen = prev_by_log.get(log_key)
+
+        print(f"seq {seq}  consensus {ts}")
+        print(f"  log        {log_key[0]} / {log_key[1]}")
+        print(f"  registry   {(metadata.get('stream') or {}).get('registry')}")
+        print(f"  profile    {metadata.get('vaaraProfile', '(none)')}")
+        print(f"  leaf       {(metadata.get('log') or {}).get('leaf')}")
+        print(f"  treeSize   {tree_size}")
+        print(f"  root       {root_hash}")
+
+        # Structural rules HCS-27 states, checked rather than assumed.
+        if not isinstance(tree_size, str) or not tree_size.isdigit():
+            print("  FAIL: treeSize is not a canonical decimal string")
+            failures += 1
+        if not isinstance(root_hash, str) or "=" in root_hash or "+" in root_hash:
+            print("  FAIL: rootHashB64u is not unpadded base64url")
+            failures += 1
+
+        # The chain between successive checkpoints on this topic.
+        prev = metadata.get("prev")
+        if prev_seen is not None:
+            if not prev:
+                print("  FAIL: non-genesis checkpoint carries no prev")
+                failures += 1
+            elif (
+                prev.get("treeSize") != prev_seen["treeSize"]
+                or prev.get("rootHashB64u") != prev_seen["rootHashB64u"]
+            ):
+                print(
+                    f"  FAIL: prev does not match the previous checkpoint "
+                    f"({prev.get('treeSize')}, {prev.get('rootHashB64u')})"
+                )
+                failures += 1
+            elif int(tree_size) < int(prev_seen["treeSize"]):
+                print("  FAIL: the log shrank")
+                failures += 1
+            elif (
+                tree_size == prev_seen["treeSize"]
+                and root_hash != prev_seen["rootHashB64u"]
+            ):
+                # Same size, different root. The log did not grow, it was
+                # replaced. `prev` chaining cannot catch this on its own,
+                # because the new checkpoint honestly names the old one; only
+                # comparing the pair says the contents changed underneath.
+                print(
+                    "  FAIL: same treeSize as the previous checkpoint but a "
+                    "different root, so this log was replaced, not extended"
+                )
+                failures += 1
+            else:
+                print("  ok: prev chains to the previous checkpoint in this log")
+        else:
+            print("  first checkpoint seen for this log")
+
+        if root_hash == local_root and tree_size == str(len(entries)):
+            print("  ok: root recomputes from the local entries")
+            matched_root = True
+
+        prev_by_log[log_key] = {"treeSize": tree_size, "rootHashB64u": root_hash}
+        print()
+
+    if not matched_root:
+        print(
+            f"FAIL: no checkpoint on the topic publishes the root of the "
+            f"{len(entries)} local entries"
+        )
+        failures += 1
+
+    if failures:
+        print(f"FAIL: {failures} problem(s) across {len(checkpoints)} checkpoint(s)")
+        return 1
+
+    print(
+        f"PASS: {len(checkpoints)} checkpoint(s) read off the ledger, "
+        f"root recomputed independently, chain intact"
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--topic-id", required=True, help="e.g. 0.0.12345")
+    parser.add_argument("--network", default="testnet", choices=sorted(MIRROR))
+    parser.add_argument(
+        "--entries",
+        default=str(DEFAULT_ENTRIES),
+        help="entries the published root should commit to (default: the committed vector)",
+    )
+    parser.add_argument("--limit", type=int, default=100)
+    args = parser.parse_args()
+
+    entries = json.loads(Path(args.entries).read_text(encoding="utf-8"))
+    return check_topic(args.network, args.topic_id, entries, args.limit)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hcs27_publish.py
+++ b/scripts/hcs27_publish.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Create an HCS-27 checkpoint topic and submit a Vaara checkpoint to it.
+
+This is the network half of `vaara.audit.hcs27`. The module itself is stdlib
+only and never touches a network; everything that speaks to Hedera lives here,
+behind the `hedera` extra, so a checkpoint can still be built and verified on a
+machine that has no SDK and no account.
+
+    pip install 'vaara[hedera]'
+
+Credentials are never written, logged or echoed. They come from the
+environment, or from an env file that is not in the repository:
+
+    HEDERA_ACCOUNT_ID    operator account, e.g. 0.0.12345      (public)
+    HEDERA_PRIVATE_KEY   operator key, DER or hex               (SECRET)
+    HEDERA_NETWORK       testnet (default), previewnet, mainnet
+
+The default env file is `.shared/hedera/testnet.env`, under the one gitignored
+root, so a key put there cannot reach a commit. A real environment variable
+always wins over the file, and the file is refused if its permissions let
+anyone but the owner read it.
+
+Two steps, deliberately separate, because they have very different costs. A
+topic is created once and lives forever. Messages are submitted against it many
+times.
+
+    scripts/hcs27_publish.py create-topic
+    scripts/hcs27_publish.py submit --topic-id 0.0.NNNNN
+
+What gets submitted
+-------------------
+By default, the checkpoint from the committed conformance vector
+`tests/vectors/hcs27_checkpoint_v0/`. That is the useful thing to publish
+first: the root on the ledger can then be checked against entries any stranger
+can download from the repository, so the claim "this root commits to these
+seven records" is checkable by someone who trusts neither of us.
+
+`--from-checkpoint` takes any checkpoint message JSON instead, which is what a
+real trail run will pass.
+
+On the admin key
+----------------
+The topic is created with the operator key as admin key, so it can be updated
+or deleted later. Pass `--immutable` to create a topic with no admin key at
+all, which nobody can ever change or remove. That is the right choice for a
+production checkpoint stream and the wrong one for a first experiment, so it is
+opt-in.
+
+HIP-991 custom fees are not set here. The SDK supports them
+(`set_custom_fees`, `set_fee_schedule_key`, `set_fee_exempt_keys`) and the fee
+schedule key cannot be added after creation, so a topic intended to carry fees
+later has to be created with one from the start. That is a commercial decision
+rather than a technical default, so this script does not quietly make it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO = Path(__file__).resolve().parent.parent
+VECTOR = REPO / "tests" / "vectors" / "hcs27_checkpoint_v0"
+DEFAULT_ENV_FILE = REPO / ".shared" / "hedera" / "testnet.env"
+
+NETWORKS = ("testnet", "previewnet", "mainnet")
+
+CREDENTIAL_KEYS = (
+    "HEDERA_ACCOUNT_ID",
+    "HEDERA_PRIVATE_KEY",
+    "HEDERA_NETWORK",
+    "HEDERA_KEY_TYPE",
+)
+
+#: A raw 32-byte key is ambiguous: the SDK's own warning says there is no way
+#: to tell an Ed25519 seed from an ECDSA scalar, so it tries Ed25519 first and
+#: silently succeeds either way. Signing with the wrong curve produces a key
+#: that parses, an account that does not match, and an error at submit time
+#: that names neither. Say which curve it is.
+KEY_TYPES = ("ed25519", "ecdsa", "auto")
+
+
+def _fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _load_env_file(path: Path) -> dict[str, str]:
+    """Read KEY=value lines, without ever putting a value in a message.
+
+    A real environment variable wins over the file, so an operator can override
+    a stored key for one run without editing anything.
+    """
+    if not path.exists():
+        return {}
+
+    mode = path.stat().st_mode & 0o077
+    if mode:
+        _fail(
+            f"{path} is readable or writable by others (mode {oct(path.stat().st_mode & 0o777)}). "
+            f"Run: chmod 600 {path}"
+        )
+
+    values: dict[str, str] = {}
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if "=" not in stripped:
+            _fail(f"{path}:{lineno} is not a KEY=value line")
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        if key not in CREDENTIAL_KEYS:
+            _fail(
+                f"{path}:{lineno} sets {key!r}, which is not one of "
+                f"{', '.join(CREDENTIAL_KEYS)}"
+            )
+        values[key] = value.strip().strip("'\"")
+    return values
+
+
+def _client(env_file: Path | None = None) -> Any:
+    """Build an operator-bound client, or explain exactly what is missing."""
+    try:
+        from hiero_sdk_python import AccountId, Client, Network, PrivateKey
+    except ImportError:
+        _fail(
+            "the hiero-sdk-python package is not installed. "
+            "Install the extra with: pip install 'vaara[hedera]'"
+        )
+
+    path = env_file if env_file is not None else DEFAULT_ENV_FILE
+    from_file = _load_env_file(path)
+
+    def _get(key: str, default: str = "") -> str:
+        return (os.environ.get(key) or from_file.get(key) or default).strip()
+
+    account_id = _get("HEDERA_ACCOUNT_ID")
+    private_key = _get("HEDERA_PRIVATE_KEY")
+    network = _get("HEDERA_NETWORK", "testnet") or "testnet"
+
+    if not account_id:
+        _fail(
+            "HEDERA_ACCOUNT_ID is not set. Export it, or put it in "
+            f"{path} as HEDERA_ACCOUNT_ID=0.0.12345"
+        )
+    if not private_key:
+        _fail(f"HEDERA_PRIVATE_KEY is not set. Export it, or put it in {path}")
+    if network not in NETWORKS:
+        _fail(f"HEDERA_NETWORK must be one of {', '.join(NETWORKS)}, got {network!r}")
+
+    key_type = (_get("HEDERA_KEY_TYPE", "ed25519") or "ed25519").lower()
+    if key_type not in KEY_TYPES:
+        _fail(f"HEDERA_KEY_TYPE must be one of {', '.join(KEY_TYPES)}, got {key_type!r}")
+
+    parser = {
+        "ed25519": PrivateKey.from_string_ed25519,
+        "ecdsa": PrivateKey.from_string_ecdsa,
+        "auto": PrivateKey.from_string,
+    }[key_type]
+
+    try:
+        key = parser(private_key)
+    except Exception:
+        # Deliberately does not include the exception text, which some parsers
+        # render with the offending key material in it.
+        _fail(
+            f"HEDERA_PRIVATE_KEY could not be parsed as a {key_type} private key. "
+            f"If the account was created with the other curve, set HEDERA_KEY_TYPE."
+        )
+
+    client = Client(Network(network=network))
+    client.set_operator(AccountId.from_string(account_id), key)
+    return client, key, network, account_id
+
+
+def cmd_create_topic(args: argparse.Namespace) -> int:
+    from hiero_sdk_python import TopicCreateTransaction
+
+    client, key, network, account_id = _client(args.env_file and Path(args.env_file))
+
+    tx = TopicCreateTransaction().set_memo(args.memo)
+    if not args.immutable:
+        tx = tx.set_admin_key(key.public_key())
+    if args.submit_key:
+        tx = tx.set_submit_key(key.public_key())
+
+    receipt = tx.execute(client)
+    topic_id = str(receipt.topic_id)
+
+    print(f"network   {network}")
+    print(f"operator  {account_id}")
+    print(f"topic     {topic_id}")
+    print(f"memo      {args.memo}")
+    print(f"admin key {'none, this topic is immutable' if args.immutable else 'operator'}")
+    print(f"submit    {'operator key only' if args.submit_key else 'open to anyone'}")
+    print()
+    print("Next:")
+    print(f"  scripts/hcs27_publish.py submit --topic-id {topic_id}")
+    return 0
+
+
+def _load_checkpoint(args: argparse.Namespace) -> dict[str, Any]:
+    if args.from_checkpoint:
+        return json.loads(Path(args.from_checkpoint).read_text(encoding="utf-8"))
+    checkpoints = json.loads((VECTOR / "checkpoints.json").read_text(encoding="utf-8"))
+    return checkpoints["current"]
+
+
+def cmd_submit(args: argparse.Namespace) -> int:
+    checkpoint = _load_checkpoint(args)
+
+    # Exact submitted bytes. json.dumps with these settings is what
+    # vaara.audit.hcs27.message_bytes emits, and the digest on the wire has to
+    # be the digest anyone recomputing from the vector gets.
+    payload = json.dumps(checkpoint, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    if len(payload) > 1024:
+        _fail(f"message is {len(payload)} bytes, over Hedera's 1024-byte cap")
+
+    root = checkpoint["metadata"]["root"]
+
+    # Before the client, so a dry run needs no SDK, no key and no network. It
+    # is the step you use to see the exact bytes before anything is spent.
+    if args.dry_run:
+        print("DRY RUN, nothing submitted")
+        print(f"topic      {args.topic_id}")
+        print(f"bytes      {len(payload)}")
+        print(f"treeSize   {root['treeSize']}")
+        print(f"root       {root['rootHashB64u']}")
+        print()
+        print(payload.decode("utf-8"))
+        return 0
+
+    from hiero_sdk_python import TopicId, TopicMessageSubmitTransaction
+
+    client, _key, network, account_id = _client(args.env_file and Path(args.env_file))
+
+    receipt = (
+        TopicMessageSubmitTransaction(
+            topic_id=TopicId.from_string(args.topic_id), message=payload
+        )
+    ).execute(client)
+
+    sequence = getattr(receipt, "topic_sequence_number", None)
+
+    print(f"network    {network}")
+    print(f"operator   {account_id}")
+    print(f"topic      {args.topic_id}")
+    print(f"bytes      {len(payload)}")
+    print(f"treeSize   {root['treeSize']}")
+    print(f"root       {root['rootHashB64u']}")
+    print(f"sequence   {sequence}")
+    print()
+    print("Read it back with a checker that imports neither Vaara nor the SDK:")
+    print(
+        f"  scripts/hcs27_mirror_check.py --topic-id {args.topic_id} "
+        f"--network {network}"
+    )
+
+    if args.receipt:
+        out = Path(args.receipt)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(
+            json.dumps(
+                {
+                    "network": network,
+                    "topicId": args.topic_id,
+                    "sequenceNumber": sequence,
+                    "messageBytes": len(payload),
+                    "treeSize": root["treeSize"],
+                    "rootHashB64u": root["rootHashB64u"],
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        print(f"\nreceipt written to {out}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    create = sub.add_parser("create-topic", help="create a checkpoint topic, once")
+    create.add_argument(
+        "--memo",
+        default="vaara trail checkpoints, HCS-27",
+        help="topic memo, 100 bytes max",
+    )
+    create.add_argument(
+        "--immutable",
+        action="store_true",
+        help="create with no admin key, so the topic can never be changed or deleted",
+    )
+    create.add_argument(
+        "--submit-key",
+        action="store_true",
+        help="restrict submission to the operator key (default: anyone may submit)",
+    )
+    create.set_defaults(func=cmd_create_topic)
+
+    submit = sub.add_parser("submit", help="submit a checkpoint message")
+    submit.add_argument("--topic-id", required=True, help="e.g. 0.0.12345")
+    submit.add_argument(
+        "--from-checkpoint",
+        help="path to a checkpoint message JSON (default: the committed vector)",
+    )
+    submit.add_argument(
+        "--receipt", help="write a JSON receipt of the submission to this path"
+    )
+    submit.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the exact bytes and stop, touching no network and no credentials",
+    )
+    submit.set_defaults(func=cmd_submit)
+
+    for p_ in (create, submit):
+        p_.add_argument(
+            "--env-file",
+            help=f"credentials file (default: {DEFAULT_ENV_FILE})",
+        )
+
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_hcs27_mirror_check.py
+++ b/tests/test_hcs27_mirror_check.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for ``scripts/hcs27_mirror_check.py``, the off-ledger checker.
+
+The checker's whole value is that it needs nothing: no account, no key, no
+install, no Vaara. That makes it the piece a stranger runs, and the piece
+whose behaviour has to be pinned down here rather than discovered against a
+live network.
+
+Three layers:
+
+  agreement    the checker rebuilds the root top-down, splitting at the
+               largest power of two below n. Vaara folds bottom-up. The two
+               must land on the same bytes for every size, or an honest
+               publisher looks like a tampering one.
+  framing      what the checker accepts off the mirror node, and what it
+               refuses to guess at.
+  rules        the append-only rules, including the three defects that only
+               showed up when this ran against a real topic.
+
+The network is never touched. ``fetch_messages`` is replaced with a list of
+mirror-node rows, which is also the only way to construct the dishonest
+publishers these rules exist to catch.
+"""
+
+from __future__ import annotations
+
+import ast
+import base64
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from vaara.audit.hcs27 import b64u, root_for_entries
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "hcs27_mirror_check.py"
+VECTOR = REPO / "tests" / "vectors" / "hcs27_checkpoint_v0"
+
+
+def _load_checker() -> Any:
+    spec = importlib.util.spec_from_file_location("_hcs27_mirror_check", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mc = _load_checker()
+
+
+def _entries(n: int) -> list[dict[str, Any]]:
+    return [{"v": 1, "recordId": f"rec-{i:04d}"} for i in range(n)]
+
+
+def _root(entries: list[dict[str, Any]]) -> str:
+    return b64u(root_for_entries(entries))
+
+
+def _checkpoint(
+    entries: list[dict[str, Any]],
+    *,
+    log_id: str = "log-a",
+    registry: str = "0.0.900",
+    prev: dict[str, str] | None = None,
+    tree_size: str | None = None,
+    root: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "stream": {"registry": registry, "log_id": log_id},
+        "root": {
+            "treeSize": str(len(entries)) if tree_size is None else tree_size,
+            "rootHashB64u": _root(entries) if root is None else root,
+        },
+        "log": {"leaf": "sha256(0x00 || jcs(entry))"},
+        "vaaraProfile": "vaara-trail-v1",
+    }
+    if prev is not None:
+        metadata["prev"] = prev
+    return {"p": "hcs-27", "op": "register", "metadata": metadata}
+
+
+def _prev_of(checkpoint: dict[str, Any]) -> dict[str, str]:
+    root = checkpoint["metadata"]["root"]
+    return {"treeSize": root["treeSize"], "rootHashB64u": root["rootHashB64u"]}
+
+
+def _wire(seq: int, message: Any, *, chunk_total: int = 1) -> dict[str, Any]:
+    if isinstance(message, bytes):
+        payload = message
+    else:
+        payload = json.dumps(message).encode("utf-8")
+    return {
+        "sequence_number": seq,
+        "consensus_timestamp": f"1756220400.{seq:09d}",
+        "message": base64.b64encode(payload).decode("ascii"),
+        "chunk_info": {"number": 1, "total": chunk_total},
+    }
+
+
+def _run(
+    monkeypatch: pytest.MonkeyPatch,
+    messages: list[dict[str, Any]],
+    entries: list[dict[str, Any]],
+) -> int:
+    monkeypatch.setattr(
+        mc, "fetch_messages", lambda network, topic_id, limit: list(messages)
+    )
+    return mc.check_topic("testnet", "0.0.12345", entries, 100)
+
+
+def _toplevel_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            modules.add(node.module.split(".")[0])
+    return modules
+
+
+# --- agreement between the two constructions ---------------------------------
+
+def test_top_down_root_matches_the_bottom_up_fold_for_every_small_size():
+    """Vaara folds bottom-up, the checker splits top-down. Same bytes, or the
+    checker calls an honest publisher a liar."""
+    for n in range(65):
+        entries = _entries(n)
+        top_down = mc.merkle_root([mc.jcs(e) for e in entries])
+        assert top_down == root_for_entries(entries), f"diverged at tree size {n}"
+
+
+def test_the_two_constructions_agree_at_power_of_two_boundaries():
+    """The split point is the largest power of two below n, so 2^k and its
+    neighbours are where an off-by-one would hide."""
+    sizes = sorted(
+        {s for k in range(11) for s in (2**k - 1, 2**k, 2**k + 1) if 0 <= s <= 1025}
+    )
+    for n in sizes:
+        entries = _entries(n)
+        top_down = mc.merkle_root([mc.jcs(e) for e in entries])
+        assert top_down == root_for_entries(entries), f"diverged at tree size {n}"
+
+
+def test_the_empty_tree_agrees():
+    assert mc.merkle_root([]) == root_for_entries([])
+
+
+def test_the_checker_canonicalises_identically_to_vaara():
+    from vaara.audit.hcs27 import canonical_json
+
+    entries = json.loads((VECTOR / "entries.json").read_text(encoding="utf-8"))
+    for entry in entries:
+        assert mc.jcs(entry) == canonical_json(entry)
+
+
+def test_the_shipped_vector_root_recomputes_top_down():
+    entries = json.loads((VECTOR / "entries.json").read_text(encoding="utf-8"))
+    assert b64u(mc.merkle_root([mc.jcs(e) for e in entries])) == _root(entries)
+
+
+def test_reordering_entries_changes_the_top_down_root():
+    entries = _entries(7)
+    swapped = list(entries)
+    swapped[1], swapped[2] = swapped[2], swapped[1]
+    assert mc.merkle_root([mc.jcs(e) for e in swapped]) != mc.merkle_root(
+        [mc.jcs(e) for e in entries]
+    )
+
+
+# --- what comes off the mirror node ------------------------------------------
+
+def test_a_chunked_message_is_not_reassembled():
+    """A Vaara checkpoint is a few hundred bytes and never chunks. Reassembling
+    someone else's framing would be guessing."""
+    assert mc.decode_message(_wire(1, _checkpoint(_entries(3)), chunk_total=4)) is None
+
+
+def test_an_unchunked_message_is_decoded():
+    checkpoint = _checkpoint(_entries(3))
+    assert mc.decode_message(_wire(1, checkpoint)) == checkpoint
+
+
+def test_a_message_that_is_not_json_is_skipped():
+    assert mc.decode_message(_wire(1, b"\x00\x01 not json")) is None
+
+
+def test_a_message_with_no_chunk_info_is_decoded():
+    row = _wire(1, _checkpoint(_entries(3)))
+    del row["chunk_info"]
+    assert mc.decode_message(row) is not None
+
+
+def test_a_topic_carrying_no_hcs27_register_fails(monkeypatch, capsys):
+    other = {"p": "hcs-2", "op": "update"}
+    assert _run(monkeypatch, [_wire(1, other)], _entries(3)) == 1
+    assert "none an hcs-27 register" in capsys.readouterr().out
+
+
+def test_an_empty_topic_fails(monkeypatch, capsys):
+    assert _run(monkeypatch, [], _entries(3)) == 1
+    assert "no messages on the topic" in capsys.readouterr().out
+
+
+# --- the append-only rules ---------------------------------------------------
+
+def test_a_clean_chain_passes(monkeypatch, capsys):
+    first = _checkpoint(_entries(3))
+    second = _checkpoint(_entries(7), prev=_prev_of(first))
+    assert _run(monkeypatch, [_wire(1, first), _wire(2, second)], _entries(7)) == 0
+    out = capsys.readouterr().out
+    assert "PASS" in out
+    assert "root recomputes from the local entries" in out
+
+
+def test_two_logs_on_one_topic_do_not_report_a_false_break(monkeypatch, capsys):
+    """HCS-27 gives each log a stream.log_id, so prev chains within a log and
+    says nothing across logs. Chaining per topic reported a break the first
+    time a second stream shared a topic."""
+    a1 = _checkpoint(_entries(3), log_id="log-a")
+    b1 = _checkpoint(_entries(5), log_id="log-b")
+    a2 = _checkpoint(_entries(7), log_id="log-a", prev=_prev_of(a1))
+    messages = [_wire(1, a1), _wire(2, b1), _wire(3, a2)]
+    assert _run(monkeypatch, messages, _entries(7)) == 0
+    out = capsys.readouterr().out
+    assert "FAIL" not in out
+    assert out.count("first checkpoint seen for this log") == 2
+
+
+def test_the_same_log_id_under_a_different_registry_is_a_different_log(
+    monkeypatch, capsys
+):
+    a1 = _checkpoint(_entries(3), log_id="log-a", registry="0.0.900")
+    b1 = _checkpoint(_entries(7), log_id="log-a", registry="0.0.901")
+    assert _run(monkeypatch, [_wire(1, a1), _wire(2, b1)], _entries(7)) == 0
+    assert capsys.readouterr().out.count("first checkpoint seen for this log") == 2
+
+
+def test_a_shrinking_log_fails(monkeypatch, capsys):
+    first = _checkpoint(_entries(7))
+    second = _checkpoint(_entries(3), prev=_prev_of(first))
+    assert _run(monkeypatch, [_wire(1, first), _wire(2, second)], _entries(3)) == 1
+    assert "the log shrank" in capsys.readouterr().out
+
+
+def test_a_log_replaced_at_the_same_size_fails(monkeypatch, capsys):
+    """prev chaining alone cannot catch this: the new checkpoint honestly names
+    the old one. Only comparing the pair says the contents moved underneath."""
+    first = _checkpoint(_entries(7))
+    replacement = _entries(7)
+    replacement[2] = {"v": 1, "recordId": "rec-swapped"}
+    second = _checkpoint(replacement, prev=_prev_of(first))
+    assert _run(monkeypatch, [_wire(1, first), _wire(2, second)], replacement) == 1
+    assert "replaced, not extended" in capsys.readouterr().out
+
+
+def test_a_non_genesis_checkpoint_without_prev_fails(monkeypatch, capsys):
+    first = _checkpoint(_entries(3))
+    second = _checkpoint(_entries(7))
+    assert _run(monkeypatch, [_wire(1, first), _wire(2, second)], _entries(7)) == 1
+    assert "carries no prev" in capsys.readouterr().out
+
+
+def test_a_prev_naming_the_wrong_checkpoint_fails(monkeypatch, capsys):
+    first = _checkpoint(_entries(3))
+    second = _checkpoint(
+        _entries(7), prev={"treeSize": "4", "rootHashB64u": _root(_entries(4))}
+    )
+    assert _run(monkeypatch, [_wire(1, first), _wire(2, second)], _entries(7)) == 1
+    assert "prev does not match the previous checkpoint" in capsys.readouterr().out
+
+
+def test_a_tree_size_that_is_not_a_decimal_string_fails(monkeypatch, capsys):
+    checkpoint = _checkpoint(_entries(7), tree_size="0x7")
+    assert _run(monkeypatch, [_wire(1, checkpoint)], _entries(7)) == 1
+    assert "treeSize is not a canonical decimal string" in capsys.readouterr().out
+
+
+def test_a_tree_size_carried_as_a_number_fails(monkeypatch, capsys):
+    checkpoint = _checkpoint(_entries(7))
+    checkpoint["metadata"]["root"]["treeSize"] = 7
+    assert _run(monkeypatch, [_wire(1, checkpoint)], _entries(7)) == 1
+    assert "treeSize is not a canonical decimal string" in capsys.readouterr().out
+
+
+def test_a_padded_or_non_url_safe_root_fails(monkeypatch, capsys):
+    entries = _entries(7)
+    padded = base64.b64encode(root_for_entries(entries)).decode("ascii")
+    checkpoint = _checkpoint(entries, root=padded)
+    assert _run(monkeypatch, [_wire(1, checkpoint)], entries) == 1
+    assert "rootHashB64u is not unpadded base64url" in capsys.readouterr().out
+
+
+def test_a_topic_that_never_publishes_the_local_root_fails(monkeypatch, capsys):
+    """The checker's real question is whether the ledger carries the root of
+    the entries in front of you, not merely a well-formed chain."""
+    published = _checkpoint(_entries(7))
+    assert _run(monkeypatch, [_wire(1, published)], _entries(5)) == 1
+    assert "no checkpoint on the topic publishes the root" in capsys.readouterr().out
+
+
+def test_a_matching_root_at_the_wrong_tree_size_does_not_count(monkeypatch, capsys):
+    entries = _entries(7)
+    checkpoint = _checkpoint(entries, tree_size="8", root=_root(entries))
+    assert _run(monkeypatch, [_wire(1, checkpoint)], entries) == 1
+    assert "no checkpoint on the topic publishes the root" in capsys.readouterr().out
+
+
+# --- the checker needs nothing -----------------------------------------------
+
+def test_the_checker_imports_nothing_outside_the_standard_library():
+    """This is the file a stranger runs. The moment it needs an install, the
+    independent check stops being independent."""
+    outside = _toplevel_imports(SCRIPT) - set(sys.stdlib_module_names)
+    assert outside == set(), f"{SCRIPT.name} now needs {sorted(outside)}"
+
+
+def test_the_checker_imports_neither_vaara_nor_the_hedera_sdk():
+    imported = _toplevel_imports(SCRIPT)
+    assert "vaara" not in imported
+    assert "hiero_sdk_python" not in imported
+
+
+def test_the_checkpoint_module_needs_no_third_party_package():
+    """vaara.audit.hcs27 builds and verifies with the standard library alone,
+    so a machine with no SDK and no Hedera account can do everything except
+    submit. Its own imports are stdlib plus Vaara; note this says nothing
+    about what importing the vaara package as a whole drags in."""
+    outside = _toplevel_imports(REPO / "src" / "vaara" / "audit" / "hcs27.py")
+    outside -= set(sys.stdlib_module_names)
+    assert outside == {"vaara"}, f"hcs27.py now needs {sorted(outside)}"
+
+
+def test_only_the_publisher_needs_the_hedera_sdk():
+    assert "hiero_sdk_python" in _toplevel_imports(REPO / "scripts" / "hcs27_publish.py")


### PR DESCRIPTION
The HCS-27 module shipped in v1.78.0 could build a checkpoint, but nothing could put one on a network or read one off. Three scripts close that, and the split between them is the point: everything that needs an account lives in one file, and the file that verifies needs no account, no key and no install.

## What is here

**scripts/hcs27_publish.py** creates a topic and submits a checkpoint. It is the only piece that needs the SDK, behind a new `hedera` extra (hiero-sdk-python, Apache-2.0).

**scripts/hcs27_mirror_check.py** reads a topic off the public mirror node REST API and recomputes the published root by recursive top-down split, the opposite construction to the bottom-up fold that produced it. Standard library only. It imports no Vaara and no Hedera SDK.

**scripts/demo_mcp_guardian.py** drives the real pipeline over a persistent trail, prints what the gate decided, checkpoints the head and submits it.

## Three defects found by running against a real network

A raw 32-byte private key is ambiguous. The SDK's own warning says an Ed25519 seed cannot be distinguished from an ECDSA scalar, so `from_string` tries Ed25519 first and succeeds either way, producing a key that parses and a failure at submit time that names neither cause. `HEDERA_KEY_TYPE` now selects the parser explicitly and defaults to ed25519.

One topic may legitimately carry several logs. HCS-27 gives each a `stream.log_id`, so `prev` chains within a log and says nothing across logs. The first version chained per topic and reported a false break the moment a second stream shared a topic, which happened on the first real run.

`prev` chaining alone does not prove append-only growth. A publisher that discards a log and starts another still produces a chain that links. Two cases are now caught from the checkpoints alone, a shrinking tree and a tree that kept its size while its root moved. The general case needs an RFC 9162 consistency proof, which HCS-27 serves off-ledger, and the file says so rather than leaving it to be discovered.

The demo also refuses to start if any tool name is absent from the taxonomy. An unregistered name classifies as unknown with a local blast radius and scores low enough to be allowed, so a demo written against a plausible-looking but non-existent tool would show the gate waving through the thing it exists to stop.

## Tests

The checker is the file a stranger runs, so its behaviour is pinned rather than discovered against a live network. 28 tests, no network touched: `fetch_messages` is replaced with mirror-node rows, which is also the only way to build the dishonest publishers these rules exist to catch.

The two Merkle constructions are asserted to agree rather than re-derived by inspection: every tree size 0 to 64, and 2^k either side up to 1025. Replacing the split point with n//2 fails six of those tests.

Each of the three defects has a test that fails when the fix is removed. That was checked by removing each fix in turn: chaining per topic fails the two-logs tests, dropping the shrink check fails the shrinking-log test, dropping the same-size comparison fails the replaced-log test.

The checker's value is a property of its import list, so the import list is checked.

One limit is worth stating plainly. `vaara.audit.hcs27` uses only the standard library in its own code, so a machine with no SDK and no Hedera account can do everything except submit. Importing it still goes through the `vaara` package, which brings numpy and joblib with it. The test asserts the first and says it does not cover the second. The checker script has no such caveat: it imports nothing outside the standard library at all.

Credentials come from the environment or an env file under the one gitignored root, are never echoed, and are stripped out of parse errors. The script refuses an env file that others can read.

3474 tests pass, 26 skipped. Conformance suites unchanged.