### PR TITLE
release: 1.79.0, the checkpoint reaches a ledger, and the file that checks it needs nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.79.0] - 2026-08-31
+
+### Added
+
+- Three scripts put an HCS-27 checkpoint on a Hedera topic and read it back off one. The module shipped in 1.78.0 could build a checkpoint and nothing could publish or retrieve it. The split between the three is the point: everything needing an account lives in `scripts/hcs27_publish.py`, behind a new `hedera` extra, while `scripts/hcs27_mirror_check.py` reads a topic off the public mirror node and recomputes the published root with no account, no key and no install. The checker imports nothing outside the standard library, no Vaara and no Hedera SDK, and a test now asserts that rather than leaving it as an intention. `scripts/demo_mcp_guardian.py` drives the pipeline over a persistent trail, prints what the gate decided, checkpoints the head and submits it.
+
+  Three defects came out of running these against a real network rather than reasoning about them. A raw 32-byte private key is ambiguous, because an Ed25519 seed cannot be distinguished from an ECDSA scalar, so both parse and the failure arrives at submit time naming neither cause; `HEDERA_KEY_TYPE` now selects the parser and defaults to ed25519. One topic may legitimately carry several logs, and HCS-27 gives each a `stream.log_id`, so `prev` chains within a log and says nothing across logs; chaining per topic reported a false break the moment a second stream shared a topic. And `prev` chaining alone does not prove append-only growth, because a publisher that discards a log and starts another still produces a chain that links, so a shrinking tree and a tree that kept its size while its root moved are now both caught from the checkpoints alone. The general case needs an RFC 9162 consistency proof, which HCS-27 serves off-ledger, and the file says so.
+
+### Fixed
+
+- The checker is pinned by 28 tests that touch no network. The two Merkle constructions are asserted to agree at every tree size 0 to 64 and at 2^k either side up to 1025, rather than re-derived by inspection, and each of the three defects above has a test that fails when its fix is removed.
+
+  One claim from the scripts' own description did not survive those tests. `vaara.audit.hcs27` uses only the standard library in its own code, so a machine with no SDK and no Hedera account can do everything except submit, but importing it goes through the `vaara` package, which brings numpy and joblib with it. The test asserts the first and records that it does not cover the second. The checker script carries no such caveat.
+
 ## [1.78.0] - 2026-08-27
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.78.0"
+appVersion: "1.79.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.78.0, Helm chart 0.1.0.
+Vaara 1.79.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.78.0",
+  "version": "1.79.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.78.0"
+version = "1.79.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.78.0",
+  "version": "1.79.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.78.0",
+"version": "1.79.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.78.0",
+  "version": "1.79.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.78.0",
+"version": "1.79.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.78.0"
+__version__ = "1.79.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Release 1.79.0.

The HCS-27 module shipped in 1.78.0 could build a checkpoint. Nothing could put one on a network or read one back off it. This release closes that with three scripts, and the split between them is the point: everything that needs an account lives in one file, and the file that verifies needs no account, no key and no install.

## What ships

**Publish.** `scripts/hcs27_publish.py` creates a topic and submits a checkpoint. It is the only piece that needs the SDK, behind a new `hedera` extra (hiero-sdk-python, Apache-2.0).

**Check.** `scripts/hcs27_mirror_check.py` reads a topic off the public mirror node REST API and recomputes the published root by recursive top-down split, the opposite construction to the bottom-up fold that produced it. It imports nothing outside the standard library, no Vaara and no Hedera SDK. That is the property that makes it worth running at all, so it is now asserted by a test rather than left as an intention.

**Demonstrate.** `scripts/demo_mcp_guardian.py` drives the pipeline over a persistent trail, prints what the gate decided, checkpoints the head and submits it. It refuses to start if any tool name is absent from the taxonomy, because an unregistered name classifies as unknown with a local blast radius and scores low enough to be allowed, which would show the gate waving through the thing it exists to stop.

## Three defects a real network found

A raw 32-byte private key is ambiguous. An Ed25519 seed cannot be distinguished from an ECDSA scalar, so `from_string` succeeds either way and the failure arrives at submit time naming neither cause. `HEDERA_KEY_TYPE` now selects the parser explicitly and defaults to ed25519.

One topic may legitimately carry several logs. HCS-27 gives each a `stream.log_id`, so `prev` chains within a log and says nothing across logs. Chaining per topic reported a false break the moment a second stream shared a topic.

`prev` chaining alone does not prove append-only growth. A publisher that discards a log and starts another still produces a chain that links. A shrinking tree and a tree that kept its size while its root moved are now both caught from the checkpoints alone. The general case needs an RFC 9162 consistency proof, which HCS-27 serves off-ledger, and the file says so rather than leaving it to be discovered.

## Tests

The scripts arrived with none. The checker is now pinned, because it is the file a stranger runs. 28 tests, no network touched.

The two Merkle constructions are asserted to agree at every tree size 0 to 64 and at 2^k either side up to 1025, rather than re-derived by inspection. Each of the three defects has a test that fails when its fix is removed, which was checked by removing each fix in turn.

One claim did not survive. `vaara.audit.hcs27` uses only the standard library in its own code, so a machine with no SDK and no Hedera account can do everything except submit. Importing it still goes through the `vaara` package, which brings numpy and joblib. The test asserts the first and records that it does not cover the second. The checker script carries no such caveat.

## Verification

3474 tests pass, 26 skipped. Conformance suites unchanged. Credentials come from the environment or an env file under the one gitignored root, are never echoed, and are stripped out of parse errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated Vaara to version 1.79.0 across packages, server components, plugins, and deployment metadata.

- **Documentation**
  - Added release documentation covering HCS-27 publishing, mirror-based verification, configurable key types, per-log chaining, checkpoint-based tree-change detection, and RFC 9162 consistency-proof support.
  - Documented expanded network-free test coverage and the remaining package-import limitation.
  - Updated the supported-platforms information for version 1.79.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->