### PR TITLE
revocation: state the freshness bound a clean answer was decided under

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.80.0] - 2026-09-02
+
+### Added
+
+- A revocation registry now records when it was observed, and a clean answer states how far into the past it reaches. Until this release `RevocationRegistry.status()` returned `revoked=False` with nothing attached, which reads as "this key is fine" when what the computation supports is "nothing in the entries I hold revoked it, as of whenever I obtained them". `RevocationRegistry` takes an optional `as_of`, `status()` takes the deployment's `now` and `max_staleness_seconds`, and `RevocationStatus` carries `registry_as_of`, `freshness` and `establishes_current`.
+
+  `freshness` is `fresh`, `stale` or `unknown`. `unknown` covers a registry with no `as_of`, a caller who stated no bound, and an `as_of` later than `now`. That last one is a clock disagreement, so the bound cannot be evaluated honestly and is not quietly treated as met. `establishes_current` is true for exactly one combination, not revoked and fresh, and every other combination is a statement about the past.
+
+  Staleness weakens the negative answer alone. A revocation the verifier can see binds however old the registry is, because a revocation fact does not expire. An implementation reasoning "the registry is stale, so we know nothing" would discard a revocation it is plainly holding, which is worse than the gap this closes.
+
+  The rule is `draft-sirkkavaara-vaara-receipt-08` Section 10, posted to the datatracker the same day: offline verification is a computation over the parameters the consumer holds, revocation is a property of the present, and where a decision depends on revocation state the staleness a deployment accepts is an operational parameter that deployment must state. The shape is the one RPKI uses, where a router validates against a locally held cache whose refresh interval is a stated parameter rather than something the validation establishes.
+
+- `revocation_freshness_v0` is the 49th vector suite. Seven cases, six of them negative, and `establishes_current` is true in exactly one row of its table. `revoked_stale` pins the asymmetry above and is the case most likely to regress. `future_as_of` pins the clock-disagreement rule. The checker imports the standard library plus `rfc8785`, rebuilds both the revocation-in-time predicate and the freshness rule from the text rather than calling the implementation it grades, and is the form of local, third-party-runnable detection the European Commission's Article 50 transparency guidelines describe at paragraph 76.
+
+  Compatibility is checkable rather than asserted. `as_of` serialises only when set, so a registry without one produces the bytes it produced before the field existed. The `undated_clean` case digests to `sha256:a6a20076da005b27c9afc3a5d5b2457798c0ac817d1abc38b2fee4398ac3f133`, byte-identical to the `clean` case in `cross_stack_revocation_v0`, so no previously issued digest moved. Callers passing neither `now` nor `max_staleness_seconds` get the previous `revoked` answer with `freshness="unknown"` attached.
+
 ## [1.79.0] - 2026-08-31
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.79.0",
+  "version": "1.80.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.79.0"
+appVersion: "1.80.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/conformance-profile.md
+++ b/docs/conformance-profile.md
@@ -23,7 +23,7 @@ reproduce the published verdicts under the same checker. The aggregate runner
 `scripts/conformance_runner.py` discovers every suite, runs each checker in a
 subprocess, and returns a single pass/fail.
 
-Profile v1 covers the 48 suites listed below, at the `v0` vector format. The
+Profile v1 covers the 49 suites listed below, at the `v0` vector format. The
 authoritative, always-current enumeration for any tagged release is the runner's
 own `--list` output at that tag.
 
@@ -96,7 +96,7 @@ Suites reported `SKIP`, not pass, in an aggregate run:
   both run.
 
 So a clean checkout with `rfc8785` and `cryptography` alone grades 45 passed,
-0 failed, 3 skipped across the 48 suites.
+0 failed, 3 skipped across the 49 suites.
 
 ## What a pass means, and what it does not
 
@@ -112,30 +112,31 @@ grows; conformance is always against a named version.
 ## Suites in Profile v1
 
 ```
-acp_checkout_v0                decision_pairing_v0
-agent_decision_v0              decision_vocabulary_v0
-agent_identity_v0              enforcement_attestation_v0
-ap2_v0                         enforcement_set_v0
-article12_fold_v0              evidence_bundle_v0
-atlas_threat_v0                evidence_ref_v0
-attestation_result_v0          execution_receipt_v0
-attribute_attestation_v0       external_evidence_v0
-attribute_attestation_zk_v0    fallback_projection_v0
-audit_summary_v0               governance_decision_v0
-authorization_v0               handoff_set_v0
-build_bundle_v0                hcs27_checkpoint_v0
-bundle_doc_v0                  ingest_v0
-bundle_set_v0                  key_rotation_v0
-capability_scope_v0            normalize_v0
-class_gate_v0                  pq_hybrid_v0
-conformance_statement_v0       qualified_time_v0
-contiguity_v0                  record_conformance_v0
-credential_binding_v0          record_set_v0
-credential_grant_v0            release_condition_v0
+acp_checkout_v0                decision_vocabulary_v0
+agent_decision_v0              enforcement_attestation_v0
+agent_identity_v0              enforcement_set_v0
+ap2_v0                         evidence_bundle_v0
+article12_fold_v0              evidence_ref_v0
+atlas_threat_v0                execution_receipt_v0
+attestation_result_v0          external_evidence_v0
+attribute_attestation_v0       fallback_projection_v0
+attribute_attestation_zk_v0    governance_decision_v0
+audit_summary_v0               handoff_set_v0
+authorization_v0               hcs27_checkpoint_v0
+build_bundle_v0                ingest_v0
+bundle_doc_v0                  key_rotation_v0
+bundle_set_v0                  normalize_v0
+capability_scope_v0            pq_hybrid_v0
+class_gate_v0                  qualified_time_v0
+conformance_statement_v0       record_conformance_v0
+contiguity_v0                  record_set_v0
+credential_binding_v0          release_condition_v0
+credential_grant_v0            revocation_freshness_v0
 crewai_enforcement_v0          sep2787_attestation_v0
 cross_org_handoff_v0           tap_v0
 cross_stack_revocation_v0      transparency_consistency_v0
 data_locality_v0               x402_settlement_v0
+decision_pairing_v0
 ```
 
 ## Related

--- a/docs/design/cross-stack-revocation-spec.md
+++ b/docs/design/cross-stack-revocation-spec.md
@@ -107,3 +107,71 @@ Purely additive. The receipt envelope, canonicalization, inclusion- and
 consistency-proof formats, and signature verification are unchanged; the
 envelope version stays 1. `export_signed` with no `revocation` argument
 produces a byte-identical manifest to v0.54.
+
+## Freshness: what a clean answer is allowed to claim (v1.80.0)
+
+The registry answers one question, and until v1.80.0 it answered it without
+saying when it had last looked. `revoked=False` therefore read as "this key is
+fine", when what the computation supports is "nothing in the entries I hold
+revoked it, as of whenever I obtained them".
+
+`draft-sirkkavaara-vaara-receipt-08` Section 10 states the limit directly:
+offline verification is a computation over the parameters the consumer holds,
+revocation is a property of the present, and where a decision depends on
+revocation state the staleness a deployment accepts is an operational
+parameter that deployment must state. The same shape appears in RPKI, where a
+router validates against a locally held cache and the cache's refresh interval
+is a stated operational parameter rather than something validation establishes.
+
+### The model
+
+`RevocationRegistry` gains an optional `as_of`, the instant the registry was
+observed. `RevocationRegistry.status()` gains `now` and
+`max_staleness_seconds`, which are the deployment's stated parameters, and
+`RevocationStatus` gains `registry_as_of` and `freshness`.
+
+`freshness` is `"fresh"`, `"stale"`, or `"unknown"`:
+
+- `"fresh"` requires an `as_of`, a stated `max_staleness_seconds`, both
+  instants parseable, and an age from zero to the bound inclusive.
+- `"stale"` is an age beyond the bound.
+- `"unknown"` is everything else, including a registry with no `as_of`, a
+  caller who stated no bound, and an `as_of` later than `now`. A future
+  observation instant means the clocks disagree, so the bound cannot be
+  evaluated honestly and is not silently treated as satisfied.
+
+`RevocationStatus.establishes_current` is true for exactly one combination:
+not revoked and fresh. Every other combination is a statement about the past.
+
+### The asymmetry, and why it is the part to protect
+
+Staleness weakens the negative answer only. A revocation the verifier can see
+is binding however old the registry is, because a revocation fact does not
+expire: the key was revoked at that instant whether the list is an hour old or
+a year old. An implementation that reasons "the registry is stale, so we know
+nothing" would drop a revocation it is plainly holding, which is strictly
+worse than the gap this change closes.
+
+### Conformance
+
+The `revocation_freshness_v0` vector set pins seven cases, six of them
+negative. `revoked_stale` pins the asymmetry above. `future_as_of` pins the
+clock-disagreement rule. `establishes_current` is true in exactly one row of
+the table, which is the property the suite exists to defend.
+
+The checker imports the standard library plus `rfc8785` and rebuilds both the
+revocation-in-time predicate and the freshness rule from the text, so a second
+implementation can confirm the rules from the committed bytes alone. That is
+what the European Commission's Article 50 transparency guidelines describe at
+paragraph 76 as detection "ideally locally executable on the digital device".
+
+### Compatibility
+
+Additive, and checkable rather than asserted. `as_of` is serialised only when
+set, so a registry without one produces the bytes it produced before the field
+existed. The `undated_clean` case in `revocation_freshness_v0` has registry
+digest `sha256:a6a20076da005b27c9afc3a5d5b2457798c0ac817d1abc38b2fee4398ac3f133`,
+byte-identical to the `clean` case in `cross_stack_revocation_v0`. No
+previously issued digest moved. Callers that pass neither `now` nor
+`max_staleness_seconds` get the previous `revoked` answer with
+`freshness="unknown"` attached.

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.79.0, Helm chart 0.1.0.
+Vaara 1.80.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.79.0",
+  "version": "1.80.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.79.0"
+version = "1.80.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.79.0",
+  "version": "1.80.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.79.0",
+"version": "1.80.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.79.0",
+  "version": "1.80.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.79.0",
+"version": "1.80.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.79.0"
+__version__ = "1.80.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/attestation/_revocation.py
+++ b/src/vaara/attestation/_revocation.py
@@ -43,6 +43,11 @@ from vaara.attestation._receipt_types import ExecutionReceipt
 
 RevocationScope = Literal["key", "identity"]
 
+# How recent the registry was, relative to the bound the deployment stated.
+# "unknown" is the honest default: it is what a registry with no observation
+# instant, or a caller who named no bound, is entitled to claim.
+RevocationFreshness = Literal["fresh", "stale", "unknown"]
+
 
 def _parse_iso(value: object) -> Optional[datetime]:
     """Parse an ISO 8601 instant to an aware UTC datetime, or None.
@@ -121,13 +126,26 @@ class RevocationEntry:
 
 @dataclass(frozen=True)
 class RevocationStatus:
-    """Verdict of a revocation check.
+    """Verdict of a revocation check, and the freshness bound it was decided under.
 
     ``revoked`` is the single answer: was the receipt's issuer (or its bound
     key) revoked at or before the receipt was issued. ``revoked_at`` and
     ``matched_by`` name the binding entry when one matched. ``issued_at`` is
     surfaced so a verifier with a stronger time anchor than the receipt's
     self-asserted ``iat`` can re-decide.
+
+    ``registry_as_of`` and ``freshness`` carry what the verdict cannot
+    establish on its own. A revocation check is a computation over the
+    entries the verifier holds, so a ``revoked=False`` answer only ever means
+    "nothing in this registry revoked it", never "the key is valid now".
+    ``freshness`` says whether the registry was recent enough for the
+    deployment's stated bound: ``"fresh"``, ``"stale"``, or ``"unknown"``
+    when no ``as_of`` or no bound was supplied.
+
+    The asymmetry is deliberate. A revocation the verifier can see is binding
+    however old the registry is, because the fact does not expire. Only the
+    negative verdict weakens with staleness, so :attr:`establishes_current`
+    is true for exactly one combination.
     """
 
     revoked: bool
@@ -135,6 +153,19 @@ class RevocationStatus:
     revoked_at: Optional[str]
     issued_at: Optional[str]
     reason: str
+    registry_as_of: Optional[str] = None
+    freshness: RevocationFreshness = "unknown"
+
+    @property
+    def establishes_current(self) -> bool:
+        """Whether this verdict may be read as a statement about now.
+
+        Only a not-revoked answer from a registry observed inside the
+        deployment's stated staleness bound. Everything else, including a
+        clean answer from a registry with no ``as_of``, says something about
+        the past and must not be promoted to a claim about the present.
+        """
+        return not self.revoked and self.freshness == "fresh"
 
 
 class RevocationRegistry:
@@ -147,15 +178,61 @@ class RevocationRegistry:
     a receipt gets the same revoked verdict whichever lens looks.
     """
 
-    def __init__(self, entries: Iterable[RevocationEntry] = ()) -> None:
+    def __init__(
+        self,
+        entries: Iterable[RevocationEntry] = (),
+        *,
+        as_of: Optional[str] = None,
+    ) -> None:
         self._entries: tuple[RevocationEntry, ...] = tuple(entries)
+        self._as_of = as_of
 
     @property
     def entries(self) -> tuple[RevocationEntry, ...]:
         return self._entries
 
+    @property
+    def as_of(self) -> Optional[str]:
+        """When this registry was observed, if the source said.
+
+        A registry carries facts about revocations up to some instant. Without
+        that instant a verifier cannot say how far into the past its clean
+        answer reaches, which is why its absence produces ``"unknown"``
+        freshness rather than being quietly treated as current.
+        """
+        return self._as_of
+
     def __len__(self) -> int:
         return len(self._entries)
+
+    def freshness(
+        self,
+        *,
+        now: Optional[str] = None,
+        max_staleness_seconds: Optional[float] = None,
+    ) -> RevocationFreshness:
+        """How recent this registry is against a stated staleness bound.
+
+        Returns ``"unknown"`` unless the registry carries an ``as_of``, the
+        caller states a bound, and both instants parse. That is not a
+        degraded answer, it is the correct one: without an observation
+        instant and a deployment-stated bound there is no basis on which to
+        call a clean verdict current.
+
+        A registry observed after ``now`` is treated as ``"unknown"`` rather
+        than fresh, because a future observation instant means the two clocks
+        disagree and the bound cannot be evaluated honestly.
+        """
+        if self._as_of is None or max_staleness_seconds is None:
+            return "unknown"
+        observed = _parse_iso(self._as_of)
+        current = _parse_iso(now) if now is not None else datetime.now(timezone.utc)
+        if observed is None or current is None:
+            return "unknown"
+        age = (current - observed).total_seconds()
+        if age < 0:
+            return "unknown"
+        return "fresh" if age <= max_staleness_seconds else "stale"
 
     def status(
         self,
@@ -163,6 +240,8 @@ class RevocationRegistry:
         issued_at: str,
         *,
         keyid: Optional[str] = None,
+        now: Optional[str] = None,
+        max_staleness_seconds: Optional[float] = None,
     ) -> RevocationStatus:
         """Whether the issuer (or bound key) was revoked at or before issuance.
 
@@ -171,7 +250,14 @@ class RevocationRegistry:
         the earliest revocation wins, since the strictest fact governs. A
         key-scope match is reported in preference to an identity-scope one at
         the same instant, because it is the more specific statement.
+
+        ``now`` and ``max_staleness_seconds`` are the deployment's stated
+        freshness parameters. They do not change the revoked answer. They
+        decide whether a not-revoked answer may be read as a statement about
+        the present, which is recorded on the returned
+        :attr:`RevocationStatus.freshness`.
         """
+        fresh = self.freshness(now=now, max_staleness_seconds=max_staleness_seconds)
         best: Optional[tuple[datetime, RevocationEntry]] = None
         unparseable: Optional[RevocationEntry] = None
         for entry in self._entries:
@@ -205,6 +291,8 @@ class RevocationRegistry:
                     f"{entry.scope} {entry.subject!r} was revoked at or before "
                     f"issuance (revoked_at={entry.revoked_at}, iat={issued_at})"
                 ),
+                registry_as_of=self._as_of,
+                freshness=fresh,
             )
         if unparseable is not None:
             return RevocationStatus(
@@ -216,22 +304,48 @@ class RevocationRegistry:
                     f"{unparseable.scope} {unparseable.subject!r} revocation or "
                     f"issuance instant is unparseable; failing closed"
                 ),
+                registry_as_of=self._as_of,
+                freshness=fresh,
             )
+        # The clean answer. This is the one staleness weakens, so the reason
+        # states the reach of the check rather than stopping at "no match".
+        qualifier = {
+            "fresh": (
+                f" registry observed {self._as_of}, inside the stated bound"
+            ),
+            "stale": (
+                f" registry observed {self._as_of}, outside the stated bound, so "
+                f"this says nothing about revocations since"
+            ),
+            "unknown": (
+                " registry freshness unknown, so this establishes nothing about now"
+            ),
+        }[fresh]
         return RevocationStatus(
             revoked=False,
             matched_by=None,
             revoked_at=None,
             issued_at=issued_at,
-            reason="no matching revocation at or before issuance",
+            reason="no matching revocation at or before issuance;" + qualifier,
+            registry_as_of=self._as_of,
+            freshness=fresh,
         )
 
     def to_dict(self) -> dict[str, object]:
-        """Canonical, sorted dict form. Stable across constructions."""
+        """Canonical, sorted dict form. Stable across constructions.
+
+        ``as_of`` is emitted only when the registry carries one, so a registry
+        without an observation instant serialises to exactly the bytes it did
+        before this field existed and its digest is unchanged.
+        """
         entries = sorted(
             (e.to_dict() for e in self._entries),
             key=lambda d: (d["scope"], d["subject"], d["revoked_at"]),
         )
-        return {"version": 1, "entries": entries}
+        out: dict[str, object] = {"version": 1, "entries": entries}
+        if self._as_of is not None:
+            out["as_of"] = self._as_of
+        return out
 
     def canonical_bytes(self) -> bytes:
         """RFC 8785 JCS bytes over :meth:`to_dict`, for a stable digest."""
@@ -255,7 +369,13 @@ class RevocationRegistry:
         raw = data.get("entries", [])
         if not isinstance(raw, list):
             raise ValueError("revocation registry 'entries' must be a list")
-        return cls(RevocationEntry.from_dict(e) for e in raw)
+        as_of = data.get("as_of")
+        if as_of is not None and (not isinstance(as_of, str) or not as_of):
+            raise ValueError("revocation registry 'as_of' must be a non-empty string")
+        return cls(
+            (RevocationEntry.from_dict(e) for e in raw),
+            as_of=as_of,
+        )
 
     @classmethod
     def from_did_document(

--- a/tests/vectors/revocation_freshness_v0/README.md
+++ b/tests/vectors/revocation_freshness_v0/README.md
@@ -1,0 +1,75 @@
+# revocation_freshness_v0
+
+What a clean revocation answer is allowed to claim.
+
+## The rule these vectors hold
+
+`draft-sirkkavaara-vaara-receipt-08` Section 10 states the limit:
+
+> Offline verification is a computation over the parameters the consumer
+> holds, while revocation is a property of the present, and this document
+> defines no revocation mechanism and places no freshness requirement on key
+> material. A consumer MUST NOT treat a signature that verifies as evidence
+> that the signing key is still valid. Where a decision depends on revocation
+> state, the key resolution path and the staleness a deployment accepts are
+> operational parameters of that deployment and MUST be stated by it.
+
+So a registry answer of "not revoked" is a statement about the entries the
+verifier holds and the instant it holds them for. This suite pins the two
+consequences.
+
+**A clean answer speaks to the present only under three conditions.** The
+registry carries an `as_of`, the caller states a `max_staleness_seconds`, and
+the registry falls inside that bound. Missing any one of them gives
+`freshness: "unknown"` and `establishes_current: false`. The absence of a
+freshness parameter is never read as permission to treat the answer as
+current.
+
+**A revocation binds however stale the registry is.** A revocation fact does
+not expire, so staleness weakens only the negative answer. `revoked_stale` is
+the case that pins this asymmetry and it is the one most likely to regress,
+because a naive "stale means we know nothing" implementation would drop a
+revocation it can plainly see.
+
+## The seven cases
+
+| case | revoked | freshness | establishes_current |
+|---|---|---|---|
+| `fresh_clean` | false | fresh | **true** |
+| `stale_clean` | false | stale | false |
+| `undated_clean` | false | unknown | false |
+| `unbounded_clean` | false | unknown | false |
+| `revoked_fresh` | true | fresh | false |
+| `revoked_stale` | true | stale | false |
+| `future_as_of` | false | unknown | false |
+
+`establishes_current` is true for exactly one row. That is the point of the
+suite: the honest answer is narrow, and every other combination is a
+statement about the past.
+
+`future_as_of` is `unknown` rather than trivially fresh. An observation
+instant after `now` means the two clocks disagree, and a bound cannot be
+evaluated honestly across disagreeing clocks.
+
+## Backward compatibility, checkable rather than asserted
+
+`undated_clean` has registry digest
+`sha256:a6a20076da005b27c9afc3a5d5b2457798c0ac817d1abc38b2fee4398ac3f133`,
+which is byte-identical to the `clean` case in `cross_stack_revocation_v0`.
+A registry with no `as_of` serialises to exactly the bytes it did before the
+field existed, so no previously issued digest moved.
+
+## Running it
+
+```
+python tests/vectors/revocation_freshness_v0/_check_independent.py
+```
+
+The checker imports only the standard library plus `rfc8785`. It does not
+import Vaara, and it rebuilds both the revocation-in-time predicate and the
+freshness rule from the text rather than calling into the implementation it
+is checking. Exit code 0 means every case matched.
+
+Regenerate with `python tests/vectors/revocation_freshness_v0/_generate.py`.
+Every instant in the suite is a literal and no keys are involved, so
+regeneration is byte-stable.

--- a/tests/vectors/revocation_freshness_v0/_check_independent.py
+++ b/tests/vectors/revocation_freshness_v0/_check_independent.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Independent conformance checker for the revocation_freshness_v0 vectors.
+
+Imports only the standard library plus ``rfc8785``. It does not import Vaara.
+A second implementation can run this file to confirm the freshness rules are
+consumable from the committed bytes alone, which is what
+draft-sirkkavaara-vaara-receipt-08 Section 10 asks of a consumer and what the
+European Commission's Article 50 transparency guidelines describe at
+paragraph 76 as detection "ideally locally executable on the digital device".
+
+Two rules are reproduced from scratch:
+
+1. **Revocation in time.** A registry entry binds when its ``revoked_at`` is
+   at or before the receipt's ``issued_at``. Identity-scope entries match on
+   ``iss``, key-scope entries on the bound keyid. Unparseable instants fail
+   closed, so an unreadable date revokes rather than being skipped.
+2. **Freshness.** ``fresh`` requires an ``as_of`` on the registry, a stated
+   ``max_staleness_seconds``, both instants parseable, and an age between
+   zero and the bound inclusive. Anything else is ``unknown``, except an age
+   beyond the bound, which is ``stale``. An ``as_of`` in the future is
+   ``unknown``, not fresh, because the clocks disagree.
+
+``establishes_current`` is then true for exactly one combination: not revoked
+AND fresh. A revoked verdict never establishes current validity, and neither
+does a clean verdict the checker cannot date.
+
+Run: ``python tests/vectors/revocation_freshness_v0/_check_independent.py``.
+Exit code 0 means every case matched its expected verdict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import rfc8785
+
+HERE = Path(__file__).resolve().parent
+
+
+def _parse_iso(value):
+    """ISO 8601 to an aware datetime, or None when it will not parse."""
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _revoked(registry, iss, issued_at, keyid):
+    """The revocation-in-time predicate, rebuilt from the text."""
+    issued = _parse_iso(issued_at)
+    for entry in registry.get("entries", []):
+        scope = entry.get("scope")
+        subject = entry.get("subject")
+        if scope == "key":
+            if keyid is None or subject != keyid:
+                continue
+        elif scope == "identity":
+            if subject != iss:
+                continue
+        else:
+            continue
+        revoked_at = _parse_iso(entry.get("revoked_at"))
+        if revoked_at is None or issued is None:
+            return True  # fail closed on an instant that will not parse
+        if revoked_at <= issued:
+            return True
+    return False
+
+
+def _freshness(registry, now, bound):
+    if bound is None:
+        return "unknown"
+    as_of = registry.get("as_of")
+    if as_of is None:
+        return "unknown"
+    observed = _parse_iso(as_of)
+    current = _parse_iso(now)
+    if observed is None or current is None:
+        return "unknown"
+    age = (current - observed).total_seconds()
+    if age < 0:
+        return "unknown"
+    return "fresh" if age <= bound else "stale"
+
+
+def _digest(registry):
+    return "sha256:" + hashlib.sha256(rfc8785.dumps(registry)).hexdigest()
+
+
+def _evaluate(case):
+    registry = case["registry"]
+    revoked = _revoked(registry, case["iss"], case["issued_at"], case.get("keyid"))
+    freshness = _freshness(registry, case.get("now"), case.get("max_staleness_seconds"))
+    return {
+        "revoked": revoked,
+        "freshness": freshness,
+        "establishes_current": (not revoked) and freshness == "fresh",
+        "registry_digest": _digest(registry),
+    }
+
+
+def main() -> int:
+    cases = json.loads((HERE / "cases.json").read_text(encoding="utf-8"))["cases"]
+    expected = json.loads((HERE / "expected.json").read_text(encoding="utf-8"))
+
+    failures = 0
+    for case in cases:
+        name = case["name"]
+        got = _evaluate(case)
+        want = expected.get(name)
+        if want is None:
+            print(f"FAIL {name}: no expected verdict committed")
+            failures += 1
+            continue
+        if got != want:
+            print(f"FAIL {name}")
+            for key in sorted(set(got) | set(want)):
+                if got.get(key) != want.get(key):
+                    print(f"       {key}: got {got.get(key)!r} want {want.get(key)!r}")
+            failures += 1
+        else:
+            print(
+                f"ok   {name}: revoked={got['revoked']} "
+                f"freshness={got['freshness']} "
+                f"establishes_current={got['establishes_current']}"
+            )
+
+    print(f"\n{len(cases) - failures}/{len(cases)} cases matched")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/vectors/revocation_freshness_v0/_generate.py
+++ b/tests/vectors/revocation_freshness_v0/_generate.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate the revocation_freshness_v0 conformance vectors.
+
+draft-sirkkavaara-vaara-receipt-08 Section 10 states the limit these vectors
+hold a verifier to: offline verification is a computation over the parameters
+the consumer holds, revocation is a property of the present, and a signature
+that verifies is not evidence that the signing key is still valid. Where a
+decision depends on revocation state, the freshness a deployment accepts is
+an operational parameter that deployment must state.
+
+So the suite is about the QUALIFIER on a clean answer, not about the answer.
+Seven cases pin the two rules that follow:
+
+1. A not-revoked verdict may be read as a statement about now only when the
+   registry carries an observation instant AND the caller states a staleness
+   bound AND the registry falls inside it. Missing either input yields
+   ``unknown``, never a quiet promotion to current.
+2. A revocation the verifier can see is binding however stale the registry
+   is, because a revocation fact does not expire. Only the negative verdict
+   weakens. ``revoked_stale`` is the case that pins this and it is the one
+   most likely to regress.
+
+Deterministic: no keys, no signatures, no clock. Every instant is a literal,
+so re-running produces byte-identical cases. Run from the repo root:
+``python tests/vectors/revocation_freshness_v0/_generate.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from vaara.attestation.receipt import RevocationEntry, RevocationRegistry
+
+HERE = Path(__file__).resolve().parent
+
+ISS = "did:web:agent.example"
+KEYID = "key-1"
+IAT = "2026-09-01T00:00:00Z"
+NOW = "2026-09-02T12:00:00Z"
+HOUR = 3600.0
+
+# Observed two hours before NOW: inside a one-day bound, outside a one-hour one.
+RECENT = "2026-09-02T10:00:00Z"
+OLD = "2026-08-01T00:00:00Z"
+FUTURE = "2026-12-01T00:00:00Z"
+
+REVOKED_BEFORE_IAT = "2026-08-15T00:00:00Z"
+
+
+def main() -> None:
+    cases: list[dict] = []
+    expected: dict[str, dict] = {}
+
+    def case(name, registry, *, now, bound, note):
+        st = registry.status(
+            ISS, IAT, keyid=KEYID, now=now, max_staleness_seconds=bound
+        )
+        cases.append(
+            {
+                "name": name,
+                "note": note,
+                "iss": ISS,
+                "keyid": KEYID,
+                "issued_at": IAT,
+                "now": now,
+                "max_staleness_seconds": bound,
+                "registry": registry.to_dict(),
+            }
+        )
+        expected[name] = {
+            "revoked": st.revoked,
+            "freshness": st.freshness,
+            "establishes_current": st.establishes_current,
+            "registry_digest": registry.digest(),
+        }
+
+    case(
+        "fresh_clean",
+        RevocationRegistry([], as_of=RECENT),
+        now=NOW,
+        bound=24 * HOUR,
+        note="observed two hours ago against a one day bound; the only case "
+        "whose clean answer speaks to the present",
+    )
+    case(
+        "stale_clean",
+        RevocationRegistry([], as_of=RECENT),
+        now=NOW,
+        bound=HOUR,
+        note="same registry, one hour bound; two hours old is outside it, so "
+        "the clean answer says nothing about revocations since",
+    )
+    case(
+        "undated_clean",
+        RevocationRegistry([]),
+        now=NOW,
+        bound=24 * HOUR,
+        note="no observation instant, so there is no basis on which to call "
+        "the clean answer current however generous the bound",
+    )
+    case(
+        "unbounded_clean",
+        RevocationRegistry([], as_of=RECENT),
+        now=NOW,
+        bound=None,
+        note="registry is dated but the deployment stated no bound; Section 10 "
+        "puts that parameter on the deployment, so absent it the answer is unknown",
+    )
+    case(
+        "revoked_fresh",
+        RevocationRegistry(
+            [RevocationEntry("key", KEYID, REVOKED_BEFORE_IAT)], as_of=RECENT
+        ),
+        now=NOW,
+        bound=24 * HOUR,
+        note="revoked in time and the registry is fresh; revoked, and a "
+        "revoked verdict never establishes current validity either",
+    )
+    case(
+        "revoked_stale",
+        RevocationRegistry(
+            [RevocationEntry("key", KEYID, REVOKED_BEFORE_IAT)], as_of=OLD
+        ),
+        now=NOW,
+        bound=HOUR,
+        note="THE ASYMMETRY. The registry is a month stale and the receipt is "
+        "still revoked, because a revocation fact does not expire. Staleness "
+        "weakens only the negative answer",
+    )
+    case(
+        "future_as_of",
+        RevocationRegistry([], as_of=FUTURE),
+        now=NOW,
+        bound=24 * HOUR,
+        note="observed after now, so the two clocks disagree and the bound "
+        "cannot be evaluated honestly; unknown rather than trivially fresh",
+    )
+
+    (HERE / "cases.json").write_text(
+        json.dumps({"version": 1, "cases": cases}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (HERE / "expected.json").write_text(
+        json.dumps(expected, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {len(cases)} cases")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/vectors/revocation_freshness_v0/cases.json
+++ b/tests/vectors/revocation_freshness_v0/cases.json
@@ -1,0 +1,114 @@
+{
+  "cases": [
+    {
+      "iss": "did:web:agent.example",
+      "issued_at": "2026-09-01T00:00:00Z",
+      "keyid": "key-1",
+      "max_staleness_seconds": 86400.0,
+      "name": "fresh_clean",
+      "note": "observed two hours ago against a one day bound; the only case whose clean answer speaks to the present",
+      "now": "2026-09-02T12:00:00Z",
+      "registry": {
+        "as_of": "2026-09-02T10:00:00Z",
+        "entries": [],
+        "version": 1
+      }
+    },
+    {
+      "iss": "did:web:agent.example",
+      "issued_at": "2026-09-01T00:00:00Z",
+      "keyid": "key-1",
+      "max_staleness_seconds": 3600.0,
+      "name": "stale_clean",
+      "note": "same registry, one hour bound; two hours old is outside it, so the clean answer says nothing about revocations since",
+      "now": "2026-09-02T12:00:00Z",
+      "registry": {
+        "as_of": "2026-09-02T10:00:00Z",
+        "entries": [],
+        "version": 1
+      }
+    },
+    {
+      "iss": "did:web:agent.example",
+      "issued_at": "2026-09-01T00:00:00Z",
+      "keyid": "key-1",
+      "max_staleness_seconds": 86400.0,
+      "name": "undated_clean",
+      "note": "no observation instant, so there is no basis on which to call the clean answer current however generous the bound",
+      "now": "2026-09-02T12:00:00Z",
+      "registry": {
+        "entries": [],
+        "version": 1
+      }
+    },
+    {
+      "iss": "did:web:agent.example",
+      "issued_at": "2026-09-01T00:00:00Z",
+      "keyid": "key-1",
+      "max_staleness_seconds": null,
+      "name": "unbounded_clean",
+      "note": "registry is dated but the deployment stated no bound; Section 10 puts that parameter on the deployment, so absent it the answer is unknown",
+      "now": "2026-09-02T12:00:00Z",
+      "registry": {
+        "as_of": "2026-09-02T10:00:00Z",
+        "entries": [],
+        "version": 1
+      }
+    },
+    {
+      "iss": "did:web:agent.example",
+      "issued_at": "2026-09-01T00:00:00Z",
+      "keyid": "key-1",
+      "max_staleness_seconds": 86400.0,
+      "name": "revoked_fresh",
+      "note": "revoked in time and the registry is fresh; revoked, and a revoked verdict never establishes current validity either",
+      "now": "2026-09-02T12:00:00Z",
+      "registry": {
+        "as_of": "2026-09-02T10:00:00Z",
+        "entries": [
+          {
+            "revoked_at": "2026-08-15T00:00:00Z",
+            "scope": "key",
+            "subject": "key-1"
+          }
+        ],
+        "version": 1
+      }
+    },
+    {
+      "iss": "did:web:agent.example",
+      "issued_at": "2026-09-01T00:00:00Z",
+      "keyid": "key-1",
+      "max_staleness_seconds": 3600.0,
+      "name": "revoked_stale",
+      "note": "THE ASYMMETRY. The registry is a month stale and the receipt is still revoked, because a revocation fact does not expire. Staleness weakens only the negative answer",
+      "now": "2026-09-02T12:00:00Z",
+      "registry": {
+        "as_of": "2026-08-01T00:00:00Z",
+        "entries": [
+          {
+            "revoked_at": "2026-08-15T00:00:00Z",
+            "scope": "key",
+            "subject": "key-1"
+          }
+        ],
+        "version": 1
+      }
+    },
+    {
+      "iss": "did:web:agent.example",
+      "issued_at": "2026-09-01T00:00:00Z",
+      "keyid": "key-1",
+      "max_staleness_seconds": 86400.0,
+      "name": "future_as_of",
+      "note": "observed after now, so the two clocks disagree and the bound cannot be evaluated honestly; unknown rather than trivially fresh",
+      "now": "2026-09-02T12:00:00Z",
+      "registry": {
+        "as_of": "2026-12-01T00:00:00Z",
+        "entries": [],
+        "version": 1
+      }
+    }
+  ],
+  "version": 1
+}

--- a/tests/vectors/revocation_freshness_v0/expected.json
+++ b/tests/vectors/revocation_freshness_v0/expected.json
@@ -1,0 +1,44 @@
+{
+  "fresh_clean": {
+    "establishes_current": true,
+    "freshness": "fresh",
+    "registry_digest": "sha256:7f5430e76cc3b309b1aa4f463011502d90c4c3b671a070a77d388cf226a5febd",
+    "revoked": false
+  },
+  "future_as_of": {
+    "establishes_current": false,
+    "freshness": "unknown",
+    "registry_digest": "sha256:26356ffc246512a1f8ede4cb8f6c962666185405db0e9a73e274127e097d2146",
+    "revoked": false
+  },
+  "revoked_fresh": {
+    "establishes_current": false,
+    "freshness": "fresh",
+    "registry_digest": "sha256:886ee24a3a89421249afbc4fba13b6c68da810ea64c363bd3260add94c3555cb",
+    "revoked": true
+  },
+  "revoked_stale": {
+    "establishes_current": false,
+    "freshness": "stale",
+    "registry_digest": "sha256:d1bef942713515165e675e6e43edeb5947bd7caf76c94c55ec42cb243214a521",
+    "revoked": true
+  },
+  "stale_clean": {
+    "establishes_current": false,
+    "freshness": "stale",
+    "registry_digest": "sha256:7f5430e76cc3b309b1aa4f463011502d90c4c3b671a070a77d388cf226a5febd",
+    "revoked": false
+  },
+  "unbounded_clean": {
+    "establishes_current": false,
+    "freshness": "unknown",
+    "registry_digest": "sha256:7f5430e76cc3b309b1aa4f463011502d90c4c3b671a070a77d388cf226a5febd",
+    "revoked": false
+  },
+  "undated_clean": {
+    "establishes_current": false,
+    "freshness": "unknown",
+    "registry_digest": "sha256:a6a20076da005b27c9afc3a5d5b2457798c0ac817d1abc38b2fee4398ac3f133",
+    "revoked": false
+  }
+}

--- a/webpage/badge/conformance.svg
+++ b/webpage/badge/conformance.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="248" height="20" role="img" aria-label="Vaara conformance corpus: 48 suites, 0 failing">
-  <title>Vaara conformance corpus: 48 suites, 0 failing</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="248" height="20" role="img" aria-label="Vaara conformance corpus: 49 suites, 0 failing">
+  <title>Vaara conformance corpus: 49 suites, 0 failing</title>
   <filter id="blur"><feGaussianBlur stdDeviation="16"/></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
@@ -28,10 +28,10 @@
     </g>
     <g transform="scale(.1)">
       <g aria-hidden="true" fill="#010101">
-        <text x="1926" y="150" fill-opacity=".8" filter="url(#blur)">48 suites, 0 failing</text>
-        <text x="1926" y="150" fill-opacity=".3">48 suites, 0 failing</text>
+        <text x="1926" y="150" fill-opacity=".8" filter="url(#blur)">49 suites, 0 failing</text>
+        <text x="1926" y="150" fill-opacity=".3">49 suites, 0 failing</text>
       </g>
-      <text x="1926" y="140">48 suites, 0 failing</text>
+      <text x="1926" y="140">49 suites, 0 failing</text>
     </g>
   </g>
 </svg>

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -47,7 +47,7 @@
       "url": "https://vaara.io/conformance.html",
       "name": "Vaara Conformance Results",
       "description": "Every Vaara conformance suite, its verdict, and every independent party who reproduced the vectors and said so in public. Generated from the runner's own report.",
-      "dateModified": "2026-08-29T12:12:27Z",
+      "dateModified": "2026-09-02T11:46:30Z",
       "inLanguage": "en",
       "isPartOf": {
         "@id": "https://vaara.io/#website"
@@ -96,7 +96,7 @@
       "alternateName": "Vaara conformance corpus",
       "description": "Committed case files for every Vaara conformance suite. Each suite ships an independent checker that imports no Vaara code and recomputes its verdicts from the bytes of its own cases, so a stranger can disagree with an expected result and show their work. The vectors are Vaara's own and no ratification body stands behind them.",
       "url": "https://vaara.io/conformance.html",
-      "dateModified": "2026-08-29T12:12:27Z",
+      "dateModified": "2026-09-02T11:46:30Z",
       "identifier": "https://doi.org/10.5281/zenodo.22027975",
       "sameAs": [
         "https://doi.org/10.5281/zenodo.22027975",
@@ -126,12 +126,12 @@
         {
           "@type": "PropertyValue",
           "name": "suites",
-          "value": 48
+          "value": 49
         },
         {
           "@type": "PropertyValue",
           "name": "passed",
-          "value": 47
+          "value": 48
         },
         {
           "@type": "PropertyValue",
@@ -360,13 +360,13 @@
   did rather than what a document claims they do.</p>
 
   <div class="stats">
-    <div class="stat"><b>48</b><span>suites</span></div>
-    <div class="stat"><b>47</b><span>passed</span></div>
+    <div class="stat"><b>49</b><span>suites</span></div>
+    <div class="stat"><b>48</b><span>passed</span></div>
     <div class="stat"><b>0</b><span>failed</span></div>
     <div class="stat"><b>1</b><span>skipped</span></div>
     <div class="stat"><b>88</b><span>cases</span></div>
   </div>
-  <p class="mono" style="color:var(--faint)">generated 2026-08-29T12:12:27Z</p>
+  <p class="mono" style="color:var(--faint)">generated 2026-09-02T11:46:30Z</p>
 
   <h2>Run it yourself</h2>
   <p>Nothing here needs Vaara installed. The checkers use the standard library
@@ -524,6 +524,7 @@ python scripts/vcr_chain.py            # nothing removed from the table</code></
 <tr><td class="mono">record_conformance_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">record_set_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">release_condition_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
+<tr><td class="mono">revocation_freshness_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">sep2787_attestation_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">tap_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">transparency_consistency_v0</td><td class="ok">PASS</td><td class="why"></td></tr>


### PR DESCRIPTION
`RevocationRegistry.status()` returned `revoked=False` with nothing attached. That reads as "this key is fine", when the computation only supports "nothing in the entries I hold revoked it, as of whenever I obtained them".

Section 10 of `draft-sirkkavaara-vaara-receipt-08`, posted to the datatracker today, states the limit: offline verification is a computation over the parameters the consumer holds, revocation is a property of the present, and where a decision depends on revocation state the staleness a deployment accepts is an operational parameter that deployment must state. RPKI has the same shape, where a router validates against a locally held cache whose refresh interval is a stated parameter rather than something the validation establishes.

## What changed

`RevocationRegistry` takes an optional `as_of`, the instant it was observed. `status()` takes the deployment's `now` and `max_staleness_seconds`. `RevocationStatus` carries `registry_as_of`, `freshness` and `establishes_current`.

`freshness` is `fresh`, `stale` or `unknown`. `unknown` covers a registry with no `as_of`, a caller who stated no bound, and an `as_of` later than `now`. That last one is a clock disagreement, so the bound cannot be evaluated honestly and is not quietly treated as met.

`establishes_current` is true for exactly one combination, not revoked and fresh. Every other combination is a statement about the past.

## The asymmetry

Staleness weakens the negative answer alone. A revocation the verifier can see binds however old the registry is, because a revocation fact does not expire. An implementation reasoning "the registry is stale, so we know nothing" would discard a revocation it is plainly holding, which is worse than the gap this closes. `revoked_stale` is the vector that pins it.

## Conformance

`revocation_freshness_v0` is the 49th suite. Seven cases, six negative, `establishes_current` true in one row. The checker imports the standard library plus `rfc8785` and rebuilds both the revocation-in-time predicate and the freshness rule from the text rather than calling the implementation it grades.

## Compatibility, checkable rather than asserted

`as_of` serialises only when set, so a registry without one produces the bytes it produced before the field existed. `undated_clean` digests to `sha256:a6a20076da005b27c9afc3a5d5b2457798c0ac817d1abc38b2fee4398ac3f133`, byte-identical to the `clean` case in `cross_stack_revocation_v0`. No previously issued digest moved.

Callers passing neither `now` nor `max_staleness_seconds` get the previous `revoked` answer with `freshness="unknown"` attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added revocation-registry freshness tracking with `fresh`, `stale`, and `unknown` statuses.
  * Clean results establish current validity only when the registry is verified as fresh; confirmed revocations remain binding even when stale.
  * Preserved existing serialized digests for registries without an observation timestamp.

* **Documentation**
  * Updated conformance documentation to include the new revocation-freshness suite and seven validation scenarios.
  * Published version 1.80.0 release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->