### PR TITLE
fix(site): close three media query preludes on verify.html

### DIFF
--- a/tests/test_webpage_css_parses.py
+++ b/tests/test_webpage_css_parses.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""A malformed media query is dropped silently, so nothing here can be silent.
+
+verify.html shipped with three media queries written `@media (max-width:640px{`,
+missing the closing parenthesis. CSS treats an invalid media prelude as never
+matching, so the browser discards the whole block without a console error and
+without a visible failure anywhere a server can see it. The page served
+byte-identical bytes, every asset returned 200, the CSS braces balanced and the
+HTML parsed clean. Three of the four responsive blocks were dead and the only
+symptom was that the layout collapsed on a narrow window.
+
+That is the failure mode worth a test: valid enough to serve, invalid enough to
+ignore, and invisible to every check that does not parse the prelude itself.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+WEBPAGE = Path(__file__).resolve().parent.parent / "webpage"
+PAGES = sorted(p.name for p in WEBPAGE.glob("*.html"))
+
+
+def _style_blocks(html: str) -> list[str]:
+    return re.findall(r"<style[^>]*>(.*?)</style>", html, re.S)
+
+
+@pytest.mark.parametrize("page", PAGES)
+def test_every_media_query_prelude_is_balanced(page: str) -> None:
+    """`@media (max-width:640px{` parses as a query that can never match."""
+    html = (WEBPAGE / page).read_text(encoding="utf-8")
+    broken = []
+    for match in re.finditer(r"@media([^{]*)\{", html):
+        condition = match.group(1)
+        if condition.count("(") != condition.count(")"):
+            line = html[: match.start()].count("\n") + 1
+            broken.append(f"{page}:{line} @media{condition.strip()}")
+    assert not broken, (
+        "media query prelude has unbalanced parentheses, so the browser drops "
+        "the whole block and the page loses those rules with no error: "
+        + "; ".join(broken)
+    )
+
+
+@pytest.mark.parametrize("page", PAGES)
+def test_inline_css_braces_balance(page: str) -> None:
+    """An unclosed rule swallows every rule after it."""
+    html = (WEBPAGE / page).read_text(encoding="utf-8")
+    for index, css in enumerate(_style_blocks(html)):
+        opens, closes = css.count("{"), css.count("}")
+        assert opens == closes, (
+            f"{page} style block {index}: {opens} '{{' against {closes} '}}'. "
+            "An unbalanced block silently discards the rules after it."
+        )
+
+
+@pytest.mark.parametrize("page", PAGES)
+def test_no_custom_property_is_used_without_being_defined(page: str) -> None:
+    """A var() with no definition and no fallback resolves to nothing."""
+    html = (WEBPAGE / page).read_text(encoding="utf-8")
+    for index, css in enumerate(_style_blocks(html)):
+        defined = set(re.findall(r"(--[A-Za-z0-9_-]+)\s*:", css))
+        # A var() carrying a fallback survives a missing definition, so only
+        # the bare form is a defect.
+        used = set(re.findall(r"var\(\s*(--[A-Za-z0-9_-]+)\s*\)", css))
+        missing = sorted(used - defined)
+        assert not missing, (
+            f"{page} style block {index} reads {missing} with no definition and "
+            "no fallback, which resolves to an empty value."
+        )

--- a/webpage/verify.html
+++ b/webpage/verify.html
@@ -201,7 +201,7 @@
      cannot happen at all. */
   main { max-width:760px; margin: 0 auto; padding:20px 28px 96px; }
   :root{--edge:16px}
-  @media (max-width:640px{
+  @media (max-width:640px){
     .topbar{gap:8px;padding:8px 12px}
     .nav-jump a{padding:4px 8px;letter-spacing:.12em}
   }
@@ -217,7 +217,7 @@
              text-transform:uppercase; color:var(--faint); font-weight:600; }
   .tile .v { font-family:var(--mono); font-size:15px; color:var(--ink); margin-top:6px;
              word-break:break-all; }
-  @media (max-width:560px{ .tiles{grid-template-columns:1fr} }
+  @media (max-width:560px){ .tiles{grid-template-columns:1fr} }
   .drop { border:1px dashed var(--line); border-radius:8px; padding:1.5rem;
           background:var(--panel); text-align:center; color:var(--dim);
           transition:border-color .15s; }
@@ -335,7 +335,7 @@
   .searchrow { display:flex; gap:.5rem; align-items:stretch; }
   .searchrow input { flex:1 1 auto; min-width:0; font-size:13px; padding:.7rem .8rem; }
   .searchrow button { margin-top:0; white-space:nowrap; }
-  @media (max-width:560px {
+  @media (max-width:560px) {
     .searchrow { flex-wrap:wrap; }
     .searchrow input { flex:1 1 100%; }
   }


### PR DESCRIPTION
verify.html carried three media queries written `@media (max-width:640px{` with no closing parenthesis.

CSS treats an invalid media prelude as one that never matches, so the browser discards the entire block. No console error, no visible failure, and nothing a server-side check can see. Three of the page's four responsive blocks were dead, and the only symptom was the layout collapsing on a narrow window.

## Why nothing caught it

Every check that should have found this passed. The bytes served from vaara.io were identical to the repository copy. Every referenced asset returned 200. The inline CSS had balanced braces and closed comments. The HTML parsed with zero structural errors and nothing left open at EOF. The style block held 97 selectors and all 15 custom properties were defined.

The defect only appears if you parse the media prelude itself.

## The test

`tests/test_webpage_css_parses.py` covers every page in `webpage/` for three things that fail silently rather than loudly:

- a media prelude with unbalanced parentheses, which drops the block
- an unbalanced style block, which swallows every rule after it
- a bare `var(--x)` with no definition and no fallback, which resolves to nothing

Putting the missing parenthesis back makes the first one fail, so the test is pinned to the real defect rather than to its description.