### PR TITLE
conformance: independent second-runner run on the EP-SCITT PR 662 vectors

### DIFF
--- a/conformance/independent/ep-scitt-pr662/README.md
+++ b/conformance/independent/ep-scitt-pr662/README.md
@@ -1,0 +1,79 @@
+# Independent second runner: EP-SCITT-STATEMENT-IDENTITY-v0.1
+
+A second party's verifier run over EMILIA Protocol's statement-identity
+vectors, published so anyone can fetch the artifacts and run them again.
+
+Iman Schrock asked on the SCITT mailing list for a second runner to consume
+`vectors.reference.json` with its own verifier instead of the bundled one,
+and to report both positive signatures, the distinct exact-entry digests,
+the common signing-input digest and the hostile substitutions. This
+directory is that run.
+
+This is the opposite direction from `conformance/reproductions.json`. That
+file records other parties reproducing Vaara's vectors. This one records
+Vaara's maintainer running somebody else's.
+
+## What is here
+
+```
+independent_verify.py     the verifier, human-readable output
+emit_report.py            the same checks as deterministic JSON
+vectors.reference.json    the author's file, mirrored unmodified
+RESULT.txt                the run
+report.independent.json   the run, machine-readable
+```
+
+The verifier imports nothing from EMILIA and nothing from Vaara. It is the
+Python standard library plus `cryptography` for raw P-256, and it
+reconstructs every digest from the base64url fields in the vectors.
+
+## Running it
+
+```
+python independent_verify.py                 # vectors from this directory
+python independent_verify.py path/to/file    # or point it somewhere else
+python emit_report.py > report.independent.json
+```
+
+`emit_report.py` carries no timestamps and no random values, so a re-run on
+the same inputs produces byte-identical output and the same SHA-256. The
+one value that moves is `verifier.sha256`, which is a digest of
+`independent_verify.py` itself and changes when that file changes.
+
+## The result
+
+Both signatures verify over the Sig_structure. The two exact-entry digests
+differ, the signing-input digest is common to both, and the relation is
+same `r` with `s_B = n - s_A`, A high-S and B in canonical low-S form. The
+classification came out of these checks as
+`same_signing_input_different_envelope`.
+
+All seven hostile substitutions were refused: a payload bit flip against
+each signature, reversed `s` bytes, an all-zero signature, `s` plus the
+group order, a valid signature offered against a different key, and the
+envelope bytes used as the signing input.
+
+Totals: 11 of 11 positive assertions matched, 7 of 7 hostile cases refused.
+
+## What the run establishes, and what it does not
+
+It establishes that the published vectors reproduce under an independent
+implementation, in a different language on a different platform, and that
+the three identities stay separate when a second party computes them.
+
+It does not establish independently derived vectors, EP profile
+verification, Transparency Service registration, or anything about the
+specification text. None of those were run here.
+
+## Provenance
+
+`vectors.reference.json` is mirrored unmodified from
+
+  https://github.com/emiliaprotocol/emilia-protocol/tree/e507acdf8efbe8951cb4294801d4c440f0b86a5a/conformance/composition/scitt-statement-identity-v0.1
+
+on branch `feat/aic-ccs-partner-artifacts`, sha-256
+`889e410cceec75f4c0955ca9a373d4a8375c00300cbe4d2be375a559958de697`, which
+matches the pin the author published. The file is the author's work and is
+carried here only so this run names an exact byte set. Cite this directory
+by commit sha, so a link keeps pointing at the same bytes after the branch
+moves.

--- a/conformance/independent/ep-scitt-pr662/RESULT.txt
+++ b/conformance/independent/ep-scitt-pr662/RESULT.txt
@@ -1,0 +1,31 @@
+profile          EP-SCITT-STATEMENT-IDENTITY-v0.1
+runner           independent Python, cryptography only
+platform         Linux-6.18.37-0-virt-aarch64-with-glibc2.41
+python           3.12.13
+vectors sha-256  889e410cceec75f4c0955ca9a373d4a8375c00300cbe4d2be375a559958de697
+
+=== POSITIVE CASES ===
+  [PASS] signature_a_valid                  got=True
+  [PASS] signature_b_valid                  got=True
+  [PASS] statement_entry_digest_a           got=sha256:ba36963493c183eea6c8f71e492121d49d14c1f0338574a6171b1312c763b4e1
+  [PASS] statement_entry_digest_b           got=sha256:be2becd5536416c02adec625fff8aca3b75beb691543d458935bfce7ea857ef0
+  [PASS] entry_digests_differ               got=True
+  [PASS] signing_input_digest               got=sha256:c4b229193fd4f871f431daf6f6bc7c5cab5f13896c42b7fc3a7397a3ff67dd86
+  [PASS] same_r                             got=True
+  [PASS] s_b_equals_n_minus_s_a             got=True
+  [PASS] a_is_high_s                        got=True
+  [PASS] b_is_low_s                         got=True
+  [PASS] classification                     got=same_signing_input_different_envelope
+
+=== HOSTILE SUBSTITUTIONS (all must be refused) ===
+  [PASS] payload_bit_flip_vs_sig_a          accepted=False
+  [PASS] payload_bit_flip_vs_sig_b          accepted=False
+  [PASS] reversed_s_bytes                   accepted=False
+  [PASS] all_zero_signature                 accepted=False
+  [PASS] s_plus_group_order                 accepted=False
+  [PASS] valid_sig_wrong_key                accepted=False
+  [PASS] envelope_a_bytes_as_signing_input  accepted=False
+
+positive: 11/11 matched
+hostile:  7/7 refused
+RESULT: independent verifier agrees with vectors.reference.json in full

--- a/conformance/independent/ep-scitt-pr662/emit_report.py
+++ b/conformance/independent/ep-scitt-pr662/emit_report.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Deterministic machine-readable report for the second-runner result on
+EP-SCITT-STATEMENT-IDENTITY-v0.1.
+
+Emits report.independent.json. Contains no timestamps and no random values, so
+re-running on the same inputs produces byte-identical output and the same
+SHA-256. Import surface is stdlib plus `cryptography`. Nothing from EMILIA,
+nothing from Vaara.
+
+Usage:  python emit_report.py > report.independent.json
+"""
+
+import base64
+import hashlib
+import json
+import os
+import platform
+import sys
+
+import cryptography
+from cryptography.hazmat.backends.openssl.backend import backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+N = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+VECTORS = os.path.join(HERE, "vectors.reference.json")
+VERIFIER = os.path.join(HERE, "independent_verify.py")
+
+
+def b64u(s):
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def tag(b):
+    return "sha256:" + hashlib.sha256(b).hexdigest()
+
+
+def digest_file(p):
+    return hashlib.sha256(open(p, "rb").read()).hexdigest()
+
+
+def verify(key, sig, msg):
+    if len(sig) != 64:
+        return False
+    r = int.from_bytes(sig[:32], "big")
+    s = int.from_bytes(sig[32:], "big")
+    try:
+        key.verify(utils.encode_dss_signature(r, s), msg, ec.ECDSA(hashes.SHA256()))
+        return True
+    except Exception:
+        return False
+
+
+def main():
+    raw = open(VECTORS, "rb").read()
+    v = json.loads(raw)
+    fx, exp = v["fixture"], v["expected"]
+
+    jwk = fx["public_jwk"]
+    key = ec.EllipticCurvePublicNumbers(
+        int.from_bytes(b64u(jwk["x"]), "big"),
+        int.from_bytes(b64u(jwk["y"]), "big"),
+        ec.SECP256R1(),
+    ).public_key()
+
+    si = b64u(fx["sig_structure_base64url"])
+    sa = b64u(fx["signature_a_base64url"])
+    sb = b64u(fx["signature_b_base64url"])
+    ea = b64u(fx["cose_sign1_a_base64url"])
+    eb = b64u(fx["cose_sign1_b_base64url"])
+
+    ra, va = int.from_bytes(sa[:32], "big"), int.from_bytes(sa[32:], "big")
+    rb, vb = int.from_bytes(sb[:32], "big"), int.from_bytes(sb[32:], "big")
+
+    positive = {
+        "signature_a_valid": verify(key, sa, si),
+        "signature_b_valid": verify(key, sb, si),
+        "statement_entry_digest_a": tag(ea),
+        "statement_entry_digest_b": tag(eb),
+        "entry_digests_differ": tag(ea) != tag(eb),
+        "signing_input_digest": tag(si),
+        "same_r": ra == rb,
+        "s_b_equals_n_minus_s_a": vb == N - va,
+        "a_is_high_s": va > N // 2,
+        "b_is_low_s": vb <= N // 2,
+    }
+    positive["classification"] = (
+        "same_signing_input_different_envelope"
+        if positive["signature_a_valid"]
+        and positive["signature_b_valid"]
+        and positive["entry_digests_differ"]
+        and positive["same_r"]
+        else "other"
+    )
+
+    expected = {
+        "signature_a_valid": exp["signature_a_valid"],
+        "signature_b_valid": exp["signature_b_valid"],
+        "statement_entry_digest_a": exp["statement_entry_digest_a"],
+        "statement_entry_digest_b": exp["statement_entry_digest_b"],
+        "entry_digests_differ": True,
+        "signing_input_digest": exp["signing_input_digest"],
+        "same_r": True,
+        "s_b_equals_n_minus_s_a": True,
+        "a_is_high_s": True,
+        "b_is_low_s": True,
+        "classification": exp["classification"],
+    }
+
+    tampered = bytearray(si)
+    tampered[-1] ^= 0x01
+    other_key = ec.EllipticCurvePublicNumbers(
+        int.from_bytes(b64u(jwk["x"]), "big") ^ 1,
+        int.from_bytes(b64u(jwk["y"]), "big"),
+        ec.SECP256R1(),
+    )
+    hostile = {
+        "payload_bit_flip_vs_sig_a": verify(key, sa, bytes(tampered)),
+        "payload_bit_flip_vs_sig_b": verify(key, sb, bytes(tampered)),
+        "reversed_s_bytes": verify(key, sa[:32] + sb[32:64][::-1], si),
+        "all_zero_signature": verify(key, b"\x00" * 64, si),
+        "s_plus_group_order": verify(
+            key, sa[:32] + ((va + N) % (1 << 256)).to_bytes(32, "big"), si
+        ),
+        "envelope_a_bytes_as_signing_input": verify(key, sa, ea),
+    }
+    try:
+        hostile["valid_sig_wrong_key"] = verify(other_key.public_key(), sa, si)
+    except ValueError:
+        # x^1 is not on the curve; use a deterministic on-curve alternative.
+        alt = ec.derive_private_key(2, ec.SECP256R1()).public_key()
+        hostile["valid_sig_wrong_key"] = verify(alt, sa, si)
+
+    report = {
+        "report_version": "independent-second-runner-v1",
+        "profile": v["profile"],
+        "vectors_version": v["@version"],
+        "consumed_input": {
+            "file": "vectors.reference.json",
+            "sha256": hashlib.sha256(raw).hexdigest(),
+            "source": (
+                "https://github.com/emiliaprotocol/emilia-protocol/tree/"
+                "e507acdf8efbe8951cb4294801d4c440f0b86a5a/conformance/"
+                "composition/scitt-statement-identity-v0.1"
+            ),
+            "branch": "feat/aic-ccs-partner-artifacts",
+        },
+        "verifier": {
+            "file": "independent_verify.py",
+            "sha256": digest_file(VERIFIER),
+            "language": "Python",
+            "imports_emilia_code": False,
+            "imports_vaara_code": False,
+            "third_party_imports": ["cryptography"],
+        },
+        "environment": {
+            "python": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "cryptography": cryptography.__version__,
+            "openssl": backend.openssl_version_text(),
+            "os": "Linux",
+            "kernel": platform.release(),
+            "machine": platform.machine(),
+            "libc": platform.libc_ver()[0] + " " + platform.libc_ver()[1],
+        },
+        "positive": positive,
+        "positive_expected": expected,
+        "positive_all_match": all(positive[k] == expected[k] for k in expected),
+        "hostile_accepted": hostile,
+        "hostile_all_refused": not any(hostile.values()),
+        "establishes": (
+            "Independent implementation over pinned, author-supplied vectors. "
+            "The published vectors reproduce in a different language on a "
+            "different platform, and the three identities remain separate when "
+            "computed by a second party."
+        ),
+        "does_not_establish": [
+            "independently derived vectors",
+            "EP profile verification",
+            "Transparency Service registration",
+            "validation of the specification text",
+        ],
+        "run_kind": "independent-implementation",
+        "runner": "Henri Sirkkavaara, Vaara",
+    }
+
+    sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/independent/ep-scitt-pr662/independent_verify.py
+++ b/conformance/independent/ep-scitt-pr662/independent_verify.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Independent second runner for EP-SCITT-STATEMENT-IDENTITY-v0.1.
+
+Consumes vectors.reference.json only. Imports nothing from EMILIA and nothing
+from Vaara. Python stdlib plus `cryptography` for raw P-256 verification.
+
+Reports what Iman asked a second runner to report:
+  1. both positive signatures
+  2. the distinct exact-entry digests
+  3. the common signing-input digest
+  4. the hostile substitutions
+"""
+
+import base64
+import hashlib
+import json
+import os
+import platform
+import sys
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+# SEC p256r1 group order.
+N = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+
+# The vectors sit next to this file. Pass a path to point it somewhere else.
+HERE = os.path.dirname(os.path.abspath(__file__))
+VECTORS = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, "vectors.reference.json")
+
+
+def b64u(s):
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def sha256_tag(b):
+    return "sha256:" + hashlib.sha256(b).hexdigest()
+
+
+def load_key(jwk):
+    return ec.EllipticCurvePublicNumbers(
+        int.from_bytes(b64u(jwk["x"]), "big"),
+        int.from_bytes(b64u(jwk["y"]), "big"),
+        ec.SECP256R1(),
+    ).public_key()
+
+
+def verify_p1363(key, sig_raw, msg):
+    """ES256: IEEE P1363 r||s, converted to DER for the library."""
+    if len(sig_raw) != 64:
+        return False
+    r = int.from_bytes(sig_raw[:32], "big")
+    s = int.from_bytes(sig_raw[32:], "big")
+    try:
+        key.verify(
+            utils.encode_dss_signature(r, s),
+            msg,
+            ec.ECDSA(hashes.SHA256()),
+        )
+        return True
+    except Exception:
+        return False
+
+
+def rs(sig_raw):
+    return (
+        int.from_bytes(sig_raw[:32], "big"),
+        int.from_bytes(sig_raw[32:], "big"),
+    )
+
+
+def main():
+    raw = open(VECTORS, "rb").read()
+    v = json.loads(raw)
+    fx, exp = v["fixture"], v["expected"]
+
+    key = load_key(fx["public_jwk"])
+    sig_struct = b64u(fx["sig_structure_base64url"])
+    sig_a = b64u(fx["signature_a_base64url"])
+    sig_b = b64u(fx["signature_b_base64url"])
+    env_a = b64u(fx["cose_sign1_a_base64url"])
+    env_b = b64u(fx["cose_sign1_b_base64url"])
+
+    print(f"profile          {v['profile']}")
+    print("runner           independent Python, cryptography only")
+    print(f"platform         {platform.platform()}")
+    print(f"python           {sys.version.split()[0]}")
+    print(f"vectors sha-256  {hashlib.sha256(raw).hexdigest()}")
+    print()
+
+    results = []
+
+    # 1. both positive signatures
+    ok_a = verify_p1363(key, sig_a, sig_struct)
+    ok_b = verify_p1363(key, sig_b, sig_struct)
+    results.append(("signature_a_valid", ok_a, exp["signature_a_valid"]))
+    results.append(("signature_b_valid", ok_b, exp["signature_b_valid"]))
+
+    # 2. distinct exact-entry digests
+    da, db = sha256_tag(env_a), sha256_tag(env_b)
+    results.append(("statement_entry_digest_a", da, exp["statement_entry_digest_a"]))
+    results.append(("statement_entry_digest_b", db, exp["statement_entry_digest_b"]))
+    results.append(("entry_digests_differ", da != db, True))
+
+    # 3. common signing-input digest
+    si = sha256_tag(sig_struct)
+    results.append(("signing_input_digest", si, exp["signing_input_digest"]))
+
+    # the malleability relation itself
+    ra, sa = rs(sig_a)
+    rb, sb = rs(sig_b)
+    results.append(("same_r", ra == rb, True))
+    results.append(("s_b_equals_n_minus_s_a", sb == N - sa, True))
+    results.append(("a_is_high_s", sa > N // 2, True))
+    results.append(("b_is_low_s", sb <= N // 2, True))
+
+    cls = (
+        "same_signing_input_different_envelope"
+        if (ok_a and ok_b and da != db and ra == rb)
+        else "other"
+    )
+    results.append(("classification", cls, exp["classification"]))
+
+    print("=== POSITIVE CASES ===")
+    for name, got, want in results:
+        mark = "PASS" if got == want else "FAIL"
+        print(f"  [{mark}] {name:34s} got={got}")
+
+    # 4. hostile substitutions
+    print("\n=== HOSTILE SUBSTITUTIONS (all must be refused) ===")
+    hostile = []
+
+    tampered = bytearray(sig_struct)
+    tampered[-1] ^= 0x01
+    hostile.append(("payload_bit_flip_vs_sig_a", verify_p1363(key, sig_a, bytes(tampered))))
+    hostile.append(("payload_bit_flip_vs_sig_b", verify_p1363(key, sig_b, bytes(tampered))))
+
+    swapped = sig_a[:32] + sig_b[32:64][::-1]
+    hostile.append(("reversed_s_bytes", verify_p1363(key, swapped, sig_struct)))
+
+    zero = b"\x00" * 64
+    hostile.append(("all_zero_signature", verify_p1363(key, zero, sig_struct)))
+
+    s_plus_n = sig_a[:32] + ((sa + N) % (1 << 256)).to_bytes(32, "big")
+    hostile.append(("s_plus_group_order", verify_p1363(key, s_plus_n, sig_struct)))
+
+    other = ec.generate_private_key(ec.SECP256R1()).public_key()
+    hostile.append(("valid_sig_wrong_key", verify_p1363(other, sig_a, sig_struct)))
+
+    hostile.append(("envelope_a_bytes_as_signing_input", verify_p1363(key, sig_a, env_a)))
+
+    for name, accepted in hostile:
+        mark = "PASS" if not accepted else "FAIL"
+        print(f"  [{mark}] {name:34s} accepted={accepted}")
+
+    pos_fail = [r[0] for r in results if r[1] != r[2]]
+    hos_fail = [h[0] for h in hostile if h[1]]
+    print()
+    print(f"positive: {len(results) - len(pos_fail)}/{len(results)} matched")
+    print(f"hostile:  {len(hostile) - len(hos_fail)}/{len(hostile)} refused")
+    if pos_fail or hos_fail:
+        print(f"FAILURES: {pos_fail + hos_fail}")
+        return 1
+    print("RESULT: independent verifier agrees with vectors.reference.json in full")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/independent/ep-scitt-pr662/report.independent.json
+++ b/conformance/independent/ep-scitt-pr662/report.independent.json
@@ -1,0 +1,77 @@
+{
+  "consumed_input": {
+    "branch": "feat/aic-ccs-partner-artifacts",
+    "file": "vectors.reference.json",
+    "sha256": "889e410cceec75f4c0955ca9a373d4a8375c00300cbe4d2be375a559958de697",
+    "source": "https://github.com/emiliaprotocol/emilia-protocol/tree/e507acdf8efbe8951cb4294801d4c440f0b86a5a/conformance/composition/scitt-statement-identity-v0.1"
+  },
+  "does_not_establish": [
+    "independently derived vectors",
+    "EP profile verification",
+    "Transparency Service registration",
+    "validation of the specification text"
+  ],
+  "environment": {
+    "cryptography": "49.0.0",
+    "implementation": "CPython",
+    "kernel": "6.18.37-0-virt",
+    "libc": "glibc 2.41",
+    "machine": "aarch64",
+    "openssl": "OpenSSL 4.0.1 9 Jun 2026",
+    "os": "Linux",
+    "python": "3.12.13"
+  },
+  "establishes": "Independent implementation over pinned, author-supplied vectors. The published vectors reproduce in a different language on a different platform, and the three identities remain separate when computed by a second party.",
+  "hostile_accepted": {
+    "all_zero_signature": false,
+    "envelope_a_bytes_as_signing_input": false,
+    "payload_bit_flip_vs_sig_a": false,
+    "payload_bit_flip_vs_sig_b": false,
+    "reversed_s_bytes": false,
+    "s_plus_group_order": false,
+    "valid_sig_wrong_key": false
+  },
+  "hostile_all_refused": true,
+  "positive": {
+    "a_is_high_s": true,
+    "b_is_low_s": true,
+    "classification": "same_signing_input_different_envelope",
+    "entry_digests_differ": true,
+    "s_b_equals_n_minus_s_a": true,
+    "same_r": true,
+    "signature_a_valid": true,
+    "signature_b_valid": true,
+    "signing_input_digest": "sha256:c4b229193fd4f871f431daf6f6bc7c5cab5f13896c42b7fc3a7397a3ff67dd86",
+    "statement_entry_digest_a": "sha256:ba36963493c183eea6c8f71e492121d49d14c1f0338574a6171b1312c763b4e1",
+    "statement_entry_digest_b": "sha256:be2becd5536416c02adec625fff8aca3b75beb691543d458935bfce7ea857ef0"
+  },
+  "positive_all_match": true,
+  "positive_expected": {
+    "a_is_high_s": true,
+    "b_is_low_s": true,
+    "classification": "same_signing_input_different_envelope",
+    "entry_digests_differ": true,
+    "s_b_equals_n_minus_s_a": true,
+    "same_r": true,
+    "signature_a_valid": true,
+    "signature_b_valid": true,
+    "signing_input_digest": "sha256:c4b229193fd4f871f431daf6f6bc7c5cab5f13896c42b7fc3a7397a3ff67dd86",
+    "statement_entry_digest_a": "sha256:ba36963493c183eea6c8f71e492121d49d14c1f0338574a6171b1312c763b4e1",
+    "statement_entry_digest_b": "sha256:be2becd5536416c02adec625fff8aca3b75beb691543d458935bfce7ea857ef0"
+  },
+  "profile": "EP-SCITT-STATEMENT-IDENTITY-v0.1",
+  "report_version": "independent-second-runner-v1",
+  "run_kind": "independent-implementation",
+  "runner": "Henri Sirkkavaara, Vaara",
+  "vectors_version": "EP-SCITT-STATEMENT-IDENTITY-VECTORS-v1",
+  "verifier": {
+    "file": "independent_verify.py",
+    "imports_emilia_code": false,
+    "imports_vaara_code": false,
+    "language": "Python",
+    "sha256": "d051feb07780be1e727f05c56b9419ffb1514850d8872f9483e9453f9fb4da7b",
+    "third_party_imports": [
+      "cryptography"
+    ]
+  }
+}

--- a/conformance/independent/ep-scitt-pr662/vectors.reference.json
+++ b/conformance/independent/ep-scitt-pr662/vectors.reference.json
@@ -1,0 +1,28 @@
+{
+  "@version": "EP-SCITT-STATEMENT-IDENTITY-VECTORS-v1",
+  "profile": "EP-SCITT-STATEMENT-IDENTITY-v0.1",
+  "fixture": {
+    "description": "One RFC 9943-shaped ES256 signing input with a high-S and canonical low-S ECDSA signature pair",
+    "public_jwk": {
+      "kty": "EC",
+      "x": "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY",
+      "y": "T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU",
+      "crv": "P-256"
+    },
+    "protected_bstr_base64url": "pAEmA3gYYXBwbGljYXRpb24vZXhhbXBsZStqc29uBFVzY2l0dC1pZGVudGl0eS1wMjU2LTEPogF4HGh0dHBzOi8vaXNzdWVyLmV4YW1wbGUvc2NpdHQCeCF1cm46ZXhhbXBsZTpzY2l0dC1pZGVudGl0eS1wMjU2OjE",
+    "payload_bstr_base64url": "eyJjbGFpbSI6Im9uZSBzaWduaW5nIGlucHV0LCB0d28gdmFsaWQgZW52ZWxvcGVzIiwic2VxdWVuY2UiOjF9",
+    "sig_structure_base64url": "hGpTaWduYXR1cmUxWHqkASYDeBhhcHBsaWNhdGlvbi9leGFtcGxlK2pzb24EVXNjaXR0LWlkZW50aXR5LXAyNTYtMQ-iAXgcaHR0cHM6Ly9pc3N1ZXIuZXhhbXBsZS9zY2l0dAJ4IXVybjpleGFtcGxlOnNjaXR0LWlkZW50aXR5LXAyNTY6MUBYP3siY2xhaW0iOiJvbmUgc2lnbmluZyBpbnB1dCwgdHdvIHZhbGlkIGVudmVsb3BlcyIsInNlcXVlbmNlIjoxfQ",
+    "signature_a_base64url": "8bROu_-rarrAsfzFu5oDi-LzZJYbr2gnTUCH-yqhUAr1cRohP2Vb3J1RFYwwELP7rq2grUIsASfBeVlhNelD2Q",
+    "signature_b_base64url": "8bROu_-rarrAsfzFu5oDi-LzZJYbr2gnTUCH-yqhUAoKjuXdwJqkJGKu6nPP70wEDjlaAGTrnV0yQHFhxnnheA",
+    "cose_sign1_a_base64url": "0oRYeqQBJgN4GGFwcGxpY2F0aW9uL2V4YW1wbGUranNvbgRVc2NpdHQtaWRlbnRpdHktcDI1Ni0xD6IBeBxodHRwczovL2lzc3Vlci5leGFtcGxlL3NjaXR0AnghdXJuOmV4YW1wbGU6c2NpdHQtaWRlbnRpdHktcDI1NjoxoFg_eyJjbGFpbSI6Im9uZSBzaWduaW5nIGlucHV0LCB0d28gdmFsaWQgZW52ZWxvcGVzIiwic2VxdWVuY2UiOjF9WEDxtE67_6tqusCx_MW7mgOL4vNklhuvaCdNQIf7KqFQCvVxGiE_ZVvcnVEVjDAQs_uuraCtQiwBJ8F5WWE16UPZ",
+    "cose_sign1_b_base64url": "0oRYeqQBJgN4GGFwcGxpY2F0aW9uL2V4YW1wbGUranNvbgRVc2NpdHQtaWRlbnRpdHktcDI1Ni0xD6IBeBxodHRwczovL2lzc3Vlci5leGFtcGxlL3NjaXR0AnghdXJuOmV4YW1wbGU6c2NpdHQtaWRlbnRpdHktcDI1NjoxoFg_eyJjbGFpbSI6Im9uZSBzaWduaW5nIGlucHV0LCB0d28gdmFsaWQgZW52ZWxvcGVzIiwic2VxdWVuY2UiOjF9WEDxtE67_6tqusCx_MW7mgOL4vNklhuvaCdNQIf7KqFQCgqO5d3AmqQkYq7qc8_vTAQOOVoAZOudXTJAcWHGeeF4"
+  },
+  "expected": {
+    "signature_a_valid": true,
+    "signature_b_valid": true,
+    "statement_entry_digest_a": "sha256:ba36963493c183eea6c8f71e492121d49d14c1f0338574a6171b1312c763b4e1",
+    "statement_entry_digest_b": "sha256:be2becd5536416c02adec625fff8aca3b75beb691543d458935bfce7ea857ef0",
+    "signing_input_digest": "sha256:c4b229193fd4f871f431daf6f6bc7c5cab5f13896c42b7fc3a7397a3ff67dd86",
+    "classification": "same_signing_input_different_envelope"
+  }
+}


### PR DESCRIPTION
Iman Schrock asked on the SCITT list for a second runner to consume `vectors.reference.json` with its own verifier, rather than the bundled runner, and to report both positive signatures, the distinct exact-entry digests, the common signing-input digest and the hostile substitutions. This publishes that run so anyone can fetch the artifacts and repeat it.

## What is here

`conformance/independent/ep-scitt-pr662/` holds:

- `independent_verify.py`, the verifier. Python standard library plus `cryptography` for raw P-256. It imports nothing from EMILIA and nothing from Vaara.
- `vectors.reference.json`, the author's vectors mirrored unmodified, sha-256 `889e410cceec75f4c0955ca9a373d4a8375c00300cbe4d2be375a559958de697`.
- `emit_report.py` and `report.independent.json`, a deterministic machine-readable report.
- `RESULT.txt`, the run output.
- `README.md`.

Both scripts read the vectors from their own directory, so a clone runs them without editing paths.

## Result

11 of 11 positive assertions matched, 7 of 7 hostile substitutions refused.

The two exact-entry digests come out distinct, the signing-input digest is common to both, and the signature relation reproduces: same r, s_B equals n minus s_A, A high-S and B canonical low-S. Classification `same_signing_input_different_envelope`.

Refused: payload bit flip against each signature, reversed s bytes, all-zero signature, s plus the group order, a valid signature offered against a freshly generated key, and the envelope bytes used as the signing input.

Environment pinned in the README: Linux aarch64, kernel 6.18.37, CPython 3.12.13.

## Scope

This establishes that the published vectors reproduce under an independent implementation on a different platform. It does not establish independently derived vectors, EP profile verification, Transparency Service registration, or anything about the specification text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an independent conformance verification suite for EP-SCITT statement identity.
  * Added reference vectors covering ES256 signatures, COSE_Sign1 envelopes, digest values, and expected classifications.
  * Added deterministic verification and report generation tools.

* **Documentation**
  * Added instructions for running the verification suite and describing its scope and provenance.

* **Tests**
  * Verified 11 of 11 positive assertions and rejected all seven hostile substitutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->