### PR TITLE
credential: verify_grant can honour a stated revocation staleness bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- `verify_grant()` can now honour a deployment's revocation staleness bound. It takes optional `revocation_now` and `max_staleness_seconds`, forwards them to `RevocationRegistry.status()`, and refuses with the new reason `revocation_stale` when the registry cannot establish anything about the present under the stated bound.
+
+  1.80.0 gave `RevocationStatus` a `freshness` verdict and an `establishes_current` property, but no shipped path read them. `verify_grant()` called `status()` with no `now` and no bound, so on that path `freshness` could only ever be `unknown`, and the only line consuming the status was `if status.revoked:`. A registry that stated in its own words that it could say nothing about revocations since it was observed still produced `GrantVerdict(ok=True, reason='ok')`. The verdict was computed, exposed, pinned by vectors, and enforced nowhere.
+
+  The bound stays opt-in, because `draft-sirkkavaara-vaara-receipt-08` Section 10 puts the staleness a deployment accepts on the deployment rather than on the verifier. Callers that pass neither parameter get the behaviour they had before it existed, which `test_stale_registry_admits_when_no_bound_is_stated` pins.
+
+  The asymmetry is preserved and pinned separately. A revocation the registry can see binds however old the registry is, so `revoked` is answered before staleness is considered and a stale registry never downgrades a refusal to `revocation_stale`. Staleness weakens only the negative answer. `test_revocation_binds_however_stale_the_registry_is` is the case most likely to regress.
+
 ## [1.80.0] - 2026-09-02
 
 ### Added

--- a/src/vaara/credential/_grant_verify.py
+++ b/src/vaara/credential/_grant_verify.py
@@ -17,9 +17,26 @@ signature:
    committed scope (args re-derived with ``make_args_digest``).
 4. ``revoked``        - the issuer or its bound key was revoked at or before
    issuance (``RevocationRegistry``).
-5. ``binding_unknown``- the bound attestation digest is not in the set of
+5. ``revocation_stale``- the deployment stated a staleness bound and the
+   registry cannot establish anything about the present under it. Only
+   reachable when the caller passes ``max_staleness_seconds``; see below.
+6. ``binding_unknown``- the bound attestation digest is not in the set of
    known mediation digests the verifier was given (fail-closed when no set is
    supplied).
+
+Revocation freshness is opt-in, and deliberately so. ``draft-sirkkavaara-vaara-receipt-08``
+Section 10 puts the staleness a deployment accepts on the deployment, not on
+the verifier, so ``verify_grant`` imposes no bound of its own. Pass
+``max_staleness_seconds`` (and optionally ``revocation_now`` for a
+deterministic instant) and the bound is honoured: a clean answer the registry
+cannot vouch for as current refuses instead of admitting.
+
+Omit it and behaviour is exactly what it was before this parameter existed.
+
+The asymmetry from ``RevocationStatus`` is preserved here. A visible revocation
+binds however stale the registry is, so ``revoked`` is checked first and a
+stale registry never downgrades it to ``revocation_stale``. Staleness weakens
+only the negative answer.
 
 This is detection of a defeated broker, not a mathematical-completeness claim.
 Completeness holds only for tools placed behind a gateway that runs this; see
@@ -59,6 +76,8 @@ def verify_grant(
     known_attestation_digests: Optional[frozenset[str]] = None,
     now: Optional[float] = None,
     clock_skew_seconds: int = 30,
+    revocation_now: Optional[str] = None,
+    max_staleness_seconds: Optional[float] = None,
 ) -> GrantVerdict:
     """Check a credential against the runtime call. See module docstring."""
     if not verify_grant_signature(credential, verifying_material=verifying_material):
@@ -92,10 +111,22 @@ def verify_grant(
 
     if revocation is not None:
         status = revocation.status(
-            asserted.iss, asserted.iat, keyid=asserted.secret_version
+            asserted.iss,
+            asserted.iat,
+            keyid=asserted.secret_version,
+            now=revocation_now,
+            max_staleness_seconds=max_staleness_seconds,
         )
+        # Order matters. A revocation the registry can see binds however old
+        # the registry is, so it is answered before staleness is considered
+        # and a stale registry never downgrades "revoked" to "revocation_stale".
         if status.revoked:
             return GrantVerdict(False, "revoked")
+        # Only reachable when the deployment stated a bound. Without one there
+        # is nothing to honour and the clean answer stands, which is the
+        # behaviour every caller had before these parameters existed.
+        if max_staleness_seconds is not None and not status.establishes_current:
+            return GrantVerdict(False, "revocation_stale")
 
     known = known_attestation_digests or frozenset()
     if credential.binding.attestation_digest not in known:

--- a/tests/credential/test_grant_emit_verify.py
+++ b/tests/credential/test_grant_emit_verify.py
@@ -147,6 +147,86 @@ def test_revocation_identity_scope_revoked():
     assert _ok(_mint(), revocation=reg).reason == "revoked"
 
 
+# --- revocation freshness ------------------------------------------------
+#
+# v1.80.0 gave RevocationStatus a freshness verdict, but no shipped path read
+# it: verify_grant called status() with no bound and consumed only .revoked,
+# so a registry that said in its own words it could establish nothing about
+# the present still produced ok=True. These pin the pass-through that closes
+# that, and pin that omitting the bound changes nothing.
+
+STALE_REG = RevocationRegistry((), as_of="2026-06-18T00:00:00Z")  # 12h before iat
+FRESH_REG = RevocationRegistry((), as_of="2026-06-18T11:59:00Z")  # 60s before iat
+REVOKED_STALE_REG = RevocationRegistry(
+    (RevocationEntry(scope="key", subject="key-v1", revoked_at="2026-06-18T11:00:00Z"),),
+    as_of="2026-06-18T00:00:00Z",
+)
+CHECK_AT = "2026-06-18T12:00:05Z"  # matches now=IAT_EPOCH + 5
+
+
+def test_stale_registry_admits_when_no_bound_is_stated():
+    # Backward compatibility. Section 10 puts the bound on the deployment, so
+    # a caller that states none gets exactly the pre-existing behaviour.
+    assert _ok(_mint(), revocation=STALE_REG).ok
+
+
+def test_stale_registry_refuses_once_a_bound_is_stated():
+    v = _ok(
+        _mint(),
+        revocation=STALE_REG,
+        revocation_now=CHECK_AT,
+        max_staleness_seconds=300,
+    )
+    assert not v.ok and v.reason == "revocation_stale"
+
+
+def test_fresh_registry_inside_the_bound_admits():
+    v = _ok(
+        _mint(),
+        revocation=FRESH_REG,
+        revocation_now=CHECK_AT,
+        max_staleness_seconds=300,
+    )
+    assert v.ok and v.reason == "ok"
+
+
+def test_registry_without_as_of_refuses_under_a_bound():
+    # freshness is "unknown", not "fresh". Absence of an observation instant
+    # is never read as permission to treat the answer as current.
+    v = _ok(
+        _mint(),
+        revocation=RevocationRegistry(()),
+        revocation_now=CHECK_AT,
+        max_staleness_seconds=300,
+    )
+    assert not v.ok and v.reason == "revocation_stale"
+
+
+def test_future_as_of_refuses_under_a_bound():
+    # Observation instant after now means the clocks disagree, so the bound
+    # cannot be evaluated honestly and is not quietly treated as met.
+    v = _ok(
+        _mint(),
+        revocation=RevocationRegistry((), as_of="2026-06-19T00:00:00Z"),
+        revocation_now=CHECK_AT,
+        max_staleness_seconds=300,
+    )
+    assert not v.ok and v.reason == "revocation_stale"
+
+
+def test_revocation_binds_however_stale_the_registry_is():
+    # THE ASYMMETRY, and the case most likely to regress. A revocation fact
+    # does not expire, so staleness must not downgrade "revoked" to
+    # "revocation_stale" and must never turn a refusal into an admit.
+    v = _ok(
+        _mint(),
+        revocation=REVOKED_STALE_REG,
+        revocation_now=CHECK_AT,
+        max_staleness_seconds=300,
+    )
+    assert not v.ok and v.reason == "revoked"
+
+
 def test_binding_absent_unknown():
     assert _ok(_mint(), known_attestation_digests=frozenset()).reason == "binding_unknown"
 


### PR DESCRIPTION
v1.80.0 gave `RevocationStatus` a `freshness` verdict and an `establishes_current` property, and no shipped path read either one.

`verify_grant` called `status()` with no `now` and no bound, so on that path `freshness` could only ever be `unknown` and `establishes_current` only ever `False`. The single line consuming the status was `if status.revoked:`. A registry that stated in its own words that it could say nothing about revocations since it was observed still produced `GrantVerdict(ok=True, reason='ok')`.

The verdict was computed, exposed, pinned by a 49th vector suite, and enforced nowhere.

## What changes

`verify_grant()` takes optional `revocation_now` and `max_staleness_seconds`, forwards them to `RevocationRegistry.status()`, and refuses with the new reason `revocation_stale` when the registry cannot establish anything about the present under the stated bound.

Before and after, same registry observed 12 hours before the call, deployment stating a 300 second bound:

```
what the deployment learns if it asks:
   revoked             False
   freshness           'stale'
   establishes_current False

BEFORE (no bound passed):  GrantVerdict(ok=True,  reason='ok')
AFTER  (bound stated):     GrantVerdict(ok=False, reason='revocation_stale')
```

## Why the bound stays opt-in

`draft-sirkkavaara-vaara-receipt-08` Section 10 puts the staleness a deployment accepts on the deployment, not on the verifier:

> Where a decision depends on revocation state, the key resolution path and the staleness a deployment accepts are operational parameters of that deployment and MUST be stated by it.

So `verify_grant` imposes no bound of its own. A caller that passes neither parameter gets behaviour identical to before this existed, which `test_stale_registry_admits_when_no_bound_is_stated` pins.

## The asymmetry, pinned separately

A revocation the registry can see binds however old the registry is, because the fact does not expire. `revoked` is answered before staleness is considered, so a stale registry never downgrades a refusal to `revocation_stale` and never turns one into an admit. Staleness weakens only the negative answer.

`test_revocation_binds_however_stale_the_registry_is` is the case most likely to regress.

## Tests

Six cases added to `tests/credential/test_grant_emit_verify.py`: no bound admits, stale refuses, fresh inside the bound admits, absent `as_of` refuses, future `as_of` refuses (clock disagreement is not quietly treated as met), and a visible revocation still reads `revoked`.

Full suite: 3517 passed, 26 skipped.
