### PR TITLE
transparency: verify_consistency reports when it could not compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking.** `verify_consistency()` returns a three-valued `ConsistencyVerdict` instead of a `bool`. Only `CONSISTENT` is truthy, so a caller written against the old return refuses a check that did not happen.
+
+  The old code answered `True` for an empty first tree without looking at either root:
+
+  ```python
+  if first_size == 0:
+      return not proof.hashes
+  ```
+
+  That is a verdict on a comparison that never happened. It would have returned `True` for any pair of roots at all, as long as the proof list was empty, including a first root and a second root from two unrelated logs. The branch immediately above it, for equal sizes, does compare the roots before answering, so the looseness was not even consistent within the same function.
+
+  RFC 9162 section 2.1.4.2 bounds a consistency proof at `0 < m < n`. For sizes outside that range the function has no comparison to report, so it now returns `COULD_NOT_COMPARE`, which is the absence of a claim about the log. That verdict is decided before any comparison is attempted, so an out-of-range input can never be reported as `INCONSISTENT` by a path that never reached a root. Out-of-range today is `first_size <= 0`, `second_size < first_size`, and a proof whose declared sizes describe a different pair of heads than the one asked about.
+
+  Blake Morrison found the disagreement by running an independent implementation against the pinned `transparency_consistency_v0` vectors, and proposed the shape on the SCITT list: put the third value on what the checker answers rather than tagging the vector, because a vector tagged out-of-range is a row a harness can skip while a checker that answers `true` still passes.
+
+  `verify_evidence_bundle()` reports the new verdict as its own reason rather than folding it into the failure text. A bundle whose tree heads fall outside the defined range was not shown to have forked, it was never checked, and the two now read differently.
+
+- `transparency_consistency_v0` carries ten cases, and `expected.json` now pins a `verdict` string per case where it used to pin a `consistent` boolean. Each case checks which verdict came back, so a checker returning a truthy value for the wrong reason fails. `consistent_0_to_12` is renamed to `out_of_range_0_to_12` and expects `could_not_compare`; `out_of_range_8_to_4` is new. The rename is deliberate, so that a harness carrying the old expectation fails loudly.
+
 ### Added
 
 - `verify_grant()` can now honour a deployment's revocation staleness bound. It takes optional `revocation_now` and `max_staleness_seconds`, forwards them to `RevocationRegistry.status()`, and refuses with the new reason `revocation_stale` when the registry cannot establish anything about the present under the stated bound.

--- a/docs/design/transparency-log-consistency-spec.md
+++ b/docs/design/transparency-log-consistency-spec.md
@@ -39,10 +39,38 @@ New surface, all additive:
   leaves, so a monitor can pin a historical signed tree head before asking for
   a proof against a later one.
 - `verify_consistency(first_size, first_root, second_size, second_root, proof)`
-  recomputes both roots from the proof and returns a single `bool`. The two
-  roots are supplied by the verifier (the signed tree heads it holds at two
+  recomputes both roots from the proof and returns a `ConsistencyVerdict`. The
+  two roots are supplied by the verifier (the signed tree heads it holds at two
   points in time); the proof hashes alone do not bind to a specific pair of
   roots, exactly as with inclusion proofs.
+
+## The verdict is three-valued
+
+RFC 9162 section 2.1.4.2 bounds a consistency proof at `0 < m < n`. For sizes
+outside that range there is no comparison to perform, and a two-valued answer
+has to lie in one direction or the other: `true` claims the log is append-only
+on the strength of a check that never ran, `false` claims the log was
+inconsistent on the same absence of evidence.
+
+`ConsistencyVerdict` has three members, and only `CONSISTENT` is truthy:
+
+| Verdict | Meaning |
+|---|---|
+| `CONSISTENT` | Both roots were recomputed from the proof and matched. |
+| `INCONSISTENT` | A comparison ran and the roots disagreed. |
+| `COULD_NOT_COMPARE` | No comparison ran. Not a claim about the log. |
+
+The third value only constrains anything if two further rules hold:
+
+1. `COULD_NOT_COMPARE` is decided first, before any comparison is attempted.
+   If invalid were decided first it would swallow the third value, which
+   would then exist in the type without ever reaching a caller.
+2. The verdict is falsy unless it is `CONSISTENT`. A caller written against
+   the older `bool` return refuses a check that did not happen.
+
+Out-of-range inputs today are `first_size <= 0`, `second_size < first_size`,
+and a proof whose declared sizes describe a different pair of heads than the
+one asked about.
 
 The receipt envelope, canonicalization, inclusion-proof format, and signature
 verification are unchanged. The envelope version stays 1.
@@ -73,9 +101,15 @@ without changing verifier code.
 
 ## Conformance
 
-`tests/vectors/transparency_consistency_v0/` carries nine cases over a
-twelve-leaf log: power-of-two and non-power-of-two prefixes, an empty prefix,
-identical trees, and two negatives (a flipped proof hash, and a proof checked
-against a forked second root). `_check_independent.py` reproduces every
-verdict using only the Python standard library and without importing Vaara,
-so the append-only guarantee is consumable by a second implementation.
+`tests/vectors/transparency_consistency_v0/` carries ten cases over a
+twelve-leaf log: power-of-two and non-power-of-two prefixes, identical trees,
+two negatives (a flipped proof hash, and a proof checked against a forked
+second root), and two out-of-range cases (an empty prefix, and a second tree
+smaller than the first). `_check_independent.py` reproduces every verdict
+using only the Python standard library and without importing Vaara, so the
+append-only guarantee is consumable by a second implementation.
+
+Each case pins the exact verdict string it expects. A checker that answers
+`consistent` or `inconsistent` on an input RFC 9162 leaves undefined fails
+the case, where a check on truthiness alone would have let the wrong answer
+stay green.

--- a/src/vaara/attestation/__init__.py
+++ b/src/vaara/attestation/__init__.py
@@ -65,6 +65,7 @@ from vaara.attestation.iap import (
 )
 from vaara.attestation.transparency_log import (
     ConsistencyProof,
+    ConsistencyVerdict,
     InProcessTransparencyLog,
     InclusionProof,
     LogEntry,
@@ -167,6 +168,7 @@ __all__ = [
     "EnforcementVerdict",
     "ConformalExtension",
     "ConsistencyProof",
+    "ConsistencyVerdict",
     "EnvelopeError",
     "EvidenceBundle",
     "ExecutionReceipt",

--- a/src/vaara/attestation/_bundle.py
+++ b/src/vaara/attestation/_bundle.py
@@ -50,6 +50,7 @@ from vaara.attestation._revocation import (
 from vaara.attestation._attest_types import Attestation
 from vaara.attestation.transparency_log import (
     ConsistencyProof,
+    ConsistencyVerdict,
     InclusionProof,
     verify_consistency,
     verify_inclusion,
@@ -257,19 +258,30 @@ def _consistency_lens(bundle: EvidenceBundle) -> LensResult:
         return LensResult(
             "consistency", False, False, "no consistency proof and tree heads supplied"
         )
-    ok = verify_consistency(
+    verdict = verify_consistency(
         first_size=bundle.consistency.first_size,
         first_root=bundle.consistency_first_root,
         second_size=bundle.consistency.second_size,
         second_root=bundle.consistency_second_root,
         proof=bundle.consistency,
     )
-    reason = (
-        "log is append-only across the two supplied tree heads"
-        if ok
-        else "consistency proof does not reproduce the supplied tree heads"
-    )
-    return LensResult("consistency", True, ok, reason)
+    # The could-not-compare verdict is reported as its own reason rather than
+    # folded into the failure text. A bundle whose tree heads sit outside
+    # RFC 9162's 0 < m < n was not shown to have forked; it was never checked,
+    # and the reader has to be able to tell those apart.
+    reasons = {
+        ConsistencyVerdict.CONSISTENT: (
+            "log is append-only across the two supplied tree heads"
+        ),
+        ConsistencyVerdict.INCONSISTENT: (
+            "consistency proof does not reproduce the supplied tree heads"
+        ),
+        ConsistencyVerdict.COULD_NOT_COMPARE: (
+            "consistency was not checked: the supplied tree heads fall outside "
+            "the range RFC 9162 defines a proof over, so no roots were compared"
+        ),
+    }
+    return LensResult("consistency", True, bool(verdict), reasons[verdict])
 
 
 def _revocation_lens(bundle: EvidenceBundle, keyid: Optional[str]) -> LensResult:

--- a/src/vaara/attestation/transparency_log.py
+++ b/src/vaara/attestation/transparency_log.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import hashlib
 import threading
 from dataclasses import dataclass
+from enum import Enum
 
 
 class TransparencyLogError(RuntimeError):
@@ -163,6 +164,28 @@ def _subproof(m: int, leaves: list[bytes], on_path: bool) -> list[bytes]:
     return _subproof(m - k, leaves[k:], False) + [_root_from_leaves(leaves[:k])]
 
 
+class ConsistencyVerdict(Enum):
+    """Three-valued result of an RFC 9162 consistency check.
+
+    A two-valued verdict cannot distinguish "I compared the roots and they
+    disagreed" from "I never compared anything", and the second silently
+    becomes the first at any call site that reads the result as a boolean.
+    ``COULD_NOT_COMPARE`` keeps that distinction alive past the function
+    that made it.
+
+    Only ``CONSISTENT`` is truthy, so a caller written against the older
+    ``bool`` return fails closed: it refuses a check that did not happen
+    rather than passing it.
+    """
+
+    CONSISTENT = "consistent"
+    INCONSISTENT = "inconsistent"
+    COULD_NOT_COMPARE = "could_not_compare"
+
+    def __bool__(self) -> bool:
+        return self is ConsistencyVerdict.CONSISTENT
+
+
 def verify_consistency(
     *,
     first_size: int,
@@ -170,24 +193,42 @@ def verify_consistency(
     second_size: int,
     second_root: bytes,
     proof: ConsistencyProof,
-) -> bool:
+) -> ConsistencyVerdict:
     """Verify an RFC 9162 consistency proof between two tree heads.
 
     Recomputes both ``first_root`` and ``second_root`` from the proof and
-    returns whether both match. A ``True`` result means the ``first_size``
-    tree is a verifiable prefix of the ``second_size`` tree: the log is
-    append-only across the two snapshots. Implements RFC 9162 section 2.1.4.2.
+    reports whether both match. ``CONSISTENT`` means the ``first_size`` tree
+    is a verifiable prefix of the ``second_size`` tree: the log is
+    append-only across the two snapshots. Implements RFC 9162 section
+    2.1.4.2.
+
+    RFC 9162 section 2.1.4.2 bounds a consistency proof at ``0 < m < n``.
+    Inputs outside that range are not a log that disagreed, they are a
+    question this function cannot answer, and they return
+    ``COULD_NOT_COMPARE``. That verdict is decided *first*, before any
+    comparison is attempted, so an out-of-range input can never be reported
+    as ``INCONSISTENT`` by a path that never reached a root.
     """
+    # Could-not-compare is evaluated before anything else. If it ran second,
+    # an "invalid" answer would swallow it and the distinction would exist in
+    # the type without ever being reported.
+    if first_size <= 0:
+        # Outside RFC 9162's 0 < m: no prefix root exists to compare against.
+        return ConsistencyVerdict.COULD_NOT_COMPARE
+    if second_size < first_size:
+        # Outside RFC 9162's m < n: there is no larger tree to be a prefix of.
+        return ConsistencyVerdict.COULD_NOT_COMPARE
     if proof.first_size != first_size or proof.second_size != second_size:
-        return False
-    if first_size > second_size:
-        return False
+        # The proof describes a different pair of heads than the one asked
+        # about, so nothing was compared for the requested pair.
+        return ConsistencyVerdict.COULD_NOT_COMPARE
+
     if first_size == second_size:
-        # Same tree: nothing to prove beyond identical roots.
-        return not proof.hashes and first_root == second_root
-    if first_size == 0:
-        # The empty tree is a prefix of every tree; no path hashes needed.
-        return not proof.hashes
+        # Same tree: nothing to prove beyond identical roots. The roots are
+        # compared, so this branch can return a real verdict either way.
+        if not proof.hashes and first_root == second_root:
+            return ConsistencyVerdict.CONSISTENT
+        return ConsistencyVerdict.INCONSISTENT
 
     # 0 < first_size < second_size. For a power-of-two first tree the spec
     # omits first_root from the path because the verifier already holds it;
@@ -196,7 +237,7 @@ def verify_consistency(
     if first_size & (first_size - 1) == 0:
         path = [first_root, *path]
     if not path:
-        return False
+        return ConsistencyVerdict.INCONSISTENT
 
     fn = first_size - 1
     sn = second_size - 1
@@ -211,7 +252,7 @@ def verify_consistency(
     for sibling in nodes:
         if sn == 0:
             # More path nodes than the second tree can account for.
-            return False
+            return ConsistencyVerdict.INCONSISTENT
         if fn & 1 or fn == sn:
             fr = _hash_node(sibling, fr)
             sr = _hash_node(sibling, sr)
@@ -223,7 +264,9 @@ def verify_consistency(
         fn >>= 1
         sn >>= 1
 
-    return sn == 0 and fr == first_root and sr == second_root
+    if sn == 0 and fr == first_root and sr == second_root:
+        return ConsistencyVerdict.CONSISTENT
+    return ConsistencyVerdict.INCONSISTENT
 
 
 def verify_inclusion(

--- a/tests/test_transparency_consistency.py
+++ b/tests/test_transparency_consistency.py
@@ -5,11 +5,19 @@ earlier size is a verifiable prefix of the log at a later size, so a fork or
 a rewrite of earlier history is detectable even when every inclusion proof
 still verifies.
 
+The verdict is three-valued. RFC 9162 section 2.1.4.2 bounds a consistency
+proof at 0 < m < n, and for sizes outside that range there is no comparison
+to report: `could_not_compare` is not a claim about the log, it is the
+absence of one. It is decided before any comparison is attempted, and it is
+falsy, so a caller written against the older bool return fails closed.
+
 Coverage:
 1. Genuine prover/verifier agreement across every (first, second) size pair
    in a range, including the non-power-of-two cases.
 2. Rejection of a tampered proof, a wrong root, and a forked second tree.
-3. Edge cases (empty prefix, identical trees) and input-range guards.
+3. Out-of-range inputs (empty prefix, first larger than second, a proof for
+   another pair of heads) report could_not_compare, are decided before
+   invalid, and stay falsy.
 4. The committed transparency_consistency_v0 vectors verify two ways: via
    Vaara, and via the standalone stdlib-only checker.
 """
@@ -26,6 +34,7 @@ import pytest
 
 from vaara.attestation.transparency_log import (
     ConsistencyProof,
+    ConsistencyVerdict,
     InProcessTransparencyLog,
     TransparencyLogError,
     verify_consistency,
@@ -46,7 +55,9 @@ def _log(n: int) -> InProcessTransparencyLog:
 @pytest.mark.parametrize("second", range(0, 18))
 def test_genuine_proof_verifies_for_every_prefix(second: int) -> None:
     log = _log(second)
-    for first in range(0, second + 1):
+    # first == 0 is outside RFC 9162's 0 < m and is covered by
+    # test_empty_prefix_cannot_be_compared, not here.
+    for first in range(1, second + 1):
         proof = log.consistency_proof(first, second)
         assert verify_consistency(
             first_size=first,
@@ -54,7 +65,7 @@ def test_genuine_proof_verifies_for_every_prefix(second: int) -> None:
             second_size=second,
             second_root=log.root_at(second),
             proof=proof,
-        ), f"genuine proof {first} to {second} failed"
+        ) is ConsistencyVerdict.CONSISTENT, f"genuine proof {first} to {second} failed"
 
 
 def test_root_at_matches_root_hash_at_full_size() -> None:
@@ -113,16 +124,6 @@ def test_forked_history_is_rejected() -> None:
         )
 
 
-def test_proof_size_mismatch_is_rejected() -> None:
-    log = _log(10)
-    proof = log.consistency_proof(3, 10)
-    mismatched = dataclasses.replace(proof, second_size=9)
-    assert not verify_consistency(
-        first_size=3, first_root=log.root_at(3),
-        second_size=10, second_root=log.root_at(10), proof=mismatched,
-    )
-
-
 def test_extra_proof_hash_is_rejected() -> None:
     log = _log(12)
     proof = log.consistency_proof(3, 12)
@@ -135,14 +136,42 @@ def test_extra_proof_hash_is_rejected() -> None:
 
 # ── Edge cases and input guards ─────────────────────────────────────────────
 
-def test_empty_prefix_is_trivially_consistent() -> None:
+def test_empty_prefix_cannot_be_compared() -> None:
+    """An empty first tree is outside RFC 9162's 0 < m, so nothing is compared.
+
+    The old answer here was ``True``, which asserted the log was append-only
+    on the strength of a check that never looked at either root. It would have
+    held for any pair of roots at all, as long as the proof list was empty.
+    """
     log = _log(7)
     proof = log.consistency_proof(0, 7)
     assert proof.hashes == ()
     assert verify_consistency(
         first_size=0, first_root=log.root_at(0),
         second_size=7, second_root=log.root_at(7), proof=proof,
+    ) is ConsistencyVerdict.COULD_NOT_COMPARE
+
+
+def test_empty_prefix_verdict_is_falsy_so_old_callers_fail_closed() -> None:
+    """A caller written against the old bool must refuse, not pass."""
+    log = _log(7)
+    proof = log.consistency_proof(0, 7)
+    verdict = verify_consistency(
+        first_size=0, first_root=log.root_at(0),
+        second_size=7, second_root=log.root_at(7), proof=proof,
     )
+    assert not verdict
+    assert not bool(verdict)
+
+
+def test_empty_prefix_does_not_launder_an_unrelated_root() -> None:
+    """The exact case Blake Morrison found: any second_root used to pass."""
+    log = _log(7)
+    proof = log.consistency_proof(0, 7)
+    assert verify_consistency(
+        first_size=0, first_root=b"\x00" * 32,
+        second_size=7, second_root=b"\xff" * 32, proof=proof,
+    ) is ConsistencyVerdict.COULD_NOT_COMPARE
 
 
 def test_identical_trees_need_empty_proof_and_equal_roots() -> None:
@@ -164,13 +193,45 @@ def test_identical_trees_need_empty_proof_and_equal_roots() -> None:
     )
 
 
-def test_first_larger_than_second_is_rejected() -> None:
+def test_first_larger_than_second_cannot_be_compared() -> None:
+    """Outside RFC 9162's m < n: there is no larger tree to be a prefix of.
+
+    ``inconsistent`` would be a claim about the log. Nothing was compared, so
+    the honest answer is that the question could not be asked.
+    """
     log = _log(8)
-    assert not verify_consistency(
+    assert verify_consistency(
         first_size=8, first_root=log.root_at(8),
         second_size=4, second_root=log.root_at(4),
         proof=ConsistencyProof(8, 4, ()),
-    )
+    ) is ConsistencyVerdict.COULD_NOT_COMPARE
+
+
+def test_proof_for_a_different_pair_of_heads_cannot_be_compared() -> None:
+    """A proof describing other sizes says nothing about the pair asked about."""
+    log = _log(10)
+    proof = log.consistency_proof(3, 10)
+    mismatched = dataclasses.replace(proof, second_size=9)
+    assert verify_consistency(
+        first_size=3, first_root=log.root_at(3),
+        second_size=10, second_root=log.root_at(10), proof=mismatched,
+    ) is ConsistencyVerdict.COULD_NOT_COMPARE
+
+
+def test_could_not_compare_is_decided_before_invalid() -> None:
+    """Ordering is the other half of the rule.
+
+    An out-of-range pair carrying a proof that would also fail verification
+    must report that it could not be compared. If invalid were decided first
+    the third value would exist in the type and never reach a caller.
+    """
+    log = _log(8)
+    junk = ConsistencyProof(8, 4, (b"\x99" * 32, b"\x88" * 32))
+    assert verify_consistency(
+        first_size=8, first_root=log.root_at(8),
+        second_size=4, second_root=b"\x00" * 32,
+        proof=junk,
+    ) is ConsistencyVerdict.COULD_NOT_COMPARE
 
 
 def test_consistency_proof_out_of_range_raises() -> None:
@@ -209,7 +270,9 @@ def test_vaara_reproduces_committed_vectors() -> None:
             second_root=bytes.fromhex(case["second_root"]),
             proof=proof,
         )
-        assert got is expected[case["name"]]["consistent"], case["name"]
+        # Identity, not truthiness: folding could_not_compare into a boolean
+        # would leave the wrong answer green.
+        assert got.value == expected[case["name"]]["verdict"], case["name"]
 
 
 def test_independent_checker_passes() -> None:

--- a/tests/vectors/transparency_consistency_v0/README.md
+++ b/tests/vectors/transparency_consistency_v0/README.md
@@ -25,22 +25,66 @@ with only the standard library:
 - `cases.json`: each case carries `first_size`, `second_size`, the two roots a
   verifier would hold at those sizes (`first_root`, `second_root`), and the
   `proof` hashes (hex).
-- `expected.json`: the expected `consistent` verdict per case.
+- `expected.json`: the expected `verdict` per case, one of `consistent`,
+  `inconsistent`, or `could_not_compare`.
+
+## The verdict is three-valued
+
+RFC 9162 section 2.1.4.2 bounds a consistency proof at `0 < m < n`. Asked
+about sizes outside that range, a checker has nothing to compare, and a
+two-valued answer has to lie in one direction or the other: `true` says the
+log is append-only on the strength of a check that never ran, `false` says
+the log was inconsistent on the same absence of evidence.
+
+The third value comes with two rules that make it enforceable:
+
+1. `could_not_compare` is decided first, before any comparison is attempted.
+   Deciding invalid first would swallow it.
+2. The verdict is falsy unless it is `consistent`, so a checker written
+   against a boolean return fails closed on an input it could not compare.
+
+Each case pins the exact verdict string. A case merely tagged as
+out-of-range would be a row a harness could skip, and a checker answering
+`true` on it would still pass. Requiring the checker to report that it did
+not compare turns the case into a real negative.
 
 ## Cases
 
-Positive cases (`consistent: true`) cover the sizes the algorithm most often
-gets wrong: an empty prefix (`0 to 12`, empty proof), a power-of-two prefix
-(`1 to 12`, `8 to 12`), non-power-of-two prefixes (`3 to 12`, `7 to 12`,
-`5 to 9`), and identical trees (`12 to 12`, empty proof).
+Positive cases (`consistent`) cover the sizes the algorithm most often gets
+wrong: a power-of-two prefix (`1 to 12`, `8 to 12`), non-power-of-two
+prefixes (`3 to 12`, `7 to 12`, `5 to 9`), and identical trees (`12 to 12`,
+empty proof).
 
-Negative cases (`consistent: false`) keep a genuine proof but corrupt one
-input, so a checker that always returned `true` is caught:
+Negative cases (`inconsistent`) keep a genuine proof but corrupt one input,
+so a checker that always answered yes is caught:
 
 - `tampered_proof_hash_3_to_12`: one sibling hash in the proof is flipped.
 - `forked_second_root_3_to_12`: the proof is checked against a `second_root`
   taken from an unrelated (forked) log, the rewrite a consistency proof exists
   to detect.
+
+Out-of-range cases (`could_not_compare`) carry genuine roots and a
+well-formed empty proof. Only the sizes are outside what the document
+defines:
+
+- `out_of_range_0_to_12`: an empty first tree, outside `0 < m`.
+- `out_of_range_8_to_4`: a second tree smaller than the first, outside
+  `m < n`.
+
+### Changed in this revision
+
+`out_of_range_0_to_12` was previously committed as **`consistent_0_to_12`,
+expecting `true`**. That was wrong, and it was a verdict on a comparison that
+never happened: the checker returned true for the empty-prefix case without
+looking at either root, so it would have returned true for any pair of roots
+at all as long as the proof list was empty. Blake Morrison found the
+disagreement by running a second implementation against the pinned vectors,
+and the fix is the shape he proposed on the SCITT list: put the third value
+on what the checker answers rather than tagging the vector.
+
+A runner pinning the old case name will not find it. The rename is
+deliberate, so that a harness carrying the old expectation fails loudly
+rather than skipping a row.
 
 ## Reproducing
 

--- a/tests/vectors/transparency_consistency_v0/_check_independent.py
+++ b/tests/vectors/transparency_consistency_v0/_check_independent.py
@@ -7,6 +7,12 @@ given two tree sizes, the two roots a verifier holds, and the proof hashes,
 recompute both roots and confirm the smaller tree is a verifiable prefix of
 the larger one. Verdicts are compared against ``expected.json``.
 
+The verdict is three-valued: ``consistent``, ``inconsistent``, or
+``could_not_compare``. RFC 9162 section 2.1.4.2 bounds a consistency proof at
+``0 < m < n``, and a checker asked about sizes outside that range has no
+comparison to report. Cases assert the verdict identity, not its truthiness,
+so folding ``could_not_compare`` into either boolean fails the case.
+
 As a second, stronger check it recomputes ``first_root`` and ``second_root``
 directly from the committed log leaves and confirms each positive case's roots
 are the genuine Merkle roots over those leaves, so the vectors cannot pass by
@@ -20,6 +26,7 @@ Exit code 0 means every case matched its expected verdict.
 
 from __future__ import annotations
 
+import enum
 import hashlib
 import json
 import sys
@@ -51,26 +58,55 @@ def _root_from_leaves(leaf_hashes: list[bytes]) -> bytes:
     return nodes[0]
 
 
+class Verdict(enum.Enum):
+    """Three-valued consistency verdict.
+
+    ``COULD_NOT_COMPARE`` is the value that makes this vector set a
+    constraint rather than a documented disagreement: a checker that answers
+    either ``CONSISTENT`` or ``INCONSISTENT`` on an input RFC 9162 does not
+    define has answered a question it never asked, and fails the case.
+
+    Only ``CONSISTENT`` is truthy, so a checker written against a boolean
+    return fails closed on an input it could not compare.
+    """
+
+    CONSISTENT = "consistent"
+    INCONSISTENT = "inconsistent"
+    COULD_NOT_COMPARE = "could_not_compare"
+
+    def __bool__(self) -> bool:
+        return self is Verdict.CONSISTENT
+
+
 def verify_consistency(
     first_size: int,
     first_root: bytes,
     second_size: int,
     second_root: bytes,
     proof: list[bytes],
-) -> bool:
-    """RFC 9162 section 2.1.4.2 consistency-proof verification."""
-    if first_size > second_size:
-        return False
+) -> Verdict:
+    """RFC 9162 section 2.1.4.2 consistency-proof verification.
+
+    Section 2.1.4.2 bounds the proof at ``0 < m < n``. Sizes outside that
+    range are decided first and return ``COULD_NOT_COMPARE``, so an input
+    the document does not define can never be reported as a verdict about
+    the log.
+    """
+    if first_size <= 0:
+        return Verdict.COULD_NOT_COMPARE
+    if second_size < first_size:
+        return Verdict.COULD_NOT_COMPARE
+
     if first_size == second_size:
-        return not proof and first_root == second_root
-    if first_size == 0:
-        return not proof
+        if not proof and first_root == second_root:
+            return Verdict.CONSISTENT
+        return Verdict.INCONSISTENT
 
     path = list(proof)
     if first_size & (first_size - 1) == 0:
         path = [first_root, *path]
     if not path:
-        return False
+        return Verdict.INCONSISTENT
 
     fn = first_size - 1
     sn = second_size - 1
@@ -82,7 +118,7 @@ def verify_consistency(
     fr = sr = next(nodes)
     for sibling in nodes:
         if sn == 0:
-            return False
+            return Verdict.INCONSISTENT
         if fn & 1 or fn == sn:
             fr = _hash_node(sibling, fr)
             sr = _hash_node(sibling, sr)
@@ -94,7 +130,9 @@ def verify_consistency(
         fn >>= 1
         sn >>= 1
 
-    return sn == 0 and fr == first_root and sr == second_root
+    if sn == 0 and fr == first_root and sr == second_root:
+        return Verdict.CONSISTENT
+    return Verdict.INCONSISTENT
 
 
 def main() -> int:
@@ -115,16 +153,19 @@ def main() -> int:
             case["first_size"], first_root,
             case["second_size"], second_root, proof,
         )
-        want = expected[name]["consistent"]
-        if got != want:
-            print(f"FAIL {name}: consistency={got}, expected {want}")
+        # The case asserts the verdict identity, not its truthiness. A checker
+        # that folds could-not-compare into either boolean answer fails here,
+        # which is the whole point of the third value.
+        want = expected[name]["verdict"]
+        if got.value != want:
+            print(f"FAIL {name}: verdict={got.value}, expected {want}")
             failures += 1
             continue
 
         # For positive cases, the committed roots must be the genuine Merkle
         # roots over the log prefixes. (Negative cases intentionally carry a
         # corrupted root, so this stronger check applies only when consistent.)
-        if want:
+        if got is Verdict.CONSISTENT:
             real_first = _root_from_leaves(leaf_hashes[: case["first_size"]])
             real_second = _root_from_leaves(leaf_hashes[: case["second_size"]])
             if real_first != first_root or real_second != second_root:
@@ -132,7 +173,7 @@ def main() -> int:
                 failures += 1
                 continue
 
-        print(f"ok   {name}: consistent={got}")
+        print(f"ok   {name}: verdict={got.value}")
 
     if failures:
         print(f"\n{failures} case(s) failed")

--- a/tests/vectors/transparency_consistency_v0/_generate.py
+++ b/tests/vectors/transparency_consistency_v0/_generate.py
@@ -10,10 +10,16 @@ guarantee a transparency log exists to provide.
 The committed log is a fixed sequence of leaves. Each case names a
 ``first_size`` and ``second_size`` and carries the proof hashes plus the two
 roots an independent verifier would hold (the signed tree heads at those two
-points). Positive cases expect ``consistent: true``. Negative cases keep a
-genuine proof but corrupt an input (a flipped proof hash, a root from an
-unrelated tree); they expect ``consistent: false``, so a checker that always
-returned true would be caught.
+points).
+
+Each case expects one of three verdicts. Positive cases expect
+``consistent``. Negative cases keep a genuine proof but corrupt an input (a
+flipped proof hash, a root from an unrelated tree) and expect
+``inconsistent``, so a checker that always answered yes is caught.
+Out-of-range cases sit outside RFC 9162 section 2.1.4.2's ``0 < m < n`` and
+expect ``could_not_compare``, so a checker that answers either boolean on an
+input the document does not define is caught too. Cases assert the verdict
+identity rather than its truthiness, or a wrong answer would stay green.
 
 Hashing is RFC 6962: ``SHA-256(0x00 || leaf)`` for leaves,
 ``SHA-256(0x01 || left || right)`` for internal nodes. No signatures, so the
@@ -52,7 +58,6 @@ def main() -> None:
         forked.append(f"forked-{i:02d}".encode())
 
     positive_pairs = [
-        (0, 12),   # empty prefix: trivially consistent, empty proof
         (1, 12),   # single-leaf (power-of-two) prefix
         (3, 12),   # non-power-of-two first size
         (7, 12),   # odd, deep first size
@@ -99,16 +104,43 @@ def main() -> None:
         "proof": [_hex(h) for h in p.hashes],
     })
 
+    # Out-of-range 1: an empty first tree. RFC 9162 section 2.1.4.2 bounds the
+    # proof at 0 < m < n, so m = 0 is outside what the document defines. The
+    # roots are genuine and the proof is empty; the only correct answer is
+    # that nothing was compared. Previously committed as
+    # `consistent_0_to_12` expecting true, which was a verdict on a
+    # comparison that never happened.
+    cases.append({
+        "name": "out_of_range_0_to_12",
+        "first_size": 0,
+        "second_size": 12,
+        "first_root": _hex(log.root_at(0)),
+        "second_root": _hex(log.root_at(12)),
+        "proof": [],
+    })
+
+    # Out-of-range 2: the second tree is smaller than the first, so there is
+    # no larger tree for the prefix to sit inside. Outside m < n.
+    cases.append({
+        "name": "out_of_range_8_to_4",
+        "first_size": 8,
+        "second_size": 4,
+        "first_root": _hex(log.root_at(8)),
+        "second_root": _hex(log.root_at(4)),
+        "proof": [],
+    })
+
     expected = {
-        "consistent_0_to_12": {"consistent": True},
-        "consistent_1_to_12": {"consistent": True},
-        "consistent_3_to_12": {"consistent": True},
-        "consistent_7_to_12": {"consistent": True},
-        "consistent_8_to_12": {"consistent": True},
-        "consistent_12_to_12": {"consistent": True},
-        "consistent_5_to_9": {"consistent": True},
-        "tampered_proof_hash_3_to_12": {"consistent": False},
-        "forked_second_root_3_to_12": {"consistent": False},
+        "consistent_1_to_12": {"verdict": "consistent"},
+        "consistent_3_to_12": {"verdict": "consistent"},
+        "consistent_7_to_12": {"verdict": "consistent"},
+        "consistent_8_to_12": {"verdict": "consistent"},
+        "consistent_12_to_12": {"verdict": "consistent"},
+        "consistent_5_to_9": {"verdict": "consistent"},
+        "tampered_proof_hash_3_to_12": {"verdict": "inconsistent"},
+        "forked_second_root_3_to_12": {"verdict": "inconsistent"},
+        "out_of_range_0_to_12": {"verdict": "could_not_compare"},
+        "out_of_range_8_to_4": {"verdict": "could_not_compare"},
     }
 
     log_doc = {

--- a/tests/vectors/transparency_consistency_v0/cases.json
+++ b/tests/vectors/transparency_consistency_v0/cases.json
@@ -1,13 +1,5 @@
 [
   {
-    "name": "consistent_0_to_12",
-    "first_size": 0,
-    "second_size": 12,
-    "first_root": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
-    "proof": []
-  },
-  {
     "name": "consistent_1_to_12",
     "first_size": 1,
     "second_size": 12,
@@ -107,5 +99,21 @@
       "4cad0fdb69d80c4668b49335603a9a1ce781af4d71d5388135eca696fc4d6b05",
       "d9891e6ddaaf11f458297eebeaf87e2ccb596786c929974b3abdf4a956be3b9d"
     ]
+  },
+  {
+    "name": "out_of_range_0_to_12",
+    "first_size": 0,
+    "second_size": 12,
+    "first_root": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "second_root": "6ce56e85bcd4acf388b120048f31b0b1562d5d4232af6c1fdb88f9a234b09f6a",
+    "proof": []
+  },
+  {
+    "name": "out_of_range_8_to_4",
+    "first_size": 8,
+    "second_size": 4,
+    "first_root": "cf13081aab6a87268ae7ed59230cad72abce4d476ce0ffe98ac68ff5b5aaab6b",
+    "second_root": "8070185a3e93a45a1e2d4c4149ef795d8543249c0295dc95245d2a2a513a0ba8",
+    "proof": []
   }
 ]

--- a/tests/vectors/transparency_consistency_v0/expected.json
+++ b/tests/vectors/transparency_consistency_v0/expected.json
@@ -1,29 +1,32 @@
 {
-  "consistent_0_to_12": {
-    "consistent": true
-  },
   "consistent_1_to_12": {
-    "consistent": true
+    "verdict": "consistent"
   },
   "consistent_3_to_12": {
-    "consistent": true
+    "verdict": "consistent"
   },
   "consistent_7_to_12": {
-    "consistent": true
+    "verdict": "consistent"
   },
   "consistent_8_to_12": {
-    "consistent": true
+    "verdict": "consistent"
   },
   "consistent_12_to_12": {
-    "consistent": true
+    "verdict": "consistent"
   },
   "consistent_5_to_9": {
-    "consistent": true
+    "verdict": "consistent"
   },
   "tampered_proof_hash_3_to_12": {
-    "consistent": false
+    "verdict": "inconsistent"
   },
   "forked_second_root_3_to_12": {
-    "consistent": false
+    "verdict": "inconsistent"
+  },
+  "out_of_range_0_to_12": {
+    "verdict": "could_not_compare"
+  },
+  "out_of_range_8_to_4": {
+    "verdict": "could_not_compare"
   }
 }


### PR DESCRIPTION
## What was wrong

`verify_consistency()` answered `True` for an empty first tree without looking at either root:

```python
if first_size == 0:
    return not proof.hashes
```

That is a verdict on a comparison that never happened. It would have returned `True` for any pair of roots at all, as long as the proof list was empty, including a first root and a second root taken from two unrelated logs. The branch immediately above it, for equal sizes, does compare the roots before answering, so the looseness was not even consistent within the same function.

This sat in shipped code, not only in the standalone conformance checker. `verify_consistency` is exported from `vaara.attestation` and `verify_evidence_bundle()` reads it through the consistency lens, so a bundle could pass that lens on a check that never ran.

## The shape

RFC 9162 section 2.1.4.2 bounds a consistency proof at `0 < m < n`. For sizes outside that range there is no comparison to report, and a two-valued answer has to pick a direction: `true` claims the log is append-only on the strength of a check that never ran, `false` claims the log was inconsistent on the same absence of evidence.

`verify_consistency()` now returns `ConsistencyVerdict`, with three members:

| Verdict | Meaning |
|---|---|
| `CONSISTENT` | Both roots were recomputed from the proof and matched. |
| `INCONSISTENT` | A comparison ran and the roots disagreed. |
| `COULD_NOT_COMPARE` | No comparison ran. Not a claim about the log. |

The third value only constrains anything if two further rules hold, and both are pinned by tests:

1. `COULD_NOT_COMPARE` is decided before any comparison is attempted. Deciding invalid first would swallow it, and the value would exist in the type without ever reaching a caller.
2. The verdict is falsy unless it is `CONSISTENT`, so a caller written against the old `bool` return refuses a check that did not happen.

Out-of-range today is `first_size <= 0`, `second_size < first_size`, and a proof whose declared sizes describe a different pair of heads than the one asked about. The first two are the conditions settled on the SCITT list. The third is a Vaara-only guard, since `ConsistencyProof` carries its own sizes; it is called out here because it goes past what was discussed there.

## Vectors

`transparency_consistency_v0` moves from a `consistent` boolean to a `verdict` string and carries ten cases. Each case pins the exact verdict, so a checker returning a truthy value for the wrong reason fails.

- `consistent_0_to_12` is renamed `out_of_range_0_to_12` and expects `could_not_compare`.
- `out_of_range_8_to_4` is new and covers `second_size < first_size`.

The rename is deliberate, so that a harness carrying the old expectation fails loudly. Anyone who has run these vectors independently will need the new name.

## Credit

Blake Morrison found the disagreement by running a second implementation against the pinned vectors and reported it on the SCITT list. The design here is the one he proposed: put the third value on what the checker answers, not on the vector, because a vector tagged out-of-range is a row a harness can skip while a checker answering `true` still passes. His implementation already made the same change.

## Verification

- `pytest -q`: 3520 passed, 26 skipped
- `ruff check .`: clean
- `_check_independent.py`: 10 of 10 cases matched, stdlib only, no Vaara import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Transparency consistency verification now returns one of three verdicts: consistent, inconsistent, or could not compare.
  - Invalid or out-of-range comparisons are explicitly reported as “could not compare” rather than inconsistent.
  - Evidence reports now distinguish unavailable comparisons from detected inconsistencies.

- **New Features**
  - The consistency verdict type is available through the public attestation package.

- **Documentation**
  - Updated specifications, changelog entries, and conformance examples to describe the three-valued verdict system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->