### PR TITLE
credential: the MCP proxy can check revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Added
+
+- The MCP proxy can now check revocation. Four new flags on `vaara-mcp-proxy`: `--attest-revocation-registry`, `--attest-max-revocation-staleness-seconds`, `--attest-clock-skew-seconds`, and `--attest-expected-tenant`. All opt-in, all absent-means-off, no verdict changes for anyone who passes nothing.
+
+  `verify_grant()` has been able to refuse with `revoked` for some time, and with `revocation_stale` since the staleness bound landed. Neither verdict was reachable from the shipped enforcement path. `AttestPairEmitter` built its `CredentialGateway` with a verifying key and a receipts directory and nothing else, so `revocation` was always `None` and the revocation branch never ran. `AttestPairEmitter.__init__` had no parameter to supply one from. Separately, `CredentialGateway` never forwarded `max_staleness_seconds` to `verify_grant`, so the bound was unreachable through that class even when a registry was passed directly.
+
+  The proxy has one enforcement call site. Before this change it could not check revocation at all, whatever the operator configured.
+
+  A proxy with no registry configured still does not check revocation, and that is now stated in `docs/design/credential-broker-spec.md` under both the verification section and the honest-limits list. The check does not run; it is not that every credential passes it.
+
+  Configuration that cannot mean anything is refused at startup rather than ignored: a staleness bound with no registry, a registry file that is missing, and a registry file that does not parse all stop the proxy with a message instead of falling back to no registry.
+
+- `--attest-clock-skew-seconds` makes the 30 second default adjustable. The tolerance extends a grant's effective lifetime by that many seconds, so a credential one second past a 300 second lifetime is admitted under the default and refused at `0`. A freshness margin smaller than the skew cannot separate a verifier with no expiry check from one that has an expiry check plus any tolerance. `test_default_skew_admits_a_credential_one_second_past_its_bound` pins both halves.
+
 ### Changed
 
 - **Breaking.** `verify_consistency()` returns a three-valued `ConsistencyVerdict` instead of a `bool`. Only `CONSISTENT` is truthy, so a caller written against the old return refuses a check that did not happen.

--- a/docs/design/credential-broker-spec.md
+++ b/docs/design/credential-broker-spec.md
@@ -76,6 +76,33 @@ loads the known digests by recomputing `attestation_digest` over every
 `*-attest.json` in the proxy's receipts directory, and runs `verify_grant`. A
 missing `_meta` returns `missing_credential`.
 
+### What each check needs before it runs
+
+The `revoked` and `revocation_stale` gates above are inert unless the
+deployment supplies something. A check that passed and a check that never
+ran are different results, and an operator has to be able to tell which one
+a given configuration produces.
+
+**`revoked` needs a registry.** `verify_grant` skips its revocation branch
+entirely when `revocation` is `None`, and reports nothing when it does. A
+proxy started without `--attest-revocation-registry` does not check
+revocation. That is the shipped default. It is not that every credential
+passes the check; the check does not run. Supply a registry to turn it on.
+
+**`revocation_stale` needs a bound as well as a registry.** Per
+`draft-sirkkavaara-vaara-receipt-08` Section 10 the staleness a deployment
+accepts is the deployment's to state, so absent
+`--attest-max-revocation-staleness-seconds` a clean answer stands at any
+registry age. Stating the bound without a registry is refused at startup
+rather than ignored.
+
+**Clock skew widens `expired`.** The 30 second default extends a grant's
+effective lifetime by 30 seconds, so a freshness margin smaller than the
+tolerance is absorbed and admitted. A boundary case one second past a 300
+second lifetime cannot distinguish a verifier with no expiry check from one
+with an expiry check plus any tolerance at all. Set
+`--attest-clock-skew-seconds 0` to accept no skew.
+
 ## D. Auditor reconciliation
 
 For tools not behind the gateway, completeness is recovered after the fact, not
@@ -99,6 +126,9 @@ What it does NOT cover:
   mediation chokepoint to put a gateway in front of.
 - `_meta` stripping by an intermediary. This degrades to a
   `missing_credential` refusal, which is fail-closed and acceptable.
+- Revocation, unless a registry is configured. See "What each check needs
+  before it runs" above. This one is off by default and silent about it at
+  call time, so it belongs on this list until an operator turns it on.
 
 The mint-before-receipt ordering means a true grant-to-receipt binding is
 fully checkable only at reconciliation; the live shim checks

--- a/src/vaara/credential/gateway.py
+++ b/src/vaara/credential/gateway.py
@@ -49,6 +49,7 @@ class CredentialGateway:
         expected_tenant: Optional[str] = None,
         revocation: Any = None,
         clock_skew_seconds: int = 30,
+        max_staleness_seconds: Optional[float] = None,
         signer: Optional[ReceiptSigner] = None,
     ) -> None:
         self._vm = verifying_material
@@ -56,6 +57,13 @@ class CredentialGateway:
         self._expected_tenant = expected_tenant
         self._rev = revocation
         self._clock_skew_seconds = clock_skew_seconds
+        # The staleness bound a deployment accepts, per
+        # draft-sirkkavaara-vaara-receipt-08 Section 10, which puts that choice
+        # on the deployment. None means no bound was stated and a clean answer
+        # from any registry age stands, which is what every caller had before
+        # this parameter existed. Without it, verify_grant's revocation_stale
+        # verdict was unreachable through this gateway.
+        self._max_staleness_seconds = max_staleness_seconds
         # Opt-in: when a signer is supplied, authorize_and_receipt mints a signed
         # proof of every grant-bound decision. Absent it, the gateway only
         # verifies and the authority layer stays observation-free (off by default).
@@ -112,6 +120,7 @@ class CredentialGateway:
             revocation=self._rev,
             known_attestation_digests=self._load_known_digests(),
             clock_skew_seconds=self._clock_skew_seconds,
+            max_staleness_seconds=self._max_staleness_seconds,
         )
         return verdict, cred
 

--- a/src/vaara/integrations/_mcp_attest.py
+++ b/src/vaara/integrations/_mcp_attest.py
@@ -77,6 +77,10 @@ class AttestPairEmitter:
         upstream_commands: dict[str, list[str]],
         exp_seconds: int = 300,
         tool_constraints: "Optional[dict[str, tuple[Any, ...]]]" = None,
+        revocation: Any = None,
+        clock_skew_seconds: int = 30,
+        expected_tenant: Optional[str] = None,
+        max_staleness_seconds: Optional[float] = None,
     ) -> None:
         from vaara.attestation._attest_types import VALID_ALGS
         if alg not in VALID_ALGS:
@@ -88,6 +92,10 @@ class AttestPairEmitter:
         self._secret_version = secret_version
         self._exp_seconds = exp_seconds
         self._tool_constraints: dict[str, tuple[Any, ...]] = tool_constraints or {}
+        self._revocation = revocation
+        self._clock_skew_seconds = clock_skew_seconds
+        self._expected_tenant = expected_tenant
+        self._max_staleness_seconds = max_staleness_seconds
         self._counter = 0
         # Per-coverage-boundary sequence for authorization receipts, gap-free by
         # construction. Distinct from ``_counter`` (the per-call attestation id):
@@ -105,6 +113,13 @@ class AttestPairEmitter:
         # Fail-closed gateway for tools listed in tool_constraints. Built once at
         # init so the verifying material stays paired with the signing key. Only
         # present when tool_constraints is non-empty; absent = no enforcement.
+        #
+        # revocation defaults to None, and verify_grant skips its revocation
+        # branch entirely when no registry is supplied. A proxy started without
+        # --attest-revocation-registry therefore does not check revocation at
+        # all: it is not that every credential passes the check, it is that the
+        # check does not run. The same holds for the staleness bound, which
+        # needs a registry before it can mean anything.
         self._gateway: "Optional[Any]" = None
         if self._tool_constraints:
             try:
@@ -117,6 +132,10 @@ class AttestPairEmitter:
                 self._gateway = CredentialGateway(
                     verifying_material=vm,
                     receipts_dir=self._receipts_dir,
+                    expected_tenant=self._expected_tenant,
+                    revocation=self._revocation,
+                    clock_skew_seconds=self._clock_skew_seconds,
+                    max_staleness_seconds=self._max_staleness_seconds,
                 )
             except Exception:
                 logger.exception("Failed to build CredentialGateway for tool constraints")
@@ -477,6 +496,10 @@ def build_attest_emitter(
     secret_version: Optional[str] = None,
     exp_seconds: int = 300,
     tool_constraints_path: Optional[Path] = None,
+    revocation_registry_path: Optional[Path] = None,
+    clock_skew_seconds: int = 30,
+    expected_tenant: Optional[str] = None,
+    max_staleness_seconds: Optional[float] = None,
 ) -> AttestPairEmitter:
     """Load signing key from path and return an ``AttestPairEmitter``.
 
@@ -559,6 +582,34 @@ def build_attest_emitter(
         for tname, cap_list in raw_cfg.get("tools", {}).items():
             tool_constraints[tname] = tuple(capability_from_dict(c) for c in cap_list)
 
+    revocation = None
+    if revocation_registry_path is not None:
+        from vaara.attestation._revocation import RevocationRegistry
+
+        rev_path = Path(revocation_registry_path).expanduser()
+        if not rev_path.is_file():
+            raise AttestConfigError(
+                f"--attest-revocation-registry file not found: {rev_path}"
+            )
+        try:
+            revocation = RevocationRegistry.from_dict(
+                json.loads(rev_path.read_text(encoding="utf-8"))
+            )
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            # Refuse to start rather than fall back to no registry. Starting
+            # without one is a valid configuration, but it has to be chosen,
+            # not arrived at because a file failed to parse.
+            raise AttestConfigError(
+                f"--attest-revocation-registry is not a usable registry: {exc}"
+            ) from exc
+
+    if max_staleness_seconds is not None and revocation is None:
+        raise AttestConfigError(
+            "--attest-max-revocation-staleness-seconds has no effect without "
+            "--attest-revocation-registry: there is no registry whose age "
+            "could be bounded."
+        )
+
     return AttestPairEmitter(
         signing_key=signing_material,
         alg=alg,
@@ -567,4 +618,8 @@ def build_attest_emitter(
         upstream_commands=upstream_commands,
         exp_seconds=exp_seconds,
         tool_constraints=tool_constraints or None,
+        revocation=revocation,
+        clock_skew_seconds=clock_skew_seconds,
+        expected_tenant=expected_tenant,
+        max_staleness_seconds=max_staleness_seconds,
     )

--- a/src/vaara/integrations/mcp_proxy.py
+++ b/src/vaara/integrations/mcp_proxy.py
@@ -2015,6 +2015,33 @@ def main(argv: Optional[list[str]] = None) -> None:
                              "{arg, op, value} objects (op: le/ge/eq/in). Grants for listed "
                              "tools carry typed constraints; unlisted tools get exact-args "
                              "grants. Has no effect without --attest-signing-key.")
+    parser.add_argument("--attest-revocation-registry", type=Path, default=None,
+                        metavar="PATH",
+                        help="JSON revocation registry consulted when authorizing "
+                             "gateway-protected tool calls. WITHOUT THIS FLAG THE PROXY "
+                             "DOES NOT CHECK REVOCATION: the check does not run at all, "
+                             "rather than running and passing. Format is the "
+                             "RevocationRegistry dict ({version, entries[, as_of]}). "
+                             "Has no effect without --tool-constraints.")
+    parser.add_argument("--attest-clock-skew-seconds", type=int, default=30,
+                        metavar="N",
+                        help="Clock skew tolerance applied to credential issuance and "
+                             "expiry when authorizing gateway-protected calls (default "
+                             "30). The tolerance extends a grant's effective lifetime by "
+                             "this many seconds, so a freshness margin smaller than it is "
+                             "absorbed. Set 0 to accept no skew.")
+    parser.add_argument("--attest-expected-tenant", type=str, default=None,
+                        metavar="TENANT",
+                        help="Tenant id every credential's scope must match. When absent "
+                             "the gateway requires an empty tenant scope. Has no effect "
+                             "without --tool-constraints.")
+    parser.add_argument("--attest-max-revocation-staleness-seconds", type=float,
+                        default=None, metavar="SECONDS",
+                        help="Refuse with 'revocation_stale' when the registry's as_of is "
+                             "older than this bound, so a registry that cannot speak to "
+                             "the present stops admitting calls. Requires "
+                             "--attest-revocation-registry. Absent means no bound is "
+                             "stated and a clean answer stands at any registry age.")
     parser.add_argument("--overt-signing-key", type=Path, default=None,
                         help="Ed25519 PEM private key used to sign OVERT 1.0 Base "
                              "Envelopes for every governed MCP interaction. Off when "
@@ -2330,6 +2357,14 @@ def _build_attest_emitter_from_args(
             receipts_dir=args.attest_receipts_dir,
             upstream_commands=upstreams,
             tool_constraints_path=getattr(args, "tool_constraints", None),
+            revocation_registry_path=getattr(
+                args, "attest_revocation_registry", None
+            ),
+            clock_skew_seconds=getattr(args, "attest_clock_skew_seconds", 30),
+            expected_tenant=getattr(args, "attest_expected_tenant", None),
+            max_staleness_seconds=getattr(
+                args, "attest_max_revocation_staleness_seconds", None
+            ),
         )
     except AttestConfigError as exc:
         print(f"vaara-mcp-proxy: {exc}", file=sys.stderr)

--- a/tests/credential/test_gateway_revocation_reachable.py
+++ b/tests/credential/test_gateway_revocation_reachable.py
@@ -1,0 +1,232 @@
+"""The revocation check and the staleness bound are reachable from the proxy.
+
+Before this, ``verify_grant`` could refuse with ``revoked`` and (since the
+staleness bound landed) ``revocation_stale``, but neither verdict could be
+produced through the shipped enforcement path. ``CredentialGateway`` never
+forwarded ``max_staleness_seconds``, and ``AttestPairEmitter`` built its
+gateway with only a verifying key and a receipts directory, so the registry
+argument was always ``None`` and the revocation branch never ran.
+
+These tests pin the reachability, and pin the default that made the gap
+invisible: with no registry configured the check does not run at all, which
+is not the same as running and passing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("rfc8785")
+pytest.importorskip("cryptography")
+
+from vaara.attestation._revocation import RevocationRegistry  # noqa: E402
+from vaara.credential import CredentialGateway  # noqa: E402
+from vaara.integrations._mcp_attest import (  # noqa: E402
+    AttestConfigError,
+    build_attest_emitter,
+)
+
+KEY = b"x" * 32
+TOOL = "read_file"
+ARGS = {"path": "/tmp/x"}
+TENANT = "t1"
+
+# The grant is minted now, so a registry observed long ago cannot speak to it.
+OLD_AS_OF = "2020-01-01T00:00:00Z"
+
+
+def _keyfile(d: Path) -> Path:
+    p = d.parent / "attest.key"
+    p.write_bytes(KEY)
+    return p
+
+
+def _emitter(receipts_dir: Path, **kwargs: Any) -> Any:
+    return build_attest_emitter(
+        signing_key_path=_keyfile(receipts_dir),
+        receipts_dir=receipts_dir,
+        upstream_commands={"default": ["echo"]},
+        **kwargs,
+    )
+
+
+def _mint(receipts_dir: Path) -> dict:
+    em = _emitter(receipts_dir)
+    att, counter = em.emit_attestation(
+        tool_name=TOOL, arguments=ARGS, upstream_name="default", tenant_id=TENANT
+    )
+    cred = em.emit_grant(
+        attestation=att, counter=counter, tool_name=TOOL,
+        upstream_name="default", tenant_id=TENANT,
+    )
+    return cred.to_dict()
+
+
+def _params(cred: dict) -> dict:
+    return {"_meta": {"vaara/credential": cred}}
+
+
+def _registry_file(path: Path, *, as_of: str | None = None) -> Path:
+    doc: dict[str, Any] = {"version": 1, "entries": []}
+    if as_of is not None:
+        doc["as_of"] = as_of
+    path.write_text(json.dumps(doc), encoding="utf-8")
+    return path
+
+
+# ── The gateway forwards the bound at all ───────────────────────────────────
+
+def test_gateway_without_bound_admits_a_registry_of_any_age(tmp_path: Path):
+    cred = _mint(tmp_path)
+    gw = CredentialGateway(
+        verifying_material=KEY,
+        receipts_dir=tmp_path,
+        expected_tenant=TENANT,
+        revocation=RevocationRegistry((), as_of=OLD_AS_OF),
+    )
+    verdict = gw.authorize(_params(cred), tool_name=TOOL, arguments=ARGS)
+    assert verdict.ok, verdict.reason
+
+
+def test_gateway_with_bound_refuses_a_registry_that_cannot_speak_to_now(
+    tmp_path: Path,
+):
+    """The verdict that was unreachable through this class."""
+    cred = _mint(tmp_path)
+    gw = CredentialGateway(
+        verifying_material=KEY,
+        receipts_dir=tmp_path,
+        expected_tenant=TENANT,
+        revocation=RevocationRegistry((), as_of=OLD_AS_OF),
+        max_staleness_seconds=300,
+    )
+    verdict = gw.authorize(_params(cred), tool_name=TOOL, arguments=ARGS)
+    assert not verdict.ok
+    assert verdict.reason == "revocation_stale"
+
+
+# ── The emitter can be given a registry at all ──────────────────────────────
+
+def test_emitter_without_registry_does_not_check_revocation(tmp_path: Path):
+    """The shipped default, pinned so the gap cannot reappear silently.
+
+    The point is not that the credential passes a revocation check. It is
+    that no revocation check runs, because there is no registry to run it
+    against.
+    """
+    em = _emitter(
+        tmp_path, tool_constraints_path=None,
+    )
+    assert em._revocation is None
+    assert em._max_staleness_seconds is None
+
+
+def test_emitter_loads_a_registry_from_disk(tmp_path: Path):
+    reg = _registry_file(tmp_path / "rev.json", as_of=OLD_AS_OF)
+    em = _emitter(tmp_path, revocation_registry_path=reg)
+    assert em._revocation is not None
+    assert em._revocation.as_of == OLD_AS_OF
+
+
+def test_emitter_forwards_skew_and_tenant(tmp_path: Path):
+    em = _emitter(tmp_path, clock_skew_seconds=0, expected_tenant=TENANT)
+    assert em._clock_skew_seconds == 0
+    assert em._expected_tenant == TENANT
+
+
+# ── Configuration that cannot mean anything is refused, not ignored ─────────
+
+def test_bound_without_a_registry_refuses_to_start(tmp_path: Path):
+    with pytest.raises(AttestConfigError, match="no registry"):
+        _emitter(tmp_path, max_staleness_seconds=300)
+
+
+def test_unparseable_registry_refuses_to_start(tmp_path: Path):
+    bad = tmp_path / "rev.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(AttestConfigError, match="not a usable registry"):
+        _emitter(tmp_path, revocation_registry_path=bad)
+
+
+def test_missing_registry_file_refuses_to_start(tmp_path: Path):
+    with pytest.raises(AttestConfigError, match="file not found"):
+        _emitter(tmp_path, revocation_registry_path=tmp_path / "nope.json")
+
+
+# ── Clock skew widens a stated lifetime, and now it can be turned off ───────
+
+def test_default_skew_admits_a_credential_one_second_past_its_bound(tmp_path: Path):
+    """The finding reported against VATE's just-over-boundary case.
+
+    ``clock_skew_seconds`` defaults to 30, so a grant one second past a 300
+    second lifetime is still admitted. A freshness margin smaller than the
+    skew cannot separate a verifier with no expiry check from a verifier
+    that has one plus any tolerance at all.
+    """
+    from vaara.credential import verify_grant
+    from vaara.credential._grant_verify import iso8601_to_epoch
+
+    em = _emitter(tmp_path)
+    att, counter = em.emit_attestation(
+        tool_name=TOOL, arguments=ARGS, upstream_name="default", tenant_id=TENANT
+    )
+    cred = em.emit_grant(
+        attestation=att, counter=counter, tool_name=TOOL,
+        upstream_name="default", tenant_id=TENANT,
+    )
+    iat = iso8601_to_epoch(cred.asserted.iat)
+    assert iat is not None
+    one_second_over = iat + cred.asserted.exp_seconds + 1
+
+    common = dict(
+        verifying_material=KEY,
+        runtime_tool_name=TOOL,
+        runtime_args=ARGS,
+        runtime_tenant_id=TENANT,
+        known_attestation_digests=frozenset(
+            {cred.binding.attestation_digest}
+        ),
+        now=one_second_over,
+    )
+
+    assert verify_grant(cred, **common).ok, "default skew absorbs the margin"
+    strict = verify_grant(cred, clock_skew_seconds=0, **common)
+    assert not strict.ok
+    assert strict.reason == "expired"
+
+
+# ── End to end: the emitter's own gateway produces the verdict ──────────────
+
+def test_emitter_gateway_refuses_on_a_stale_registry(tmp_path: Path):
+    """Reachable from the object the proxy actually holds."""
+    constraints = tmp_path / "constraints.json"
+    constraints.write_text(
+        json.dumps({"tools": {TOOL: [{"arg": "path", "op": "eq", "value": "/tmp/x"}]}}),
+        encoding="utf-8",
+    )
+    reg = _registry_file(tmp_path / "rev.json", as_of=OLD_AS_OF)
+    em = _emitter(
+        tmp_path,
+        tool_constraints_path=constraints,
+        revocation_registry_path=reg,
+        max_staleness_seconds=300,
+        expected_tenant=TENANT,
+    )
+    assert em.gateway is not None
+
+    att, counter = em.emit_attestation(
+        tool_name=TOOL, arguments=ARGS, upstream_name="default", tenant_id=TENANT
+    )
+    cred = em.emit_grant(
+        attestation=att, counter=counter, tool_name=TOOL,
+        upstream_name="default", tenant_id=TENANT,
+    )
+    verdict = em.gateway.authorize(
+        _params(cred.to_dict()), tool_name=TOOL, arguments=ARGS
+    )
+    assert not verdict.ok
+    assert verdict.reason == "revocation_stale"


### PR DESCRIPTION
## The gap

`verify_grant()` has been able to refuse with `revoked` for some time, and with `revocation_stale` since #660 landed the staleness bound. Neither verdict was reachable from the shipped enforcement path.

`AttestPairEmitter` built its gateway like this:

```python
self._gateway = CredentialGateway(
    verifying_material=vm,
    receipts_dir=self._receipts_dir,
)
```

No registry, and no constructor parameter to supply one from. The word "revocation" did not appear anywhere under `src/vaara/integrations/`. So `revocation` was always `None`, and `verify_grant` skips its revocation branch entirely in that case.

Separately, `CredentialGateway._decide()` never forwarded `max_staleness_seconds` to `verify_grant`, so the bound was unreachable through that class even for a caller who constructed the gateway with a registry by hand.

The proxy has exactly one enforcement call site, in `mcp_proxy.py`. Before this change it could not check revocation whatever the operator configured.

This is the same shape as the consistency verdict fixed in #661: a value computed, exposed, pinned by vectors, and never reaching a caller.

## What this adds

Four flags on `vaara-mcp-proxy`, all opt-in, all absent-means-off. A caller who passes nothing gets exactly the behaviour it had before.

| Flag | Effect |
|---|---|
| `--attest-revocation-registry` | Supplies the registry. Without it, no revocation check runs. |
| `--attest-max-revocation-staleness-seconds` | Refuses `revocation_stale` when the registry cannot speak to the present. Requires a registry. |
| `--attest-clock-skew-seconds` | Makes the 30 second default adjustable. |
| `--attest-expected-tenant` | Tenant id every credential scope must match. |

## The default is still off, and now it says so

A proxy with no registry configured does not check revocation. The check does not run, which is a different result from running and passing. `docs/design/credential-broker-spec.md` now states that in the verification section and repeats it in the honest-limits list, because it is a real limit until an operator turns it on.

Configuration that cannot mean anything is refused at startup rather than ignored. A staleness bound with no registry, a missing registry file, and a registry that does not parse each stop the proxy with a message instead of silently falling back to no registry.

## Clock skew

`--attest-clock-skew-seconds` closes the item raised against VATE's just-over-boundary case in discussion #502. The tolerance extends a grant's effective lifetime by its value, so a credential one second past a 300 second lifetime is admitted under the default and refused at `0`. A freshness margin smaller than the skew cannot separate a verifier with no expiry check from one that has an expiry check plus any tolerance at all.

## Verification

- `pytest -q`: 3530 passed, 26 skipped
- `ruff check .`: clean
- 10 new tests in `tests/credential/test_gateway_revocation_reachable.py`, covering both reachability paths, the three startup refusals, and both sides of the skew boundary
- `--help` renders all four flags
