### PR TITLE
audit: every shipped export path can pin its revocation registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- Every shipped export path can pin the revocation registry it used. `--revocations PATH` on `vaara trail export`, `export-threshold`, `export-article12` and `export-article50`, and a `revocation=` argument on `export_signed_threshold`, `export_article12`, `export_article50` and `rotate`.
+
+  `export_signed()` has carried a `revocation` argument for a while. It writes `revocation.json` into the zip and pins `registry_sha256` into the signed manifest, so a regulator recomputes each receipt's revocation-in-time verdict against the exact registry the exporter held. No shipped caller passed it. The four callers in the tree, the CLI export command, `export_article12`, `export_article50` and `rotate`, all omitted it, and the last three had no parameter to pass. `export_signed_threshold` had none either. Only tests reached the feature, so every package a regulator actually received was produced with no revocation state in it.
+
+  The threshold path pins the digest into the same manifest every custodian signs, so `revocation.json` is covered transitively by all k signatures. Article 12's threshold branch forwards it too, which is where it would otherwise have been dropped while the single-signer branch kept it.
+
+  An export without a registry still carries no `revocation` key and no `revocation.json`, byte-identical to before. That absence is now a stated position: a bundle pinning an empty registry says nothing was revoked as of an instant, and a bundle with no registry says nothing at all. A `--revocations` path that is supplied and unusable stops the export instead of falling back to an unpinned bundle.
+
 - The MCP proxy can now check revocation. Four new flags on `vaara-mcp-proxy`: `--attest-revocation-registry`, `--attest-max-revocation-staleness-seconds`, `--attest-clock-skew-seconds`, and `--attest-expected-tenant`. All opt-in, all absent-means-off, no verdict changes for anyone who passes nothing.
 
   `verify_grant()` has been able to refuse with `revoked` for some time, and with `revocation_stale` since the staleness bound landed. Neither verdict was reachable from the shipped enforcement path. `AttestPairEmitter` built its `CredentialGateway` with a verifying key and a receipts directory and nothing else, so `revocation` was always `None` and the revocation branch never ran. `AttestPairEmitter.__init__` had no parameter to supply one from. Separately, `CredentialGateway` never forwarded `max_staleness_seconds` to `verify_grant`, so the bound was unreachable through that class even when a registry was passed directly.

--- a/docs/design/cross-stack-revocation-spec.md
+++ b/docs/design/cross-stack-revocation-spec.md
@@ -101,12 +101,42 @@ Vaara-free, standard-library-plus-`cryptography`-plus-`rfc8785` checker
 reproduces every verdict, so the cross-stack guarantee is verifiable without
 depending on Vaara.
 
+## Reaching it from an export a regulator receives
+
+Pinning only happens when the exporter supplies a registry, and every
+shipped export path can now do that:
+
+| Path | How |
+|---|---|
+| `vaara trail export` | `--revocations PATH` |
+| `vaara trail export-threshold` | `--revocations PATH` |
+| `vaara trail export-article12` | `--revocations PATH` |
+| `vaara trail export-article50` | `--revocations PATH` |
+| `export_signed`, `export_signed_threshold` | `revocation=` |
+| `export_article12`, `export_article50`, `rotate` | `revocation=` |
+
+An export without a registry carries no `revocation` key in its manifest
+and no `revocation.json` in the zip. A reader who wants to recompute a
+revocation-in-time verdict from that bundle has nothing to recompute
+against, and the absence is visible in the bundle itself: a bundle that
+pins an empty registry states that nothing was revoked as of a given
+instant, and a bundle with no registry states nothing at all. Those are different
+packages and a regulator can tell them apart.
+
+A `--revocations` path that is supplied and unusable stops the export
+instead of falling back to an unpinned bundle.
+
 ## Compatibility
 
 Purely additive. The receipt envelope, canonicalization, inclusion- and
 consistency-proof formats, and signature verification are unchanged; the
 envelope version stays 1. `export_signed` with no `revocation` argument
-produces a byte-identical manifest to v0.54.
+produces a byte-identical manifest to v0.54, and so does every export
+command invoked without `--revocations`.
+
+In the threshold export the registry digest goes into the same manifest
+every custodian signs, so `revocation.json` is covered transitively by all
+k signatures rather than by a signature of its own.
 
 ## Freshness: what a clean answer is allowed to claim (v1.80.0)
 

--- a/src/vaara/audit/article12_export.py
+++ b/src/vaara/audit/article12_export.py
@@ -224,6 +224,7 @@ def export_article12(
     enforcements: "Optional[Sequence[tuple[str, dict, bytes, bytes]]]" = None,
     trusted_did_document: Optional[dict] = None,
     expected_measurement: Optional[str] = None,
+    revocation=None,
     fmt: str = "md",
     agent_id: str = "",
 ) -> ExportResult:
@@ -281,11 +282,13 @@ def export_article12(
         result = export_signed_threshold(
             trail, out_path, signers=signers,
             threshold_k=threshold_k, agent_id=agent_id,
+            revocation=revocation,
         )
     else:
         result = export_signed(
             trail, out_path, signer_key=signer_key,
             signer=signer, agent_id=agent_id,
+            revocation=revocation,
         )
 
     # Build the report from the trail bytes that were actually signed.

--- a/src/vaara/audit/article50.py
+++ b/src/vaara/audit/article50.py
@@ -587,6 +587,7 @@ def export_article50(
     system_meta: Optional[dict] = None,
     period: Optional[tuple] = None,
     agent_id: str = "",
+    revocation=None,
 ):
     """Write a signed Article 50 transparency evidence package.
 
@@ -601,7 +602,7 @@ def export_article50(
     out_path = Path(out_path)
     result = export_signed(
         trail, out_path, signer_key=signer_key, signer=signer,
-        agent_id=agent_id,
+        agent_id=agent_id, revocation=revocation,
     )
 
     records, manifest = _records_from_zip(out_path)

--- a/src/vaara/audit/export.py
+++ b/src/vaara/audit/export.py
@@ -349,6 +349,7 @@ def export_signed_threshold(
     authorized_pubkeys: Optional[list[bytes]] = None,
     member_algorithm: str = "Ed25519",
     agent_id: str = "",
+    revocation: Optional["RevocationRegistry"] = None,
 ) -> ExportResult:
     """Produce a k-of-n threshold-signed audit-trail export.
 
@@ -440,6 +441,7 @@ def export_signed_threshold(
         n=n,
         member_algorithm=member_algorithm,
         agent_id=agent_id,
+        revocation=revocation,
     )
 
 
@@ -453,6 +455,7 @@ def _write_threshold_zip(
     n: int,
     member_algorithm: str,
     agent_id: str,
+    revocation: Optional["RevocationRegistry"] = None,
 ) -> ExportResult:
     """Build the manifest, collect member signatures, write the zip."""
     from vaara import __version__ as vaara_version
@@ -484,6 +487,19 @@ def _write_threshold_zip(
     manifest["signers_n"] = n
     manifest["member_algorithm"] = member_algorithm
     manifest["signer_fingerprints"] = signer_fingerprints
+
+    # Same shape as export_signed: the registry's digest goes into the signed
+    # manifest, so revocation.json is covered transitively by every member
+    # signature and a regulator recomputes verdicts against the exact registry
+    # the exporter used.
+    revocation_bytes: Optional[bytes] = None
+    if revocation is not None:
+        revocation_bytes = revocation.canonical_bytes()
+        manifest["revocation"] = {
+            "entry_count": len(revocation),
+            "registry_sha256": revocation.digest(),
+        }
+
     manifest_bytes = json.dumps(manifest, sort_keys=True, indent=2).encode("utf-8")
 
     # Every custodian signs the identical digest over the trail and the
@@ -493,6 +509,8 @@ def _write_threshold_zip(
     with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("trail.jsonl", trail_bytes)
         zf.writestr("manifest.json", manifest_bytes)
+        if revocation_bytes is not None:
+            zf.writestr("revocation.json", revocation_bytes)
         for fp, s in signing_by_fp.items():
             zf.writestr(f"sigs/{fp}.sig", s.sign(to_sign))
         for fp, raw in authorized_by_fp.items():

--- a/src/vaara/audit/rotate.py
+++ b/src/vaara/audit/rotate.py
@@ -49,6 +49,7 @@ def rotate(
     *,
     tenant_id: str = "",
     dry_run: bool = False,
+    revocation=None,
 ) -> RotateResult:
     """Export the whole trail as a signed zip, verify it, then purge.
 
@@ -70,7 +71,10 @@ def rotate(
         exported = backend.count()
 
         try:
-            export_result = export_signed(backend.load_trail(), out, signer_key=signer_key)
+            export_result = export_signed(
+                backend.load_trail(), out, signer_key=signer_key,
+                revocation=revocation,
+            )
         except Exception as exc:
             return RotateResult(
                 ok=False,

--- a/src/vaara/cli.py
+++ b/src/vaara/cli.py
@@ -476,6 +476,23 @@ def _add_trail_source_args(sub_parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _load_export_revocations(args: argparse.Namespace):
+    """Load the registry an export should pin, or None when none was given.
+
+    An export without a registry pins no revocation state, so a reader
+    recomputing a revocation-in-time verdict from the bundle has nothing to
+    recompute against. That is a valid choice; it just has to be a choice,
+    so a path that is supplied and unusable stops the export instead of
+    quietly producing an unpinned bundle.
+    """
+    path = getattr(args, "revocations", None)
+    if not path:
+        return None
+    from vaara.attestation import RevocationRegistry
+
+    return RevocationRegistry.from_dict(_load_json_file(path, "revocations"))
+
+
 def _cmd_trail_export(args: argparse.Namespace) -> int:
     try:
         from vaara.audit.export import export_signed
@@ -487,6 +504,12 @@ def _cmd_trail_export(args: argparse.Namespace) -> int:
     if trail is None:
         return err
 
+    try:
+        revocation = _load_export_revocations(args)
+    except (OSError, ValueError) as exc:
+        print(f"vaara trail export: --revocations: {exc}", file=sys.stderr)
+        return 2
+
     out = Path(args.out).expanduser()
     out.parent.mkdir(parents=True, exist_ok=True)
 
@@ -495,6 +518,7 @@ def _cmd_trail_export(args: argparse.Namespace) -> int:
         out_path=out,
         signer_key=Path(args.key).expanduser(),
         agent_id=args.agent_id or "",
+        revocation=revocation,
     )
 
     print(f"Exported signed trail to {result.path}")
@@ -551,8 +575,9 @@ def _cmd_trail_export_threshold(args: argparse.Namespace) -> int:
             signers=signers,
             threshold_k=args.threshold_k,
             agent_id=args.agent_id or "",
+            revocation=_load_export_revocations(args),
         )
-    except ValueError as exc:
+    except (OSError, ValueError) as exc:
         print(f"threshold export failed: {exc}", file=sys.stderr)
         return 2
 
@@ -987,7 +1012,11 @@ def _cmd_trail_export_article50(args: argparse.Namespace) -> int:
         result = export_article50(
             trail, out, signer_key=Path(args.key).expanduser(),
             system_meta=system_meta, period=period,
+            revocation=_load_export_revocations(args),
         )
+    except (OSError, ValueError) as exc:
+        print(f"vaara trail export-article50: {exc}", file=sys.stderr)
+        return 2
     except ImportError:
         print(_INSTALL_HINT, file=sys.stderr)
         return 2
@@ -1144,10 +1173,11 @@ def _cmd_trail_export_article12(args: argparse.Namespace) -> int:
             enforcements=enforcements,
             trusted_did_document=trusted,
             expected_measurement=expected,
+            revocation=_load_export_revocations(args),
             fmt=args.format,
             agent_id=args.agent_id or "",
         )
-    except (ValueError, ImportError, TimeAnchorError) as exc:
+    except (OSError, ValueError, ImportError, TimeAnchorError) as exc:
         print(f"Article 12 export failed: {exc}", file=sys.stderr)
         return 2
 
@@ -5098,6 +5128,8 @@ def build_parser() -> argparse.ArgumentParser:
     pe.add_argument("--out", required=True, help="Path to write the signed zip")
     pe.add_argument("--key", required=True, help="Path to Ed25519 signing private key (PEM)")
     pe.add_argument("--agent-id", default="", help="Optional agent_id tag for the manifest")
+    pe.add_argument("--revocations", default=None,
+                        help="Optional revocation-registry JSON to pin into the signed manifest as revocation.registry_sha256, with the registry written to revocation.json inside the zip. Without it the export pins no revocation state, so a reader cannot recompute a revocation-in-time verdict from the bundle.")
     pe.set_defaults(func=_cmd_trail_export)
 
     pet = tsub.add_parser(
@@ -5120,6 +5152,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Quorum: minimum valid custodian signatures required to verify.",
     )
     pet.add_argument("--agent-id", default="", help="Optional agent_id tag for the manifest")
+    pet.add_argument("--revocations", default=None,
+                        help="Optional revocation-registry JSON to pin into the signed manifest as revocation.registry_sha256, with the registry written to revocation.json inside the zip. Without it the export pins no revocation state, so a reader cannot recompute a revocation-in-time verdict from the bundle.")
     pet.set_defaults(func=_cmd_trail_export_threshold)
 
     pv = tsub.add_parser("verify", help="Verify a signed trail zip")
@@ -5273,6 +5307,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Vetted SHA-384 launch measurement (96 hex chars) to pin folded "
              "enforcement bindings against.",
     )
+    pa12.add_argument("--revocations", default=None,
+                        help="Optional revocation-registry JSON to pin into the signed manifest as revocation.registry_sha256, with the registry written to revocation.json inside the zip. Without it the export pins no revocation state, so a reader cannot recompute a revocation-in-time verdict from the bundle.")
     pa12.set_defaults(func=_cmd_trail_export_article12)
 
     pa50 = tsub.add_parser(
@@ -5296,6 +5332,8 @@ def build_parser() -> argparse.ArgumentParser:
              "side may be empty. Narrows the summary counts only; the signed "
              "trail stays whole.",
     )
+    pa50.add_argument("--revocations", default=None,
+                        help="Optional revocation-registry JSON to pin into the signed manifest as revocation.registry_sha256, with the registry written to revocation.json inside the zip. Without it the export pins no revocation state, so a reader cannot recompute a revocation-in-time verdict from the bundle.")
     pa50.set_defaults(func=_cmd_trail_export_article50)
 
     prd = tsub.add_parser(

--- a/tests/test_export_revocation_reachable.py
+++ b/tests/test_export_revocation_reachable.py
@@ -47,6 +47,11 @@ def _trail(n: int = 3) -> AuditTrail:
 
 
 def _registry() -> RevocationRegistry:
+    # Pinning a registry canonicalises it, which needs vaara[attestation].
+    # The skip lives here rather than at module scope so the two tests that
+    # pin nothing still run on the base matrix, which is where the honest
+    # default matters: no registry means no revocation key in the manifest.
+    pytest.importorskip("rfc8785")
     return RevocationRegistry((), as_of="2026-09-03T00:00:00Z")
 
 

--- a/tests/test_export_revocation_reachable.py
+++ b/tests/test_export_revocation_reachable.py
@@ -1,0 +1,162 @@
+"""Every shipped export path can pin the revocation registry it used.
+
+``export_signed`` has carried a ``revocation`` parameter for a while: it
+writes ``revocation.json`` into the zip and pins ``registry_sha256`` into
+the signed manifest, so a regulator recomputes each receipt's
+revocation-in-time verdict against the exact registry the exporter held.
+
+No shipped caller passed it. ``export_article12``, ``export_article50`` and
+``rotate`` had no such parameter at all, ``export_signed_threshold`` had
+none either, and the CLI had no flag. So every package a regulator actually
+receives was produced without any revocation state in it, and the
+capability was reachable only from tests.
+
+These tests pin the reachability on every path, and pin the honest default:
+an export with no registry carries no ``revocation`` key, which is a
+different bundle from one that pins an empty registry.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("cryptography")
+
+from vaara.attestation import RevocationRegistry  # noqa: E402
+from vaara.audit.export import export_signed, export_signed_threshold  # noqa: E402
+from vaara.audit.signer import Ed25519Signer  # noqa: E402
+from vaara.audit.trail import AuditTrail  # noqa: E402
+
+
+def _trail(n: int = 3) -> AuditTrail:
+    from vaara.taxonomy.actions import ActionRequest, create_default_registry
+
+    reg = create_default_registry()
+    tx = reg.get("tx.transfer")
+    trail = AuditTrail()
+    for i in range(n):
+        trail.record_action_requested(ActionRequest(
+            agent_id=f"agent-{i}", tool_name="send_funds", action_type=tx,
+            parameters={"to": f"0xabc{i}", "amount": 10 * i},
+        ))
+    return trail
+
+
+def _registry() -> RevocationRegistry:
+    return RevocationRegistry((), as_of="2026-09-03T00:00:00Z")
+
+
+def _signer() -> Ed25519Signer:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    return Ed25519Signer(Ed25519PrivateKey.generate())
+
+
+def _manifest(path: Path) -> dict:
+    with zipfile.ZipFile(path) as zf:
+        return json.loads(zf.read("manifest.json"))
+
+
+def _names(path: Path) -> set[str]:
+    with zipfile.ZipFile(path) as zf:
+        return set(zf.namelist())
+
+
+# ── The threshold path, which had no parameter at all ───────────────────────
+
+def test_threshold_export_without_registry_pins_nothing(tmp_path: Path):
+    out = tmp_path / "t.zip"
+    export_signed_threshold(
+        _trail(), out, signers=[_signer()], threshold_k=1,
+    )
+    assert "revocation" not in _manifest(out)
+    assert "revocation.json" not in _names(out)
+
+
+def test_threshold_export_pins_the_registry(tmp_path: Path):
+    out = tmp_path / "t.zip"
+    reg = _registry()
+    export_signed_threshold(
+        _trail(), out, signers=[_signer()], threshold_k=1, revocation=reg,
+    )
+    manifest = _manifest(out)
+    assert manifest["revocation"]["registry_sha256"] == reg.digest()
+    assert "revocation.json" in _names(out)
+
+
+def test_threshold_pinned_registry_is_covered_by_the_signatures(tmp_path: Path):
+    """Tampering with revocation.json must break verification.
+
+    The file is bound through registry_sha256 in the signed manifest, so its
+    integrity is transitive rather than direct. That only holds if the digest
+    really is in the bytes every custodian signed.
+    """
+    out = tmp_path / "t.zip"
+    reg = _registry()
+    export_signed_threshold(
+        _trail(), out, signers=[_signer()], threshold_k=1, revocation=reg,
+    )
+    manifest = _manifest(out)
+    assert manifest["revocation"]["registry_sha256"] == reg.digest()
+
+    with zipfile.ZipFile(out) as zf:
+        stored = zf.read("revocation.json")
+    assert RevocationRegistry.from_dict(json.loads(stored)).digest() == reg.digest()
+
+
+# ── The regulatory exporters, which had no parameter at all ─────────────────
+
+def test_article12_pins_the_registry(tmp_path: Path):
+    from vaara.audit.article12_export import export_article12
+
+    out = tmp_path / "a12.zip"
+    reg = _registry()
+    export_article12(_trail(), out, signer=_signer(), revocation=reg)
+    assert _manifest(out)["revocation"]["registry_sha256"] == reg.digest()
+    assert "revocation.json" in _names(out)
+
+
+def test_article12_threshold_branch_also_pins_it(tmp_path: Path):
+    """The branch that would have silently dropped it."""
+    from vaara.audit.article12_export import export_article12
+
+    out = tmp_path / "a12t.zip"
+    reg = _registry()
+    export_article12(
+        _trail(), out, signers=[_signer()], threshold_k=1, revocation=reg,
+    )
+    assert _manifest(out)["revocation"]["registry_sha256"] == reg.digest()
+
+
+def test_article50_pins_the_registry(tmp_path: Path):
+    from vaara.audit.article50 import export_article50
+
+    out = tmp_path / "a50.zip"
+    reg = _registry()
+    export_article50(_trail(), out, signer=_signer(), revocation=reg)
+    assert _manifest(out)["revocation"]["registry_sha256"] == reg.digest()
+
+
+def test_article12_without_registry_is_unchanged(tmp_path: Path):
+    from vaara.audit.article12_export import export_article12
+
+    out = tmp_path / "a12.zip"
+    export_article12(_trail(), out, signer=_signer())
+    assert "revocation" not in _manifest(out)
+
+
+# ── An empty registry is a claim; no registry is not ────────────────────────
+
+def test_no_registry_and_empty_registry_produce_different_bundles(tmp_path: Path):
+    """Absent means "nothing was pinned", not "nothing was revoked"."""
+    unpinned = tmp_path / "u.zip"
+    pinned = tmp_path / "p.zip"
+    export_signed(_trail(), unpinned, signer=_signer())
+    export_signed(_trail(), pinned, signer=_signer(), revocation=_registry())
+
+    assert "revocation" not in _manifest(unpinned)
+    assert _manifest(pinned)["revocation"]["entry_count"] == 0


### PR DESCRIPTION
## The gap

`export_signed()` has carried a `revocation` argument for a while. It writes `revocation.json` into the zip and pins `registry_sha256` into the signed manifest, so a regulator recomputes each receipt's revocation-in-time verdict against the exact registry the exporter held.

No shipped caller passed it.

| Caller | Passed `revocation`? |
|---|---|
| `cli.py` `_cmd_trail_export` | no |
| `export_article12` | no parameter existed |
| `export_article50` | no parameter existed |
| `rotate` | no parameter existed |
| `export_signed_threshold` | no parameter existed |

Only `tests/test_cross_stack_revocation.py` reached it. So every package a regulator actually receives, including the Article 12 and Article 50 ones, was produced with no revocation state in it.

Third instance today of the same shape, after #661 and #662: a capability that exists, is documented, is covered by vectors, and has no shipped path that reaches it.

## What this adds

`--revocations PATH` on `trail export`, `export-threshold`, `export-article12` and `export-article50`. A `revocation=` argument on `export_signed_threshold`, `export_article12`, `export_article50` and `rotate`.

The threshold path pins the digest into the same manifest every custodian signs, so `revocation.json` is covered transitively by all k signatures rather than needing one of its own.

Article 12's threshold branch forwards it as well. That branch is where it would otherwise have been dropped while the single-signer branch kept it, which would have been a fresh instance of the defect this PR closes. `test_article12_threshold_branch_also_pins_it` holds that.

## The default stays off and now says so

An export with no registry carries no `revocation` key and no `revocation.json`, byte-identical to before. `docs/design/cross-stack-revocation-spec.md` now states what that means: a bundle pinning an empty registry says nothing was revoked as of an instant, a bundle with no registry says nothing at all, and a reader can tell the two apart.

A `--revocations` path that is supplied and unusable stops the export instead of falling back to an unpinned bundle.

## Verification

- `pytest -q`: 3538 passed, 26 skipped
- `ruff check .`: clean
- 8 new tests in `tests/test_export_revocation_reachable.py` covering the threshold path, both regulatory exporters, the Article 12 threshold branch, and the difference between an unpinned bundle and one pinning an empty registry
- `--revocations` renders in `--help` for all four commands


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signed trail exports can include a pinned revocation registry using `--revocations PATH`.
  * Revocation data is included in exported packages and covered by their signatures.
  * Supported across threshold, Article 12, Article 50, standard, and rotation exports.
  * Invalid or inaccessible registry paths now stop the export instead of producing an unpinned package.
  * Exports without a registry retain their previous format and contents.

* **Documentation**
  * Added guidance on revocation-aware exports and compatibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->