### PR TITLE
audit: a decision record says what kind of party disposed of it

### DIFF
--- a/docs/conformance-profile.md
+++ b/docs/conformance-profile.md
@@ -23,7 +23,7 @@ reproduce the published verdicts under the same checker. The aggregate runner
 `scripts/conformance_runner.py` discovers every suite, runs each checker in a
 subprocess, and returns a single pass/fail.
 
-Profile v1 covers the 49 suites listed below, at the `v0` vector format. The
+Profile v1 covers the 50 suites listed below, at the `v0` vector format. The
 authoritative, always-current enumeration for any tagged release is the runner's
 own `--list` output at that tag.
 
@@ -96,7 +96,7 @@ Suites reported `SKIP`, not pass, in an aggregate run:
   both run.
 
 So a clean checkout with `rfc8785` and `cryptography` alone grades 45 passed,
-0 failed, 3 skipped across the 49 suites.
+0 failed, 3 skipped across the 50 suites.
 
 ## What a pass means, and what it does not
 
@@ -136,6 +136,7 @@ crewai_enforcement_v0          sep2787_attestation_v0
 cross_org_handoff_v0           tap_v0
 cross_stack_revocation_v0      transparency_consistency_v0
 data_locality_v0               x402_settlement_v0
+decision_disposition_v0
 decision_pairing_v0
 ```
 

--- a/src/vaara/_disposition.py
+++ b/src/vaara/_disposition.py
@@ -1,0 +1,77 @@
+"""Who disposed of a decision, as a closed vocabulary rather than as prose.
+
+A decision record already says WHAT was decided (``allow``, ``deny``,
+``escalate``) and, through ``decision_detail``, which refinement produced it.
+It did not say what KIND of party disposed of it, and three cases that a
+relying party must treat differently all surfaced as ``allow``:
+
+* policy allowed the action outright;
+* a human approved it at escalation;
+* a prior human approval was replayed from the trail by
+  :meth:`~vaara.audit.trail.AuditTrail.find_prior_approval` inside its window.
+
+The third is a policy disposition wearing a human's earlier decision. The
+pipeline has always recorded it honestly, but only in the free-text ``reason``
+string ("auto-allowed by prior approval (action_id=..., ...)"), so separating
+it from a live human approval meant parsing English. This module makes the
+distinction a field.
+
+The vocabulary is CLOSED and is not registry-governed. An unrecognised
+``approver`` is not a conforming disposition, which is deliberate: a value an
+implementation may invent is a value a relying party cannot branch on.
+
+The invariant that earns the module: ``human_disposed`` is true ONLY when a
+human actually acted. A producer MUST NOT claim a human disposed what a policy
+did, so ``human_disposed=True`` requires ``approver="human"``.
+
+Imports nothing, so the enforcement path (``vaara.pipeline``) and the evidence
+path (``vaara.audit.trail``) can hold the same table without one depending on
+the other.
+"""
+
+from __future__ import annotations
+
+#: The only approver kinds a conforming disposition carries. Closed.
+APPROVER: frozenset[str] = frozenset({"human", "policy"})
+
+#: Recorded when a policy disposed of the action with no human in the loop.
+POLICY = "policy"
+
+#: Recorded when a human actually acted on this action, at this decision.
+HUMAN = "human"
+
+
+class DispositionError(ValueError):
+    """Raised when a disposition would misreport who acted."""
+
+
+def check(approver: str, human_disposed: bool) -> tuple[str, bool]:
+    """Validate a disposition pair and return it normalised.
+
+    Raises :class:`DispositionError` rather than coercing, because every
+    failure mode here is a record that would overstate human involvement.
+    A silent coercion would produce exactly the claim this module exists to
+    prevent.
+    """
+    if not isinstance(approver, str):
+        raise DispositionError(
+            f"approver must be a string, got {type(approver).__name__}"
+        )
+    if not isinstance(human_disposed, bool):
+        # A truthy non-bool (1, "yes", a non-empty object) must not become
+        # a claim that a human acted.
+        raise DispositionError(
+            f"human_disposed must be a bool, got {type(human_disposed).__name__}"
+        )
+    normalized = approver.strip().lower()
+    if normalized not in APPROVER:
+        raise DispositionError(
+            f"approver {approver!r} is not one of {sorted(APPROVER)}; "
+            "the vocabulary is closed and an unknown value is non-conforming"
+        )
+    if human_disposed and normalized != HUMAN:
+        raise DispositionError(
+            f"human_disposed=True requires approver='human', got {normalized!r}; "
+            "a producer must not claim a human disposed what a policy did"
+        )
+    return normalized, human_disposed

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -854,6 +854,8 @@ class AuditTrail:
         regulatory_domains: frozenset[RegulatoryDomain] = frozenset(),
         decision_detail: Optional[str] = None,
         modified_parameters: Optional[dict] = None,
+        approver: str = "",
+        human_disposed: bool = False,
     ) -> None:
         """Record the allow/deny/escalate decision.
 
@@ -863,6 +865,13 @@ class AuditTrail:
         arguments a ``modify`` proposed. Both keys are omitted entirely when
         absent, so a record without a refinement is byte-identical to one
         written before this vocabulary existed and its hash does not move.
+
+        ``approver`` and ``human_disposed`` say what kind of party disposed of
+        the action. They matter most on the ``allow`` that
+        :meth:`find_prior_approval` produces: that allow replays a human's
+        earlier decision by cache lookup, so a human did not act on THIS
+        action and the record must not read as though one did. Same omission
+        rule as above; empty approver adds no keys.
         """
         event_type = (
             EventType.ACTION_BLOCKED if decision == "deny"
@@ -905,6 +914,29 @@ class AuditTrail:
             )
             modified_parameters = None
 
+        # The disposition raises rather than dropping, which is the opposite
+        # of the refinement handling directly above, and the difference is
+        # deliberate. A bad refinement is a record that is less specific than
+        # it could be. A bad disposition is a record that OVERSTATES human
+        # involvement, and dropping it quietly would leave the same allow it
+        # was meant to qualify. Fail loudly instead.
+        disposition: dict = {}
+        if approver:
+            from vaara._disposition import check
+
+            checked_approver, checked_flag = check(approver, human_disposed)
+            disposition = {
+                "approver": checked_approver,
+                "human_disposed": checked_flag,
+            }
+        elif human_disposed:
+            from vaara._disposition import DispositionError
+
+            raise DispositionError(
+                "human_disposed=True requires approver='human'; "
+                "a producer must not claim a human disposed what a policy did"
+            )
+
         data: dict = {
             "decision": self._cap_record_str(decision, self._MAX_DECISION_LABEL_LEN),
             "reason": self._cap_record_str(reason, self._MAX_DECISION_REASON_LEN),
@@ -919,6 +951,7 @@ class AuditTrail:
                 {str(k): json_safe(v) for k, v in modified_parameters.items()},
                 self._MAX_EXECUTION_RESULT_JSON_BYTES,
             )
+        data.update(disposition)
 
         self._append(AuditRecord(
             record_id=str(uuid.uuid4()),
@@ -1018,17 +1051,45 @@ class AuditTrail:
         reviewer: str,
         justification: str = "",
         args_digest: str = "",
+        approver: str = "",
+        human_disposed: bool = False,
     ) -> None:
-        """Record human resolution of an escalation.
+        """Record resolution of an escalation.
 
         ``args_digest`` is the argument-shape digest carried over from the
         ESCALATION_SENT record. find_prior_approval requires it to match
         before auto-allowing a later action, so approving ``tx.transfer``
         with amount 10 does not auto-allow amount 100000.
+
+        ``approver`` and ``human_disposed`` say what KIND of party disposed of
+        this, which ``reviewer`` does not: reviewer is free text naming who,
+        and both shipped call sites pass a mechanism name. When ``approver``
+        is empty the two keys are omitted entirely, so a caller that does not
+        supply a disposition produces a record that hashes exactly as it did
+        before these parameters existed.
         """
         articles = self._get_regulatory_articles(
             EventType.ESCALATION_RESOLVED, frozenset({RegulatoryDomain.EU_AI_ACT}),
         )
+
+        disposition: dict = {}
+        if approver:
+            from vaara._disposition import check  # local import: avoid cycle
+
+            checked_approver, checked_flag = check(approver, human_disposed)
+            disposition = {
+                "approver": checked_approver,
+                "human_disposed": checked_flag,
+            }
+        elif human_disposed:
+            # A flag with no approver beside it is the exact claim this
+            # vocabulary exists to prevent, so it fails rather than recording.
+            from vaara._disposition import DispositionError
+
+            raise DispositionError(
+                "human_disposed=True requires approver='human'; "
+                "a producer must not claim a human disposed what a policy did"
+            )
 
         self._append(AuditRecord(
             record_id=str(uuid.uuid4()),
@@ -1044,6 +1105,7 @@ class AuditTrail:
                 "args_digest": self._cap_record_str(
                     args_digest, self._MAX_ARGS_DIGEST_LEN,
                 ),
+                **disposition,
             },
             regulatory_articles=articles,
             tenant_id=self._tenant_for(action_id),

--- a/src/vaara/integrations/claude_code_hooks.py
+++ b/src/vaara/integrations/claude_code_hooks.py
@@ -415,6 +415,12 @@ def _handle_escalation(cfg: dict, pipeline, result, tool_name: str) -> int:
                     result.action_id, resolution,
                     reviewer="approvals-handshake",
                     justification="human decision via ~/.vaara/approvals",
+                    # A person wrote the decision file. Only approve and deny
+                    # reach here; timeout and an unreadable file both fall
+                    # through without resolving, so this branch is the one
+                    # place a human demonstrably acted.
+                    approver="human",
+                    human_disposed=True,
                 )
             except Exception as exc:
                 _emit(f"vaara-governance: could not record resolution ({exc!r}).")

--- a/src/vaara/integrations/mcp_server.py
+++ b/src/vaara/integrations/mcp_server.py
@@ -730,6 +730,10 @@ class VaaraMCPServer:
                 "allow" if human == "approve" else "deny",
                 reviewer="approvals-handshake",
                 justification="human decision via ~/.vaara/approvals",
+                # Guarded above: anything other than approve or deny already
+                # returned, so reaching this line means a person answered.
+                approver="human",
+                human_disposed=True,
             )
         except Exception:
             logger.warning(

--- a/src/vaara/pipeline.py
+++ b/src/vaara/pipeline.py
@@ -42,6 +42,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Sequence
 
+from vaara import _disposition
 from vaara._decision_vocabulary import FINE_TO_COARSE
 from vaara._sanitize import json_safe
 from pathlib import Path
@@ -675,6 +676,13 @@ class InterceptionPipeline:
         #    case governance failure named in step 6: the record and
         #    the behaviour disagree.
         args_digest = ""
+        # Empty approver means the record carries no disposition keys and
+        # hashes exactly as it did before this vocabulary existed. Only the
+        # replay branch below fills it in, because that is the only place in
+        # intercept() where an allow means something other than "policy
+        # allowed it" and the difference is invisible in the word `allow`.
+        approver = ""
+        human_disposed = False
         if decision_str == "escalate":
             args_digest = hashlib.sha256(
                 json.dumps(safe_params or {}, sort_keys=True).encode()
@@ -695,6 +703,15 @@ class InterceptionPipeline:
                     f"(action_id={prior.action_id}, {prior.timestamp})",
                     _MAX_DECISION_REASON_LEN, "reason",
                 )
+                # A human approved the EARLIER action. This one was disposed
+                # of by a cache lookup, so the record says policy. The reason
+                # string above already back-references the approval it
+                # replayed; this makes the same fact a field, so a relying
+                # party separating "a human approved this" from "a human
+                # approved something shaped like this, yesterday" does not
+                # have to parse prose to do it.
+                approver = _disposition.POLICY
+                human_disposed = False
 
         # 8. Record the decision in audit. `decision` stays inside the
         # documented allow/escalate/deny enum; the refinement and any
@@ -712,6 +729,8 @@ class InterceptionPipeline:
             regulatory_domains=action_type.regulatory_domains,
             decision_detail=decision_detail,
             modified_parameters=modified_parameters,
+            approver=approver,
+            human_disposed=human_disposed,
         )
 
         if decision_str == "escalate":
@@ -986,14 +1005,25 @@ class InterceptionPipeline:
         resolution: str,
         reviewer: str,
         justification: str = "",
+        approver: str = "",
+        human_disposed: bool = False,
     ) -> None:
-        """Record human resolution of an escalated action.
+        """Record resolution of an escalated action.
 
         Args:
             action_id: The action that was escalated.
             resolution: "allow" or "deny".
-            reviewer: Who made the decision.
+            reviewer: Who made the decision. Free text, and both shipped
+                call sites pass a mechanism name rather than a person, so it
+                answers who and never what kind.
             justification: Why.
+            approver: "human" or "policy". The closed vocabulary in
+                :mod:`vaara._disposition`. Left empty, the record carries no
+                disposition keys and hashes as it did before.
+            human_disposed: True ONLY when a human actually acted on this
+                action. Requires approver="human"; the pair is validated in
+                the trail rather than here, so every writer goes through the
+                same check.
         """
         # Narrow the resolution to the two values downstream compliance
         # queries assume. Unchecked, a typo like "alllow" or a caller
@@ -1090,6 +1120,8 @@ class InterceptionPipeline:
             reviewer=reviewer,
             justification=justification,
             args_digest=args_digest,
+            approver=approver,
+            human_disposed=human_disposed,
         )
 
     def run_compliance_assessment(

--- a/tests/test_decision_disposition_vectors.py
+++ b/tests/test_decision_disposition_vectors.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Bind the shipped disposition check to decision_disposition_v0.
+
+The vectors ship with `_check_independent.py`, which reimplements the rules
+from the text and imports nothing from Vaara. This file runs the SHIPPED
+implementation over the same cases and requires the same verdicts, so the two
+cannot drift apart without a test going red.
+
+That is the same arrangement the other suites use, and it is the reason a
+published vector is worth more than a published assertion.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vaara._disposition import DispositionError, check
+
+VECTORS = Path(__file__).parent / "vectors" / "decision_disposition_v0"
+
+
+def _load(name):
+    return json.loads((VECTORS / f"{name}.json").read_text())
+
+
+CASES = _load("cases")
+EXPECTED = _load("expected")
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_shipped_check_agrees_with_the_vector(name):
+    case, want = CASES[name], EXPECTED[name]
+    approver, flag = case.get("approver"), case.get("human_disposed")
+
+    if approver is None and flag is None:
+        # Absent disposition never reaches check(); the trail omits the keys.
+        assert want["conforming"] is True
+        assert want["keys_present"] is False
+        return
+
+    if approver is None:
+        # A bare flag is rejected by the trail before check() is reached, so
+        # the vector's verdict is asserted against that rule rather than here.
+        assert want["conforming"] is False
+        assert want["reason_class"] == "human_claim_by_policy"
+        return
+
+    if want["conforming"]:
+        got_approver, got_flag = check(approver, flag)
+        assert got_approver == want["approver"]
+        assert got_flag == want["human_disposed"]
+    else:
+        with pytest.raises(DispositionError):
+            check(approver, flag)
+
+
+def test_the_independent_checker_passes_on_its_own_bytes():
+    """The checker a third party would run, run here on every commit."""
+    result = subprocess.run(
+        [sys.executable, str(VECTORS / "_check_independent.py")],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "0 disagreement(s)" in result.stdout
+
+
+def test_the_suite_covers_the_three_allow_shaped_cases():
+    """A regression guard on the vectors themselves. If someone deletes the
+    replay case, the suite stops testing the thing it exists for."""
+    allow_cases = {
+        n for n, c in CASES.items()
+        if c["decision"] == "allow" and EXPECTED[n]["conforming"]
+    }
+    assert {
+        "policy_allow",
+        "human_approved_at_escalation",
+        "replayed_prior_approval",
+    } <= allow_cases
+
+    live = EXPECTED["human_approved_at_escalation"]
+    replayed = EXPECTED["replayed_prior_approval"]
+    assert live["human_disposed"] != replayed["human_disposed"]

--- a/tests/test_disposition.py
+++ b/tests/test_disposition.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The disposition vocabulary, and that the three allow-shaped cases separate.
+
+The point of these tests is not that a boolean exists. It is that a relying
+party holding only the record can tell a live human approval from a replayed
+one WITHOUT reading prose. Every assertion below compares field identity, not
+truthiness, which is the rule the transparency_consistency_v0 suite already
+encodes.
+"""
+
+import pytest
+
+from vaara._disposition import APPROVER, DispositionError, check
+
+
+class TestVocabulary:
+    def test_the_set_is_closed_and_exactly_two(self):
+        assert APPROVER == {"human", "policy"}
+
+    @pytest.mark.parametrize("approver", ["human", "policy"])
+    def test_both_members_pass_with_matching_flag(self, approver):
+        expected = approver == "human"
+        assert check(approver, expected) == (approver, expected)
+
+    def test_case_and_whitespace_normalise(self):
+        assert check("  HUMAN ", True) == ("human", True)
+
+    @pytest.mark.parametrize(
+        "approver", ["counterparty", "auto", "system", "Dr. Smith", ""],
+    )
+    def test_unknown_approver_is_rejected_not_tolerated(self, approver):
+        with pytest.raises(DispositionError, match="closed"):
+            check(approver, False)
+
+
+class TestTheInvariant:
+    def test_policy_cannot_claim_a_human_acted(self):
+        with pytest.raises(DispositionError, match="must not claim a human"):
+            check("policy", True)
+
+    def test_human_approver_may_record_a_false_flag(self):
+        # A human reviewed and the disposition was still automatic; allowed,
+        # because the flag only ever narrows the claim.
+        assert check("human", False) == ("human", False)
+
+    @pytest.mark.parametrize("truthy", [1, "yes", [1], object()])
+    def test_truthy_non_bool_cannot_become_a_human_claim(self, truthy):
+        # A caller passing 1 rather than True must not silently produce
+        # "a human acted". This is the coercion that would defeat the module.
+        with pytest.raises(DispositionError, match="must be a bool"):
+            check("human", truthy)
+
+    def test_falsy_non_bool_is_also_rejected(self):
+        with pytest.raises(DispositionError, match="must be a bool"):
+            check("policy", 0)
+
+    def test_non_string_approver_is_rejected(self):
+        with pytest.raises(DispositionError, match="must be a string"):
+            check(None, False)
+
+
+class TestNoCoercion:
+    """Every failure here would produce a record overstating human involvement,
+    so the module raises rather than repairing."""
+
+    def test_check_never_returns_a_repaired_pair(self):
+        for approver, flag in [("policy", True), ("nonsense", False)]:
+            with pytest.raises(DispositionError):
+                check(approver, flag)

--- a/tests/test_disposition_in_trail.py
+++ b/tests/test_disposition_in_trail.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Three allow-shaped cases must separate by FIELD, not by prose.
+
+Before this vocabulary, a relying party holding the trail saw `allow` in all
+three of these and could only tell them apart by reading the English in
+`reason`:
+
+  a) policy allowed it outright
+  b) a human approved it at escalation
+  c) a prior human approval was replayed by cache lookup inside its window
+
+(c) is a policy disposition wearing a human's earlier decision, and it is the
+one worth catching. Assertions below compare field identity, never truthiness.
+"""
+
+import pytest
+
+from vaara._disposition import DispositionError
+from vaara.audit.trail import AuditTrail, EventType
+
+
+def _trail():
+    return AuditTrail()
+
+
+def _data(trail, event_type):
+    records = trail.get_records_by_type(event_type)
+    if not records:
+        raise AssertionError(f"no {event_type} record")
+    return records[-1].data or {}
+
+
+class TestTheThreeCasesSeparate:
+    def test_a_plain_policy_allow_carries_no_disposition_keys(self):
+        t = _trail()
+        t.record_decision(
+            action_id="act-a", agent_id="a1", tool_name="fs.read",
+            decision="allow", reason="low risk", risk_score=0.1,
+        )
+        data = _data(t, EventType.DECISION_MADE)
+        assert "approver" not in data
+        assert "human_disposed" not in data
+
+    def test_b_human_approval_says_human_and_true(self):
+        t = _trail()
+        t.record_decision(
+            action_id="act-b", agent_id="a1", tool_name="tx.transfer",
+            decision="allow", reason="approved at escalation", risk_score=0.6,
+            approver="human", human_disposed=True,
+        )
+        data = _data(t, EventType.DECISION_MADE)
+        assert data["approver"] == "human"
+        assert data["human_disposed"] is True
+
+    def test_c_replayed_approval_says_policy_and_false(self):
+        t = _trail()
+        t.record_decision(
+            action_id="act-c", agent_id="a1", tool_name="tx.transfer",
+            decision="allow",
+            reason="auto-allowed by prior approval (action_id=act-b, 123.0)",
+            risk_score=0.6,
+            approver="policy", human_disposed=False,
+        )
+        data = _data(t, EventType.DECISION_MADE)
+        assert data["approver"] == "policy"
+        assert data["human_disposed"] is False
+
+    def test_b_and_c_are_distinguishable_without_reading_reason(self):
+        """The whole point. Same decision word, different disposition."""
+        t = _trail()
+        t.record_decision(
+            action_id="act-b", agent_id="a1", tool_name="tx.transfer",
+            decision="allow", reason="x", risk_score=0.6,
+            approver="human", human_disposed=True,
+        )
+        live = _data(t, EventType.DECISION_MADE)
+        t.record_decision(
+            action_id="act-c", agent_id="a1", tool_name="tx.transfer",
+            decision="allow", reason="y", risk_score=0.6,
+            approver="policy", human_disposed=False,
+        )
+        replayed = _data(t, EventType.DECISION_MADE)
+
+        assert live["decision"] == replayed["decision"] == "allow"
+        assert live["human_disposed"] != replayed["human_disposed"]
+        assert live["approver"] != replayed["approver"]
+
+
+class TestTheRecordCannotOverstate:
+    def test_policy_claiming_a_human_raises(self):
+        t = _trail()
+        with pytest.raises(DispositionError, match="must not claim a human"):
+            t.record_decision(
+                action_id="act-x", agent_id="a1", tool_name="t",
+                decision="allow", reason="r", risk_score=0.1,
+                approver="policy", human_disposed=True,
+            )
+
+    def test_bare_flag_with_no_approver_raises(self):
+        t = _trail()
+        with pytest.raises(DispositionError, match="requires approver"):
+            t.record_decision(
+                action_id="act-y", agent_id="a1", tool_name="t",
+                decision="allow", reason="r", risk_score=0.1,
+                human_disposed=True,
+            )
+
+    def test_unknown_approver_raises_rather_than_being_dropped(self):
+        """Contrast with decision_detail, which is dropped with a warning.
+        A bad disposition overstates; it must not degrade to silence."""
+        t = _trail()
+        with pytest.raises(DispositionError, match="closed"):
+            t.record_decision(
+                action_id="act-z", agent_id="a1", tool_name="t",
+                decision="allow", reason="r", risk_score=0.1,
+                approver="counterparty", human_disposed=False,
+            )
+
+
+class TestHashesDoNotMove:
+    def test_a_record_without_a_disposition_hashes_as_before(self):
+        """Every existing trail must verify unchanged, so the no-disposition
+        path has to produce byte-identical data to the pre-vocabulary code."""
+        a, b = _trail(), _trail()
+        for t in (a, b):
+            t.record_decision(
+                action_id="act-1", agent_id="a1", tool_name="fs.read",
+                decision="allow", reason="low risk", risk_score=0.25,
+            )
+        rec_a = _data(a, EventType.DECISION_MADE)
+        rec_b = _data(b, EventType.DECISION_MADE)
+        assert rec_a == rec_b
+        assert set(rec_a) == {"decision", "reason", "risk_score"}
+
+    def test_empty_approver_adds_nothing_even_when_passed_explicitly(self):
+        t = _trail()
+        t.record_decision(
+            action_id="act-2", agent_id="a1", tool_name="fs.read",
+            decision="allow", reason="low risk", risk_score=0.25,
+            approver="", human_disposed=False,
+        )
+        assert set(_data(t, EventType.DECISION_MADE)) == {
+            "decision", "reason", "risk_score",
+        }
+
+    def test_the_chain_still_verifies_with_dispositions_present(self):
+        t = _trail()
+        t.record_decision(
+            action_id="act-3", agent_id="a1", tool_name="t",
+            decision="allow", reason="r", risk_score=0.1,
+            approver="human", human_disposed=True,
+        )
+        t.record_decision(
+            action_id="act-4", agent_id="a1", tool_name="t",
+            decision="allow", reason="r", risk_score=0.1,
+            approver="policy", human_disposed=False,
+        )
+        # verify_chain returns None when the chain is intact, or a string
+        # describing the first break.
+        assert t.verify_chain() is None

--- a/tests/vectors/decision_disposition_v0/README.md
+++ b/tests/vectors/decision_disposition_v0/README.md
@@ -1,0 +1,83 @@
+# decision_disposition_v0
+
+Nine cases covering who disposed of a decision, and whether a record can be
+made to overstate human involvement.
+
+## What this suite is for
+
+A decision record says WHAT was decided: `allow`, `deny`, `escalate`. Three
+different things produce `allow`, and a relying party has to treat them
+differently:
+
+1. policy allowed the action outright
+2. a human approved it at escalation
+3. a prior human approval was replayed by cache lookup inside its window
+
+Case 3 is a policy disposition wearing a human's earlier decision. The human
+acted on a different action, at a different time, and consented to a different
+instance of the same argument shape.
+
+Before this vocabulary all three surfaced as `allow`, and the only thing
+separating them was English in the `reason` field
+(`"auto-allowed by prior approval (action_id=..., ...)"`). A record that is
+honest only to a reader who parses prose is not machine-checkable, which is the
+same defect one level down from the one the `transparency_consistency_v0` suite
+exists for.
+
+## The rules, reproduced in `_check_independent.py`
+
+**The closed set.** `approver` is exactly `human` or `policy`. An unknown value
+is non-conforming rather than tolerated. A value an implementation may invent
+is a value a relying party cannot branch on, so this vocabulary is not
+registry-governed and is not expected to grow by registration.
+
+**The honest flag.** `human_disposed` is true ONLY when a human actually acted.
+
+- It must be a real boolean. A truthy `1` or `"yes"` is non-conforming and
+  never becomes a human claim.
+- `human_disposed: true` requires `approver: "human"`. A producer must not
+  claim a human disposed what a policy did.
+- The converse is legal. `approver: "human"` with `human_disposed: false`
+  records a human who reviewed while the disposition stayed automatic, and the
+  flag only ever narrows the claim.
+
+**Silence is valid.** A record carrying neither key is conforming. Records
+written before this vocabulary existed carry nothing and must keep hashing
+exactly as they did, so absence is never read as "a human acted".
+
+## Files
+
+| File | What it is |
+|---|---|
+| `cases.json` | The nine inputs |
+| `expected.json` | The verdict each one must produce |
+| `_check_independent.py` | Standard library only, imports no Vaara code |
+
+## Running it
+
+```
+python3 _check_independent.py
+```
+
+Exit 0 when every case agrees with `expected.json`. The last line reports the
+number of disagreements.
+
+`tests/test_decision_disposition_vectors.py` runs the SHIPPED implementation
+over the same cases and requires the same verdicts, so the checker and the
+product cannot drift apart without a test going red.
+
+## What the suite asserts about itself
+
+The checker ends by asserting the property the suite exists for: that
+`human_approved_at_escalation` and `replayed_prior_approval` both carry
+`decision: "allow"` and disagree on `human_disposed`. If a future edit made
+those two identical, the vectors would still pass their individual expectations
+while testing nothing, so that comparison is checked explicitly.
+
+## Provenance
+
+The requirement was found on 2026-09-04 by reading
+`draft-mih-scitt-agent-action-capsule-04` Section 5.5, which states the rule as
+a normative MUST for its own format. The property is worth having on its own
+terms and the field names here are this project's own; nothing in this suite
+claims interoperability with that document.

--- a/tests/vectors/decision_disposition_v0/_check_independent.py
+++ b/tests/vectors/decision_disposition_v0/_check_independent.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Independent conformance checker for the decision_disposition_v0 vectors.
+
+Imports the standard library only. It does not import Vaara. A second
+implementation can run this file to confirm the disposition rules are
+consumable from the committed bytes alone.
+
+The property under test is that three ALLOW-shaped outcomes are separable by
+field rather than by prose:
+
+  1. policy allowed the action outright
+  2. a human approved it at escalation
+  3. a prior human approval was replayed by cache lookup inside its window
+
+(3) is a policy disposition wearing a human's earlier decision. All three carry
+``decision: "allow"``. Only the disposition fields tell them apart, and a
+relying party that branches on ``human_disposed`` must not have to read the
+``reason`` string to get the right answer.
+
+Two rules are reproduced from scratch:
+
+**The closed set.** ``approver`` is exactly "human" or "policy". An unknown
+value is non-conforming rather than tolerated, because a value an
+implementation may invent is a value a relying party cannot branch on.
+
+**The honest flag.** ``human_disposed`` is true ONLY when a human actually
+acted. It must be a real boolean, so a truthy 1 or "yes" is non-conforming and
+never becomes a human claim. ``human_disposed: true`` requires
+``approver: "human"``: a producer must not claim a human disposed what a policy
+did. The converse is legal, since a human approver with a false flag only
+narrows the claim.
+
+Absent disposition is conforming. A record written before this vocabulary
+existed carries neither key and must keep hashing as it did, so silence is a
+valid state and is not read as "a human acted".
+
+Exit 0 when every case agrees with expected.json, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+APPROVER = frozenset({"human", "policy"})
+
+
+def evaluate(case: dict) -> dict:
+    """Return the conformance verdict for one case, from its bytes alone."""
+    approver = case.get("approver")
+    flag = case.get("human_disposed")
+
+    # Silence is a valid state: neither key present.
+    if approver is None and flag is None:
+        return {
+            "conforming": True,
+            "keys_present": False,
+            "approver": None,
+            "human_disposed": None,
+        }
+
+    # A flag standing on its own is the claim with nothing behind it.
+    if approver is None:
+        return {"conforming": False, "reason_class": "human_claim_by_policy"}
+
+    if not isinstance(approver, str):
+        return {"conforming": False, "reason_class": "approver_not_in_closed_set"}
+
+    normalized = approver.strip().lower()
+    if normalized not in APPROVER:
+        return {"conforming": False, "reason_class": "approver_not_in_closed_set"}
+
+    # Checked before truthiness is ever consulted. `1` is truthy and is not a
+    # boolean, and letting it through here is exactly how a policy disposition
+    # becomes a human claim.
+    if not isinstance(flag, bool):
+        return {"conforming": False, "reason_class": "flag_not_boolean"}
+
+    if flag and normalized != "human":
+        return {"conforming": False, "reason_class": "human_claim_by_policy"}
+
+    return {
+        "conforming": True,
+        "keys_present": True,
+        "approver": normalized,
+        "human_disposed": flag,
+    }
+
+
+def main() -> int:
+    here = Path(__file__).resolve().parent
+    cases = json.loads((here / "cases.json").read_text())
+    expected = json.loads((here / "expected.json").read_text())
+
+    if set(cases) != set(expected):
+        print("case names do not match expected names", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for name in sorted(cases):
+        got = evaluate(cases[name])
+        want = expected[name]
+        # Compare on the keys the expectation states, so an implementation
+        # carrying extra diagnostic keys is not penalised for them.
+        narrowed = {k: got.get(k) for k in want}
+        if narrowed != want:
+            failures += 1
+            print(f"FAIL {name}\n  expected {want}\n  got      {narrowed}")
+        else:
+            print(f"ok   {name}  {want}")
+
+    # The property the suite exists for, asserted rather than implied.
+    live = evaluate(cases["human_approved_at_escalation"])
+    replayed = evaluate(cases["replayed_prior_approval"])
+    if cases["human_approved_at_escalation"]["decision"] != "allow" or \
+            cases["replayed_prior_approval"]["decision"] != "allow":
+        failures += 1
+        print("FAIL both comparison cases must carry decision 'allow'")
+    elif live["human_disposed"] == replayed["human_disposed"]:
+        failures += 1
+        print("FAIL a live approval and a replayed one are indistinguishable")
+    else:
+        print("ok   live and replayed approvals separate on human_disposed")
+
+    print(f"\n{len(cases)} cases, {failures} disagreement(s)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/vectors/decision_disposition_v0/cases.json
+++ b/tests/vectors/decision_disposition_v0/cases.json
@@ -1,0 +1,63 @@
+{
+  "policy_allow": {
+    "note": "Policy allowed the action outright. No human was involved and no disposition is claimed.",
+    "decision": "allow",
+    "reason": "risk 0.11 below allow threshold",
+    "approver": null,
+    "human_disposed": null
+  },
+  "human_approved_at_escalation": {
+    "note": "A person wrote the decision file during the approvals handshake. A human acted on THIS action.",
+    "decision": "allow",
+    "reason": "approved at escalation",
+    "approver": "human",
+    "human_disposed": true
+  },
+  "replayed_prior_approval": {
+    "note": "find_prior_approval matched an earlier resolution inside its 24h window. The allow replays a human decision taken on a DIFFERENT action, so no human acted on this one.",
+    "decision": "allow",
+    "reason": "auto-allowed by prior approval (action_id=act-b, 1788500000.0)",
+    "approver": "policy",
+    "human_disposed": false
+  },
+  "human_denied_at_escalation": {
+    "decision": "deny",
+    "reason": "denied at escalation",
+    "approver": "human",
+    "human_disposed": true
+  },
+  "human_reviewed_but_policy_disposed": {
+    "note": "A human looked at it and the disposition was still automatic. Legal: the flag only ever narrows the claim.",
+    "decision": "allow",
+    "reason": "reviewed, auto-cleared",
+    "approver": "human",
+    "human_disposed": false
+  },
+  "policy_claiming_human": {
+    "note": "The lie this vocabulary exists to prevent.",
+    "decision": "allow",
+    "reason": "r",
+    "approver": "policy",
+    "human_disposed": true
+  },
+  "bare_flag_no_approver": {
+    "decision": "allow",
+    "reason": "r",
+    "approver": null,
+    "human_disposed": true
+  },
+  "unknown_approver": {
+    "note": "The vocabulary is closed. counterparty is a value another specification uses and this one does not.",
+    "decision": "allow",
+    "reason": "r",
+    "approver": "counterparty",
+    "human_disposed": false
+  },
+  "truthy_non_bool_flag": {
+    "note": "A caller passing 1 rather than True must not silently produce a human claim.",
+    "decision": "allow",
+    "reason": "r",
+    "approver": "human",
+    "human_disposed": 1
+  }
+}

--- a/tests/vectors/decision_disposition_v0/expected.json
+++ b/tests/vectors/decision_disposition_v0/expected.json
@@ -1,0 +1,11 @@
+{
+  "policy_allow": { "conforming": true, "keys_present": false, "approver": null, "human_disposed": null },
+  "human_approved_at_escalation": { "conforming": true, "keys_present": true, "approver": "human", "human_disposed": true },
+  "replayed_prior_approval": { "conforming": true, "keys_present": true, "approver": "policy", "human_disposed": false },
+  "human_denied_at_escalation": { "conforming": true, "keys_present": true, "approver": "human", "human_disposed": true },
+  "human_reviewed_but_policy_disposed": { "conforming": true, "keys_present": true, "approver": "human", "human_disposed": false },
+  "policy_claiming_human": { "conforming": false, "reason_class": "human_claim_by_policy" },
+  "bare_flag_no_approver": { "conforming": false, "reason_class": "human_claim_by_policy" },
+  "unknown_approver": { "conforming": false, "reason_class": "approver_not_in_closed_set" },
+  "truthy_non_bool_flag": { "conforming": false, "reason_class": "flag_not_boolean" }
+}

--- a/webpage/badge/conformance.svg
+++ b/webpage/badge/conformance.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="248" height="20" role="img" aria-label="Vaara conformance corpus: 49 suites, 0 failing">
-  <title>Vaara conformance corpus: 49 suites, 0 failing</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="248" height="20" role="img" aria-label="Vaara conformance corpus: 50 suites, 0 failing">
+  <title>Vaara conformance corpus: 50 suites, 0 failing</title>
   <filter id="blur"><feGaussianBlur stdDeviation="16"/></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
@@ -28,10 +28,10 @@
     </g>
     <g transform="scale(.1)">
       <g aria-hidden="true" fill="#010101">
-        <text x="1926" y="150" fill-opacity=".8" filter="url(#blur)">49 suites, 0 failing</text>
-        <text x="1926" y="150" fill-opacity=".3">49 suites, 0 failing</text>
+        <text x="1926" y="150" fill-opacity=".8" filter="url(#blur)">50 suites, 0 failing</text>
+        <text x="1926" y="150" fill-opacity=".3">50 suites, 0 failing</text>
       </g>
-      <text x="1926" y="140">49 suites, 0 failing</text>
+      <text x="1926" y="140">50 suites, 0 failing</text>
     </g>
   </g>
 </svg>

--- a/webpage/conformance.html
+++ b/webpage/conformance.html
@@ -47,7 +47,7 @@
       "url": "https://vaara.io/conformance.html",
       "name": "Vaara Conformance Results",
       "description": "Every Vaara conformance suite, its verdict, and every independent party who reproduced the vectors and said so in public. Generated from the runner's own report.",
-      "dateModified": "2026-09-02T11:46:30Z",
+      "dateModified": "2026-09-04T09:33:02Z",
       "inLanguage": "en",
       "isPartOf": {
         "@id": "https://vaara.io/#website"
@@ -96,7 +96,7 @@
       "alternateName": "Vaara conformance corpus",
       "description": "Committed case files for every Vaara conformance suite. Each suite ships an independent checker that imports no Vaara code and recomputes its verdicts from the bytes of its own cases, so a stranger can disagree with an expected result and show their work. The vectors are Vaara's own and no ratification body stands behind them.",
       "url": "https://vaara.io/conformance.html",
-      "dateModified": "2026-09-02T11:46:30Z",
+      "dateModified": "2026-09-04T09:33:02Z",
       "identifier": "https://doi.org/10.5281/zenodo.22027975",
       "sameAs": [
         "https://doi.org/10.5281/zenodo.22027975",
@@ -126,12 +126,12 @@
         {
           "@type": "PropertyValue",
           "name": "suites",
-          "value": 49
+          "value": 50
         },
         {
           "@type": "PropertyValue",
           "name": "passed",
-          "value": 48
+          "value": 49
         },
         {
           "@type": "PropertyValue",
@@ -360,13 +360,13 @@
   did rather than what a document claims they do.</p>
 
   <div class="stats">
-    <div class="stat"><b>49</b><span>suites</span></div>
-    <div class="stat"><b>48</b><span>passed</span></div>
+    <div class="stat"><b>50</b><span>suites</span></div>
+    <div class="stat"><b>49</b><span>passed</span></div>
     <div class="stat"><b>0</b><span>failed</span></div>
     <div class="stat"><b>1</b><span>skipped</span></div>
     <div class="stat"><b>88</b><span>cases</span></div>
   </div>
-  <p class="mono" style="color:var(--faint)">generated 2026-09-02T11:46:30Z</p>
+  <p class="mono" style="color:var(--faint)">generated 2026-09-04T09:33:02Z</p>
 
   <h2>Run it yourself</h2>
   <p>Nothing here needs Vaara installed. The checkers use the standard library
@@ -504,6 +504,7 @@ python scripts/vcr_chain.py            # nothing removed from the table</code></
 <tr><td class="mono">cross_org_handoff_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">cross_stack_revocation_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">data_locality_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
+<tr><td class="mono">decision_disposition_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">decision_pairing_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">decision_vocabulary_v0</td><td class="ok">PASS</td><td class="why"></td></tr>
 <tr><td class="mono">enforcement_attestation_v0</td><td class="ok">PASS</td><td class="why"></td></tr>


### PR DESCRIPTION
Three different things produce `allow`, and a relying party has to treat them differently:

1. policy allowed the action outright
2. a human approved it at escalation
3. a prior human approval was replayed by `find_prior_approval` inside its 24h window

The third is a policy disposition wearing a human's earlier decision. The human acted on a different action, at a different time, and consented to a different instance of the same argument shape.

The pipeline already recorded that honestly, but only in the free-text `reason` string (`"auto-allowed by prior approval (action_id=..., ...)"`), so separating a live approval from a replayed one meant parsing English. `resolve_escalation` took a free-text `reviewer`, and both shipped call sites fill it with `"approvals-handshake"`, which names a mechanism and asserts nothing about a human.

## What changed

`vaara._disposition` holds the vocabulary in one place and imports nothing, so the enforcement path and the evidence path can share it without either depending on the other.

- `approver`: a **closed** two-member set, `human` or `policy`. Not registry-governed. A value an implementation may invent is a value a relying party cannot branch on.
- `human_disposed`: true only when a human actually acted.
- The invariant: `human_disposed=True` requires `approver="human"`. The converse stays legal, since a human approver with a false flag only narrows the claim.

The disposition **raises** on a bad pair, where `decision_detail` is dropped with a warning. That difference is deliberate. A bad refinement makes a record less specific than it could be. A bad disposition overstates human involvement, and dropping it silently would leave the same `allow` it was meant to qualify. A truthy non-bool is rejected before truthiness is ever consulted, because `1` quietly becoming "a human acted" is the failure this exists to prevent.

## Wire format is unchanged

The decision enum stays `allow` / `deny` / `escalate`. The two keys ride as additional data, which the 1.0 payload schema permits and which `decision_detail` already uses. Empty `approver` adds no keys, so every existing record hashes exactly as before. That is tested directly rather than assumed.

## Vectors

`tests/vectors/decision_disposition_v0`, nine cases with an independent checker that imports no Vaara code, plus a test running the shipped implementation over the same cases so the two cannot drift apart.

The checker ends by asserting the property the suite exists for: that a live approval and a replayed one both carry `decision: "allow"` and disagree on `human_disposed`. Without that, a future edit could make the two identical and every individual expectation would still pass while the suite tested nothing.

## Provenance

Found by reading `draft-mih-scitt-agent-action-capsule-04` Section 5.5, which makes this a normative MUST for its own format. The property is worth having on its own terms. Field names here are this project's own and no interoperability with that document is claimed.

Full suite: 3566 passed, 26 skipped, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit records now identify whether a decision was disposed by a human or policy.
  * Human approvals and policy-based replayed approvals are recorded distinctly.
  * Invalid or inconsistent disposition details are rejected with clear validation errors.

* **Documentation**
  * Added documentation and conformance vectors describing valid decision-disposition outcomes.

* **Tests**
  * Added coverage for disposition validation, audit trail integrity, replay behavior, and conformance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->