### PR TITLE
webpage: surfaces.html carries structured data and a link preview

### DIFF
--- a/tests/test_webpage_assets.py
+++ b/tests/test_webpage_assets.py
@@ -22,7 +22,9 @@ PAGES = ("index.html", "verify.html")
 #: Every page that ships structured data. A crawler or a model arriving at any
 #: of these reads the block instead of guessing from the layout, so a block
 #: that does not parse is worse than none: it is silently dropped.
-PAGES_WITH_STRUCTURED_DATA = ("index.html", "verify.html", "conformance.html")
+PAGES_WITH_STRUCTURED_DATA = (
+    "index.html", "verify.html", "conformance.html", "surfaces.html",
+)
 
 #: The nodes the whole site shares. Declared with the same @id on every page so
 #: the graphs join into one Vaara instead of describing three unrelated ones.

--- a/webpage/surfaces.html
+++ b/webpage/surfaces.html
@@ -12,6 +12,121 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
 <link rel="alternate icon" href="/favicon.ico">
 <link rel="apple-touch-icon" href="/favicon-180.png">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Vaara">
+<meta property="og:title" content="What Vaara publishes">
+<meta property="og:description" content="Every page, record and package Vaara publishes, each in one line: six independent reproductions of the conformance vectors, the receipt Internet-Draft, the verifier, the packages and the documents. Each item links to the thing itself.">
+<meta property="og:url" content="https://vaara.io/surfaces.html">
+<meta property="og:image" content="https://vaara.io/vaara-wordmark-light.png">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="346">
+<meta property="og:image:alt" content="Vaara">
+<meta property="og:locale" content="en_US">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="What Vaara publishes">
+<meta name="twitter:description" content="Every page, record and package Vaara publishes, each in one line: six independent reproductions of the conformance vectors, the receipt Internet-Draft, the verifier, the packages and the documents. Each item links to the thing itself.">
+<meta name="twitter:image" content="https://vaara.io/vaara-wordmark-light.png">
+<meta name="twitter:image:alt" content="Vaara">
+<link rel="author" href="https://vaara.io/">
+<link rel="alternate" type="text/plain" href="/llms.txt" title="The same surfaces as plain text for machine readers">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": [
+        "WebPage",
+        "CollectionPage"
+      ],
+      "@id": "https://vaara.io/surfaces.html#page",
+      "url": "https://vaara.io/surfaces.html",
+      "name": "What Vaara publishes",
+      "description": "Every page, record and package Vaara publishes, each in one line: six independent reproductions of the conformance vectors, the receipt Internet-Draft, the verifier, the packages and the documents. Each item links to the thing itself.",
+      "inLanguage": "en",
+      "isPartOf": {
+        "@id": "https://vaara.io/#website"
+      },
+      "publisher": {
+        "@id": "https://vaara.io/#organization"
+      },
+      "author": {
+        "@id": "https://vaara.io/#henri"
+      },
+      "mainEntity": {
+        "@id": "https://vaara.io/surfaces.html#surfaces"
+      }
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://vaara.io/#website",
+      "name": "Vaara",
+      "url": "https://vaara.io/",
+      "inLanguage": "en"
+    },
+    {
+      "@type": "Organization",
+      "@id": "https://vaara.io/#organization",
+      "name": "Vaara",
+      "url": "https://vaara.io/",
+      "logo": "https://vaara.io/vaara-wordmark-light.png",
+      "founder": {
+        "@id": "https://vaara.io/#henri"
+      }
+    },
+    {
+      "@type": "Person",
+      "@id": "https://vaara.io/#henri",
+      "name": "Henri Sirkkavaara",
+      "url": "https://vaara.io/"
+    },
+    {
+      "@type": "ItemList",
+      "@id": "https://vaara.io/surfaces.html#surfaces",
+      "name": "Everything Vaara publishes that a reader can check",
+      "description": "Each entry is a surface someone outside the project can open and verify without asking the maintainer.",
+      "itemListOrder": "https://schema.org/ItemListUnordered",
+      "numberOfItems": 5,
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Independent reproductions",
+          "url": "https://vaara.io/conformance.html",
+          "description": "Six parties other than the maintainer ran the conformance checkers and reported the result somewhere public. Each entry links to that party's own record."
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Check it yourself",
+          "url": "https://vaara.io/verify.html",
+          "description": "The results register, the verifier, the register as one machine-readable file, and the badge."
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "name": "Specification",
+          "url": "https://datatracker.ietf.org/doc/draft-sirkkavaara-vaara-receipt/",
+          "description": "The receipt format as an IETF Internet-Draft, and the standards it builds on."
+        },
+        {
+          "@type": "ListItem",
+          "position": 4,
+          "name": "Code and packages",
+          "url": "https://github.com/vaaraio/vaara",
+          "description": "Source, PyPI, npm, the GitHub Action, and the OpenSSF Best Practices entry."
+        },
+        {
+          "@type": "ListItem",
+          "position": 5,
+          "name": "Documents",
+          "url": "https://vaara.io/llms.txt",
+          "description": "Why logs are not evidence, the EU AI Act Article 12 reading, execution receipts, and the compliance mapping."
+        }
+      ]
+    }
+  ]
+}
+</script>
 <link rel="sitemap" type="application/xml" href="/sitemap.xml">
 <style>
 :root{


### PR DESCRIPTION
`surfaces.html` was the one page in the sitemap with no structured data: six meta tags, no `og:` or `twitter:` tags, no JSON-LD. So the page whose entire job is answering "what does Vaara publish and who checked it" was read as layout by anything that reads structured data.

## What changed

The same graph shape the other three pages use, joined on the identical `@id` strings (`#website`, `#organization`, `#henri`) so the site describes one Vaara rather than four. Plus a `CollectionPage` node and an `ItemList` of the five sections the page actually has.

The `ItemList` states nothing the page does not already state. Six reproductions, because the register holds six. The sections and their links are read off the page rather than composed.

`surfaces.html` joins `PAGES_WITH_STRUCTURED_DATA`, so the three existing guards now cover it: the structured data has to parse, it has to carry the shared ids, and it has to declare a canonical URL, a description and a link preview.

Full suite: 3580 passed, 26 skipped.

## What this deliberately does not touch

`webpage/llms.txt` and `webpage/conformance.json`. I regenerated both from the real `vcr` rows first, on the theory that the committed `llms.txt` saying "No independent reproduction is recorded yet" was stale. `test_site_stamp` failed and it was right to.

The committed copies are generated from the empty register stub on `main` **on purpose**, and `stamp_site.py` rewrites them from the `vcr` rows at publish time. Verified by fetching rather than assumed: the live `llms.txt` reads "Listed reproductions, 6 to date" and the live `conformance.json` carries 6 rows and 2 witnessed heads.

Both files were reverted. The repo copies are meant to look stale and the guard holds them that way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Added richer sharing and search metadata to the Surfaces page, including Open Graph and Twitter Card previews.
  - Added structured information describing the page, site, organization, author, and five available surfaces.
  - Added alternate guidance for language-model and automated discovery tools.
- **Quality Improvements**
  - The Surfaces page is now included in checks that verify consistent structured data and page information across the website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->