### PR TITLE
audit: a trail that stops recording says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+### Fixed
+
+- A trail that stops recording now says so. The Claude Code hook could fail to persist every single record, print a traceback, and exit 0, and nothing anywhere surfaced it. Found by dogfooding: on the maintainer's own machine the trail had been dead for thirteen days, and it turned up only because someone went looking for an unrelated reason.
+
+  The signal was a full traceback on every tool call, which reads as ordinary hook noise within minutes. The failure counter printed beside it lived in `AuditTrail`, which is per-process, while the hook is a fresh process per tool call, so it could never climb past 1 and never crossed any threshold.
+
+  The count now lives beside the database, in `<db>.write-failure.json`, where it survives the process and accumulates. `vaara hook session-start` reads it and states that the trail is not recording, with the first failure time, the running count and the recovery commands. When no marker exists it runs `PRAGMA quick_check` at session start instead, which catches a trail damaged while nothing was writing to it. On the write path the stack trace is kept for the first failure of an outage and every failure after it is one line. A successful write stamps the marker resolved and keeps the file, so how long the trail was down stays on disk.
+
+  Opening the trail also no longer takes the hook down: an unreadable `audit.db` on the `mcp__*` path raised through `PreToolUse`, and in the fallback scripts it raised from `_record_call` too. Both now pass the call through and report.
+
+  Fail-open is unchanged and deliberate. A governance hook that blocks the session gets uninstalled, and an uninstalled hook records nothing at all. The defect was the silence. Fixed in both the packaged hooks and the bundled fallback scripts, which had the same shape.
+
 ### Added
 
 - Every shipped export path can pin the revocation registry it used. `--revocations PATH` on `vaara trail export`, `export-threshold`, `export-article12` and `export-article50`, and a `revocation=` argument on `export_signed_threshold`, `export_article12`, `export_article50` and `rotate`.

--- a/plugins/claude-code-vaara-governance/hooks/_trail_health.py
+++ b/plugins/claude-code-vaara-governance/hooks/_trail_health.py
@@ -74,4 +74,7 @@ def report(db_path, existed: bool) -> None:
             )
             _raw_notify("TRAIL DAMAGED", "audit trail", problem)
     except Exception:
+        # Reporting on the trail's health must never break the session it is
+        # reporting to. There is nowhere left to escalate to from here: the
+        # thing that would carry the error is the trail itself.
         pass

--- a/plugins/claude-code-vaara-governance/hooks/_trail_health.py
+++ b/plugins/claude-code-vaara-governance/hooks/_trail_health.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Say when the audit trail is not recording. The fallback scripts' half.
+
+These scripts are the fallback path: ``hooks.json`` runs the ``vaara`` binary
+when it is on PATH and these files otherwise. Both paths had the same defect,
+so fixing only the packaged one would leave half the installs silent. The
+logic lives in ``vaara.audit.write_failure``; this is the thin wrapper that
+lets a script use it without importing the whole hook module.
+
+Never raises, and never blocks a tool call. See the module docstring in
+``vaara/audit/write_failure.py`` for what happened on 2026-08-22 and why the
+answer is a durable marker rather than a fail-closed hook.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _notify import notify as _raw_notify  # noqa: E402
+
+
+def _emit(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def note_failure(db_path, exc: BaseException, *, stage: str) -> None:
+    """Count a failed trail write and say so, at most once a minute."""
+    try:
+        from vaara.audit.write_failure import failure_banner, record_failure
+
+        state = record_failure(db_path, exc, stage=stage)
+        if state is None:
+            _emit(f"vaara-governance: trail write failed ({exc!r}); NOT recording.")
+            return
+        if state.get("notify"):
+            _emit(failure_banner(state))
+            _raw_notify(
+                "TRAIL NOT RECORDING", "audit trail",
+                f"{state.get('count', '?')} failed writes since "
+                f"{state.get('first_failure_utc', 'an unknown time')}",
+            )
+    except Exception:
+        # Reporting a failure must never become the failure.
+        pass
+
+
+def report(db_path, existed: bool) -> None:
+    """Once per session: a standing outage, else whether the file reads clean."""
+    try:
+        from vaara.audit.write_failure import (
+            active_failure, failure_banner, quick_check,
+        )
+
+        state = active_failure(db_path)
+        if state is not None:
+            _emit(failure_banner(state))
+            _raw_notify(
+                "TRAIL NOT RECORDING", "audit trail",
+                f"{state.get('count', '?')} failed writes since "
+                f"{state.get('first_failure_utc', 'an unknown time')}",
+            )
+            return
+        if not existed:
+            return
+        problem = quick_check(db_path)
+        if problem is not None:
+            _emit(
+                f"vaara-governance: the audit trail at {db_path} does not read "
+                f"clean ({problem}). Records may not be persisting. Check it with "
+                f"`sqlite3 {db_path} 'PRAGMA integrity_check'` and recover with "
+                "`.recover`. Do not delete the file, it is the evidence."
+            )
+            _raw_notify("TRAIL DAMAGED", "audit trail", problem)
+    except Exception:
+        pass

--- a/plugins/claude-code-vaara-governance/hooks/post_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/post_tool_use.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 import _config  # noqa: E402
+import _trail_health  # noqa: E402
 
 CFG = _config.load_config()
 
@@ -102,9 +103,13 @@ def main() -> int:
     if not db_path.exists():
         return 0
 
-    backend = SQLiteAuditBackend(db_path)
-    trail = backend.load_trail()
-    trail._on_record = backend.write_record
+    try:
+        backend = SQLiteAuditBackend(db_path)
+        trail = backend.load_trail()
+        trail._on_record = backend.write_record
+    except Exception as exc:
+        _trail_health.note_failure(db_path, exc, stage="open")
+        return 0
 
     target_action_id = None
     for record in reversed(trail._records):
@@ -125,7 +130,8 @@ def main() -> int:
         pipeline = InterceptionPipeline(trail=trail)
         pipeline._pending_outcomes[target_action_id] = (0.5, {})
         pipeline.report_outcome(target_action_id, outcome_severity=severity)
-    except Exception:
+    except Exception as exc:
+        _trail_health.note_failure(db_path, exc, stage="post_tool_use")
         return 0
     return 0
 

--- a/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
+++ b/plugins/claude-code-vaara-governance/hooks/pre_tool_use.py
@@ -36,6 +36,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 import _config  # noqa: E402
 from _deny_patterns import load_deny_rules, match_deny_rule  # noqa: E402
 from _notify import notify as _raw_notify  # noqa: E402
+from _trail_health import note_failure  # noqa: E402
 
 CFG = _config.load_config()
 
@@ -81,12 +82,12 @@ def _record_call(
     except ImportError:
         return
     db_path = _audit_db_path()
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    backend = SQLiteAuditBackend(db_path)
-    trail = backend.load_trail()
-    trail._on_record = backend.write_record
-    pipeline = InterceptionPipeline(trail=trail, enforce=False)
     try:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        backend = SQLiteAuditBackend(db_path)
+        trail = backend.load_trail()
+        trail._on_record = backend.write_record
+        pipeline = InterceptionPipeline(trail=trail, enforce=False)
         pipeline.intercept(
             agent_id=agent_id,
             tool_name=tool_name,
@@ -94,8 +95,12 @@ def _record_call(
             context=context,
             session_id=session_id,
         )
-    except Exception:
-        pass
+    except Exception as exc:
+        # Fail-open, and say so. Opening the trail used to sit outside this
+        # try, so an unreadable audit.db took the hook down with a traceback;
+        # everything after it was swallowed whole and the trail could stop
+        # recording without anything saying it had.
+        note_failure(db_path, exc, stage="record_call")
 
 
 def _classify_mcp(
@@ -126,10 +131,14 @@ def _classify_mcp(
         return 2
 
     db_path = _audit_db_path()
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    backend = SQLiteAuditBackend(db_path)
-    trail = backend.load_trail()
-    trail._on_record = backend.write_record
+    try:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        backend = SQLiteAuditBackend(db_path)
+        trail = backend.load_trail()
+        trail._on_record = backend.write_record
+    except Exception as exc:
+        note_failure(db_path, exc, stage="open")
+        return 0
     pipeline = InterceptionPipeline(trail=trail, enforce=not shadow)
 
     preset = _config.protection_preset(CFG)

--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 import _config  # noqa: E402
+import _trail_health  # noqa: E402
 
 CFG = _config.load_config()
 
@@ -104,6 +105,7 @@ def main() -> int:
         db_state = "existing" if existed else "created"
     except Exception as exc:
         db_state = f"unavailable ({exc!r})"
+        _trail_health.note_failure(db_path, exc, stage="open")
 
     disclosure = ""
     statement = _config.article50_statement(CFG)
@@ -117,6 +119,7 @@ def main() -> int:
         f"notifications={notif}, audit_db={db_path} [{db_state}]{disclosure}). "
         f"Settings: /vaara-setup"
     )
+    _trail_health.report(db_path, existed)
     return 0
 
 

--- a/plugins/claude-code-vaara-governance/hooks/session_start.py
+++ b/plugins/claude-code-vaara-governance/hooks/session_start.py
@@ -97,6 +97,7 @@ def main() -> int:
     notif = "on" if _config.notifications_enabled(CFG) else "off"
     db_path = _audit_db_path()
     existed = db_path.exists()
+    reported = False
     try:
         from vaara.audit.sqlite_backend import SQLiteAuditBackend
 
@@ -106,6 +107,9 @@ def main() -> int:
     except Exception as exc:
         db_state = f"unavailable ({exc!r})"
         _trail_health.note_failure(db_path, exc, stage="open")
+        # note_failure already printed the banner for this marker. Reporting
+        # again below would say the same thing twice.
+        reported = True
 
     disclosure = ""
     statement = _config.article50_statement(CFG)
@@ -119,7 +123,8 @@ def main() -> int:
         f"notifications={notif}, audit_db={db_path} [{db_state}]{disclosure}). "
         f"Settings: /vaara-setup"
     )
-    _trail_health.report(db_path, existed)
+    if not reported:
+        _trail_health.report(db_path, existed)
     return 0
 
 

--- a/src/vaara/audit/sqlite_backend.py
+++ b/src/vaara/audit/sqlite_backend.py
@@ -430,6 +430,17 @@ class SQLiteAuditBackend:
     _WAL_RETRY_SLEEP = 0.05
 
     @property
+    def db_path(self) -> Path:
+        """The file this trail is stored in.
+
+        Public because callers outside the backend need to name the trail:
+        the failure marker in :mod:`vaara.audit.write_failure` lives beside
+        it, and an operator-facing message about a trail that is not
+        recording is not much use without the path.
+        """
+        return self._db_path
+
+    @property
     def journal_mode(self) -> str:
         """The journal mode this trail is actually running in, lowercased."""
         with self._lock:

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -39,6 +39,7 @@ from typing import Any, Callable, Optional
 
 from vaara._decision_vocabulary import FINE_TO_COARSE, REFINEMENTS
 from vaara._sanitize import json_safe, strict_json_dumps
+from vaara.audit.write_failure import mark_recovered, record_failure
 from vaara.taxonomy.actions import ActionRequest, RegulatoryDomain
 
 logger = logging.getLogger(__name__)
@@ -596,6 +597,14 @@ class AuditTrail:
         # surfaces only at next load_trail. Article 12(2) compliance asks
         # for active detection, not forensic-only.
         self._persistence_failures = 0
+        # This counter is per-process, and the Claude Code hook is a fresh
+        # process per tool call, so on that deployment it can never exceed 1.
+        # That is why the 2026-08-22 outage ran thirteen days without crossing
+        # any threshold. The durable count lives beside the database file; see
+        # vaara.audit.write_failure. False means "the marker has not been
+        # consulted since the last failure", so the first successful write
+        # after a failure is the one that clears it.
+        self._write_marker_checked = False
         # Count of rows loaded as skeletons during load_trail because
         # their data/regulatory JSON columns were corrupt. Parallel
         # signal to persistence_failures but for the READ path — an ops
@@ -1780,36 +1789,23 @@ class AuditTrail:
                         # only evidence that this discontinuity is somebody
                         # else's record rather than a missing one.
                         self._store_anchors[record.record_id] = head
-                except Exception:
+                except Exception as exc:
                     # Store rejected the write. Keep the in-memory chain
                     # coherent off the local head and count the divergence,
                     # exactly as the on_record path below does.
                     _stamp(self._last_hash)
-                    self._persistence_failures += 1
-                    logger.exception(
-                        "append_record failed for record %s "
-                        "(persistent store now out of sync with in-memory "
-                        "chain; failure count=%d)",
-                        record.record_id,
-                        self._persistence_failures,
-                    )
+                    self._note_persistence_failure(record, exc, "append_record")
+                else:
+                    self._note_persistence_ok()
             else:
                 _stamp(self._last_hash)
                 if self._on_record:
                     try:
                         self._on_record(record)
-                    except Exception:
-                        # logger.exception preserves the stack trace so ops can
-                        # diagnose disk-full / locked-DB / permission errors
-                        # instead of seeing a bare error line.
-                        self._persistence_failures += 1
-                        logger.exception(
-                            "on_record callback failed for record %s "
-                            "(persistent store now out of sync with in-memory "
-                            "chain; failure count=%d)",
-                            record.record_id,
-                            self._persistence_failures,
-                        )
+                    except Exception as exc:
+                        self._note_persistence_failure(record, exc, "on_record")
+                    else:
+                        self._note_persistence_ok()
 
             self._last_hash = record.record_hash
             self._records.append(record)
@@ -1826,6 +1822,73 @@ class AuditTrail:
         if target is not None and hasattr(target, "append_record"):
             return target
         return None
+
+    def _persistence_path(self):
+        """The file the failure marker belongs beside, or ``None``.
+
+        An in-memory trail, a plain callable sink and a test double all
+        return ``None``, and every function in ``write_failure`` treats that
+        as "nowhere to report, do nothing".
+        """
+        for target in (self._backend, getattr(self._on_record, "__self__", None)):
+            if target is None:
+                continue
+            path = getattr(target, "db_path", None)
+            if path is None:
+                path = getattr(target, "_db_path", None)
+            if path is not None:
+                return path
+        return None
+
+    def _note_persistence_failure(self, record: AuditRecord, exc: BaseException,
+                                  stage: str) -> None:
+        """Record a failed persist so it is visible past this process.
+
+        The old behaviour was ``logger.exception`` on every record. That is
+        what hid the 2026-08-22 outage for thirteen days: a traceback per tool
+        call reads as normal hook noise within minutes, and the in-process
+        counter beside it could never climb because the hook is a new process
+        each call. So the stack trace is kept for the first failure of an
+        outage, where it is the diagnosis, and every failure after it is one
+        line that says the trail is not recording. The count that matters
+        lives in the marker file.
+        """
+        self._persistence_failures += 1
+        self._write_marker_checked = False
+        state = record_failure(self._persistence_path(), exc, stage=stage)
+        count = state.get("count", self._persistence_failures) if state else \
+            self._persistence_failures
+        if count <= 1:
+            logger.exception(
+                "%s failed for record %s (persistent store now out of sync "
+                "with in-memory chain; failure count=%d)",
+                stage, record.record_id, count,
+            )
+        else:
+            logger.error(
+                "%s failed for record %s: %s — THE TRAIL IS NOT RECORDING "
+                "(%d failed writes since %s)",
+                stage, record.record_id, exc, count,
+                state.get("first_failure_utc", "an unknown time") if state else "?",
+            )
+
+    def _note_persistence_ok(self) -> None:
+        """Clear an outage marker once, on the first write that succeeds.
+
+        Checked at most once per trail instance, and re-armed by the next
+        failure, so the steady state costs nothing.
+        """
+        if self._write_marker_checked:
+            return
+        self._write_marker_checked = True
+        state = mark_recovered(self._persistence_path())
+        if state:
+            logger.warning(
+                "the audit trail at %s is recording again after %s failed "
+                "write(s) starting %s",
+                state.get("db"), state.get("count", "?"),
+                state.get("first_failure_utc", "an unknown time"),
+            )
 
     def _get_regulatory_articles(
         self,

--- a/src/vaara/audit/write_failure.py
+++ b/src/vaara/audit/write_failure.py
@@ -63,6 +63,19 @@ def _utc(ts: float) -> str:
     return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _as_float(value: Any, default: float) -> float:
+    """A timestamp read back out of the marker, or ``default``.
+
+    Marker files are edited by hand often enough (an operator looking at why
+    a trail went quiet) that every field has to survive being the wrong type.
+    ``bool`` is excluded on purpose: it is an ``int`` to Python, and ``True``
+    as a timestamp would put the first failure in 1970.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    return float(value)
+
+
 def _describe(error: Any) -> str:
     if isinstance(error, BaseException):
         text = f"{type(error).__name__}: {error}"
@@ -141,22 +154,18 @@ def record_failure(
     previous = read_marker(db_path) or {}
     resolved = bool(previous.get("resolved"))
 
-    count = previous.get("count")
+    stored = previous.get("count")
     # A resolved marker describes a finished outage. The next failure is a new
-    # one, so it starts its own count and its own clock rather than inheriting
-    # a total that spans a working period in between.
-    if resolved or not isinstance(count, int) or isinstance(count, bool) or count < 1:
+    # one, so it starts its own count and its own clock. Inheriting the old
+    # total would span a working period in between and overstate the gap.
+    if resolved or isinstance(stored, bool) or not isinstance(stored, int) or stored < 1:
         count = 1
         first = now
         last_notified = 0.0
     else:
-        count += 1
-        first = previous.get("first_failure")
-        if not isinstance(first, (int, float)) or isinstance(first, bool):
-            first = now
-        last_notified = previous.get("last_notified")
-        if not isinstance(last_notified, (int, float)) or isinstance(last_notified, bool):
-            last_notified = 0.0
+        count = stored + 1
+        first = _as_float(previous.get("first_failure"), now)
+        last_notified = _as_float(previous.get("last_notified"), 0.0)
 
     notify = count == 1 or (now - last_notified) >= notify_interval
     state = {

--- a/src/vaara/audit/write_failure.py
+++ b/src/vaara/audit/write_failure.py
@@ -28,6 +28,17 @@ not the exit code.
 
 Nothing here raises. A failure to report a failure must not become the
 failure, and a read-only directory must not stop the agent from working.
+
+**The count is a lower bound, and deliberately so.** Two hook processes that
+fail at the same moment can read the same count and both write ``n + 1``, so
+one of the two is lost. Marker writes go through ``os.replace``, so a reader
+never sees a half-written file, but there is no lock across processes. That
+is acceptable because the operator signal is the marker's existence and its
+``first_failure`` time, and both survive the race: whichever writer lands
+last still carries the earliest start it read. An exact ledger of failed
+writes would need a lock on the reporting path for the sake of a number
+nobody acts on, on a machine that is already having a bad time. The trail
+itself is the ledger, and this file is the smoke alarm.
 """
 
 from __future__ import annotations

--- a/src/vaara/audit/write_failure.py
+++ b/src/vaara/audit/write_failure.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""A trail that stops recording has to say so somewhere durable.
+
+Found 2026-09-04 on the maintainer's own machine: the Claude Code hook had
+been unable to write a single audit record since 2026-08-22, thirteen days.
+Every attempt raised ``sqlite3.DatabaseError: database disk image is
+malformed``, printed a full traceback to stderr, and exited 0. The host read
+that as success and carried on. Nothing anywhere said the trail was dead, and
+it was found only because someone went looking for an unrelated reason.
+
+Two things made it invisible, and both are addressed here rather than by
+making the hook fail closed:
+
+* **The signal was per-record noise.** A traceback on every tool call reads
+  as normal output within minutes. Volume is not visibility.
+* **The counter could not count.** ``AuditTrail._persistence_failures`` is
+  per-process, and the hook is a fresh process per tool call, so it could
+  never exceed 1. Nothing accumulated, so nothing crossed a threshold.
+
+So the state lives next to the trail, in ``<db>.write-failure.json``. It
+survives the process, it accumulates, and the session-start hook reads it and
+says the trail is not recording in those words.
+
+Fail-open stays. A governance hook that blocks a session gets uninstalled,
+and an uninstalled hook records nothing at all. The defect was the silence,
+not the exit code.
+
+Nothing here raises. A failure to report a failure must not become the
+failure, and a read-only directory must not stop the agent from working.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Suffix appended to the database filename to locate its marker.
+MARKER_SUFFIX = ".write-failure.json"
+
+#: Minimum gap between loud, operator-facing notifications about the same
+#: outage. The first failure always notifies; after that, once a minute is
+#: enough to stay visible without becoming the noise it replaced.
+NOTIFY_INTERVAL_SECONDS = 60.0
+
+#: ``PRAGMA quick_check`` reads the whole file, so it is a startup check only
+#: while the file is small enough for that to be cheap. Above this it is
+#: skipped rather than made into a session-start stall.
+QUICK_CHECK_MAX_BYTES = 512 * 1024 * 1024
+
+_ERROR_LIMIT = 300
+
+
+def _utc(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _describe(error: Any) -> str:
+    if isinstance(error, BaseException):
+        text = f"{type(error).__name__}: {error}"
+    else:
+        text = str(error)
+    text = " ".join(text.split())
+    return text[:_ERROR_LIMIT]
+
+
+def marker_path(db_path: Any) -> Optional[Path]:
+    """Where the marker for ``db_path`` lives, or ``None`` if it cannot have one.
+
+    In-memory databases have no directory to put it in, and there is no
+    operator watching one either: they are tests and short-lived tools.
+    """
+    if db_path is None:
+        return None
+    text = str(db_path)
+    if not text or text == ":memory:" or text.startswith("file::memory:"):
+        return None
+    path = Path(text).expanduser()
+    return path.with_name(path.name + MARKER_SUFFIX)
+
+
+def read_marker(db_path: Any) -> Optional[dict]:
+    """The marker state for ``db_path``, resolved or not, or ``None``."""
+    path = marker_path(db_path)
+    if path is None:
+        return None
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return state if isinstance(state, dict) else None
+
+
+def active_failure(db_path: Any) -> Optional[dict]:
+    """The marker only while the trail is still failing to record.
+
+    This is the question the session-start hook asks, and it is deliberately
+    not "has this trail ever failed": a resolved marker is forensics and
+    stays on disk, but nagging about a fixed outage every session is how a
+    banner gets tuned out.
+    """
+    state = read_marker(db_path)
+    if state is None or state.get("resolved"):
+        return None
+    return state
+
+
+def _write_marker(path: Path, state: dict) -> None:
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def record_failure(
+    db_path: Any,
+    error: Any,
+    *,
+    stage: str = "append",
+    notify_interval: float = NOTIFY_INTERVAL_SECONDS,
+) -> Optional[dict]:
+    """Count one failed write against ``db_path`` and return the running state.
+
+    Returns ``None`` only when there is nowhere to keep state (an in-memory
+    trail). The returned dict carries a ``notify`` key the caller uses to
+    decide whether to say anything out loud this time; it is derived, not
+    stored.
+    """
+    path = marker_path(db_path)
+    if path is None:
+        return None
+
+    now = time.time()
+    previous = read_marker(db_path) or {}
+    resolved = bool(previous.get("resolved"))
+
+    count = previous.get("count")
+    # A resolved marker describes a finished outage. The next failure is a new
+    # one, so it starts its own count and its own clock rather than inheriting
+    # a total that spans a working period in between.
+    if resolved or not isinstance(count, int) or isinstance(count, bool) or count < 1:
+        count = 1
+        first = now
+        last_notified = 0.0
+    else:
+        count += 1
+        first = previous.get("first_failure")
+        if not isinstance(first, (int, float)) or isinstance(first, bool):
+            first = now
+        last_notified = previous.get("last_notified")
+        if not isinstance(last_notified, (int, float)) or isinstance(last_notified, bool):
+            last_notified = 0.0
+
+    notify = count == 1 or (now - last_notified) >= notify_interval
+    state = {
+        "db": str(db_path),
+        "stage": stage,
+        "error": _describe(error),
+        "count": count,
+        "first_failure": first,
+        "first_failure_utc": _utc(first),
+        "last_failure": now,
+        "last_failure_utc": _utc(now),
+        "last_notified": now if notify else last_notified,
+        "pid": os.getpid(),
+        "resolved": False,
+    }
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _write_marker(path, state)
+    except OSError as exc:
+        # The marker is the durable half. Losing it means the caller's own
+        # log line is the only signal left, so say that once rather than
+        # letting the reporting path fail silently in its turn.
+        logger.warning(
+            "could not write the audit-trail failure marker at %s (%s); "
+            "the trail write failure will only be visible in this process",
+            path, exc,
+        )
+
+    return dict(state, notify=notify)
+
+
+def mark_recovered(db_path: Any) -> Optional[dict]:
+    """Flip an active marker to resolved after a write succeeds.
+
+    Returns the state that was resolved, or ``None`` when there was no active
+    failure. The file is kept and stamped rather than deleted: it is the only
+    record of how long the trail was not recording, and on a product whose
+    argument is that an absent record must not read as an absent action,
+    deleting that would be the same mistake one layer up.
+    """
+    path = marker_path(db_path)
+    if path is None:
+        return None
+    state = active_failure(db_path)
+    if state is None:
+        return None
+
+    now = time.time()
+    state = dict(
+        state,
+        resolved=True,
+        resolved_at=now,
+        resolved_at_utc=_utc(now),
+        resolved_by_pid=os.getpid(),
+    )
+    try:
+        _write_marker(path, state)
+    except OSError as exc:
+        logger.warning("could not stamp the recovered failure marker at %s (%s)", path, exc)
+    return state
+
+
+#: The banner has to fit on a terminal line or two, and some of the errors it
+#: quotes are paragraphs (``AuditBackendUnreadable`` explains recovery in full).
+#: The marker keeps the longer form for whoever goes looking.
+_BANNER_ERROR_LIMIT = 140
+
+
+def failure_banner(state: dict) -> str:
+    """One operator-facing line. Says what is not happening, not what threw."""
+    error = str(state.get("error", "unknown error"))
+    if len(error) > _BANNER_ERROR_LIMIT:
+        error = error[:_BANNER_ERROR_LIMIT].rstrip() + "..."
+    return (
+        "vaara-governance: THE AUDIT TRAIL IS NOT RECORDING. "
+        f"{state.get('count', '?')} write(s) have failed since "
+        f"{state.get('first_failure_utc', 'an unknown time')} "
+        f"({state.get('stage', 'append')}: {error}). "
+        "Tool calls are still running and are NOT being recorded. "
+        f"Trail: {state.get('db', 'unknown')}. "
+        "Check it with `sqlite3 <db> 'PRAGMA integrity_check'` and recover with "
+        "`.recover`. Do not delete the file, it is the evidence."
+    )
+
+
+def quick_check(
+    db_path: Any, *, max_bytes: int = QUICK_CHECK_MAX_BYTES
+) -> Optional[str]:
+    """``None`` when the database reads clean, else a one-line description.
+
+    Read-only, and cheap enough to run once at session start. This catches the
+    case the marker cannot: a trail damaged while nothing was writing to it,
+    where the first failure would otherwise be the next record nobody watches.
+    """
+    path = marker_path(db_path)
+    if path is None:
+        return None
+    db = Path(str(db_path)).expanduser()
+    try:
+        if not db.is_file():
+            return None
+        if db.stat().st_size > max_bytes:
+            logger.debug("skipping quick_check on %s: larger than %d bytes", db, max_bytes)
+            return None
+        uri = f"{db.resolve().as_uri()}?mode=ro"
+        conn = sqlite3.connect(uri, uri=True, timeout=2.0)
+    except (OSError, ValueError, sqlite3.Error) as exc:
+        return f"unreadable ({_describe(exc)})"
+
+    try:
+        rows = conn.execute("PRAGMA quick_check(1)").fetchall()
+    except sqlite3.Error as exc:
+        return f"unreadable ({_describe(exc)})"
+    finally:
+        conn.close()
+
+    results = [str(row[0]) for row in rows if row]
+    if not results or results == ["ok"]:
+        return None
+    return _describe("; ".join(results))

--- a/src/vaara/integrations/claude_code_hooks.py
+++ b/src/vaara/integrations/claude_code_hooks.py
@@ -549,12 +549,18 @@ def run_session_start() -> int:
     notif = "on" if notifications_enabled(cfg) else "off"
     db_path = audit_db_path(cfg)
     existed = db_path.exists()
+    reported = False
     try:
         _open_trail(cfg)
         db_state = "existing" if existed else "created"
     except Exception as exc:
         db_state = f"unavailable ({exc!r})"
         _note_trail_failure(cfg, exc, stage="open")
+        # That call already printed the banner and fired the notification for
+        # this exact marker. Letting the health report print it again would
+        # make session start say the same thing three times, which is the
+        # noise this whole change exists to remove.
+        reported = True
 
     disclosure = ""
     statement = article50_statement(cfg)
@@ -588,7 +594,8 @@ def run_session_start() -> int:
         f"protection={preset}, notifications={notif}, audit_db={db_path} "
         f"[{db_state}]{disclosure}). Settings: /vaara-setup"
     )
-    _report_trail_health(cfg, db_path, existed)
+    if not reported:
+        _report_trail_health(cfg, db_path, existed)
     return 0
 
 
@@ -625,4 +632,7 @@ def _report_trail_health(cfg: dict, db_path: Path, existed: bool) -> None:
             )
             notify(cfg, "TRAIL DAMAGED", "audit trail", problem)
     except Exception:
+        # Reporting on the trail's health must never break the session it is
+        # reporting to. There is nowhere left to escalate to from here: the
+        # thing that would carry the error is the trail itself.
         pass

--- a/src/vaara/integrations/claude_code_hooks.py
+++ b/src/vaara/integrations/claude_code_hooks.py
@@ -288,7 +288,36 @@ def _record_call(cfg: dict, agent: str, tool_name: str, tool_input: dict,
             agent_id=agent, tool_name=tool_name, parameters=tool_input,
             context=context, session_id=session_id,
         )
+    except Exception as exc:
+        _note_trail_failure(cfg, exc, stage="record_call")
+
+
+def _note_trail_failure(cfg: dict, exc: BaseException, *, stage: str) -> None:
+    """Say the trail is not recording, in those words, without blocking.
+
+    The call still goes through: fail-open is the right default, because a
+    governance hook that stops the session gets uninstalled and an
+    uninstalled hook records nothing at all. What changes is that the
+    operator finds out. Rate-limited by the marker, so a persistent outage
+    stays one visible line a minute instead of the per-call traceback that
+    hid this failure mode for thirteen days.
+    """
+    try:
+        from vaara.audit.write_failure import failure_banner, record_failure
+
+        state = record_failure(audit_db_path(cfg), exc, stage=stage)
+        if state is None:
+            _emit(f"vaara-governance: trail write failed ({exc!r}); NOT recording.")
+            return
+        if state.get("notify"):
+            _emit(failure_banner(state))
+            notify(
+                cfg, "TRAIL NOT RECORDING", "audit trail",
+                f"{state.get('count', '?')} failed writes since "
+                f"{state.get('first_failure_utc', 'an unknown time')}",
+            )
     except Exception:
+        # Reporting a failure must never become the failure.
         pass
 
 
@@ -338,7 +367,15 @@ def run_pre_tool_use(deny_patterns: Optional[str] = None) -> int:
 
     from vaara.pipeline import InterceptionPipeline
 
-    pipeline = InterceptionPipeline(trail=_open_trail(cfg), enforce=not shadow)
+    try:
+        trail = _open_trail(cfg)
+    except Exception as exc:
+        # A trail that will not open used to take the hook down with it, with
+        # a traceback and no statement of what that meant. Pass the call
+        # through, and say plainly that it is not being recorded.
+        _note_trail_failure(cfg, exc, stage="open")
+        return 0
+    pipeline = InterceptionPipeline(trail=trail, enforce=not shadow)
 
     preset = protection_preset(cfg)
     custom = custom_thresholds(cfg)
@@ -490,7 +527,8 @@ def run_post_tool_use() -> int:
         pipeline = InterceptionPipeline(trail=trail)
         pipeline._pending_outcomes[target_action_id] = (0.5, {})
         pipeline.report_outcome(target_action_id, outcome_severity=severity)
-    except Exception:
+    except Exception as exc:
+        _note_trail_failure(cfg, exc, stage="post_tool_use")
         return 0
     return 0
 
@@ -516,6 +554,7 @@ def run_session_start() -> int:
         db_state = "existing" if existed else "created"
     except Exception as exc:
         db_state = f"unavailable ({exc!r})"
+        _note_trail_failure(cfg, exc, stage="open")
 
     disclosure = ""
     statement = article50_statement(cfg)
@@ -549,4 +588,41 @@ def run_session_start() -> int:
         f"protection={preset}, notifications={notif}, audit_db={db_path} "
         f"[{db_state}]{disclosure}). Settings: /vaara-setup"
     )
+    _report_trail_health(cfg, db_path, existed)
     return 0
+
+
+def _report_trail_health(cfg: dict, db_path: Path, existed: bool) -> None:
+    """Once per session, on the line the operator already reads.
+
+    Two questions, in order. Has this trail been failing to record — the
+    marker knows, across processes, which is the thing nothing knew on
+    2026-08-22. And if not, does the file still read clean — which catches a
+    trail damaged while nothing was writing to it, where the first symptom
+    would otherwise be the next record nobody is watching.
+    """
+    try:
+        from vaara.audit.write_failure import active_failure, failure_banner, quick_check
+
+        state = active_failure(db_path)
+        if state is not None:
+            _emit(failure_banner(state))
+            notify(
+                cfg, "TRAIL NOT RECORDING", "audit trail",
+                f"{state.get('count', '?')} failed writes since "
+                f"{state.get('first_failure_utc', 'an unknown time')}",
+            )
+            return
+        if not existed:
+            return
+        problem = quick_check(db_path)
+        if problem is not None:
+            _emit(
+                f"vaara-governance: the audit trail at {db_path} does not read "
+                f"clean ({problem}). Records may not be persisting. Check it with "
+                f"`sqlite3 {db_path} 'PRAGMA integrity_check'` and recover with "
+                "`.recover`. Do not delete the file, it is the evidence."
+            )
+            notify(cfg, "TRAIL DAMAGED", "audit trail", problem)
+    except Exception:
+        pass

--- a/tests/test_trail_write_failure.py
+++ b/tests/test_trail_write_failure.py
@@ -1,0 +1,389 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The trail stopped recording for thirteen days and nothing said so.
+
+Found 2026-09-04: ``vaara hook pre-tool-use`` had raised
+``sqlite3.DatabaseError: database disk image is malformed`` on every insert
+since 2026-08-22, printed a traceback, and exited 0. These tests pin the two
+things that made that invisible — a per-record traceback nobody reads, and a
+failure counter that lived in a process which exits after every tool call —
+and they pin that fail-open behaviour is unchanged.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from vaara.audit import write_failure as wf
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.audit.trail import AuditTrail, EventType
+from vaara.integrations import claude_code_hooks as hooks
+from vaara.taxonomy.actions import UNKNOWN_ACTION, ActionRequest
+
+
+def _request(tool_name: str = "Bash") -> ActionRequest:
+    return ActionRequest(
+        agent_id="claude-code", tool_name=tool_name,
+        action_type=UNKNOWN_ACTION, parameters={"command": "ls " * 20},
+    )
+
+
+def _populated_trail(tmp_path: Path, records: int = 300) -> Path:
+    """A real audit.db with enough records to span several SQLite pages."""
+    db = tmp_path / "audit.db"
+    backend = SQLiteAuditBackend(db)
+    trail = backend.load_trail()
+    trail._on_record = backend.write_record
+    for _ in range(records):
+        trail.record_action_requested(_request())
+    backend.checkpoint_wal()
+    backend.close()
+    return db
+
+
+def _corrupt_a_later_page(db: Path) -> None:
+    """Zero one B-tree page, leaving the header readable.
+
+    This is the shape of the 2026-08-22 damage: not a file that is obviously
+    not a database, but a real trail with a hole in it.
+    """
+    data = bytearray(db.read_bytes())
+    assert len(data) > 12288, "need a trail with more than three pages to damage one"
+    data[8192:12288] = b"\x00" * 4096
+    db.write_bytes(bytes(data))
+
+
+# ── the marker itself ─────────────────────────────────────────────────────
+
+class TestMarkerPath:
+    def test_sits_next_to_the_database(self, tmp_path: Path):
+        assert wf.marker_path(tmp_path / "audit.db") == (
+            tmp_path / "audit.db.write-failure.json"
+        )
+
+    @pytest.mark.parametrize("db", [None, "", ":memory:", "file::memory:?cache=shared"])
+    def test_no_marker_where_there_is_no_file(self, db):
+        assert wf.marker_path(db) is None
+
+    def test_an_in_memory_trail_reports_nowhere_and_does_not_raise(self):
+        assert wf.record_failure(":memory:", RuntimeError("boom")) is None
+        assert wf.active_failure(":memory:") is None
+        assert wf.mark_recovered(":memory:") is None
+        assert wf.quick_check(":memory:") is None
+
+
+class TestRecordFailure:
+    def test_the_first_failure_writes_a_marker(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        state = wf.record_failure(db, sqlite3.DatabaseError("database disk image is malformed"))
+
+        assert state["count"] == 1
+        assert state["notify"] is True
+        assert state["resolved"] is False
+        assert "malformed" in state["error"]
+        on_disk = json.loads((tmp_path / "audit.db.write-failure.json").read_text())
+        assert on_disk["count"] == 1
+        # `notify` is a decision for the caller, not persisted state.
+        assert "notify" not in on_disk
+
+    def test_the_count_survives_the_process_that_wrote_it(self, tmp_path: Path):
+        """The defect in one line: the old counter could never reach 2.
+
+        ``AuditTrail._persistence_failures`` is per-process and the hook is a
+        fresh process per tool call, so nothing accumulated. The marker is
+        read back off disk, so it does.
+        """
+        db = tmp_path / "audit.db"
+        for _ in range(5):
+            state = wf.record_failure(db, RuntimeError("still broken"))
+        assert state["count"] == 5
+
+    def test_the_clock_starts_at_the_first_failure_not_the_last(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        first = wf.record_failure(db, RuntimeError("x"))
+        time.sleep(0.01)
+        later = wf.record_failure(db, RuntimeError("x"))
+
+        assert later["first_failure"] == first["first_failure"]
+        assert later["last_failure"] > later["first_failure"]
+
+    def test_repeat_failures_stay_quiet_until_the_interval_passes(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        assert wf.record_failure(db, RuntimeError("x"))["notify"] is True
+        assert wf.record_failure(db, RuntimeError("x"))["notify"] is False
+        assert wf.record_failure(db, RuntimeError("x"), notify_interval=0)["notify"] is True
+
+    def test_a_new_outage_after_a_recovery_starts_its_own_count(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        wf.record_failure(db, RuntimeError("x"))
+        wf.record_failure(db, RuntimeError("x"))
+        wf.mark_recovered(db)
+
+        fresh = wf.record_failure(db, RuntimeError("x"))
+        assert fresh["count"] == 1, "a resolved outage must not inflate the next one"
+        assert fresh["notify"] is True
+
+    def test_an_unwritable_directory_does_not_raise(self, tmp_path: Path):
+        blocked = tmp_path / "nodir"
+        blocked.write_text("i am a file, not a directory")
+        assert wf.record_failure(blocked / "audit.db", RuntimeError("x")) is not None
+
+    def test_a_corrupt_marker_is_treated_as_no_marker(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        (tmp_path / "audit.db.write-failure.json").write_text("{not json")
+        assert wf.read_marker(db) is None
+        assert wf.record_failure(db, RuntimeError("x"))["count"] == 1
+
+
+class TestRecovery:
+    def test_recovery_clears_the_active_signal(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        wf.record_failure(db, RuntimeError("x"))
+        assert wf.active_failure(db) is not None
+
+        resolved = wf.mark_recovered(db)
+        assert resolved["resolved"] is True
+        assert wf.active_failure(db) is None
+
+    def test_recovery_keeps_the_record_of_the_outage(self, tmp_path: Path):
+        """Deleting it would be the same mistake the product argues against."""
+        db = tmp_path / "audit.db"
+        wf.record_failure(db, RuntimeError("x"))
+        wf.mark_recovered(db)
+
+        marker = tmp_path / "audit.db.write-failure.json"
+        assert marker.exists()
+        assert json.loads(marker.read_text())["count"] == 1
+
+    def test_recovering_twice_is_a_no_op(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        wf.record_failure(db, RuntimeError("x"))
+        assert wf.mark_recovered(db) is not None
+        assert wf.mark_recovered(db) is None
+
+
+class TestQuickCheck:
+    def test_a_healthy_trail_reads_clean(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        backend = SQLiteAuditBackend(db)
+        backend.close()
+        assert wf.quick_check(db) is None
+
+    def test_a_file_that_is_not_a_database_is_reported(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        db.write_bytes(b"\x00" * 8192)
+        assert wf.quick_check(db) is not None
+
+    def test_a_real_trail_with_a_damaged_page_is_reported(self, tmp_path: Path):
+        db = _populated_trail(tmp_path)
+        assert wf.quick_check(db) is None
+        _corrupt_a_later_page(db)
+        problem = wf.quick_check(db)
+        assert problem is not None
+        assert "page" in problem
+
+    def test_a_missing_file_is_not_a_failure(self, tmp_path: Path):
+        assert wf.quick_check(tmp_path / "absent.db") is None
+
+    def test_a_large_trail_is_skipped_rather_than_stalling_startup(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        db.write_bytes(b"\x00" * 8192)
+        assert wf.quick_check(db, max_bytes=16) is None
+
+
+# ── the trail's own write path ────────────────────────────────────────────
+
+class _BrokenBackend:
+    """A store whose inserts fail exactly the way 2026-08-22's did."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+
+    def append_record(self, record, stamp):
+        stamp("")
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    def write_record(self, record):  # pragma: no cover - the trail calls append_record
+        self.append_record(record, lambda _prev: None)
+
+
+def _trail_on(backend) -> AuditTrail:
+    trail = AuditTrail(on_record=backend.write_record)
+    trail._backend = backend
+    return trail
+
+
+class TestTrailMarksItsOwnFailures:
+    def test_a_failed_append_leaves_a_marker(self, tmp_path: Path):
+        trail = _trail_on(_BrokenBackend(tmp_path / "audit.db"))
+        trail.record_action_requested(_request())
+        state = wf.active_failure(tmp_path / "audit.db")
+        assert state is not None
+        assert "malformed" in state["error"]
+        assert state["stage"] == "append_record"
+
+    def test_the_trail_still_fails_open(self, tmp_path: Path):
+        """Fail-open is the right default and this change does not touch it."""
+        trail = _trail_on(_BrokenBackend(tmp_path / "audit.db"))
+        for i in range(3):
+            trail.record_action_requested(_request())
+        assert len(trail._records) == 3
+        assert wf.active_failure(tmp_path / "audit.db")["count"] == 3
+
+    def test_only_the_first_failure_carries_a_traceback(self, tmp_path: Path, caplog):
+        """A traceback per tool call is what made the outage read as normal."""
+        trail = _trail_on(_BrokenBackend(tmp_path / "audit.db"))
+        with caplog.at_level(logging.ERROR, logger="vaara.audit.trail"):
+            for i in range(4):
+                trail.record_action_requested(_request())
+
+        with_traceback = [r for r in caplog.records if r.exc_info]
+        assert len(with_traceback) == 1, "one diagnosis, not one per call"
+        assert len(caplog.records) == 4, "every failure is still reported"
+        assert "NOT RECORDING" in caplog.records[-1].getMessage()
+
+    def test_a_working_trail_writes_no_marker(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        backend = SQLiteAuditBackend(db)
+        trail = backend.load_trail()
+        trail._on_record = backend.write_record
+        trail.record_action_requested(_request())
+        backend.close()
+        assert wf.read_marker(db) is None
+
+    def test_the_next_good_write_clears_the_marker(self, tmp_path: Path):
+        db = tmp_path / "audit.db"
+        wf.record_failure(db, sqlite3.DatabaseError("database disk image is malformed"))
+
+        backend = SQLiteAuditBackend(db)
+        trail = backend.load_trail()
+        trail._on_record = backend.write_record
+        trail.record_action_requested(_request())
+        backend.close()
+
+        assert wf.active_failure(db) is None
+        assert wf.read_marker(db)["resolved"] is True
+
+    def test_an_in_memory_trail_is_unaffected(self):
+        trail = AuditTrail()
+        trail.record_action_requested(_request())
+        assert trail._persistence_failures == 0
+        assert len(trail._records) == 1
+
+
+# ── the hook, which is where the operator actually looks ──────────────────
+
+def _feed(monkeypatch: pytest.MonkeyPatch, event: dict) -> None:
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+
+@pytest.fixture
+def audit_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db = tmp_path / "audit.db"
+    monkeypatch.setenv("VAARA_PLUGIN_AUDIT_DB", str(db))
+    monkeypatch.setenv("VAARA_PLUGIN_NOTIFY", "0")
+    return db
+
+
+class TestHookSurfacesTheOutage:
+    def test_a_dead_trail_does_not_block_the_call(self, audit_db, monkeypatch, capsys):
+        audit_db.write_bytes(b"\x00" * 8192)
+        _feed(monkeypatch, {
+            "tool_name": "Bash", "tool_input": {"command": "ls"}, "session_id": "s1",
+        })
+        assert hooks.run_pre_tool_use() == 0
+
+    def test_a_dead_trail_says_so_on_stderr(self, audit_db, monkeypatch, capsys):
+        audit_db.write_bytes(b"\x00" * 8192)
+        _feed(monkeypatch, {
+            "tool_name": "Bash", "tool_input": {"command": "ls"}, "session_id": "s1",
+        })
+        hooks.run_pre_tool_use()
+
+        err = capsys.readouterr().err
+        assert "NOT RECORDING" in err
+        assert "Traceback" not in err
+
+    def test_an_mcp_call_passes_through_a_dead_trail(self, audit_db, monkeypatch):
+        """This path used to take the hook down with an unhandled exception."""
+        audit_db.write_bytes(b"\x00" * 8192)
+        _feed(monkeypatch, {
+            "tool_name": "mcp__github__create_issue",
+            "tool_input": {"title": "x"}, "session_id": "s1",
+        })
+        assert hooks.run_pre_tool_use() == 0
+
+    def test_session_start_reports_a_standing_outage(self, audit_db, monkeypatch, capsys):
+        audit_db.touch()
+        wf.record_failure(audit_db, sqlite3.DatabaseError("database disk image is malformed"))
+        _feed(monkeypatch, {"session_id": "s1"})
+        assert hooks.run_session_start() == 0
+
+        err = capsys.readouterr().err
+        assert "THE AUDIT TRAIL IS NOT RECORDING" in err
+        assert "integrity_check" in err
+
+    def test_session_start_surfaces_a_damaged_trail_with_no_marker(
+        self, audit_db, monkeypatch, capsys
+    ):
+        """A trail damaged while nothing was writing still gets reported."""
+        audit_db.write_bytes(b"\x00" * 8192)
+        _feed(monkeypatch, {"session_id": "s1"})
+        assert hooks.run_session_start() == 0
+
+        err = capsys.readouterr().err
+        assert "integrity_check" in err
+        assert "Do not delete the file" in err
+
+    def test_the_quick_check_branch_reports_a_trail_that_still_opens(
+        self, tmp_path: Path, capsys
+    ):
+        """The belt for damage that no write has hit yet.
+
+        Reached directly because the marker branch runs first, and a trail
+        damaged badly enough to fail to open lands there instead.
+        """
+        db = _populated_trail(tmp_path)
+        _corrupt_a_later_page(db)
+        hooks._report_trail_health({"notifications": False}, db, existed=True)
+        assert "does not read clean" in capsys.readouterr().err
+
+    def test_session_start_on_a_healthy_trail_is_quiet(self, audit_db, monkeypatch, capsys):
+        SQLiteAuditBackend(audit_db).close()
+        _feed(monkeypatch, {"session_id": "s1"})
+        assert hooks.run_session_start() == 0
+
+        err = capsys.readouterr().err
+        assert "NOT RECORDING" not in err
+        assert "does not read clean" not in err
+
+    def test_a_recovered_trail_stops_nagging(self, audit_db, monkeypatch, capsys):
+        SQLiteAuditBackend(audit_db).close()
+        wf.record_failure(audit_db, RuntimeError("x"))
+        wf.mark_recovered(audit_db)
+
+        _feed(monkeypatch, {"session_id": "s1"})
+        hooks.run_session_start()
+        assert "NOT RECORDING" not in capsys.readouterr().err
+
+    def test_the_recorded_event_type_is_unchanged_when_the_trail_works(
+        self, audit_db, monkeypatch
+    ):
+        _feed(monkeypatch, {
+            "tool_name": "Bash", "tool_input": {"command": "ls"}, "session_id": "s1",
+        })
+        assert hooks.run_pre_tool_use() == 0
+        con = sqlite3.connect(audit_db)
+        try:
+            kinds = [row[0] for row in con.execute("select event_type from audit_records")]
+        finally:
+            con.close()
+        assert EventType.ACTION_REQUESTED.value in kinds

--- a/tests/test_trail_write_failure.py
+++ b/tests/test_trail_write_failure.py
@@ -343,6 +343,15 @@ class TestHookSurfacesTheOutage:
         assert "integrity_check" in err
         assert "Do not delete the file" in err
 
+    def test_session_start_says_it_once(self, audit_db, monkeypatch, capsys):
+        """Two banners for one outage would be the noise this change removes."""
+        audit_db.write_bytes(b"\x00" * 8192)
+        _feed(monkeypatch, {"session_id": "s1"})
+        hooks.run_session_start()
+
+        err = capsys.readouterr().err
+        assert err.count("THE AUDIT TRAIL IS NOT RECORDING") == 1
+
     def test_the_quick_check_branch_reports_a_trail_that_still_opens(
         self, tmp_path: Path, capsys
     ):


### PR DESCRIPTION
Found by dogfooding. The plugin hook on the maintainer's own machine had not persisted a single audit record since 2026-08-22. Thirteen days. Every insert raised `sqlite3.DatabaseError: database disk image is malformed`, printed a full traceback to stderr, and exited 0. The host read that as success and carried on.

The corruption itself is already fixed. This PR is about the silence around it.

## Why nothing surfaced it

The signal was a traceback on every tool call, which reads as ordinary hook noise within minutes.

The counter beside it never accumulated. `AuditTrail._persistence_failures` is per-process, and the hook is a fresh process per tool call, so it could never exceed 1 and nothing ever crossed a threshold.

## What changed

`vaara/audit/write_failure.py`, new. The failure state lives beside the database at `<db>.write-failure.json` and holds the first failure time, a running count, the stage, the error and a resolved flag. It survives the process, so it accumulates.

`vaara hook session-start` reads it and says the trail is not recording, in those words, with the count, the start time and the recovery commands. When there is no marker it runs `PRAGMA quick_check`, which catches a trail damaged while nothing was writing to it.

On the write path the stack trace is kept for the first failure of an outage and every failure after it is one line. The first successful write stamps the marker resolved and says so once. The file stays on disk, so how long the trail was down is still readable afterwards.

Opening the trail no longer takes the hook down. An unreadable `audit.db` on the `mcp__*` path raised straight through `PreToolUse`, and in the fallback scripts it raised out of `_record_call` too. Both now pass the call through and report.

The bundled fallback scripts under `plugins/` had the same shape and got the same fix.

## Fail-open is unchanged

Deliberate, and it stays. A governance hook that blocks the session gets uninstalled, and an uninstalled hook records nothing at all. The defect was the silence. A test pins the behaviour.

## Tests

36 new in `tests/test_trail_write_failure.py`, covering the marker, the notify rate limit, recovery, `quick_check`, the trail write path, and all three hooks on both the packaged and fallback paths. Full suite green at 3616 passed, 26 skipped.

Section 10 of draft-sirkkavaara-vaara-receipt makes this argument to other people: an absent record must not be readable as an absent action. This is that failure mode in our own trail, and the fix closes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Audit-trail write failures are now detected across tool calls and reported clearly.
  - Session start reports when recording is unavailable, including failure timing, count, and recovery guidance.
  - Trail integrity is checked when no active failure is present.
  - Audit-trail errors no longer crash tool calls; operations continue in fail-open mode.
  - Successful writes now indicate recovery after an outage.
  - Claude Code hooks correctly record tool outcomes and surface previously missed failures.
- **Documentation**
  - Added unreleased changelog notes describing audit-trail health reporting and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->