### PR TITLE
audit: verify one record's segment without walking the trail

### DIFF
--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -551,6 +551,43 @@ def _narrative_str(val: Any, max_len: int = _NARRATIVE_FIELD_MAX) -> str:
     return s
 
 
+@dataclass
+class SegmentVerification:
+    """The result of :meth:`AuditTrail.verify_segment`.
+
+    ``ok`` is the answer and ``reason`` is why, in both directions: on a pass
+    it states what was covered and what was not, because "verified" alone
+    would let an open segment read as an attested one.
+
+    ``closed`` is the distinction that matters. True means a later anchor's
+    RFC 3161 token attests the end of the segment, so the record existed by the
+    attested time. False means the record chains correctly back to an attested
+    head but nothing external has attested it yet, which is the normal state of
+    anything written since the last anchor.
+
+    ``lower_anchor_position`` of None means the segment starts at genesis
+    (the record sits below the first anchor). ``upper_anchor_position`` of None
+    means the segment is open at the top. ``anchor_gaps`` carries the indices of
+    any ``ANCHOR_GAP`` markers inside the segment: those records verify like any
+    other, but they record a stretch where the time authority was unreachable.
+    """
+
+    ok: bool
+    reason: str = ""
+    record_id: str = ""
+    record_index: int = -1
+    lower_anchor_position: Optional[int] = None
+    upper_anchor_position: Optional[int] = None
+    records_verified: int = 0
+    closed: bool = False
+    anchor_gaps: list[int] = field(default_factory=list)
+    lower_attested_time: Optional[str] = None
+    upper_attested_time: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
 # ── Audit Trail ───────────────────────────────────────────────────────────
 
 class AuditTrail:
@@ -1582,6 +1619,187 @@ class AuditTrail:
         with self._lock:
             self._anchors.append(anchor)
         return anchor
+
+    def verify_segment(
+        self,
+        *,
+        record_id: Optional[str] = None,
+        action_id: Optional[str] = None,
+    ) -> "SegmentVerification":
+        """Verify only the anchored segment holding one record. Exact, not sampled.
+
+        The supervisory question is "show me that this action's record is what
+        it was when it was written", and answering it does not need the whole
+        trail. Anchors already make a segment independently verifiable:
+        ``previous_hash`` is part of the hashed content, so a record cannot be
+        re-parented onto a different hash without breaking its own hash, and
+        the RFC 3161 token over an anchored head verifies offline.
+
+        So the work is two token verifications and the records between the
+        bounding anchors, which is the auto-anchor cadence (32 by default)
+        regardless of how long the trail is. Records below the lower anchor are
+        NOT read and a rewrite down there does not affect this answer; that is
+        the point, and it is what makes this cheaper than a genesis walk rather
+        than a genesis walk with extra steps.
+
+        **This is not a statement about the trail.** It says one segment is
+        intact. Use :meth:`verify_chain` for the whole-chain claim.
+
+        MEASURED on this machine, 32-record cadence, best of five:
+
+            trail    verify_segment   of which id scan   of which 2 tokens
+            5,000        0.74 ms          0.12 ms            0.44 ms
+            50,000       2.41 ms          1.41 ms            0.48 ms
+
+        against 261 ms for :meth:`verify_chain` over the same 50,000 records.
+        The verification work is flat, 32 record hashes and two tokens whatever
+        the trail size. What grows is finding the record: resolving an id is a
+        linear scan of the in-memory list, and by 50,000 records that scan is
+        already most of the cost. So "milliseconds at any size" holds into the
+        low millions and then the LOOKUP becomes the wall, not the hashing.
+        Indexing id to position is a separate change and is not done here.
+
+        Fails, and never passes quietly, when: the trail has no anchors at all
+        (the common case, since anchoring is opt-in and no TSA is configured by
+        default); the selector matches nothing; an anchor's token does not
+        verify; or an anchor names a head hash the trail does not have at that
+        position, which means the chain was rewritten under it.
+
+        A record ABOVE the last anchor is reported ``ok`` with ``closed=False``.
+        It chains correctly back to an attested head, but nothing external
+        attests it yet, and those are different claims. A record BELOW the first
+        anchor is walked from genesis, with ``lower_anchor_position`` None.
+
+        Exactly one of ``record_id`` or ``action_id`` is required. An action's
+        records can straddle an anchor, so an ``action_id`` widens the walk to
+        cover all of them rather than reporting on whichever came first.
+        """
+        if (record_id is None) == (action_id is None):
+            raise ValueError("pass exactly one of record_id or action_id")
+
+        with self._lock:
+            records = list(self._records)
+            anchors = sorted(self._anchors, key=lambda a: a.chain_position)
+            store_anchors = dict(self._store_anchors)
+
+        if record_id is not None:
+            targets = [i for i, r in enumerate(records) if r.record_id == record_id]
+            label = f"record_id={record_id!r}"
+        else:
+            targets = [i for i, r in enumerate(records) if r.action_id == action_id]
+            label = f"action_id={action_id!r}"
+        if not targets:
+            return SegmentVerification(ok=False, reason=f"{label} not found in trail")
+
+        first, last = min(targets), max(targets)
+
+        if not anchors:
+            return SegmentVerification(
+                ok=False,
+                record_index=first,
+                reason=(
+                    "trail has no time anchors, so no segment can be bounded. "
+                    "Anchoring is opt-in: call anchor_head() or "
+                    "enable_auto_anchor(). Refusing to fall back to a "
+                    "whole-chain walk, which would answer a different question."
+                ),
+            )
+
+        lower = None
+        for a in anchors:
+            if a.chain_position < first:
+                lower = a
+            else:
+                break
+        upper = next((a for a in anchors if a.chain_position >= last), None)
+
+        from vaara.audit.timeanchor import TimeAnchorError, verify_anchor
+
+        def _check(anchor: Any, which: str) -> tuple[Optional[str], Optional[str]]:
+            """Verify one bounding anchor. Returns (attested_time, error)."""
+            pos = anchor.chain_position
+            if pos < 0 or pos >= len(records):
+                return None, (f"{which} anchor at position {pos} is outside the "
+                              f"trail (len={len(records)})")
+            if records[pos].record_hash != anchor.chain_head_hash:
+                return None, (f"{which} anchor at position {pos} names a head "
+                              "hash this trail does not have there: the chain "
+                              "was rewritten under the anchor")
+            try:
+                return verify_anchor(anchor).isoformat(), None
+            except TimeAnchorError as exc:
+                return None, f"{which} anchor token did not verify: {exc}"
+
+        lower_time = upper_time = None
+        if lower is not None:
+            lower_time, err = _check(lower, "lower")
+            if err:
+                return SegmentVerification(ok=False, record_index=first, reason=err)
+        if upper is not None:
+            upper_time, err = _check(upper, "upper")
+            if err:
+                return SegmentVerification(ok=False, record_index=first, reason=err)
+
+        start = 0 if lower is None else lower.chain_position + 1
+        end = last if upper is None else upper.chain_position
+        expected_prev = "" if lower is None else lower.chain_head_hash
+
+        gaps: list[int] = []
+        prev_hash = expected_prev
+        for i in range(start, end + 1):
+            record = records[i]
+            if record.previous_hash != prev_hash:
+                store_anchor = store_anchors.get(record.record_id)
+                if store_anchor is None or record.previous_hash != store_anchor:
+                    return SegmentVerification(
+                        ok=False, record_index=first,
+                        lower_anchor_position=None if lower is None else lower.chain_position,
+                        upper_anchor_position=None if upper is None else upper.chain_position,
+                        records_verified=i - start,
+                        reason=(f"Chain broken at record {i} ({record.record_id}): "
+                                f"expected previous_hash={prev_hash!r}, "
+                                f"got {record.previous_hash!r}"),
+                    )
+            expected = record.compute_hash()
+            if record.record_hash != expected:
+                return SegmentVerification(
+                    ok=False, record_index=first,
+                    lower_anchor_position=None if lower is None else lower.chain_position,
+                    upper_anchor_position=None if upper is None else upper.chain_position,
+                    records_verified=i - start,
+                    reason=(f"Hash mismatch at record {i} ({record.record_id}): "
+                            f"expected {expected!r}, got {record.record_hash!r}"),
+                )
+            if record.event_type is EventType.ANCHOR_GAP:
+                gaps.append(i)
+            prev_hash = record.record_hash
+
+        closed = upper is not None
+        if closed:
+            reason = (f"segment {start}..{end} verified and closed by the anchor "
+                      f"at {end}")
+        else:
+            reason = (f"segment {start}..{end} chains back to the anchor at "
+                      f"{lower.chain_position if lower else 'genesis'}, but is "
+                      "NOT closed by a later anchor: no external authority has "
+                      "attested these records yet")
+        if gaps:
+            reason += (f". {len(gaps)} ANCHOR_GAP marker(s) inside it at {gaps}: "
+                       "a time authority was unreachable across that stretch")
+
+        return SegmentVerification(
+            ok=True,
+            reason=reason,
+            record_id=records[first].record_id,
+            record_index=first,
+            lower_anchor_position=None if lower is None else lower.chain_position,
+            upper_anchor_position=None if upper is None else upper.chain_position,
+            records_verified=end - start + 1,
+            closed=closed,
+            anchor_gaps=gaps,
+            lower_attested_time=lower_time,
+            upper_attested_time=upper_time,
+        )
 
     def enable_auto_anchor(self, client: Any, *, every_records: int = 32) -> None:
         """Anchor the chain head automatically every ``every_records`` records.

--- a/tests/test_trail_segment_verify.py
+++ b/tests/test_trail_segment_verify.py
@@ -1,0 +1,274 @@
+"""Segment-indexed verification: prove one record without walking the trail.
+
+The question a supervisor actually asks is not "is my trail broadly sound", it
+is "show me that this action's record is what it was when it was written".
+Anchors already make that answerable exactly: a segment between two anchors is
+independently verifiable, because ``previous_hash`` is part of the hashed
+content, so a record cannot be re-parented onto a different hash without
+breaking its own hash.
+
+The load-bearing test here is ``test_tamper_before_the_lower_anchor_is_out_of
+_scope``. If that one ever fails, segment verification has stopped being
+segment-scoped and the feature has no reason to exist.
+
+Anchoring is opt-in and no TSA is configured by default, so the unanchored case
+is the COMMON one. It must fail loudly rather than degrade to a genesis walk,
+which is what ``test_unanchored_trail_fails_loudly`` pins.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.test_timeanchor import _GEN_TIME, _local_tsa_client
+from vaara.audit.trail import AuditTrail, EventType
+from vaara.taxonomy.actions import (
+    ActionCategory,
+    ActionRequest,
+    ActionType,
+    BlastRadius,
+    Reversibility,
+)
+
+_ACTION = ActionType(
+    name="t",
+    category=ActionCategory.DATA,
+    reversibility=Reversibility.FULLY,
+    blast_radius=BlastRadius.LOCAL,
+)
+
+
+def _add(trail: AuditTrail, n: int = 1) -> list[str]:
+    """Append ``n`` action records. Returns their action ids."""
+    return [
+        trail.record_action_requested(ActionRequest(
+            action_type=_ACTION, tool_name="t", agent_id="agent", parameters={"i": i},
+        ))
+        for i in range(n)
+    ]
+
+
+def _anchored_trail(client=None):
+    """A trail of 30 records with anchors at positions 9 and 19.
+
+    Leaves 10 records past the last anchor, so the open-segment case is
+    reachable without rebuilding.
+    """
+    trail = AuditTrail()
+    client = client or _local_tsa_client()
+    _add(trail, 10)
+    trail.anchor_head(client)          # position 9
+    _add(trail, 10)
+    trail.anchor_head(client)          # position 19
+    _add(trail, 10)
+    return trail
+
+
+def _rid(trail: AuditTrail, index: int) -> str:
+    return trail._records[index].record_id
+
+
+# ── The reason the feature exists ───────────────────────────────────────────
+
+def test_tamper_before_the_lower_anchor_is_out_of_scope():
+    """A record rewritten BELOW the segment does not fail the segment.
+
+    This is the whole claim. If verifying record 15 required records 0..14 to
+    be intact, segment verification would be a genesis walk wearing a hat.
+    """
+    trail = _anchored_trail()
+    trail._records[3].data = {"rewritten": True}   # breaks record 3's own hash
+
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert result.ok, result.reason
+    assert result.closed
+    # And the whole-chain walk DOES see it, so the tamper is real.
+    assert trail.verify_chain() is not None
+
+
+def test_segment_walk_is_bounded_by_the_anchors():
+    trail = _anchored_trail()
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert result.ok, result.reason
+    assert result.lower_anchor_position == 9
+    assert result.upper_anchor_position == 19
+    # Records 10..19 inclusive, not the 30 in the trail.
+    assert result.records_verified == 10
+    assert result.records_verified < trail.size
+
+
+# ── Failing loudly, which matters more than passing ─────────────────────────
+
+def test_unanchored_trail_fails_loudly():
+    """No anchors means no answer. It must not look like a pass."""
+    trail = AuditTrail()
+    _add(trail, 5)
+
+    result = trail.verify_segment(record_id=_rid(trail, 2))
+
+    assert not result.ok
+    assert "anchor" in result.reason.lower()
+    assert result.records_verified == 0
+
+
+def test_tamper_inside_the_segment_is_caught():
+    trail = _anchored_trail()
+    trail._records[15].data = {"rewritten": True}
+
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert not result.ok
+    assert "15" in result.reason
+
+
+def test_tamper_inside_segment_but_not_the_named_record_is_caught():
+    """The segment is the unit. A neighbour rewritten inside it still fails."""
+    trail = _anchored_trail()
+    trail._records[12].data = {"rewritten": True}
+
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert not result.ok
+
+
+def test_unknown_record_id_fails():
+    trail = _anchored_trail()
+    result = trail.verify_segment(record_id="no-such-record")
+
+    assert not result.ok
+    assert "not found" in result.reason.lower()
+
+
+def test_rewritten_anchor_target_is_caught():
+    """An anchor pointing at a hash the trail no longer has is a rewrite."""
+    trail = _anchored_trail()
+    trail.anchors[1].chain_head_hash = "0" * 64
+
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert not result.ok
+
+
+def test_tampered_anchor_token_is_caught():
+    trail = _anchored_trail()
+    good = trail.anchors[0].token_b64
+    trail.anchors[0].token_b64 = "!!!not base64!!!"
+
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert not result.ok
+    assert "anchor" in result.reason.lower()
+    trail.anchors[0].token_b64 = good
+
+
+# ── Edge cases the block named ──────────────────────────────────────────────
+
+def test_record_after_the_last_anchor_is_open_not_closed():
+    """Verifiable against the chain, not closed by an anchor. Say so."""
+    trail = _anchored_trail()
+    result = trail.verify_segment(record_id=_rid(trail, 25))
+
+    assert result.ok, result.reason
+    assert not result.closed
+    assert result.lower_anchor_position == 19
+    assert result.upper_anchor_position is None
+    assert "not" in result.reason.lower()   # the report explains the gap
+
+
+def test_record_before_the_first_anchor_walks_from_genesis():
+    trail = _anchored_trail()
+    result = trail.verify_segment(record_id=_rid(trail, 3))
+
+    assert result.ok, result.reason
+    assert result.closed
+    assert result.lower_anchor_position is None    # genesis, not an anchor
+    assert result.upper_anchor_position == 9
+    assert result.records_verified == 10           # 0..9
+
+
+def test_record_before_first_anchor_still_catches_a_tamper():
+    trail = _anchored_trail()
+    trail._records[3].data = {"rewritten": True}
+
+    result = trail.verify_segment(record_id=_rid(trail, 3))
+
+    assert not result.ok
+
+
+def test_anchor_gap_marker_in_the_segment_is_reported():
+    """``_record_anchor_gap`` writes a chained marker when a TSA is down.
+
+    It verifies like any other record, so the walk passes. The report has to
+    name it anyway: it means external attestation is missing across that
+    stretch, which is exactly what a segment claim rests on.
+    """
+    trail = AuditTrail()
+    client = _local_tsa_client()
+    _add(trail, 10)
+    trail.anchor_head(client)                      # position 9
+    _add(trail, 3)
+    trail._record_anchor_gap(len(trail._records) - 1,
+                             trail._records[-1].record_hash, "tsa unreachable", client)
+    _add(trail, 3)
+    trail.anchor_head(client)
+
+    target = next(i for i, r in enumerate(trail._records)
+                  if r.event_type is EventType.ANCHOR_GAP)
+    result = trail.verify_segment(record_id=_rid(trail, target + 1))
+
+    assert result.ok, result.reason
+    assert result.anchor_gaps == [target]
+
+
+def test_anchor_positions_report_attested_times():
+    trail = _anchored_trail()
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert result.ok, result.reason
+    assert result.upper_attested_time == _GEN_TIME.isoformat()
+
+
+# ── Lookup by action id ─────────────────────────────────────────────────────
+
+def test_action_id_resolves_to_its_segment():
+    trail = _anchored_trail()
+    action_id = trail._records[15].action_id
+
+    result = trail.verify_segment(action_id=action_id)
+
+    assert result.ok, result.reason
+    assert result.lower_anchor_position == 9
+    assert result.upper_anchor_position == 19
+
+
+def test_action_id_spanning_two_segments_widens_the_walk():
+    """An action's records can straddle an anchor. Cover all of them or lie."""
+    trail = AuditTrail()
+    client = _local_tsa_client()
+    _add(trail, 5)
+    action_id = trail.record_action_requested(ActionRequest(
+        action_type=_ACTION, tool_name="t", agent_id="agent", parameters={},
+    ))
+    trail.anchor_head(client)                      # anchor lands mid-action
+    trail.record_outcome(action_id, agent_id="agent", tool_name="t",
+                         outcome_severity=0.0)
+    _add(trail, 3)
+    trail.anchor_head(client)
+
+    result = trail.verify_segment(action_id=action_id)
+
+    assert result.ok, result.reason
+    indices = [i for i, r in enumerate(trail._records) if r.action_id == action_id]
+    assert len(indices) >= 2
+    assert result.upper_anchor_position == trail.anchors[-1].chain_position
+
+
+def test_requires_exactly_one_selector():
+    trail = _anchored_trail()
+
+    with pytest.raises(ValueError):
+        trail.verify_segment()
+    with pytest.raises(ValueError):
+        trail.verify_segment(record_id="a", action_id="b")


### PR DESCRIPTION
The supervisory question is not "is my trail broadly sound", it is "show me that this action's record is what it was when it was written". Answering that did not need the whole trail. The anchors already made it answerable exactly.

`verify_segment(record_id=... | action_id=...)` locates the bounding anchors, verifies both RFC 3161 tokens offline, checks the first record against the lower anchor's attested head, walks the segment recomputing hashes, and checks the last against the upper anchor. Records below the lower anchor are never read.

That last part is the whole claim, and it has its own test. A record rewritten below the segment does not fail the segment, while `verify_chain` still catches it. Without that property this would be a genesis walk with extra steps.

Exact, not sampled. No probability, no confidence bound, no seed.

## Measured

32-record cadence, best of five:

| trail | verify_segment | of which id scan | of which 2 tokens |
|---|---|---|---|
| 5,000 | 0.74 ms | 0.12 ms | 0.44 ms |
| 50,000 | 2.41 ms | 1.41 ms | 0.48 ms |

against 261 ms for `verify_chain` over the same 50,000 records.

The verification work is flat: 32 record hashes and two tokens whatever the trail size. What grows is finding the record, since resolving an id is a linear scan, and by 50,000 records that scan is already most of the cost. The docstring says so rather than claiming otherwise: this holds into the low millions and then the lookup becomes the wall, not the hashing. Indexing id to position is a separate change and is not in here.

## Fails loudly, never quietly

- **No anchors at all** returns `ok=False` and says why. Anchoring is opt-in and no TSA is configured by default, so the unanchored trail is the common case. A silent fallback to a genesis walk would answer a different question while looking like this one.
- **An anchor naming a head hash the trail does not have at that position** is reported as a chain rewritten under the anchor.
- **A token that does not verify** fails the segment.

## Edge cases, each with a test

- A record above the last anchor returns `ok` with `closed=False`. It chains back to an attested head, but nothing external attests it yet, and the reason string says which of the two it is.
- A record below the first anchor walks from genesis, with `lower_anchor_position` None.
- `ANCHOR_GAP` markers inside a segment verify like any other record, so the walk passes. The report names their positions anyway, because they mark a stretch where the time authority was unreachable and that is what a segment claim rests on.

Store-anchor semantics are unchanged and shared with `verify_chain`: a discontinuity this trail watched the store hand out is accepted, anything else is a break.

16 new tests in `tests/test_trail_segment_verify.py`. Full suite 3656 passed, 26 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added targeted audit-trail segment verification for individual records selected by record ID or action ID.
  * Verification checks anchor tokens, chain and hash integrity, and records any gaps between anchors.
  * Results indicate whether the segment is fully closed by a later anchor and include attested times, verification status, and the number of records checked.
  * Clear failure results are provided when anchors are missing or invalid, records cannot be found, or referenced trail data is unavailable.
  * Chain verification can now resume from a specified position with an expected preceding hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->