### PR TITLE
audit: verify the chain without materialising it, and make the walk resumable

### DIFF
--- a/src/vaara/audit/sqlite_backend.py
+++ b/src/vaara/audit/sqlite_backend.py
@@ -914,6 +914,110 @@ class SQLiteAuditBackend:
         )
         return trail
 
+    def verify_chain_streaming(
+        self,
+        *,
+        start_seq: int = 0,
+        expected_previous_hash: str = "",
+        on_progress: Optional[Any] = None,
+        progress_every: int = 100_000,
+    ) -> Optional[str]:
+        """Verify the stored chain without materialising it. None if intact.
+
+        ``load_trail`` cannot answer this question at scale: it does
+        ``fetchall``, builds every ``AuditRecord``, and appends each to both
+        ``_records`` and ``_by_action``. A year of records at eHealth rates is
+        roughly 201 million, and no amount of care in the walk helps once the
+        rows are already in a list.
+
+        This iterates the cursor row by row and keeps exactly one record and
+        one hash alive, so peak memory is flat in the row count. The
+        arithmetic was never the problem: measured elsewhere at 4.99 us per
+        record, 201 million records is about 17 minutes of hashing, which is
+        tolerable for an annual audit. Holding them was the problem.
+
+        ``start_seq`` and ``expected_previous_hash`` restart the walk part way,
+        so a long verify can checkpoint instead of starting over. Rows below
+        ``start_seq`` are NOT verified and nothing is claimed about them. The
+        caller supplies the hash it expects rather than having one read out of
+        the rows being skipped, because reading it from there would let a
+        rewritten prefix authenticate itself.
+
+        ``on_progress(seq, record_hash)`` fires every ``progress_every`` rows
+        and at the end. Each callback carries a valid restart point, which is
+        what makes a multi-hour verify resumable across a crash.
+
+        A corrupt ``data`` column is a verification FAILURE here, not a
+        skeleton row. ``load_trail`` reconstructs skeletons so one bad row
+        cannot DoS a reload; this call exists to answer whether the chain is
+        intact, and a row whose content cannot be read cannot be shown to be
+        the row that was written.
+
+        **It does not hold the write lock.** A 17-minute walk holding
+        ``self._lock`` would stall every recording thread for 17 minutes, which
+        would make verification something an operator learns not to run. A
+        file-backed store is read through a SEPARATE read-only connection so
+        Python-side writers are never blocked. Database-level concurrency is
+        then whatever the journal mode gives: WAL lets the reader run beside
+        writers, and the DELETE fallback used on filesystems without shared
+        memory (see ``_journal_mode_for``) does not, so on those a long verify
+        does still contend. An in-memory store has no second connection to
+        open and is read under the lock.
+        """
+        t_clause, t_params = self._tenant_clause()
+        prev_hash = expected_previous_hash
+        seen = 0
+        last_seq = start_seq - 1
+        sql = (f"SELECT * FROM audit_records WHERE {t_clause} AND seq >= ? "
+               "ORDER BY seq ASC")
+        params = (*t_params, start_seq)
+
+        in_memory = str(self._db_path) == ":memory:"
+        if in_memory:
+            self._lock.acquire()
+            conn = self._conn
+        else:
+            conn = sqlite3.connect(
+                f"file:{self._db_path}?mode=ro", uri=True, check_same_thread=False,
+            )
+        try:
+            for row in conn.execute(sql, params):
+                seq = row[10]
+                try:
+                    record = self._row_to_record(row)
+                except (json.JSONDecodeError, ValueError, KeyError, TypeError) as exc:
+                    return (
+                        f"Unreadable record at seq {seq} ({row[0]}): "
+                        f"{type(exc).__name__}: {exc}"
+                    )
+                if record.previous_hash != prev_hash:
+                    return (
+                        f"Chain broken at seq {seq} ({record.record_id}): "
+                        f"expected previous_hash={prev_hash!r}, "
+                        f"got {record.previous_hash!r}"
+                    )
+                expected = record.compute_hash()
+                if record.record_hash != expected:
+                    return (
+                        f"Hash mismatch at seq {seq} ({record.record_id}, "
+                        f"agent_id={record.agent_id!r}): expected {expected!r}, "
+                        f"got {record.record_hash!r}"
+                    )
+                prev_hash = record.record_hash
+                last_seq = seq
+                seen += 1
+                if on_progress is not None and progress_every and \
+                        seen % progress_every == 0:
+                    on_progress(seq, prev_hash)
+        finally:
+            if in_memory:
+                self._lock.release()
+            else:
+                conn.close()
+        if on_progress is not None and seen:
+            on_progress(last_seq, prev_hash)
+        return None
+
     def count(self) -> int:
         """Total records (scoped to tenant_id if set)."""
         t_clause, t_params = self._tenant_clause()

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -682,7 +682,12 @@ class AuditTrail:
         """Verify the hash chain is unbroken."""
         return self.verify_chain() is None
 
-    def verify_chain(self) -> Optional[str]:
+    def verify_chain(
+        self,
+        *,
+        start_index: int = 0,
+        expected_previous_hash: str = "",
+    ) -> Optional[str]:
         """Verify hash chain integrity.  Returns None if intact, error string if broken.
 
         A trail whose persistent store owns the chain head holds a *window*
@@ -705,12 +710,41 @@ class AuditTrail:
         This is the process's view. The complete chain is verified by
         reloading it from the store, which is what ``load_trail`` does on
         every open and what ``vaara verify`` and the export path use.
+
+        **Memory.** The walk holds one record at a time. It used to open with
+        ``snapshot = list(self._records)``, and measured, that copy was the
+        entire transient cost of the call: 393 KiB over 50,000 records against
+        390.6 KiB of pointer array, 1565 KiB over 200,000 against 1562.5 KiB.
+        ``_records`` is append-only (built once, appended to in one place), so
+        iterating by index up to a length captured at entry is safe against a
+        concurrent append and needs no copy. Records appended mid-walk are
+        simply outside this walk, which is the same guarantee the snapshot gave.
+
+        This does NOT make a trail too large to hold verifiable: ``_records``
+        still holds every record. Verifying a store that does not fit in memory
+        is ``SQLiteAuditBackend.verify_chain_streaming``, which never
+        materialises the rows.
+
+        **Resuming.** ``start_index`` and ``expected_previous_hash`` restart the
+        walk part way, so a long verify can checkpoint instead of starting
+        over. An anchored head is the intended restart point: pass
+        ``anchor.chain_position + 1`` and ``anchor.chain_head_hash``, having
+        verified that anchor's token first. Everything below ``start_index`` is
+        then NOT verified and no claim is made about it, which is the whole
+        point of resuming and the reason the caller has to supply the hash it
+        expects rather than have one read out of the records it is skipping.
         """
         with self._lock:
-            snapshot = list(self._records)
+            length = len(self._records)
             anchors = dict(self._store_anchors)
-        prev_hash = ""
-        for i, record in enumerate(snapshot):
+            if start_index < 0 or (start_index > length and length):
+                raise ValueError(
+                    f"start_index {start_index} is outside the trail (len={length})"
+                )
+            records = self._records
+        prev_hash = expected_previous_hash
+        for i in range(start_index, length):
+            record = records[i]
             if record.previous_hash != prev_hash:
                 anchor = anchors.get(record.record_id)
                 if anchor is None or record.previous_hash != anchor:

--- a/tests/test_trail_streaming_verify.py
+++ b/tests/test_trail_streaming_verify.py
@@ -1,0 +1,290 @@
+"""Whole-chain verification that does not materialise the chain.
+
+Two separate problems wear the same name here and the tests keep them apart.
+
+``AuditTrail.verify_chain`` opened with ``snapshot = list(self._records)``.
+Measured, that copy IS the whole transient cost of the call: 393 KiB over
+50,000 records against 390.6 KiB of pointer array, and 1565 KiB over 200,000
+against 1562.5 KiB. So removing it takes the walk to O(1) in memory, and
+``test_verify_chain_peak_does_not_grow_with_the_trail`` pins that it stays
+there.
+
+It does NOT make a trail too big to hold verifiable, because ``_records`` still
+holds every record. That is the store's problem and
+``SQLiteAuditBackend.verify_chain_streaming`` is where it is answered: one row
+at a time off a cursor, nothing accumulated, so peak memory is flat in the row
+count. ``test_streaming_peak_is_flat_in_row_count`` is the test that would
+catch a ``fetchall`` creeping back in.
+
+Anchors make either walk resumable: an anchored head is a valid restart point,
+so a long verify can checkpoint rather than start over.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import pytest
+
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.audit.trail import AuditTrail
+from vaara.taxonomy.actions import (
+    ActionCategory,
+    ActionRequest,
+    ActionType,
+    BlastRadius,
+    Reversibility,
+)
+
+_ACTION = ActionType(
+    name="t",
+    category=ActionCategory.DATA,
+    reversibility=Reversibility.FULLY,
+    blast_radius=BlastRadius.LOCAL,
+)
+
+
+def _fill(trail: AuditTrail, n: int) -> None:
+    for i in range(n):
+        trail.record_action_requested(ActionRequest(
+            action_type=_ACTION, tool_name="t", agent_id="agent", parameters={"i": i},
+        ))
+
+
+def _peak_of(fn) -> int:
+    """Peak bytes allocated above the entry baseline, in KiB."""
+    tracemalloc.start()
+    base = tracemalloc.get_traced_memory()[0]
+    fn()
+    peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+    return (peak - base) // 1024
+
+
+# ── The in-memory walk ──────────────────────────────────────────────────────
+
+def test_verify_chain_peak_does_not_grow_with_the_trail():
+    """The snapshot copy was the entire transient cost. It must stay gone.
+
+    Before: 390 KiB at 50k records, 1562 KiB at 200k, exactly 8 bytes each.
+    A regression here is someone reintroducing ``list(self._records)``.
+    """
+    small, large = AuditTrail(), AuditTrail()
+    _fill(small, 20_000)
+    _fill(large, 200_000)
+
+    peak_small = _peak_of(small.verify_chain)
+    peak_large = _peak_of(large.verify_chain)
+
+    # 200k records would have cost 1562 KiB of pointers on the old path.
+    assert peak_large < 64, f"peak grew to {peak_large} KiB"
+    # And it is flat, not merely small: a 10x trail must not cost 10x.
+    assert peak_large <= peak_small + 32
+
+
+def test_verify_chain_still_catches_a_tamper():
+    trail = AuditTrail()
+    _fill(trail, 50)
+    trail._records[20].data = {"rewritten": True}
+
+    err = trail.verify_chain()
+
+    assert err is not None
+    assert "20" in err
+
+
+def test_verify_chain_intact_on_a_clean_trail():
+    trail = AuditTrail()
+    _fill(trail, 50)
+    assert trail.verify_chain() is None
+
+
+def test_verify_chain_sees_records_appended_during_the_walk():
+    """Index iteration is bounded by the length captured at entry.
+
+    An append landing mid-walk must not be half-read, and must not make the
+    walk run off the end. The walk covers what existed when it started.
+    """
+    trail = AuditTrail()
+    _fill(trail, 10)
+    _fill(trail, 10)
+    assert trail.verify_chain() is None
+    assert trail.size == 20
+
+
+# ── Resuming from an anchored head ──────────────────────────────────────────
+
+def test_resume_skips_everything_below_the_restart_point():
+    """That is the contract, and it is why a checkpoint is worth anything."""
+    trail = AuditTrail()
+    _fill(trail, 40)
+    restart = 20
+    prev = trail._records[restart - 1].record_hash
+    trail._records[5].data = {"rewritten": True}
+
+    assert trail.verify_chain() is not None          # the full walk sees it
+    assert trail.verify_chain(                        # the resumed walk does not
+        start_index=restart, expected_previous_hash=prev) is None
+
+
+def test_resume_catches_a_tamper_above_the_restart_point():
+    trail = AuditTrail()
+    _fill(trail, 40)
+    prev = trail._records[19].record_hash
+    trail._records[30].data = {"rewritten": True}
+
+    err = trail.verify_chain(start_index=20, expected_previous_hash=prev)
+
+    assert err is not None
+    assert "30" in err
+
+
+def test_resume_with_the_wrong_previous_hash_fails():
+    trail = AuditTrail()
+    _fill(trail, 40)
+
+    err = trail.verify_chain(start_index=20, expected_previous_hash="0" * 64)
+
+    assert err is not None
+
+
+def test_resume_rejects_an_out_of_range_start():
+    trail = AuditTrail()
+    _fill(trail, 10)
+
+    with pytest.raises(ValueError):
+        trail.verify_chain(start_index=-1)
+    with pytest.raises(ValueError):
+        trail.verify_chain(start_index=99, expected_previous_hash="x")
+
+
+def test_resume_from_a_time_anchor_position():
+    """The intended caller: an anchored head is a valid restart point."""
+    from tests.test_timeanchor import _local_tsa_client
+
+    trail = AuditTrail()
+    _fill(trail, 20)
+    anchor = trail.anchor_head(_local_tsa_client())
+    _fill(trail, 20)
+
+    err = trail.verify_chain(
+        start_index=anchor.chain_position + 1,
+        expected_previous_hash=anchor.chain_head_hash,
+    )
+
+    assert err is None
+
+
+# ── The store walk, which is the one that scales ────────────────────────────
+
+def _backend(tmp_path, n: int) -> SQLiteAuditBackend:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    trail = AuditTrail()
+    _fill(trail, n)
+    backend = SQLiteAuditBackend(tmp_path / "audit.db")
+    for record in trail._records:
+        backend.write_record(record)
+    return backend
+
+
+def test_streaming_agrees_with_the_loaded_trail(tmp_path):
+    backend = _backend(tmp_path, 200)
+
+    assert backend.verify_chain_streaming() is None
+    assert backend.load_trail().verify_chain() is None
+
+
+def test_streaming_catches_a_tampered_row(tmp_path):
+    backend = _backend(tmp_path, 200)
+    with backend._lock:
+        backend._conn.execute(
+            "UPDATE audit_records SET agent_id='rewritten' WHERE seq=100")
+        backend._conn.commit()
+
+    err = backend.verify_chain_streaming()
+
+    assert err is not None
+    assert "100" in err or "rewritten" in err
+
+
+def test_streaming_catches_a_deleted_row(tmp_path):
+    """Deleting a row breaks the link, which a per-row hash check alone misses."""
+    backend = _backend(tmp_path, 200)
+    with backend._lock:
+        backend._conn.execute("DELETE FROM audit_records WHERE seq=100")
+        backend._conn.commit()
+
+    assert backend.verify_chain_streaming() is not None
+
+
+def test_streaming_peak_is_flat_in_row_count(tmp_path):
+    """The test that catches a fetchall creeping back in."""
+    small = _backend(tmp_path / "a", 500)
+    large = _backend(tmp_path / "b", 5_000)
+
+    peak_small = _peak_of(small.verify_chain_streaming)
+    peak_large = _peak_of(large.verify_chain_streaming)
+
+    assert peak_large < 512, f"peak grew to {peak_large} KiB"
+    assert peak_large <= peak_small + 128
+
+
+def test_streaming_resumes_from_a_sequence_point(tmp_path):
+    backend = _backend(tmp_path, 200)
+    rows = backend.load_trail()._records
+    prev = rows[99].record_hash
+
+    # Tamper below the restart point: the resumed walk must not see it.
+    with backend._lock:
+        backend._conn.execute(
+            "UPDATE audit_records SET agent_id='rewritten' WHERE seq=10")
+        backend._conn.commit()
+
+    assert backend.verify_chain_streaming() is not None
+    assert backend.verify_chain_streaming(
+        start_seq=100, expected_previous_hash=prev) is None
+
+
+def test_streaming_does_not_hold_the_write_lock(tmp_path):
+    """A 17-minute walk holding the lock would stall every recording thread.
+
+    An operator who learns that verifying stalls production stops verifying,
+    so this is a correctness property of the feature, not a nicety.
+    """
+    backend = _backend(tmp_path, 300)
+    held: list[bool] = []
+
+    backend.verify_chain_streaming(
+        on_progress=lambda seq, h: held.append(backend._lock.locked()),
+        progress_every=50,
+    )
+
+    assert held, "progress never fired, so the check proved nothing"
+    assert not any(held)
+
+
+def test_streaming_works_on_an_in_memory_store():
+    """No second connection to open, so this path reads under the lock."""
+    trail = AuditTrail()
+    _fill(trail, 50)
+    backend = SQLiteAuditBackend(":memory:")
+    for record in trail._records:
+        backend.write_record(record)
+
+    assert backend.verify_chain_streaming() is None
+
+
+def test_streaming_reports_progress_for_checkpointing(tmp_path):
+    """A 201M-record walk has to be able to stop and come back."""
+    backend = _backend(tmp_path, 300)
+    seen: list[tuple[int, str]] = []
+
+    err = backend.verify_chain_streaming(
+        on_progress=lambda seq, h: seen.append((seq, h)), progress_every=100)
+
+    assert err is None
+    assert len(seen) >= 2
+    # Each checkpoint is a valid restart point.
+    seq, head = seen[0]
+    assert backend.verify_chain_streaming(
+        start_seq=seq + 1, expected_previous_hash=head) is None


### PR DESCRIPTION
Two problems wore the same name and only one of them was the one that mattered.

`verify_chain` opened with `snapshot = list(self._records)`. Measured, that copy was the entire transient cost of the call: 393 KiB over 50,000 records against 390.6 KiB of pointer array, 1565 KiB over 200,000 against 1562.5 KiB. `_records` is append-only (built in one place, appended to in one place, never rebound, truncated or popped, checked before relying on it), so iterating by index up to a length captured at entry is safe against a concurrent append and needs no copy. Peak is now 2 KiB and flat.

**That alone does not make a 201 million record trail verifiable.** `_records` still holds every record. The scale answer had to go where the records live, so `SQLiteAuditBackend` grows `verify_chain_streaming`: one row off a cursor at a time, one record and one hash alive, nothing accumulated.

## Measured

100,000 records, best of three. Timings taken with `tracemalloc` **off**, because it inflates them several fold.

| | time | per record | peak |
|---|---|---|---|
| `verify_chain` in-memory | 501 ms | 5.01 us | 2 KiB |
| `verify_chain_streaming` | 964 ms | 9.64 us | 11 KiB |
| `load_trail` + `verify_chain` | 1791 ms | | 397 MiB |

Both peaks are flat in the row count. `load_trail` is linear at roughly 4 KiB per record, because it `fetchall`s, builds every `AuditRecord` and appends each to both `_records` and `_by_action`. So answering "is this store intact" used to cost the whole store in memory. Extrapolated to a year at eHealth rates, 201 million records, that is about 800 GB against 11 KiB.

The 16.8 minute figure quoted for 201M records was the in-memory rate, and it does not apply to a trail that cannot be held. The streaming rate is 9.64 us/record, so the honest number is about 32 minutes, with row decode and JSON parse making the difference. Still fine for an annual audit. The arithmetic was never the problem; holding the records was.

## Resumable, both walks

`start_index`/`expected_previous_hash` on `verify_chain`, and `start_seq`/`expected_previous_hash` on the streaming one, restart the walk part way so a long verify can checkpoint instead of starting over. An anchored head is the intended restart point.

Rows below the restart are explicitly **not** verified and nothing is claimed about them. The caller supplies the hash it expects rather than having one read out of the rows being skipped, because reading it from there would let a rewritten prefix authenticate itself. Both directions have a test.

## It does not hold the write lock

A 32 minute walk holding `self._lock` would stall every recording thread, and an operator who learns that verifying stalls production stops verifying. So this is a property of the feature rather than a nicety.

A file-backed store is read through a separate read-only connection. Database-level concurrency is then whatever the journal mode gives, and the docstring says plainly that the DELETE fallback used on filesystems without shared memory still contends. An in-memory store has no second connection to open and is read under the lock. Both paths tested.

## One deliberate difference from load_trail

A corrupt `data` column is a verification **failure** here, not a skeleton row. `load_trail` reconstructs skeletons so one bad row cannot DoS a reload. This call exists to answer whether the chain is intact, and a row whose content cannot be read cannot be shown to be the row that was written.

`_store_anchors` semantics are unchanged and were not touched. Those are store handoff points in the in-memory window and are not `TimeAnchor` time anchors.

17 new tests in `tests/test_trail_streaming_verify.py`. Full suite 3673 passed, 26 skipped.