### PR TITLE
perf: index record_id to position so verify_segment stops scanning the trail

### DIFF
--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -1753,13 +1753,17 @@ class AuditTrail:
             records = self._records
             anchors = list(self._anchors)
             store_anchors = dict(self._store_anchors)
+            # Exactly one of the two is set, guarded above, but the branches
+            # test each one directly so the narrowing is local.
+            targets: list[int] = []
             if record_id is not None:
                 # O(1). This was a scan, and measured it was 59 percent of the
                 # call at 50,000 records: the flat verification work was flat
                 # and finding the record was not.
                 position = self._pos_by_record_id.get(record_id)
-                targets = [position] if position is not None else []
-            else:
+                if position is not None:
+                    targets = [position]
+            elif action_id is not None:
                 # An action's records are already indexed by action_id; map
                 # each to its position rather than walking the trail. An action
                 # holds a handful of records, so this is O(that handful).

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -618,6 +618,15 @@ class AuditTrail:
         # records in a 24 hour window and this list holds the handful a human
         # actually answered. Maintained ONLY by _index_record.
         self._resolved_approvals: list[AuditRecord] = []
+        # record_id -> its position in _records, so verify_segment can locate
+        # one record without a linear scan. Unlike the list above this holds an
+        # entry per record, measured at 66 bytes each, which is about 3 percent
+        # on top of a trail whose records already cost roughly 2 KiB apiece.
+        # It exists only where _records does, so a store too large to
+        # materialise carries neither: that trail is verified by
+        # SQLiteAuditBackend.verify_chain_streaming, which holds no index and
+        # no records. Maintained ONLY by _index_record.
+        self._pos_by_record_id: dict[str, int] = {}
         self._last_hash = ""
         self._on_record = on_record
         # record_id -> the chain head the persistent store handed out for it,
@@ -1735,16 +1744,35 @@ class AuditTrail:
             raise ValueError("pass exactly one of record_id or action_id")
 
         with self._lock:
-            records = list(self._records)
-            anchors = sorted(self._anchors, key=lambda a: a.chain_position)
+            # Length and a reference, not a copy. `list(self._records)` was
+            # the same O(n) materialisation verify_chain shed: it allocated a
+            # pointer array the size of the trail to look at 32 records.
+            # _records is append-only, so indexing below a length captured here
+            # is safe against a concurrent append.
+            length = len(self._records)
+            records = self._records
+            anchors = list(self._anchors)
             store_anchors = dict(self._store_anchors)
-
-        if record_id is not None:
-            targets = [i for i, r in enumerate(records) if r.record_id == record_id]
-            label = f"record_id={record_id!r}"
-        else:
-            targets = [i for i, r in enumerate(records) if r.action_id == action_id]
-            label = f"action_id={action_id!r}"
+            if record_id is not None:
+                # O(1). This was a scan, and measured it was 59 percent of the
+                # call at 50,000 records: the flat verification work was flat
+                # and finding the record was not.
+                position = self._pos_by_record_id.get(record_id)
+                targets = [position] if position is not None else []
+            else:
+                # An action's records are already indexed by action_id; map
+                # each to its position rather than walking the trail. An action
+                # holds a handful of records, so this is O(that handful).
+                targets = sorted(
+                    p for r in self._by_action.get(action_id, [])
+                    if (p := self._pos_by_record_id.get(r.record_id)) is not None
+                )
+        label = (f"record_id={record_id!r}" if record_id is not None
+                 else f"action_id={action_id!r}")
+        # An index entry pointing past the captured length belongs to a record
+        # appended after this call started. It is outside this walk, the same
+        # as any other late arrival.
+        targets = [t for t in targets if t < length]
         if not targets:
             return SegmentVerification(ok=False, reason=f"{label} not found in trail")
 
@@ -1762,22 +1790,39 @@ class AuditTrail:
                 ),
             )
 
-        lower = None
+        # One pass, no sort. The previous form sorted the anchor list on every
+        # call, and once the record scan was indexed away that sort became the
+        # remaining term that grew with the trail: at the default 32-record
+        # cadence a 50,000 record trail carries 1,562 anchors, and it is 15,600
+        # at half a million.
+        #
+        # Not bisect, because the list is not reliably ordered. anchor_head
+        # reads the position under the lock, makes the TSA round trip outside
+        # it, then appends under the lock again, so two concurrent anchors can
+        # append in the opposite order to the positions they hold. A single
+        # scan for the tightest bounds needs no ordering assumption at all.
+        lower = upper = None
         for a in anchors:
-            if a.chain_position < first:
-                lower = a
-            else:
-                break
-        upper = next((a for a in anchors if a.chain_position >= last), None)
+            pos = a.chain_position
+            if pos < first:
+                if lower is None or pos > lower.chain_position:
+                    lower = a
+            elif pos >= last:
+                if upper is None or pos < upper.chain_position:
+                    upper = a
 
         from vaara.audit.timeanchor import TimeAnchorError, verify_anchor
 
         def _check(anchor: Any, which: str) -> tuple[Optional[str], Optional[str]]:
             """Verify one bounding anchor. Returns (attested_time, error)."""
             pos = anchor.chain_position
-            if pos < 0 or pos >= len(records):
+            # Against the length captured at entry, not the live one. Now that
+            # `records` is the live list rather than a copy, len() would drift
+            # upward mid-call and an anchor could pass a bounds check against
+            # records this walk is not covering.
+            if pos < 0 or pos >= length:
                 return None, (f"{which} anchor at position {pos} is outside the "
-                              f"trail (len={len(records)})")
+                              f"trail (len={length})")
             if records[pos].record_hash != anchor.chain_head_hash:
                 return None, (f"{which} anchor at position {pos} names a head "
                               "hash this trail does not have there: the chain "
@@ -2106,6 +2151,22 @@ class AuditTrail:
         """
         self._records.append(record)
         self._by_action[record.action_id].append(record)
+        # record_id to position, so verify_segment can find one record without
+        # walking the trail. Measured before this existed: the id scan was 16
+        # percent of the call at 5,000 records and 59 percent at 50,000, which
+        # made the lookup the wall rather than the hashing.
+        #
+        # Positions are stable because _records is append-only. Nothing in the
+        # tree removes, reorders or replaces an element: rotate purges the
+        # DATABASE and builds a fresh trail through load_trail rather than
+        # editing a live one. If that ever changes, this index has to be
+        # rebuilt at the same moment, and test_index_matches_records is what
+        # will notice.
+        #
+        # setdefault, not assignment: on a duplicate record_id the FIRST
+        # occurrence wins, because a segment claim about the earlier copy is
+        # the conservative answer, it covers more of the chain.
+        self._pos_by_record_id.setdefault(record.record_id, len(self._records) - 1)
         if record.event_type == EventType.ESCALATION_RESOLVED:
             self._resolved_approvals.append(record)
 

--- a/tests/test_trail_record_index.py
+++ b/tests/test_trail_record_index.py
@@ -1,0 +1,226 @@
+"""Finding a record must not cost a walk of the trail.
+
+`verify_segment` does flat verification work, 32 record hashes and two RFC 3161
+tokens whatever the trail size, and then spent most of its wall clock FINDING
+the record. Measured before this change:
+
+    trail     verify_segment   of which id scan
+    5,000         0.74 ms          0.12 ms   (16%)
+    50,000        2.41 ms          1.41 ms   (59%)
+
+So the "milliseconds at any trail size" claim held into the low millions and
+then stopped, and the wall was the lookup rather than the hashing.
+
+The index follows the `_resolved_approvals` pattern from PR #672 exactly: built
+in `_index_record`, which is the only place that appends to `_records`, so a
+bulk loader cannot populate one without the other. `test_index_matches_records`
+is the one that fails if that ever stops being true.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from vaara.audit.sqlite_backend import SQLiteAuditBackend
+from vaara.audit.trail import AuditTrail
+from vaara.taxonomy.actions import (
+    ActionCategory,
+    ActionRequest,
+    ActionType,
+    BlastRadius,
+    Reversibility,
+)
+
+_ACTION = ActionType(
+    name="t",
+    category=ActionCategory.DATA,
+    reversibility=Reversibility.FULLY,
+    blast_radius=BlastRadius.LOCAL,
+)
+
+
+def _fill(trail: AuditTrail, n: int) -> list[str]:
+    return [
+        trail.record_action_requested(ActionRequest(
+            action_type=_ACTION, tool_name="t", agent_id="agent",
+            parameters={"i": i},
+        ))
+        for i in range(n)
+    ]
+
+
+# ── the invariant the whole thing rests on ──────────────────────────────────
+
+def test_index_matches_records():
+    trail = AuditTrail()
+    _fill(trail, 200)
+
+    assert len(trail._pos_by_record_id) == len(trail._records)
+    for position, record in enumerate(trail._records):
+        assert trail._pos_by_record_id[record.record_id] == position
+
+
+def test_index_survives_a_reload_from_the_store(tmp_path):
+    """Reloaded records never pass through _append. load_trail must index too.
+
+    This is the path PR #672 named as the one that would be forgotten, and it
+    was right: it had already been forgotten once for the approval index.
+    """
+    trail = AuditTrail()
+    _fill(trail, 50)
+    backend = SQLiteAuditBackend(tmp_path / "audit.db")
+    for record in trail._records:
+        backend.write_record(record)
+
+    reloaded = backend.load_trail()
+
+    assert len(reloaded._pos_by_record_id) == len(reloaded._records)
+    for position, record in enumerate(reloaded._records):
+        assert reloaded._pos_by_record_id[record.record_id] == position
+
+
+def test_lookup_finds_the_same_record_the_scan_would():
+    trail = AuditTrail()
+    _fill(trail, 300)
+
+    for position in (0, 1, 150, 298, 299):
+        want = trail._records[position]
+        assert trail._pos_by_record_id[want.record_id] == position
+
+
+# ── behaviour through verify_segment, which is the caller ───────────────────
+
+def _anchored(n_before=10, n_after=10):
+    from tests.test_timeanchor import _local_tsa_client
+    trail = AuditTrail()
+    client = _local_tsa_client()
+    _fill(trail, n_before)
+    trail.anchor_head(client)
+    _fill(trail, n_after)
+    trail.anchor_head(client)
+    return trail
+
+
+def test_verify_segment_still_finds_a_record():
+    trail = _anchored()
+    target = trail._records[15].record_id
+
+    result = trail.verify_segment(record_id=target)
+
+    assert result.ok, result.reason
+    assert result.record_index == 15
+    assert result.record_id == target
+
+
+def test_verify_segment_unknown_id_still_reports_not_found():
+    trail = _anchored()
+    result = trail.verify_segment(record_id="no-such-record")
+    assert not result.ok
+    assert "not found" in result.reason.lower()
+
+
+def test_verify_segment_by_action_id_still_spans_its_records():
+    trail = _anchored(n_before=5, n_after=5)
+    action_id = trail._records[7].action_id
+
+    result = trail.verify_segment(action_id=action_id)
+
+    assert result.ok, result.reason
+    assert result.record_index == 7
+
+
+def test_verify_segment_still_catches_a_tamper():
+    """The lookup changed. The verdict must not have."""
+    trail = _anchored()
+    trail._records[15].data = {"rewritten": True}
+
+    result = trail.verify_segment(record_id=trail._records[15].record_id)
+
+    assert not result.ok
+    assert "15" in result.reason
+
+
+# ── the point of the change ─────────────────────────────────────────────────
+
+def test_lookup_does_not_scale_with_the_trail():
+    """A 10x trail must not cost 10x to find one record in.
+
+    Timed rather than asserted structurally, because the structural version
+    (patching enumerate) passes just as well against a scan hidden one call
+    deeper.
+    """
+    small, large = AuditTrail(), AuditTrail()
+    _fill(small, 2_000)
+    _fill(large, 100_000)
+
+    def timed(trail: AuditTrail) -> float:
+        """Seconds for 50,000 lookups.
+
+        A BATCH, because one dict lookup is below perf_counter's resolution and
+        the first version of this test measured the small trail at exactly 0.0,
+        which made the comparison `x < 0` and failed for a reason that had
+        nothing to do with the code under test.
+        """
+        target = trail._records[len(trail._records) // 2].record_id
+        index = trail._pos_by_record_id
+        best = float("inf")
+        for _ in range(3):
+            start = time.perf_counter()
+            for _ in range(50_000):
+                index.get(target)
+            best = min(best, time.perf_counter() - start)
+        return best
+
+    small_t, large_t = timed(small), timed(large)
+    assert small_t > 0, "the batch is still too small to measure"
+    # A scan would make the 50x trail cost ~50x. A dict does not. Two is
+    # generous room for noise while still failing a linear lookup by miles.
+    assert large_t < small_t * 2, f"{large_t=} {small_t=}"
+
+
+def test_verify_segment_does_not_copy_the_trail():
+    """It opened with `list(self._records)`, which is the same O(n) that
+    verify_chain shed. Finding one record in a 200k trail should not allocate
+    a 1.6 MB pointer array to do it."""
+    import tracemalloc
+
+    trail = _anchored(n_before=10, n_after=10)
+    _fill(trail, 100_000)
+    target = trail._records[15].record_id
+
+    tracemalloc.start()
+    base = tracemalloc.get_traced_memory()[0]
+    result = trail.verify_segment(record_id=target)
+    peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+
+    assert result.ok, result.reason
+    # 100k records would have cost ~780 KiB of pointers on the old path.
+    assert (peak - base) // 1024 < 64
+
+
+# ── duplicates, which uuid4 makes unlikely rather than impossible ───────────
+
+def test_duplicate_record_id_resolves_to_the_first_occurrence():
+    """Whatever it does, it must be decided rather than accidental.
+
+    The first occurrence wins, because a segment claim about the EARLIER copy
+    is the conservative answer: it covers more of the chain.
+    """
+    trail = AuditTrail()
+    _fill(trail, 5)
+    clone = trail._records[1]
+    duplicate = type(clone)(**{**clone.to_dict(),
+                               "event_type": clone.event_type})
+    trail._index_record(duplicate)
+
+    assert trail._pos_by_record_id[clone.record_id] == 1
+
+
+def test_empty_trail_has_an_empty_index():
+    trail = AuditTrail()
+    assert trail._pos_by_record_id == {}
+    with pytest.raises(ValueError):
+        trail.verify_segment()


### PR DESCRIPTION
`verify_segment` did flat verification work, 32 record hashes and two RFC 3161 tokens whatever the trail size, and then spent most of its wall clock **finding** the record.

Before:

| trail | verify_segment | of which id scan |
|---|---|---|
| 5,000 | 0.74 ms | 0.12 ms (16%) |
| 50,000 | 2.41 ms | 1.41 ms (59%) |

After, with a third row because the point is the shape rather than one number:

| trail | anchors | verify_segment |
|---|---|---|
| 5,000 | 156 | 0.63 ms |
| 50,000 | 1,562 | 0.78 ms |
| 150,000 | 4,687 | 1.06 ms |

`_pos_by_record_id` follows `_resolved_approvals` from #672 exactly: built in `_index_record`, the only place that appends to `_records`, so a bulk loader cannot populate one without the other. `load_trail` already calls it, so reloaded records are indexed too, and that has its own test because it is the path #672 named as the one that gets forgotten.

## The three checks the work called for, answered by looking

- **Nothing renumbers or drops records.** `_index_record` is the single appender, and `rotate` purges the *database* and builds a fresh trail through `load_trail` rather than editing a live one. Positions are stable for the life of the trail, and `test_index_matches_records` fails if that stops being true.
- **Memory is 66 bytes per record**, measured, against roughly 2 KiB per record for the records themselves, so about 3 percent. It exists only where `_records` does, so a store too large to materialise carries neither: that one is verified by `verify_chain_streaming`, which holds no index and no records.
- **Prior art is #672's list**, and this follows it rather than inventing a second pattern for the same problem.

## Two more O(n) terms went with it

Both were on the same path and both only became visible once the scan was gone.

`verify_segment` opened with `list(self._records)`, the same materialisation `verify_chain` shed: a pointer array the size of the trail, allocated to look at 32 records. Peak is now 35 KiB at 50,000 records, with a test pinning it under 64.

And it sorted the anchor list on every call. Once the record scan was indexed away, that sort was the remaining term growing with the trail. It is one pass for the tightest bounds now, with no ordering assumption: `anchor_head` reads its position under the lock and makes the TSA round trip outside it, so two concurrent anchors can append in the opposite order to the positions they hold. Bisect would have been wrong for exactly that reason.

## What did not go away

Said plainly rather than left to be found: the anchor bound search is still O(anchors), which is O(records / cadence). That is the 0.63 to 1.06 ms drift in the table. It is a 32x smaller constant than the record scan was, and it is now the largest remaining term on this path.

`verify_segment` reports exactly what it reported before. This is a lookup change and the verification semantics are untouched.

11 new tests in `tests/test_trail_record_index.py`. Full suite 3692 passed, 26 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved audit trail verification and record lookups, particularly for large trails.
  - Reduced memory usage during segment verification.
  - Improved handling of record boundaries and duplicate record identifiers.

- **Reliability**
  - Preserved verification behavior for valid, missing, and spanning records.
  - Continued detecting tampering consistently.
  - Maintained correct behavior after reloads and with empty audit trails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->