### PR TITLE
perf: bisect the anchor bound search instead of scanning every anchor

### DIFF
--- a/scripts/bench_anchor_bound_search.py
+++ b/scripts/bench_anchor_bound_search.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Measure the anchor bound search in ``AuditTrail.verify_segment``.
+
+The record lookup is O(1) since the ``_pos_by_record_id`` index. What is left
+that grows with the trail is the anchor handling: ``list(self._anchors)`` under
+the lock, then a single pass over that list to find the tightest bounding pair.
+At the default 32-record anchor cadence a trail carries len/32 anchors, so both
+terms grow linearly with the trail.
+
+This script answers the only question worth answering before adding a structure
+to maintain: at what trail size does that cost stop being free? Run it before
+and after any change and compare the same rows.
+
+Usage:  .venv/bin/python scripts/bench_anchor_bound_search.py [sizes...]
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from tests.test_timeanchor import _local_tsa_client
+from vaara.audit.trail import AuditTrail
+from vaara.taxonomy.actions import (
+    ActionCategory,
+    ActionRequest,
+    ActionType,
+    BlastRadius,
+    Reversibility,
+)
+
+_ACTION = ActionType(
+    name="bench",
+    category=ActionCategory.DATA,
+    reversibility=Reversibility.FULLY,
+    blast_radius=BlastRadius.LOCAL,
+)
+
+ANCHOR_EVERY = 32
+REPEATS = 200
+
+
+def _build(size: int, client) -> tuple[AuditTrail, str]:
+    """A trail of ``size`` records with an anchor every 32.
+
+    Returns the trail and the record id of a record near the middle, which is
+    the worst realistic case for a scan that keeps the tightest pair: it has
+    anchors on both sides and cannot stop early.
+    """
+    trail = AuditTrail()
+    for i in range(size):
+        trail.record_action_requested(ActionRequest(
+            action_type=_ACTION, tool_name="t", agent_id="a", parameters={"i": i},
+        ))
+        if (i + 1) % ANCHOR_EVERY == 0:
+            trail.anchor_head(client)
+    # record_action_requested returns an action id, not a record id, and one
+    # action can hold several records. Read the middle record's own id.
+    return trail, trail._records[size // 2].record_id
+
+
+def main(sizes: list[int]) -> None:
+    client = _local_tsa_client()
+    print(f"{'records':>10} {'anchors':>9} {'verify_segment':>16} {'per anchor':>12}")
+    for size in sizes:
+        build_start = time.perf_counter()
+        trail, rid = _build(size, client)
+        built = time.perf_counter() - build_start
+        n_anchors = len(trail.anchors)
+
+        # Warm once so the first call does not carry import cost.
+        trail.verify_segment(record_id=rid)
+
+        start = time.perf_counter()
+        for _ in range(REPEATS):
+            result = trail.verify_segment(record_id=rid)
+        elapsed = (time.perf_counter() - start) / REPEATS * 1000
+
+        assert result.ok, result.reason
+        per_anchor = elapsed / n_anchors * 1000 if n_anchors else 0.0
+        print(f"{size:>10,} {n_anchors:>9,} {elapsed:>13.3f} ms {per_anchor:>9.3f} us"
+              f"   (built in {built:.1f}s)")
+
+
+if __name__ == "__main__":
+    args = [int(a) for a in sys.argv[1:]] or [5_000, 50_000, 150_000, 500_000]
+    main(args)

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -24,6 +24,7 @@ human oversight.  This module satisfies both.
 
 from __future__ import annotations
 
+import bisect
 import hashlib
 import json
 import logging
@@ -685,6 +686,20 @@ class AuditTrail:
         # chain's existence is provable against an external clock even if the
         # signing key is later compromised. See vaara.audit.timeanchor.
         self._anchors: list = []
+        # The same anchors again, kept in chain-position order, so
+        # verify_segment can bisect for its bounding pair instead of scanning.
+        # Two lists rather than one list of tuples: two anchors can share a
+        # position, and a tuple comparison would then fall through to comparing
+        # the anchor objects themselves, which are not orderable.
+        #
+        # This has to be an insertion, never an append. anchor_head reads the
+        # position under _lock, makes the TSA round trip OUTSIDE it, then
+        # appends under _lock again, so two concurrent anchors can arrive in
+        # the opposite order to the positions they carry. _anchors is therefore
+        # unordered by construction and _index_anchor puts each one where it
+        # belongs. Maintained ONLY by _index_anchor.
+        self._anchor_positions: list[int] = []
+        self._anchors_by_position: list = []
         # v0.49 automatic cadence anchoring. Once enable_auto_anchor() sets a
         # client, the trail anchors its own head every _anchor_cadence records.
         # Fail-open: a failed anchor attempt records a chained ANCHOR_GAP marker
@@ -1683,7 +1698,7 @@ class AuditTrail:
             head_hash = self._records[-1].record_hash
         anchor = client.anchor(position, head_hash)
         with self._lock:
-            self._anchors.append(anchor)
+            self._index_anchor(anchor)
         return anchor
 
     def verify_segment(
@@ -1751,7 +1766,6 @@ class AuditTrail:
             # is safe against a concurrent append.
             length = len(self._records)
             records = self._records
-            anchors = list(self._anchors)
             store_anchors = dict(self._store_anchors)
             # Exactly one of the two is set, guarded above, but the branches
             # test each one directly so the narrowing is local.
@@ -1771,18 +1785,48 @@ class AuditTrail:
                     p for r in self._by_action.get(action_id, [])
                     if (p := self._pos_by_record_id.get(r.record_id)) is not None
                 )
+            # An index entry pointing past the captured length belongs to a
+            # record appended after this call started. It is outside this walk,
+            # the same as any other late arrival.
+            targets = [t for t in targets if t < length]
+            first = min(targets) if targets else -1
+            last = max(targets) if targets else -1
+
+            # O(log n), against the position-ordered index rather than the
+            # arrival-ordered list. This was a full pass over every anchor, and
+            # measured at a million records with the default 32-record cadence
+            # it was 6.7 ms of which about 0.58 ms was the actual verification
+            # work: 31,250 anchors scanned to use two of them.
+            #
+            # The scan existed because _anchors is genuinely unordered:
+            # anchor_head makes its TSA round trip outside the lock, so two
+            # concurrent anchors can append in the opposite order to the
+            # positions they carry. _index_anchor maintains the order instead
+            # of assuming it, which is what makes a bisect sound here.
+            #
+            # Both lookups run under _lock. Unlike _records these lists are
+            # inserted into rather than appended to, so an element can move
+            # while another thread reads, and a reference taken outside the
+            # lock would not be safe.
+            n_anchors = len(self._anchor_positions)
+            lower = upper = None
+            if targets and n_anchors:
+                # The last anchor strictly below the segment, and the first at
+                # or above its end. Ties resolve to the same position and the
+                # same head hash, so either member of a tie is the same answer.
+                low_i = bisect.bisect_left(self._anchor_positions, first) - 1
+                if low_i >= 0:
+                    lower = self._anchors_by_position[low_i]
+                up_i = bisect.bisect_left(self._anchor_positions, last)
+                if up_i < n_anchors:
+                    upper = self._anchors_by_position[up_i]
+
         label = (f"record_id={record_id!r}" if record_id is not None
                  else f"action_id={action_id!r}")
-        # An index entry pointing past the captured length belongs to a record
-        # appended after this call started. It is outside this walk, the same
-        # as any other late arrival.
-        targets = [t for t in targets if t < length]
         if not targets:
             return SegmentVerification(ok=False, reason=f"{label} not found in trail")
 
-        first, last = min(targets), max(targets)
-
-        if not anchors:
+        if not n_anchors:
             return SegmentVerification(
                 ok=False,
                 record_index=first,
@@ -1793,27 +1837,6 @@ class AuditTrail:
                     "whole-chain walk, which would answer a different question."
                 ),
             )
-
-        # One pass, no sort. The previous form sorted the anchor list on every
-        # call, and once the record scan was indexed away that sort became the
-        # remaining term that grew with the trail: at the default 32-record
-        # cadence a 50,000 record trail carries 1,562 anchors, and it is 15,600
-        # at half a million.
-        #
-        # Not bisect, because the list is not reliably ordered. anchor_head
-        # reads the position under the lock, makes the TSA round trip outside
-        # it, then appends under the lock again, so two concurrent anchors can
-        # append in the opposite order to the positions they hold. A single
-        # scan for the tightest bounds needs no ordering assumption at all.
-        lower = upper = None
-        for a in anchors:
-            pos = a.chain_position
-            if pos < first:
-                if lower is None or pos > lower.chain_position:
-                    lower = a
-            elif pos >= last:
-                if upper is None or pos < upper.chain_position:
-                    upper = a
 
         from vaara.audit.timeanchor import TimeAnchorError, verify_anchor
 
@@ -2031,6 +2054,28 @@ class AuditTrail:
         with self._publish_lock:
             self._publications.append(pub.to_dict())
 
+    def _index_anchor(self, anchor: Any) -> None:
+        """Record one anchor, in arrival order and in chain-position order.
+
+        Call under ``_lock``. The caller has already made the TSA round trip
+        outside the lock, so anchors can arrive out of position order and the
+        position-ordered list is built by insertion.
+
+        ``bisect_right`` puts a new anchor after any it ties with, which keeps
+        arrival order among equal positions. Ties are possible: two callers can
+        read the same head position before either appends. Both anchors then
+        name the same position and the same head hash, so a bound search may
+        pick either one and get the same answer, with a different token.
+
+        The insert is O(n) in list movement, and anchors arrive once per
+        cadence (32 records by default) and almost always in order, so in
+        practice it lands at the tail and costs a memmove of nothing.
+        """
+        self._anchors.append(anchor)
+        i = bisect.bisect_right(self._anchor_positions, anchor.chain_position)
+        self._anchor_positions.insert(i, anchor.chain_position)
+        self._anchors_by_position.insert(i, anchor)
+
     def _maybe_auto_anchor(self) -> None:
         """Anchor the head when the per-record cadence is reached (fail-open)."""
         if self._anchor_client is None:
@@ -2052,7 +2097,7 @@ class AuditTrail:
             self._record_anchor_gap(position, head_hash, repr(exc), client)
             return
         with self._lock:
-            self._anchors.append(anchor)
+            self._index_anchor(anchor)
 
     def _record_anchor_gap(
         self, position: int, head_hash: str, reason: str, client: Any

--- a/tests/test_trail_segment_verify.py
+++ b/tests/test_trail_segment_verify.py
@@ -272,3 +272,90 @@ def test_requires_exactly_one_selector():
         trail.verify_segment()
     with pytest.raises(ValueError):
         trail.verify_segment(record_id="a", action_id="b")
+
+
+# ── The ordering the bisect depends on ──────────────────────────────────────
+#
+# verify_segment finds its bounding pair with a bisect over a position-ordered
+# index. _anchors itself is NOT ordered: anchor_head reads the head position
+# under the lock, makes the TSA round trip outside it, then appends under the
+# lock again, so two concurrent anchors can arrive in the opposite order to the
+# positions they carry. These tests drive that arrival order directly, which is
+# what the race produces, and pin that the index puts them back in place.
+
+def test_anchors_arriving_out_of_position_order_still_bound_the_segment():
+    trail = AuditTrail()
+    client = _local_tsa_client()
+    _add(trail, 30)
+
+    # Two anchors built for positions 9 and 19, then handed over in the wrong
+    # order, which is the outcome of two concurrent anchor_head calls.
+    late = client.anchor(9, trail._records[9].record_hash)
+    early = client.anchor(19, trail._records[19].record_hash)
+    with trail._lock:
+        trail._index_anchor(early)     # position 19 arrives first
+        trail._index_anchor(late)      # position 9 arrives second
+
+    assert [a.chain_position for a in trail._anchors] == [19, 9]
+    assert trail._anchor_positions == [9, 19]
+
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert result.ok, result.reason
+    assert result.lower_anchor_position == 9
+    assert result.upper_anchor_position == 19
+
+
+def test_out_of_order_anchors_do_not_widen_the_segment():
+    """The tightest pair, not the first pair found. A wider walk would pass a
+    tamper below the true lower bound into scope and change what ok means."""
+    trail = AuditTrail()
+    client = _local_tsa_client()
+    _add(trail, 40)
+
+    anchors = [client.anchor(p, trail._records[p].record_hash)
+               for p in (9, 19, 29)]
+    with trail._lock:
+        for a in reversed(anchors):    # 29, 19, 9
+            trail._index_anchor(a)
+
+    result = trail.verify_segment(record_id=_rid(trail, 22))
+
+    assert result.ok, result.reason
+    assert result.lower_anchor_position == 19
+    assert result.upper_anchor_position == 29
+    assert result.records_verified == 10     # 20..29, not 0..29
+
+
+def test_two_anchors_at_the_same_position_are_both_usable():
+    """Two callers can read the same head before either appends. Both anchors
+    then name that position and that head hash, so either bounds the segment."""
+    trail = AuditTrail()
+    client = _local_tsa_client()
+    _add(trail, 30)
+
+    head9 = trail._records[9].record_hash
+    with trail._lock:
+        trail._index_anchor(client.anchor(9, head9))
+        trail._index_anchor(client.anchor(9, head9))
+        trail._index_anchor(client.anchor(19, trail._records[19].record_hash))
+
+    assert trail._anchor_positions == [9, 9, 19]
+
+    result = trail.verify_segment(record_id=_rid(trail, 15))
+
+    assert result.ok, result.reason
+    assert result.lower_anchor_position == 9
+    assert result.upper_anchor_position == 19
+
+
+def test_index_stays_ordered_through_ordinary_anchoring():
+    """The common path appends in order; the index must not disturb it."""
+    trail = _anchored_trail()
+    _add(trail, 10)
+    trail.anchor_head(_local_tsa_client())
+
+    assert trail._anchor_positions == sorted(trail._anchor_positions)
+    assert [a.chain_position for a in trail._anchors_by_position] == \
+        trail._anchor_positions
+    assert len(trail._anchors_by_position) == len(trail._anchors)


### PR DESCRIPTION
## What this changes

`verify_segment` found its bounding anchors by copying the anchor list under the lock and scanning it. At the default 32-record cadence that is one anchor per 32 records, so the cost grew with the trail.

Measured with `scripts/bench_anchor_bound_search.py`, 200 calls per row against a record in the middle of the trail:

| records | anchors | before | after |
|---|---|---|---|
| 5,000 | 156 | 0.613 ms | 0.614 ms |
| 50,000 | 1,562 | 0.752 ms | 0.622 ms |
| 150,000 | 4,687 | 1.004 ms | 0.619 ms |
| 500,000 | 15,625 | 2.198 ms | 0.651 ms |
| 1,000,000 | 31,250 | 6.731 ms | 0.645 ms |

At a million records the fixed verification work is about 0.58 ms, so the scan was roughly 91 percent of the call: 31,250 anchors read to use two of them. The curve is flat afterwards.

## Why it was a scan

`_anchors` is genuinely unordered. `anchor_head` reads the head position under the lock, makes the TSA round trip outside it, then appends under the lock again, so two concurrent anchors can append in the opposite order to the positions they carry. A bisect over `_anchors` would be unsound, which is why the previous code took a full pass.

## What it is now

`_index_anchor` inserts each anchor into a position-ordered index at append time, and both anchoring paths go through it. The bound search bisects that index under the same lock the rest of the capture already holds.

Two anchors can share a position, so the index is two parallel lists. A single list of tuples would fall through to comparing anchor objects on a tie.

## Tests

The new tests drive the arrival order directly, which is what the race produces. Out-of-order arrival still finds the bounds, and it finds the tightest bounds, so a tamper below the true lower bound stays out of scope. A tie at one position is usable from either member, and the ordinary in-order path leaves the index sorted.

The two out-of-order tests fail against a naive append. The other two pass against it, so they pin the index shape and not the ordering.