### PR TITLE
feat(audit): access records, so "who opened it" has an answer

### DIFF
--- a/src/vaara/audit/access.py
+++ b/src/vaara/audit/access.py
@@ -1,0 +1,355 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Who opened it: access records that survive the party who wrote them.
+
+The rest of the trail records what an agent DID. Every member of
+:class:`~vaara.audit.trail.EventType` before this one is an action:
+requested, scored, decided, executed, blocked, escalated, overridden.
+Reading was not an event, so nothing in the trail answered the question a
+supervisor actually asks first, which is who opened this.
+
+Two things make an access record different from an ordinary access log.
+
+**It names two identities and one of them is a person.** When an agent
+performs a read, "who accessed this" has two answers: the agent, and the
+principal it acted for. A single actor field collapses them and the
+collapse is not recoverable afterwards. Finnish health law is the sharp
+case: laki sosiaali- ja terveydenhuollon asiakastietojen kasittelysta
+(703/2023) section 11 gives a client the right to be told who used their
+data and on what basis, and a service account name does not answer it.
+So ``accessed_by`` and ``on_behalf_of`` are both required and neither
+defaults.
+
+**It commits to what came back, and holds none of it.** "Agent X opened
+patient Y" does not say what X saw, and a dispute is about content. The
+record therefore carries a digest over the returned set. It never carries
+the set. An access record over health data that copied the data would be
+a second unprotected copy of the thing it exists to protect, so
+:func:`record_access` takes a digest and has no parameter that could
+accept the rows.
+
+Everything else follows from living in the same trail. The record is
+hash-chained with its neighbours, so an access cannot be removed without
+breaking the chain; it is covered by ``anchor_head``, so the time is
+attested by a party outside the operator rather than asserted by the
+operator; and ``verify_segment`` proves one access record between two
+anchors without walking the trail.
+
+What it does not do, stated so nobody infers it: this proves the system
+recorded an access at that moment inside a tamper-evident chain. It does
+not prove a human read the screen, and it cannot prove that an access
+which was never recorded did not happen. Completeness over a stream of
+access records is a separate property and it is not claimed here.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping, Optional
+
+from vaara.audit.trail import EventType
+
+ACCESS_TOOL = "vaara.access.read"
+ACCESS_OUTCOME_TOOL = "vaara.access.outcome"
+
+#: Fields the record always names, so a verifier can enumerate what was
+#: captured rather than guessing from what happens to be present. A
+#: deployment adds its own through ``deployment_fields``; it cannot remove
+#: these.
+CORE_FIELDS = (
+    "subject",
+    "accessed_by",
+    "on_behalf_of",
+    "basis",
+    "returned_sha256",
+    "returned_count",
+    "authorisation_ref",
+    "channel",
+)
+
+
+def digest_returned(payload: bytes) -> str:
+    """``sha256:`` digest over the bytes a read returned.
+
+    Compute this at the point the result leaves the store and pass the
+    string to :func:`record_access`. Kept as a named helper so the caller
+    never has a reason to hand the payload itself to this module.
+    """
+    return "sha256:" + hashlib.sha256(payload).hexdigest()
+
+
+def record_access(
+    trail,
+    *,
+    subject: str,
+    accessed_by: str,
+    on_behalf_of: str,
+    basis: str,
+    returned_sha256: str = "",
+    returned_count: Optional[int] = None,
+    authorisation_ref: str = "",
+    channel: str = "",
+    session_id: str = "",
+    deployment_fields: Optional[Mapping[str, Any]] = None,
+) -> str:
+    """Record one read into ``trail``. Returns the ``action_id``.
+
+    ``subject`` identifies what was opened, in whatever identifier space
+    the deployment already uses. It is written to the trail as given, so
+    pass a reference rather than content: a record id, a pseudonym, a log
+    source name. ``accessed_by`` is the agent, service or process that
+    performed the read. ``on_behalf_of`` is the principal it acted for and
+    is the field a client's own log request has to be answerable from.
+    ``basis`` is why, in the deployment's own vocabulary, and it is the
+    "peruste" the Finnish asiakastietolaki asks for beside the identity.
+
+    ``returned_sha256`` commits to what came back; build it with
+    :func:`digest_returned`. It is optional because some callers genuinely
+    cannot compute it, and when it is absent the record says so through
+    ``fields_present`` instead of leaving a reader to assume the read
+    returned nothing. ``returned_count`` is the number of items returned,
+    which bounds an access even when the digest is missing.
+
+    ``deployment_fields`` carries whatever a sector needs beyond the core
+    set. The keys are recorded in ``fields_present`` alongside the core
+    ones, so a verifier reading the receipt can state what was captured
+    and what was not. An unbounded blob would not survive that question,
+    which is why the enumeration exists rather than a free-form note.
+
+    Raises ``ValueError`` when either identity or the basis is missing.
+    Those three are the record's reason to exist and a default for any of
+    them would produce an access record that answers nothing.
+    """
+    if not subject:
+        raise ValueError("subject must not be empty: an access record names what was opened")
+    if not accessed_by:
+        raise ValueError("accessed_by must not be empty: name the agent or process that read")
+    if not on_behalf_of:
+        raise ValueError(
+            "on_behalf_of must not be empty: an access record whose only identity is "
+            "the agent cannot answer who used the data"
+        )
+    if not basis:
+        raise ValueError("basis must not be empty: record why the read was permitted")
+    if returned_sha256 and not returned_sha256.startswith("sha256:"):
+        raise ValueError(
+            f"returned_sha256 must be a 'sha256:' prefixed digest, got {returned_sha256!r}; "
+            "use digest_returned()"
+        )
+
+    extra = dict(deployment_fields or {})
+    for reserved in CORE_FIELDS + ("fields_present",):
+        if reserved in extra:
+            raise ValueError(
+                f"deployment_fields may not shadow the core field {reserved!r}"
+            )
+
+    parameters: dict[str, Any] = {
+        "subject": subject,
+        "accessed_by": accessed_by,
+        "on_behalf_of": on_behalf_of,
+        "basis": basis,
+        "returned_sha256": returned_sha256,
+        "returned_count": returned_count,
+        "authorisation_ref": authorisation_ref,
+        "channel": channel,
+    }
+    parameters.update(extra)
+    # Present means "carries a value here", so a caller that omitted the
+    # returned digest produces a record that states the omission rather
+    # than one a reader has to interpret.
+    parameters["fields_present"] = sorted(
+        k for k, v in parameters.items()
+        if v not in ("", None) and k != "fields_present"
+    )
+
+    from vaara.pipeline import InterceptionPipeline
+
+    pipeline = InterceptionPipeline(trail=trail, enforce=False)
+    result = pipeline.intercept(
+        agent_id=accessed_by,
+        tool_name=ACCESS_TOOL,
+        parameters=parameters,
+        session_id=session_id,
+        context={"vaara_access": True},
+        _event_type_override=EventType.ACCESS_RECORDED,
+    )
+    return result.action_id
+
+
+def record_access_outcome(
+    trail,
+    access_action_id: str,
+    *,
+    outcome: str,
+    action_taken: bool,
+    by: str,
+    details: Optional[Mapping[str, Any]] = None,
+    session_id: str = "",
+) -> str:
+    """Close an access with what came of it, including nothing.
+
+    Henri's framing, 2026-09-09, and it is the reason this exists: there
+    should always be a reason to open a patient file, and if there is a
+    reason there is usually an outcome. Either somebody went and did
+    something about it, or somebody was reading for no clinical purpose.
+    Both are outcomes. Only one of them is lawful, and neither is
+    currently sayable.
+
+    ``action_taken`` is the part that carries weight. Passing ``False``
+    with an honest ``outcome`` writes a record that says the read led
+    nowhere, which is a different and much more useful fact than the read
+    simply going unmentioned. A supervisor can find those; a client
+    exercising a log request can see one.
+
+    So an access ends in one of three states, and they are three facts
+    rather than two:
+
+    * closed with an action, ``action_taken=True``
+    * closed with no action, ``action_taken=False``
+    * never closed, which is what
+      :func:`accesses_with_no_recorded_outcome` returns
+
+    The third is not the second. Nobody has said anything about it, and
+    reading that as "nothing happened" is the same collapse this project
+    refuses everywhere else: could-not-determine is not the same answer as
+    determined-negative.
+
+    Returns the ``action_id`` of the outcome record.
+    """
+    if not access_action_id:
+        raise ValueError("access_action_id must name the access being closed")
+    if not outcome:
+        raise ValueError(
+            "outcome must not be empty: closing an access with a blank reason "
+            "is the silence this record exists to replace"
+        )
+    if not by:
+        raise ValueError("by must name who is closing the access")
+
+    parameters: dict[str, Any] = {
+        "access_ref": access_action_id,
+        "outcome": outcome,
+        "action_taken": bool(action_taken),
+        "closed_by": by,
+    }
+    for k, v in dict(details or {}).items():
+        if k in parameters:
+            raise ValueError(f"details may not shadow {k!r}")
+        parameters[k] = v
+
+    from vaara.pipeline import InterceptionPipeline
+
+    pipeline = InterceptionPipeline(trail=trail, enforce=False)
+    result = pipeline.intercept(
+        agent_id=by,
+        tool_name=ACCESS_OUTCOME_TOOL,
+        parameters=parameters,
+        session_id=session_id,
+        context={"vaara_access": True},
+    )
+    return result.action_id
+
+
+def accesses_closed_with_no_action(records) -> list:
+    """Accesses somebody closed by stating that nothing came of them.
+
+    Distinct from :func:`accesses_with_no_recorded_outcome`, and the
+    distinction is the point. Here a named person said the read led
+    nowhere. There, nobody said anything at all.
+
+    This is the list worth reading first when the question is whether
+    files are being opened without a reason that survives being written
+    down.
+    """
+    closed_idle = {
+        (rec.data or {}).get("parameters", {}).get("access_ref")
+        for rec in records
+        if rec.tool_name == ACCESS_OUTCOME_TOOL
+        and (rec.data or {}).get("parameters", {}).get("action_taken") is False
+    }
+    return [
+        rec for rec in records
+        if rec.event_type == EventType.ACCESS_RECORDED
+        and rec.action_id in closed_idle
+    ]
+
+
+def follow_ups(records, access_action_id: str) -> list:
+    """Records that name ``access_action_id`` as what they followed.
+
+    A reader carries a follow-on action's ``access_ref`` in its own
+    parameters, which is how "she opened it and then wrote this" becomes
+    checkable instead of asserted.
+    """
+    out = []
+    for rec in records:
+        if rec.event_type == EventType.ACCESS_RECORDED:
+            continue
+        params = (rec.data or {}).get("parameters", {}) or {}
+        if params.get("access_ref") == access_action_id:
+            out.append(rec)
+    return out
+
+
+def accesses_with_no_recorded_outcome(records) -> list:
+    """Access records that nothing else in ``records`` refers back to.
+
+    This is the question a person actually asks, and the reason this
+    function exists: a portal that says "maintainer has seen the message"
+    tells you an entity looked and stops there. It cannot tell you whether
+    anything came of it.
+
+    **Read the result precisely.** An access appearing here means NO
+    RECORD EXISTS that refers back to it. It does not mean nothing
+    happened. A read that produced a decision nobody recorded, and a read
+    that produced nothing, land in this list together and this function
+    cannot separate them.
+
+    Separating them is what :func:`record_access_outcome` is for: closing
+    an access with ``action_taken=False`` moves it out of this list and
+    into :func:`accesses_closed_with_no_action`, where somebody has put
+    their name to the statement. What stays here is the set nobody
+    addressed at all, and that is a third fact rather than a weaker
+    version of the second.
+
+    What the list is good for is the direction people care about: it is
+    the set of times somebody opened your file and the trail has nothing
+    to show for it. Asking about those is a fair question, and today the
+    person whose file it was cannot even form it.
+    """
+    referenced = set()
+    for rec in records:
+        if rec.event_type == EventType.ACCESS_RECORDED:
+            continue
+        params = (rec.data or {}).get("parameters", {}) or {}
+        ref = params.get("access_ref")
+        if ref:
+            referenced.add(ref)
+    return [
+        rec for rec in records
+        if rec.event_type == EventType.ACCESS_RECORDED
+        and rec.action_id not in referenced
+    ]
+
+
+def find_accesses(records, *, subject: str = "", on_behalf_of: str = "") -> list:
+    """Access records in ``records``, optionally narrowed.
+
+    ``subject`` answers "who opened this record", which is the client's
+    own question under asiakastietolaki 703/2023 section 11.
+    ``on_behalf_of`` answers "what did this person open", which is the
+    supervisory direction. Both filters match exactly; no normalisation is
+    applied, because the deployment owns the identifier space and guessing
+    at case or format here would silently drop rows from a legal answer.
+    """
+    out = []
+    for rec in records:
+        if rec.event_type != EventType.ACCESS_RECORDED:
+            continue
+        params = (rec.data or {}).get("parameters", {}) or {}
+        if subject and params.get("subject") != subject:
+            continue
+        if on_behalf_of and params.get("on_behalf_of") != on_behalf_of:
+            continue
+        out.append(rec)
+    return out

--- a/src/vaara/audit/trail.py
+++ b/src/vaara/audit/trail.py
@@ -61,6 +61,7 @@ class EventType(str, Enum):
     ANCHOR_GAP = "anchor_gap"               # Auto-anchor attempt failed (fail-open marker)
     KEY_LIFECYCLE = "key_lifecycle"         # Signing-key custodian rotated/revoked/added
     DISCLOSURE_RECORDED = "disclosure_recorded"  # EU AI Act Art 50 transparency disclosure
+    ACCESS_RECORDED = "access_recorded"     # Something was opened, and by whom
 
 
 # ── Regulatory article mappings ───────────────────────────────────────────
@@ -275,6 +276,14 @@ TRANSPARENCY_DEFAULTS: dict[EventType, dict[str, str]] = {
         "data_usage": "disclosure_statement",
         "decision_making": "policy_requirement",
     },
+    EventType.ACCESS_RECORDED: {
+        "system_operation": "read_access",
+        # The record commits to what was returned by digest and holds none of
+        # it. That is the point: an access record over patient data cannot
+        # itself become a second copy of patient data.
+        "data_usage": "returned_set_digest",
+        "decision_making": "n/a",
+    },
 }
 
 
@@ -472,6 +481,17 @@ class AuditRecord:
                 f"{prefix} Article 50 disclosure: "
                 f"{_narrative_str(self.data.get('parameters', {}).get('article', '?'))}"
                 f" — {_narrative_str(self.data.get('parameters', {}).get('statement', ''), max_len=80)}"
+            ),
+            # The prefix already names the agent, so this names the person the
+            # agent acted for and the stated basis. Both belong in the line a
+            # human reads: "an entity saw it" is the transparency this record
+            # type exists to replace.
+            EventType.ACCESS_RECORDED: (
+                f"{prefix} opened "
+                f"{_narrative_str(self.data.get('parameters', {}).get('subject', '?'), max_len=64)}"
+                f" for "
+                f"{_narrative_str(self.data.get('parameters', {}).get('on_behalf_of', '?'), max_len=64)}"
+                f" ({_narrative_str(self.data.get('parameters', {}).get('basis', 'no basis given'), max_len=64)})"
             ),
         }
 

--- a/tests/test_access_records.py
+++ b/tests/test_access_records.py
@@ -1,0 +1,386 @@
+# SPDX-FileCopyrightText: 2026 Henri Sirkkavaara
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Access records: who opened it, on whose authority, and what came back.
+
+The load-bearing test here is ``test_agent_identity_alone_is_refused``. The
+whole reason this record type exists is that a service account name does not
+answer "who used this person's data". If that test ever passes with only an
+agent identity, the record has stopped answering the question it was built for.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.test_timeanchor import _local_tsa_client
+from vaara.audit.access import (
+    ACCESS_TOOL,
+    CORE_FIELDS,
+    accesses_closed_with_no_action,
+    accesses_with_no_recorded_outcome,
+    digest_returned,
+    find_accesses,
+    follow_ups,
+    record_access,
+    record_access_outcome,
+)
+from vaara.audit.trail import AuditTrail, EventType
+from vaara.taxonomy.actions import (
+    ActionCategory,
+    ActionRequest,
+    ActionType,
+    BlastRadius,
+    Reversibility,
+)
+
+
+def _read(trail, **kw):
+    base = dict(
+        subject="patient/4711/kayttoloki",
+        accessed_by="agent/log-search@istekki",
+        on_behalf_of="person/hetu-pseudonym/9f2c",
+        basis="hoitosuhteen tarkistus",
+    )
+    base.update(kw)
+    return record_access(trail, **base)
+
+
+# ── The reason the record type exists ───────────────────────────────────────
+
+def test_agent_identity_alone_is_refused():
+    """An access record whose only identity is the agent answers nothing."""
+    trail = AuditTrail()
+    with pytest.raises(ValueError, match="who used the data"):
+        record_access(
+            trail,
+            subject="patient/4711/kayttoloki",
+            accessed_by="agent/log-search@istekki",
+            on_behalf_of="",
+            basis="hoitosuhteen tarkistus",
+        )
+
+
+def test_both_identities_are_kept_apart():
+    trail = AuditTrail()
+    _read(trail)
+
+    rec = find_accesses(trail._records)[0]
+    params = rec.data["parameters"]
+
+    assert params["accessed_by"] == "agent/log-search@istekki"
+    assert params["on_behalf_of"] == "person/hetu-pseudonym/9f2c"
+    assert params["accessed_by"] != params["on_behalf_of"]
+
+
+def test_basis_is_required():
+    trail = AuditTrail()
+    with pytest.raises(ValueError, match="basis"):
+        _read(trail, basis="")
+
+
+def test_subject_and_agent_are_required():
+    trail = AuditTrail()
+    with pytest.raises(ValueError, match="what was opened"):
+        _read(trail, subject="")
+    with pytest.raises(ValueError, match="agent or process"):
+        _read(trail, accessed_by="")
+
+
+# ── It commits to what came back and holds none of it ───────────────────────
+
+def test_returned_set_is_committed_by_digest():
+    trail = AuditTrail()
+    payload = b'{"rows": ["seen this", "and this"]}'
+    _read(trail, returned_sha256=digest_returned(payload), returned_count=2)
+
+    params = find_accesses(trail._records)[0].data["parameters"]
+    assert params["returned_sha256"] == digest_returned(payload)
+    assert params["returned_count"] == 2
+
+
+def test_the_payload_never_reaches_the_record():
+    """The bytes that were returned must not appear anywhere in the trail."""
+    trail = AuditTrail()
+    payload = b"DIAGNOSIS-THAT-MUST-NOT-BE-COPIED"
+    _read(trail, returned_sha256=digest_returned(payload), returned_count=1)
+
+    blob = repr([r.to_dict() for r in trail._records])
+    assert b"DIAGNOSIS-THAT-MUST-NOT-BE-COPIED".decode() not in blob
+
+
+def test_a_bare_hex_digest_is_refused():
+    trail = AuditTrail()
+    with pytest.raises(ValueError, match="digest_returned"):
+        _read(trail, returned_sha256="a" * 64)
+
+
+# ── The fields present are enumerable ───────────────────────────────────────
+
+def test_missing_digest_is_stated_rather_than_implied():
+    trail = AuditTrail()
+    _read(trail)
+
+    present = find_accesses(trail._records)[0].data["parameters"]["fields_present"]
+    assert "returned_sha256" not in present
+    assert "on_behalf_of" in present
+    assert "basis" in present
+
+
+def test_deployment_fields_are_carried_and_enumerated():
+    trail = AuditTrail()
+    _read(trail, deployment_fields={"rekisteri": "potilastiedot", "yksikko": "KYS"})
+
+    params = find_accesses(trail._records)[0].data["parameters"]
+    assert params["rekisteri"] == "potilastiedot"
+    assert "yksikko" in params["fields_present"]
+    assert "rekisteri" in params["fields_present"]
+
+
+def test_deployment_fields_cannot_shadow_a_core_field():
+    trail = AuditTrail()
+    for reserved in CORE_FIELDS + ("fields_present",):
+        with pytest.raises(ValueError, match="shadow"):
+            _read(trail, deployment_fields={reserved: "spoofed"})
+
+
+# ── It inherits the trail's properties rather than reimplementing them ──────
+
+def test_an_access_record_is_chained_like_any_other():
+    trail = AuditTrail()
+    _read(trail)
+    _read(trail, subject="patient/4712/kayttoloki")
+
+    assert trail.verify_chain() is None
+
+
+def test_removing_an_access_record_breaks_the_chain():
+    trail = AuditTrail()
+    _read(trail)
+    _read(trail, subject="patient/4712/kayttoloki")
+    target = find_accesses(trail._records)[0]
+    target.data["parameters"]["on_behalf_of"] = "person/somebody-else"
+
+    assert trail.verify_chain() is not None
+
+
+def test_the_time_is_attested_by_an_anchor_not_asserted():
+    """A timestamp the emitter wrote is the emitter's word. Anchors are not."""
+    trail = AuditTrail()
+    client = _local_tsa_client()
+    _read(trail)
+    trail.anchor_head(client)
+    _read(trail, subject="patient/4712/kayttoloki")
+    trail.anchor_head(client)
+
+    accesses = find_accesses(trail._records)
+    result = trail.verify_segment(record_id=accesses[0].record_id)
+
+    assert result.ok, result.reason
+    assert result.upper_attested_time
+
+
+# ── Finding them ────────────────────────────────────────────────────────────
+
+def test_who_opened_this_record():
+    trail = AuditTrail()
+    _read(trail)
+    _read(trail, subject="patient/4712/kayttoloki", on_behalf_of="person/other")
+
+    hits = find_accesses(trail._records, subject="patient/4711/kayttoloki")
+
+    assert len(hits) == 1
+    assert hits[0].data["parameters"]["on_behalf_of"] == "person/hetu-pseudonym/9f2c"
+
+
+def test_what_did_this_person_open():
+    trail = AuditTrail()
+    _read(trail)
+    _read(trail, subject="patient/4712/kayttoloki")
+    _read(trail, subject="patient/9999/kayttoloki", on_behalf_of="person/other")
+
+    hits = find_accesses(trail._records, on_behalf_of="person/hetu-pseudonym/9f2c")
+
+    assert {h.data["parameters"]["subject"] for h in hits} == {
+        "patient/4711/kayttoloki", "patient/4712/kayttoloki",
+    }
+
+
+def test_it_is_its_own_event_type_not_an_ordinary_action():
+    trail = AuditTrail()
+    _read(trail)
+
+    kinds = {r.event_type for r in trail._records}
+    assert EventType.ACCESS_RECORDED in kinds
+    rec = find_accesses(trail._records)[0]
+    assert rec.tool_name == ACCESS_TOOL
+
+
+def test_the_narrative_names_both_identities_and_the_basis():
+    """"An entity saw it" is the transparency this record type replaces."""
+    trail = AuditTrail()
+    _read(trail)
+
+    line = find_accesses(trail._records)[0].narrative
+
+    assert "agent/log-search@istekki" in line
+    assert "person/hetu-pseudonym/9f2c" in line
+    assert "hoitosuhteen tarkistus" in line
+    assert "patient/4711/kayttoloki" in line
+
+
+# ── Did anything follow? ────────────────────────────────────────────────────
+#
+# The case these came from, Henri 2026-09-09: Maisa.fi says "maintainer has
+# seen the message". An anonymous entity, no name, no reason, and no way to
+# tell whether anyone acted on it. Naming the reader is half the answer. The
+# other half is whether the read produced anything.
+
+_NOTE = ActionType(
+    name="write_note",
+    category=ActionCategory.DATA,
+    reversibility=Reversibility.FULLY,
+    blast_radius=BlastRadius.LOCAL,
+)
+
+
+def _acted_on(trail, access_action_id):
+    return trail.record_action_requested(ActionRequest(
+        action_type=_NOTE, tool_name="write_note", agent_id="nurse/console",
+        parameters={"access_ref": access_action_id, "note": "callback booked"},
+    ))
+
+
+def test_an_access_that_produced_something_can_be_followed():
+    trail = AuditTrail()
+    access_id = _read(trail)
+    _acted_on(trail, access_id)
+
+    hits = follow_ups(trail._records, access_id)
+
+    assert hits
+    assert all(h.event_type != EventType.ACCESS_RECORDED for h in hits)
+    assert accesses_with_no_recorded_outcome(trail._records) == []
+
+
+def test_an_access_nothing_refers_back_to_is_listed():
+    trail = AuditTrail()
+    seen_and_dropped = _read(trail)
+    acted = _read(trail, subject="patient/4712/kayttoloki")
+    _acted_on(trail, acted)
+
+    orphans = accesses_with_no_recorded_outcome(trail._records)
+
+    assert [o.action_id for o in orphans] == [seen_and_dropped]
+
+
+def test_a_follow_up_for_one_access_does_not_cover_another():
+    trail = AuditTrail()
+    first = _read(trail)
+    second = _read(trail, subject="patient/4712/kayttoloki")
+    _acted_on(trail, first)
+
+    assert follow_ups(trail._records, second) == []
+    assert [o.action_id for o in accesses_with_no_recorded_outcome(trail._records)] == [second]
+
+
+def test_the_orphan_list_does_not_claim_nothing_happened():
+    """Absence of a follow-on record is not evidence that nothing followed.
+
+    Pinned as a test because the docstring is the only thing stopping a
+    reader from treating this list as proof of inaction, and a docstring
+    nobody executes is a comment.
+    """
+    trail = AuditTrail()
+    access_id = _read(trail)
+    # An action that really happened but was recorded without the back
+    # reference. The access still lands in the orphan list.
+    trail.record_action_requested(ActionRequest(
+        action_type=_NOTE, tool_name="write_note", agent_id="nurse/console",
+        parameters={"note": "acted, but nobody linked it"},
+    ))
+
+    orphans = accesses_with_no_recorded_outcome(trail._records)
+
+    assert [o.action_id for o in orphans] == [access_id]
+
+
+# ── Three states, not two ───────────────────────────────────────────────────
+#
+# Henri, 2026-09-09: there should always be a reason to open a patient file,
+# and if there is a reason there is usually an outcome. Either somebody went
+# and did something, or somebody was reading for no clinical purpose. Both are
+# outcomes and only one of them is lawful.
+
+def test_an_access_can_be_closed_with_an_action():
+    trail = AuditTrail()
+    access_id = _read(trail)
+    record_access_outcome(
+        trail, access_id, outcome="uusintapyynto vietiin laakarille",
+        action_taken=True, by="nurse/jarvisalo",
+    )
+
+    assert follow_ups(trail._records, access_id)
+    assert accesses_with_no_recorded_outcome(trail._records) == []
+    assert accesses_closed_with_no_action(trail._records) == []
+
+
+def test_an_access_can_be_closed_with_no_action_and_that_is_a_record():
+    trail = AuditTrail()
+    access_id = _read(trail)
+    record_access_outcome(
+        trail, access_id, outcome="selattiin ilman hoidollista tarvetta",
+        action_taken=False, by="nurse/unknown",
+    )
+
+    idle = accesses_closed_with_no_action(trail._records)
+
+    assert [a.action_id for a in idle] == [access_id]
+    # Closed is closed. It leaves the set nobody addressed.
+    assert accesses_with_no_recorded_outcome(trail._records) == []
+
+
+def test_never_closed_is_not_the_same_as_closed_with_no_action():
+    """The third value. Nobody said anything is not the same as somebody
+    saying nothing came of it, and collapsing them is the failure this
+    project refuses everywhere else."""
+    trail = AuditTrail()
+    silent = _read(trail)
+    stated = _read(trail, subject="patient/4712/kayttoloki")
+    record_access_outcome(
+        trail, stated, outcome="ei toimenpiteita", action_taken=False,
+        by="nurse/kirjaaja",
+    )
+
+    never_closed = [a.action_id for a in accesses_with_no_recorded_outcome(trail._records)]
+    closed_idle = [a.action_id for a in accesses_closed_with_no_action(trail._records)]
+
+    assert never_closed == [silent]
+    assert closed_idle == [stated]
+    assert never_closed != closed_idle
+
+
+def test_closing_an_access_needs_a_reason_and_a_name():
+    trail = AuditTrail()
+    access_id = _read(trail)
+    with pytest.raises(ValueError, match="silence this record exists to replace"):
+        record_access_outcome(trail, access_id, outcome="", action_taken=True, by="x")
+    with pytest.raises(ValueError, match="who is closing"):
+        record_access_outcome(trail, access_id, outcome="done", action_taken=True, by="")
+    with pytest.raises(ValueError, match="must name the access"):
+        record_access_outcome(trail, "", outcome="done", action_taken=True, by="x")
+
+
+def test_the_outcome_carries_its_own_timestamp_and_name():
+    trail = AuditTrail()
+    access_id = _read(trail)
+    record_access_outcome(
+        trail, access_id, outcome="soitettiin potilaalle", action_taken=True,
+        by="nurse/jarvisalo", details={"yksikko": "Oulunkyla"},
+    )
+
+    closing = follow_ups(trail._records, access_id)[0]
+    params = closing.data["parameters"]
+
+    assert params["closed_by"] == "nurse/jarvisalo"
+    assert params["action_taken"] is True
+    assert params["yksikko"] == "Oulunkyla"
+    assert closing.timestamp


### PR DESCRIPTION
## The gap

Every `EventType` member so far describes what an agent **did**: requested, scored, decided, executed, blocked, escalated, overridden, disclosed. Reading was not an event, so nothing in the trail answered the question a supervisor asks first.

## What an access record carries that an access log does not

**Two identities, and one of them is a person.** When an agent performs a read, "who accessed this" has two answers: the agent, and the principal it acted for. A single actor field collapses them and the collapse is not recoverable afterwards. `accessed_by` and `on_behalf_of` are both required and neither defaults.

The sharp case is Finnish health law. Asiakastietolaki 703/2023 section 11 gives a client the right to be told who used their data and on what basis. A service account name does not answer that, because the answer has to name a person.

**A commitment to what came back, holding none of it.** "Agent X opened patient Y" does not say what X saw, and a dispute is about content. The record carries a digest over the returned set and has no parameter that could accept the rows. An access record over health data that copied the data would be a second unprotected copy of the thing it exists to protect.

**Enumerable fields.** Deployments add their own through `deployment_fields`, and `fields_present` lists what was actually captured, so a missing returned digest is stated rather than left for a reader to interpret.

**Attested time rather than asserted time.** The record is chained, anchorable and reachable by `verify_segment` like any other record, so removing an access breaks the chain and the timestamp is backed by a party outside the operator.

## Whether anything followed

An access ends in one of three states, and they are three facts:

| state | how |
|---|---|
| closed with an action | `record_access_outcome(..., action_taken=True)` |
| closed, nothing came of it | `record_access_outcome(..., action_taken=False)` |
| never closed by anyone | `accesses_with_no_recorded_outcome()` |

The third is not the second. Reading "nobody said anything" as "nothing happened" is the same collapse this project refuses in `verify_consistency` and in `RevocationStatus`.

Closing an access with `action_taken=False` requires a reason and a name, so a read that led nowhere becomes a record somebody signed rather than a silence.

## Tests

26, all passing, and 494 across the wider audit and compliance set. The load-bearing one is `test_agent_identity_alone_is_refused`: if an access record can be written with only an agent identity, it has stopped answering the question it exists for.

`test_the_payload_never_reaches_the_record` and `test_the_orphan_list_does_not_claim_nothing_happened` pin the two claims most likely to erode quietly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added audit records for tracking information access, including who accessed it, on whose behalf, and the stated basis.
  - Added privacy-preserving digests and counts for returned data without storing the returned content.
  - Added validation for access details and protection against conflicting custom fields.
  - Added support for recording access outcomes, follow-up actions, and related details.
  - Added search and reporting tools for access records, including unresolved outcomes and follow-ups.
  - Added clear audit-trail event types and narratives for recorded access activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->