### PR TITLE
release: v1.81.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.81.0] - 2026-09-09
+
 ### Fixed
 
 - A trail that stops recording now says so. The Claude Code hook could fail to persist every single record, print a traceback, and exit 0, and nothing anywhere surfaced it. Found by dogfooding: on the maintainer's own machine the trail had been dead for thirteen days, and it turned up only because someone went looking for an unrelated reason.
@@ -74,6 +76,20 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   The bound stays opt-in, because `draft-sirkkavaara-vaara-receipt-08` Section 10 puts the staleness a deployment accepts on the deployment rather than on the verifier. Callers that pass neither parameter get the behaviour they had before it existed, which `test_stale_registry_admits_when_no_bound_is_stated` pins.
 
   The asymmetry is preserved and pinned separately. A revocation the registry can see binds however old the registry is, so `revoked` is answered before staleness is considered and a stale registry never downgrades a refusal to `revocation_stale`. Staleness weakens only the negative answer. `test_revocation_binds_however_stale_the_registry_is` is the case most likely to regress.
+
+- One record's segment can be verified without walking the trail. `verify_segment(record_id=...)` or `action_id=...` bounds a record between the two nearest time anchors, verifies that pair, and walks only the records between them. The question a supervisor asks is not whether the trail is broadly sound, it is whether one action's record is what it was when it was written, and answering it used to cost a whole-chain walk.
+
+  Anchoring is opt-in and no TSA is configured by default, so the unanchored case is the common one and it fails loudly rather than degrading to a walk from genesis, which would answer a different question. A record above the last anchor is reported `ok` with `closed=False`: it chains back to an attested head and nothing external attests it yet, and those are different claims. An `action_id` widens the walk to cover every record of that action, because an action's records can straddle an anchor.
+
+- The whole chain can be verified without materialising it, and the walk can be resumed. `verify_chain` holds one record at a time instead of opening with a copy of the record list, which was the entire transient cost of the call: 393 KiB over 50,000 records against 390.6 KiB of pointer array. `start_index` and `expected_previous_hash` restart the walk part way, so a long verification can checkpoint against an anchored head instead of starting over. Everything below the restart point is then not verified and no claim is made about it, which is why the caller supplies the hash it expects rather than having one read out of the records being skipped.
+
+  A store too large to hold in memory is verified by `SQLiteAuditBackend.verify_chain_streaming`, which never materialises the rows.
+
+### Performance
+
+- Prior-approval lookup no longer scans the trail. Resolved escalations are indexed as they are recorded, so `find_prior_approval` reads a short list instead of walking every record. At 23,000 services an hour a trail holds around 552,000 records in a 24 hour window, and a human answers a handful of them.
+
+- `verify_segment` resolves a record id in constant time. Locating the record was a linear scan and, measured at 50,000 records, it was 59 percent of the call: the verification work is flat at 32 record hashes and two tokens whatever the trail size, and finding the record was not. The index costs about 66 bytes per record, roughly 3 percent on top of records that already cost about 2 KiB each, and it exists only where the record list does.
 
 ## [1.80.0] - 2026-09-02
 

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.80.0",
+  "version": "1.81.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.80.0"
+appVersion: "1.81.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.80.0, Helm chart 0.1.0.
+Vaara 1.81.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.80.0",
+  "version": "1.81.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.80.0"
+version = "1.81.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.80.0",
+  "version": "1.81.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.80.0",
+"version": "1.81.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.80.0",
+  "version": "1.81.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.80.0",
+"version": "1.81.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.80.0"
+__version__ = "1.81.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
## What this release is about

Verifying an audit trail used to mean walking all of it. Three changes here make the common questions cheap, and one of them makes a long verification resumable.

**One record, not the whole chain.** `verify_segment(record_id=...)` bounds a record between the two nearest time anchors, verifies that pair, and walks only what lies between them. The question a supervisor asks is whether one action's record is what it was when it was written, and that used to cost a full walk.

Anchoring is opt-in and no TSA ships configured, so the unanchored case is the common one. It fails loudly rather than falling back to a walk from genesis, which would answer a different question. A record above the last anchor reports `ok` with `closed=False`, because chaining back to an attested head and being attested by something external are different claims.

**The whole chain without materialising it.** `verify_chain` holds one record at a time. The copy it used to open with was the entire transient cost of the call: 393 KiB over 50,000 records against 390.6 KiB of pointer array. `start_index` and `expected_previous_hash` restart the walk part way, so a long verification checkpoints against an anchored head. Everything below the restart point is then unverified and no claim is made about it, which is why the caller supplies the hash it expects.

**Two scans indexed away.** Prior-approval lookup reads a short list of resolved escalations instead of walking every record; at 23,000 services an hour a trail holds around 552,000 records a day and a human answers a handful. `verify_segment` resolves a record id in constant time, which was 59 percent of that call at 50,000 records, against verification work that is flat at 32 record hashes whatever the trail size.

## Also in this release

- The conformance runner's report is a portable run record that pins every checker and case file by digest, so a run can be recomputed against a clean clone. Being listed is for being seen and the record is for being believed, and nobody should have to buy the first to get the second.
- The MCP proxy records which gates ran and in what order, and reports three distinct states for the credential gateway rather than collapsing "not configured", "not constrained" and "passed" into one.
- The MCP proxy can check revocation, and every shipped export path can pin the registry it used. Both features existed and neither was reachable from a shipped caller.
- A trail that stops recording says so. The failure counter lived in a per-process object while the hook is a fresh process per tool call, so it could never climb past 1. On the maintainer's own machine the trail had been dead for thirteen days.

## Verification

Full test suite and `ruff` run in `release_prepare.sh` before the commit exists.
