### PR TITLE
Reading is now an event, and verify_segment stops scanning every anchor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.82.0] - 2026-09-09
+
+### Added
+
+- Reading is now an event. Every `EventType` member so far described what an agent did: requested, scored, decided, executed, blocked, escalated, overridden, disclosed. Nothing in the trail answered the question a supervisor asks first, which is who opened the record. `ACCESS_RECORDED` and `vaara.audit.access` add it, with four properties an ordinary access log does not have.
+
+  Two identities, and one of them is a person. When an agent performs a read, "who accessed this" has two answers: the agent, and the principal it acted for. A single actor field collapses them and the collapse cannot be recovered afterwards. `accessed_by` and `on_behalf_of` are both required and neither defaults. Finnish health law is the sharp case: asiakastietolaki 703/2023 section 11 gives a client the right to be told who used their data and on what basis, and a service account name does not answer that.
+
+  A commitment to what came back, holding none of it. "Agent X opened patient Y" does not say what X saw, and a dispute is about content, so the record carries a digest over the returned set and has no parameter that could accept the rows. An access record over health data that copied the data would be a second unprotected copy of the thing it exists to protect.
+
+  Enumerable fields. Deployments add their own through `deployment_fields`, and `fields_present` lists what was actually captured, so a missing returned digest is stated rather than left for a reader to interpret.
+
+  Attested time rather than asserted time. The record is chained, anchorable and reachable by `verify_segment` like any other, so removing an access breaks the chain and the timestamp is backed by a party outside the operator.
+
+  Then the half that matters as much: whether anything followed. An access ends in one of three states and they are three facts. Closed with an action. Closed with an explicit statement by a named person that nothing came of it. Or never closed at all, which is what `accesses_with_no_recorded_outcome` returns. Reading "nobody said anything" as "nothing happened" is the same collapse this project refuses in `verify_consistency` and in `RevocationStatus`.
+
+### Performance
+
+- `verify_segment` no longer scans every anchor to find the pair that bounds a record. With the record lookup already indexed, the anchor handling was what remained growing: a copy of the anchor list under the lock, then a full pass over it. At the default 32-record cadence that is one anchor per 32 records, so both terms scaled with the trail.
+
+  Measured with `scripts/bench_anchor_bound_search.py`, 200 calls per row against a record in the middle of the trail:
+
+  | records | anchors | before | after |
+  |---|---|---|---|
+  | 5,000 | 156 | 0.613 ms | 0.614 ms |
+  | 50,000 | 1,562 | 0.752 ms | 0.622 ms |
+  | 150,000 | 4,687 | 1.004 ms | 0.619 ms |
+  | 500,000 | 15,625 | 2.198 ms | 0.651 ms |
+  | 1,000,000 | 31,250 | 6.731 ms | 0.645 ms |
+
+  At a million records the fixed verification work is about 0.58 ms, so the scan was roughly 91 percent of the call: 31,250 anchors read to use two of them. The curve is flat afterwards.
+
+  The order is maintained rather than assumed. `_anchors` is genuinely unordered, because `anchor_head` reads the head position under the lock, makes the timestamp-authority round trip outside it, then appends under the lock again, so two concurrent anchors can append in the opposite order to the positions they carry. A bisect over `_anchors` would be unsound, which is why the previous code took a full pass. `_index_anchor` now inserts each anchor into a position-ordered index at append time, both anchoring paths go through it, and the bound search bisects that index under the lock the rest of the capture already holds.
+
 ## [1.81.0] - 2026-09-09
 
 ### Fixed

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.81.0",
+  "version": "1.82.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.81.0"
+appVersion: "1.82.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.81.0, Helm chart 0.1.0.
+Vaara 1.82.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.81.0",
+  "version": "1.82.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.81.0"
+version = "1.82.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.81.0",
+  "version": "1.82.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.81.0",
+"version": "1.82.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.81.0",
+  "version": "1.82.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.81.0",
+"version": "1.82.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.81.0"
+__version__ = "1.82.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
Two changes since v1.81.0.

## Reading is now an event

Every `EventType` member so far described what an agent did: requested, scored,
decided, executed, blocked, escalated, overridden, disclosed. Nothing in the
trail answered the question a supervisor asks first, which is who opened the
record.

`ACCESS_RECORDED` and `vaara.audit.access` add it, with four properties an
ordinary access log does not have.

**Two identities, and one of them is a person.** When an agent performs a read,
"who accessed this" has two answers: the agent, and the principal it acted for.
A single actor field collapses them and the collapse cannot be recovered
afterwards. `accessed_by` and `on_behalf_of` are both required and neither
defaults. Finnish health law is the sharp case: asiakastietolaki 703/2023
section 11 gives a client the right to be told who used their data and on what
basis, and a service account name does not answer that.

**A commitment to what came back, holding none of it.** "Agent X opened patient
Y" does not say what X saw, and a dispute is about content, so the record
carries a digest over the returned set and has no parameter that could accept
the rows. An access record over health data that copied the data would be a
second unprotected copy of the thing it exists to protect.

**Enumerable fields.** Deployments add their own through `deployment_fields`,
and `fields_present` lists what was actually captured, so a missing returned
digest is stated rather than left for a reader to interpret.

**Attested time rather than asserted time.** The record is chained, anchorable
and reachable by `verify_segment` like any other, so removing an access breaks
the chain and the timestamp is backed by a party outside the operator.

Then the half that matters as much: whether anything followed. An access ends in
one of three states and they are three facts. Closed with an action. Closed with
an explicit statement by a named person that nothing came of it. Or never closed
at all, which is what `accesses_with_no_recorded_outcome` returns.

## verify_segment stops scanning every anchor

With the record lookup already indexed, the anchor handling was what remained
growing: a copy of the anchor list under the lock, then a full pass over it to
find the tightest bounding pair. At the default 32-record cadence that is one
anchor per 32 records, so both terms scaled with the trail.

Measured with `scripts/bench_anchor_bound_search.py`, 200 calls per row against
a record in the middle of the trail:

| records | anchors | before | after |
|---|---|---|---|
| 5,000 | 156 | 0.613 ms | 0.614 ms |
| 50,000 | 1,562 | 0.752 ms | 0.622 ms |
| 150,000 | 4,687 | 1.004 ms | 0.619 ms |
| 500,000 | 15,625 | 2.198 ms | 0.651 ms |
| 1,000,000 | 31,250 | 6.731 ms | 0.645 ms |

At a million records the fixed verification work is about 0.58 ms, so the scan
was roughly 91 percent of the call: 31,250 anchors read to use two of them.

The order is maintained rather than assumed. `_anchors` is genuinely unordered,
because `anchor_head` reads the head position under the lock, makes the
timestamp-authority round trip outside it, then appends under the lock again, so
two concurrent anchors can append in the opposite order to the positions they
carry. A bisect over `_anchors` would be unsound, which is why the previous code
took a full pass. `_index_anchor` now inserts each anchor into a
position-ordered index at append time, both anchoring paths go through it, and
the bound search bisects that index under the lock the rest of the capture
already holds.
