### PR TITLE
A dropped execution receipt is now a provable gap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.83.0] - 2026-09-09
+
+### Added
+
+- Execution receipts carry a completeness sequence, so a dropped one is a provable gap. Authorization receipts have carried a per-boundary `seq` and `runningCount` since the held-set work; execution receipts carried neither, so the held-set proof covered one half of the pair.
+
+  A holder could already name every allow decision with no execution receipt, because the authorization side is provably contiguous and every execution receipt back-links to its attestation, so the set difference is computable. What they could not do was separate "the action never ran" from "the receipt was dropped or never persisted", because the execution side had no contiguity to break and therefore no gap to find.
+
+  `receiptAsserted` gains an optional `completeness` block, `{"boundaryId", "seq", "runningCount"}` with `runningCount == seq + 1`. It rides inside the signed preimage, so renumbering a receipt to close a gap invalidates it. The block is validated strictly on parse: all three keys required, non-negative integer `seq`, `bool` refused because it subclasses `int`, unknown keys refused. A malformed block fails loudly instead of being read as a smaller population.
+
+  The two streams count separately, under a boundary id that is the authorization one with `#execution` appended. A denied call mints an authorization receipt and no execution receipt by design, so a single shared counter would read every legitimate deny as a gap, and two sequences under one id would leave a reader unable to tell which population a number belongs to.
+
+  `completeness_from_execution_receipts` projects receipts into the record shape `verify_contiguity` already reads, so that checker and its seal handling are untouched. Receipts minted before this field existed carry no block and are skipped rather than counted as gaps.
+
+  Absent means byte-identical, the same additive-optional contract the envelope already keeps for `sigSuite` and `cryptoPosture`, and a test pins it.
+
+  What this does not close, stated here rather than left to be found: contiguity catches a receipt dropped in the middle of a run. A pure tail truncation is invisible to sequence contiguity alone, because the dropped records take their own numbers with them, and closing it needs a timestamp anchor over the running count or a sealing block of the kind the authorization side supports.
+
 ## [1.82.0] - 2026-09-09
 
 ### Added

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.82.0",
+  "version": "1.83.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.82.0"
+appVersion: "1.83.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.82.0, Helm chart 0.1.0.
+Vaara 1.83.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.82.0",
+  "version": "1.83.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.82.0"
+version = "1.83.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.82.0",
+  "version": "1.83.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.82.0",
+"version": "1.83.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.82.0",
+  "version": "1.83.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.82.0",
+"version": "1.83.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.82.0"
+__version__ = "1.83.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
One change since v1.82.0.

## A dropped execution receipt is now a provable gap

Authorization receipts have carried a per-boundary `seq` and `runningCount`
since the held-set work. Execution receipts carried neither, so the held-set
proof covered one half of the pair.

A holder could already name every allow decision with no execution receipt: the
authorization side is provably contiguous and every execution receipt
back-links to its attestation, so the set difference is computable. What they
could not do was separate "the action never ran" from "the receipt was dropped
or never persisted", because the execution side had no contiguity to break and
therefore no gap to find.

`receiptAsserted` gains an optional block:

```json
{ "boundaryId": "vaara-mcp-proxy#execution", "seq": 12, "runningCount": 13 }
```

It rides inside the signed preimage, so renumbering a receipt to close a gap
invalidates it. Validation on parse is strict: all three keys required,
`runningCount == seq + 1`, non-negative integer `seq`, `bool` refused because it
subclasses `int`, unknown keys refused.

## The two streams count separately

The execution boundary id is the authorization one with `#execution` appended.
A denied call mints an authorization receipt and no execution receipt by
design, so a single shared counter would read every legitimate deny as a gap.

## The checker is untouched

`completeness_from_execution_receipts` projects receipts into the record shape
`verify_contiguity` already reads, so its seal handling and worst-case-class
logic keep working. Receipts minted before this field existed are skipped
rather than counted as gaps.

## Absent means byte-identical

The same additive-optional contract the envelope already keeps for `sigSuite`
and `cryptoPosture`. A test pins it.

## What this does not close

Contiguity catches a receipt dropped in the middle of a run. A pure tail
truncation is invisible to sequence contiguity alone, because the dropped
records take their own numbers with them. Closing it needs a timestamp anchor
over the running count, or a sealing block of the kind the authorization side
supports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Execution receipts now include completeness sequences, making dropped receipts detectable as verifiable gaps.
  - Completeness data is signed and strictly validated when receipts are parsed.
  - Authorization and execution streams maintain separate sequence tracking.
  - Receipts created before completeness tracking are handled without being falsely reported as gaps.
  - Pure truncation at the end of a receipt stream remains undetectable through sequence checks alone.

- **Chores**
  - Updated the application, package, plugin, chart, and platform metadata to version 1.83.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->