### PR TITLE
The shipped classifier is v11, and a one-line corpus defect is why it moved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.84.0] - 2026-09-12
+
 ### Changed
 
 - The shipped adversarial classifier is now v11, trained on the corrected v0.40 corpus split, at threshold 0.8800. `_DEFAULT_BUNDLE` points at `adversarial_classifier_v11.joblib` and its pinned digest moves with it. v9 stays on disk as the regression baseline, because every published comparison is measured against it and removing it would make those numbers unreproducible from the package alone.

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.83.0",
+  "version": "1.84.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.83.0"
+appVersion: "1.84.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.83.0, Helm chart 0.1.0.
+Vaara 1.84.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.83.0",
+  "version": "1.84.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.83.0"
+version = "1.84.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.83.0",
+  "version": "1.84.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.83.0",
+"version": "1.84.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.83.0",
+  "version": "1.84.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.83.0",
+"version": "1.84.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.83.0"
+__version__ = "1.84.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 


### PR DESCRIPTION
One change since v1.83.0, and a corpus defect underneath it.

## The shipped classifier is v11

`_DEFAULT_BUNDLE` points at `adversarial_classifier_v11.joblib` at threshold
0.8800, and the pinned digest moves with it. v9 stays on disk as the regression
baseline, because every published comparison is measured against it and removing
it would make those figures unreproducible from the package alone.

Same trainer, same hyperparameters, same recipe as v9. The corrected corpus is
the only variable.

## The defect

`scripts/build_v040_split.py` derived a file's category prefix from
`fp.name.split("-")`. Attack files are `SR-v037-llama33.jsonl`, prefix first, so
field 0 never held the extension and the read was correct. Matched benign files
are `BT-v035-SR.jsonl`, prefix last, so field 2 was the string `"SR.jsonl"` and
matched no known prefix. Every benign file was skipped in silence.

2800 entries, 700 for each of four categories, correctly labelled
`benign_control` with `expected: ALLOW`, sat in no fold of either split. With
them absent, the false-positive rate on those categories was not computable at
any threshold. The same 2800 were also missing from `MANIFEST.sha256`.

## What it changed

Measured on 5,600 entries generated after the operating point was fixed, so none
of the data could have informed it.

| Category | v9 | v11 |
|---|---|---|
| all (n=5,600) | 63.1% / 6.6% | 87.0% / 2.5% |
| credential_exfil | 45.9% / 10.0% | 80.3% / 3.9% |
| destructive_actions | 81.1% / 8.3% | 87.7% / 4.0% |
| prompt_injection | 55.3% / 8.1% | 81.3% / 2.0% |
| ssrf_via_tools | 70.1% / 0.0% | 98.7% / 0.0% |

Cells are recall / FPR. Every category improves on both axes. Cross-model
holdout against attacks written by Qwen2.5-72B, absent from TRAIN: v9 67.4%,
v11 86.3%.

On held-out TEST n=1,827, the fold the README has always cited, recall goes
84.7% to 85.6% and FPR goes 4.1% to 5.1%. The false-positive rate on that
legacy fold is worse and it is published rather than omitted.

## The rejected candidate

An earlier candidate trained on the same split before the benigns were restored
read +7.2 points of aggregate test recall. Splitting the test fold by entry
origin showed the gain sat entirely in the refilled categories while the model
lost ground on everything inherited. It was not shipped.
`bench/V10-DECISION.md` and `bench/V11-CANDIDATE.md` carry both records.

## Guards, because the defect class was silence

- `scripts/check_corpus_manifest.py` checks `MANIFEST.sha256` against what is on
  disk, reporting unlisted, missing and changed separately. Plain
  `sha256sum -c` cannot see a file that no manifest line covers.
- `scripts/build_v040_split.py` names every file it skips and why.
- `scripts/eval_v039_v9.py` splits the test fold by entry origin when the
  manifest declares `inherits_from`, and warns when a population has no
  negatives.
- `scripts/eval_confirmation_set.py` resolves a matched benign's category from
  its filename.
- `make bench` reproduces the README's classifier figures and holds the shipped
  bundle at its shipped threshold. It had drifted twice before this.

Corpus generation ran on a single AMD Instinct MI300X under vLLM, now named in
`tests/adversarial/README.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Version 1.84.0 ships with adversarial classifier v11.

- **Documentation**
  - Updated supported-version information to reflect the 1.84.0 release.

- **Chores**
  - Updated application, package, plugin, server, and deployment metadata to version 1.84.0 for consistent release identification across supported distribution channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->