### PR TITLE
The conformance badge alt text said 46 suites, the badge says 50

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/vaaraio/vaara/blob/main/LICENSE"><img src="https://img.shields.io/pypi/l/vaara.svg" alt="License"></a>
   <a href="https://github.com/vaaraio/vaara/actions/workflows/ci.yml"><img src="https://github.com/vaaraio/vaara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/vaaraio/vaara"><img src="https://github.com/vaaraio/vaara/actions/workflows/scorecard.yml/badge.svg" alt="OpenSSF Scorecard"></a>
-  <a href="https://vaara.io/conformance.html"><img src="https://raw.githubusercontent.com/vaaraio/vaara/main/webpage/badge/conformance.svg" alt="Vaara Conformance: 46 suites, 0 failing"></a>
+  <a href="https://vaara.io/conformance.html"><img src="https://raw.githubusercontent.com/vaaraio/vaara/main/webpage/badge/conformance.svg" alt="Vaara Conformance: 50 suites, 0 failing"></a>
   <a href="https://doi.org/10.5281/zenodo.22027975"><img src="https://raw.githubusercontent.com/vaaraio/vaara/main/webpage/badge/doi.svg" alt="DOI 10.5281/zenodo.22027975"></a>
   <a href="https://www.bestpractices.dev/projects/12612"><img src="https://www.bestpractices.dev/projects/12612/badge" alt="OpenSSF Best Practices"></a>
   <a href="https://huggingface.co/spaces/vaaraio/vaara"><img src="https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Space-blue" alt="Hugging Face Space"></a>


### PR DESCRIPTION
`webpage/badge/conformance.svg` renders "50 suites, 0 failing". A live run of `scripts/conformance_runner.py` reports 50 suites, 49 passed, 0 failed, 1 skipped, 88 cases. The README alt text still said 46.

Alt text is what a screen reader announces and what renders when the image fails to load, so it is a published claim rather than decoration.

Deliberately not changed: the "46 suites" strings on `vaara.io/conformance.html`. Those sit inside third-party run rows recording what each runner measured when they ran. Editing them would falsify someone else's record, and the rows are chained so the edit would be visible to anyone. The conformance drift check of 2026-09-02 established that distinction and it still holds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README conformance badge to reflect 50 passing suites with no failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->