### PR TITLE
Release v1.85.0: sealed egress for the llm-proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.85.0] - 2026-09-13
+
+### Added
+
+- `vaara llm-proxy --seal-file PATH` holds named secrets back from the provider. Values listed in the file are replaced with stable placeholders before the request is forwarded and restored in the response, including across SSE chunk boundaries, so the caller reads the original text and the provider never receives it.
+
+  Redaction already existed and does a different job. `redact_body` replaces matches with `***` and is applied only to the copy written into the audit trail, which keeps secrets out of the record while the provider still gets the original bytes. Sealing is the reversible form, because a model handed `***` cannot answer and the conversation breaks.
+
+  Placeholders are derived from the secret's own sha256 rather than assigned per run. A placeholder that changed between runs would alter the prompt prefix on every turn and defeat provider-side prompt caching, which is a cost paid on every subsequent request rather than once.
+
+  It covers only what is named in advance. Prose that has never been registered travels in the clear, so this bounds and records the channel rather than closing it. That limit is in the module docstring as well as here, because a reader who assumes otherwise is worse off than one who never enabled it.
+
+  Fails open throughout. A sealing fault forwards the unsealed request rather than costing the call, on the grounds that a governance layer which can break a working session will be switched off.
+
+- `vaara llm-proxy --seal-listen-unix PATH` binds a unix socket instead of a TCP port, leaving filesystem permissions as the access control. The proxy holds the operator's upstream key and injects it into every forwarded call, so removing the listening port removes a class of local reachability entirely.
+
+### Changed
+
+- The chat path forwards the received request bytes instead of re-serialising the parsed body. With sealing off a payload is now byte-identical to what the client sent, which a round-trip test asserts. Re-serialisation rewrote byte layout the caller never asked to change, and any such rewrite risks the provider's cache prefix.
+
 ## [1.84.0] - 2026-09-12
 
 ### Changed

--- a/clients/ts/package.json
+++ b/clients/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vaara/client",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "mcpName": "io.github.vaaraio/vaara",
   "description": "TypeScript client for the Vaara HTTP API: accountable autonomy for every autonomous action. Conformal risk scoring, policy gating, hash-chained tamper-evident audit, named detectors.",
   "main": "dist/index.js",

--- a/deploy/helm/vaara/Chart.yaml
+++ b/deploy/helm/vaara/Chart.yaml
@@ -15,7 +15,7 @@ version: 0.1.0
 # vaara.__version__, so a release that bumps the package without bumping the
 # chart fails the build instead of shipping a chart that installs an older
 # image than it claims.
-appVersion: "1.84.0"
+appVersion: "1.85.0"
 
 # StatefulSet apps/v1, the PersistentVolumeClaim retention fields are not used,
 # and probes use plain HTTP. 1.27 is conservative: RKE2 1.27 reached end of

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -1,6 +1,6 @@
 # Supported platforms
 
-Vaara 1.84.0, Helm chart 0.1.0.
+Vaara 1.85.0, Helm chart 0.1.0.
 
 Vaara is a Python package with no runtime dependencies and a container image
 built on SUSE's SLE Base Container Image. This page lists what it runs on and,

--- a/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
+++ b/plugins/claude-code-vaara-governance/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vaara-governance",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "description": "Accountable autonomy for Claude Code. PreToolUse runs a two-layer check on Bash, WebFetch, WebSearch, Write, Edit, NotebookEdit, Task, SendMessage and MCP calls (regex deny patterns on shell, web and file mutation; conformal risk scorer on MCP). PostToolUse writes a hash-chained SQLite audit record across the same set, so file writes and subagent spawns land in the trail. Blocks and escalations pop a desktop notification (macOS/Linux). /vaara-setup configures mode, protection level, and notifications in plain language via ~/.vaara/claude-code/config.json; /vaara-stats prints a summary of the audit trail.",
   "author": {
     "name": "Vaara",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vaara"
-version = "1.84.0"
+version = "1.85.0"
 description = "Accountable Autonomy for AI agents under the EU AI Act: policy-gated tool calls, hash-chained tamper-evident audit trails with external time anchoring, and independently verifiable attestation plus execution receipts per MCP tool call"
 requires-python = ">=3.10"
 license = "AGPL-3.0-or-later"

--- a/server-vaara-server.json
+++ b/server-vaara-server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.84.0",
+  "version": "1.85.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.84.0",
+"version": "1.85.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/vaaraio/vaara",
     "source": "github"
   },
-  "version": "1.84.0",
+  "version": "1.85.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "vaara",
-"version": "1.84.0",
+"version": "1.85.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/vaara/__init__.py
+++ b/src/vaara/__init__.py
@@ -8,7 +8,7 @@ and writes a hash-chained audit trail suitable for EU AI Act Article 14
 oversight.
 """
 
-__version__ = "1.84.0"
+__version__ = "1.85.0"
 
 from vaara.pipeline import InterceptionPipeline, InterceptionResult
 

--- a/src/vaara/integrations/_llm_proxy_app.py
+++ b/src/vaara/integrations/_llm_proxy_app.py
@@ -38,11 +38,34 @@ from ._llm_proxy_shape import (
 
 logger = logging.getLogger("vaara.llm_proxy")
 
-_CHAT_PATHS = frozenset({"/v1/chat/completions", "/v1/messages"})
+#: Ordered so a matched path can be recovered *by index* from the constant
+#: rather than passed through from the request. The chat handler only ever runs
+#: for a path already known to be in this set, so forwarding the constant is
+#: both what we mean and the form that leaves no caller-controlled string in
+#: the outgoing URL at all.
+_CHAT_PATH_LIST = ["/v1/chat/completions", "/v1/messages"]
+_CHAT_PATHS = frozenset(_CHAT_PATH_LIST)
+
+
+def _canonical_chat_path(path: str) -> Optional[str]:
+    """The constant this request matched, or None.
+
+    Validating a caller-controlled string and forwarding it still forwards a
+    caller-controlled string. Returning the element of the constant list is a
+    different thing: whatever the caller sent, the value that reaches the
+    upstream URL provably originated here.
+    """
+    try:
+        return _CHAT_PATH_LIST[_CHAT_PATH_LIST.index(f"/{path}")]
+    except ValueError:
+        return None
 
 
 def _safe_upstream_path(path: str) -> Optional[str]:
     """Return a path that cannot leave the configured upstream, or None.
+
+    Used for the general pass-through, where the path is not drawn from a fixed
+    set and so cannot be replaced by a constant.
 
     The caller controls this segment, and the proxy holds the operator's
     provider key and injects it into whatever it forwards. A path beginning
@@ -203,14 +226,16 @@ def build_app(*, upstream: str, api_key: str, api_key_header: str,
                 logger.warning("sealing failed, forwarding unsealed: %s", exc)
                 outbound = body_bytes
 
-        safe_path = _safe_upstream_path(path)
-        if safe_path is None:
+        # `path` reached here only because handle_request matched it against
+        # _CHAT_PATHS, so the constant is recoverable and is what we forward.
+        chat_path = _canonical_chat_path(path)
+        if chat_path is None:  # pragma: no cover - dispatcher guarantees it
             return JSONResponse(
                 {"error": "invalid upstream path"}, status_code=400)
 
         try:
             upstream_response = await client.post(
-                safe_path, content=outbound, headers=headers,
+                chat_path, content=outbound, headers=headers,
             )
         except httpx.RequestError as exc:
             logger.error("Upstream request failed: %s", exc)
@@ -243,6 +268,13 @@ def build_app(*, upstream: str, api_key: str, api_key_header: str,
         )
 
     async def _proxy_pass_through(path: str, request: Request) -> Response:
+        # No fixed set to draw from here, so this one is validated rather than
+        # replaced. Same reason as the chat path: the proxy injects the
+        # operator's key into whatever it forwards.
+        safe_path = _safe_upstream_path(path)
+        if safe_path is None:
+            return JSONResponse(
+                {"error": "invalid upstream path"}, status_code=400)
         body_bytes = await request.body()
         headers = forward_request_headers(request.headers)
         if api_key_header.lower() == "authorization":
@@ -251,7 +283,7 @@ def build_app(*, upstream: str, api_key: str, api_key_header: str,
             headers[api_key_header] = api_key
         try:
             resp = await client.request(
-                method=request.method, url=f"/{path}",
+                method=request.method, url=safe_path,
                 content=body_bytes, headers=headers,
             )
         except httpx.RequestError as exc:

--- a/src/vaara/integrations/_llm_proxy_app.py
+++ b/src/vaara/integrations/_llm_proxy_app.py
@@ -62,6 +62,7 @@ def build_app(*, upstream: str, api_key: str, api_key_header: str,
               rate_limit_rpm: int = 0,
               redact_patterns: Optional[list[str]] = None,
               agent_id_header: str = "x-agent-id",
+              seal_registry: Optional[Any] = None,
               allowed_origins: Optional[list[str]] = None) -> FastAPI:
     app = FastAPI(title="Vaara LLM Proxy")
     # This proxy holds the operator's upstream provider key and injects it
@@ -91,6 +92,9 @@ def build_app(*, upstream: str, api_key: str, api_key_header: str,
     _model_deny_pats = _compile_glob_patterns(model_deny or [])
     _redact_pats = _compile_redact_patterns(redact_patterns) \
         if mode == "govern" else []
+    # Sealing is independent of `mode`. Redaction protects the trail; sealing
+    # protects the provider request, and an operator may want either alone.
+    _seal = seal_registry
 
     @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
     async def handle_request(path: str, request: Request):
@@ -164,9 +168,23 @@ def build_app(*, upstream: str, api_key: str, api_key_header: str,
             headers[api_key_header] = api_key
 
         is_stream = body.get("stream", False)
+
+        # Seal named secrets on the way out. Fails open: a sealing fault costs
+        # the sealing, never the request. Forwarding the raw bytes rather than
+        # re-serialising the parsed body also keeps the payload byte-identical
+        # when sealing is off, which matters because any rewrite of the early
+        # message content invalidates the provider's prompt-cache prefix.
+        outbound = body_bytes
+        if _seal is not None and _seal.active:
+            try:
+                outbound = _seal.seal_bytes(body_bytes)
+            except Exception as exc:  # pragma: no cover - guard, not a path
+                logger.warning("sealing failed, forwarding unsealed: %s", exc)
+                outbound = body_bytes
+
         try:
             upstream_response = await client.post(
-                f"/{path}", json=body, headers=headers,
+                f"/{path}", content=outbound, headers=headers,
             )
         except httpx.RequestError as exc:
             logger.error("Upstream request failed: %s", exc)
@@ -174,28 +192,28 @@ def build_app(*, upstream: str, api_key: str, api_key_header: str,
 
         if is_stream:
             return StreamingResponse(
-                _forward_stream(upstream_response, pipeline, result.action_id),
+                _forward_stream(upstream_response, pipeline,
+                                result.action_id, _seal),
                 status_code=upstream_response.status_code,
                 headers=forward_response_headers(upstream_response.headers),
                 media_type=upstream_response.headers.get("content-type"),
             )
 
-        try:
-            response_body = upstream_response.json()
-        except json.JSONDecodeError:
-            pipeline.report_outcome(result.action_id, outcome_severity=0.8)
-            return Response(
-                content=upstream_response.content,
-                status_code=upstream_response.status_code,
-                headers=forward_response_headers(upstream_response.headers),
-            )
+        raw_response = upstream_response.content
+        if _seal is not None and _seal.active:
+            try:
+                raw_response = _seal.unseal_bytes(raw_response)
+            except Exception as exc:  # pragma: no cover - guard, not a path
+                logger.warning("unsealing failed, passing through: %s", exc)
+                raw_response = upstream_response.content
 
         pipeline.report_outcome(result.action_id, outcome_severity=0.0
                                 if upstream_response.is_success else 0.5)
-        return JSONResponse(
-            content=response_body,
+        return Response(
+            content=raw_response,
             status_code=upstream_response.status_code,
             headers=forward_response_headers(upstream_response.headers),
+            media_type=upstream_response.headers.get("content-type"),
         )
 
     async def _proxy_pass_through(path: str, request: Request) -> Response:
@@ -256,10 +274,30 @@ def _build_audit_params(body: dict, body_bytes: bytes,
 
 async def _forward_stream(upstream_response: httpx.Response,
                            pipeline: InterceptionPipeline,
-                           action_id: str):
+                           action_id: str,
+                           seal: Optional[Any] = None):
+    unsealer = None
+    if seal is not None and seal.active:
+        from .llm_seal import StreamUnsealer
+        unsealer = StreamUnsealer(seal)
     try:
         async for chunk in upstream_response.aiter_bytes():
-            yield chunk
+            if unsealer is None:
+                yield chunk
+                continue
+            try:
+                out = unsealer.feed(chunk)
+            except Exception as exc:  # pragma: no cover - guard, not a path
+                logger.warning("stream unseal failed, passing through: %s", exc)
+                unsealer = None
+                yield chunk
+                continue
+            if out:
+                yield out
+        if unsealer is not None:
+            tail = unsealer.flush()
+            if tail:
+                yield tail
         pipeline.report_outcome(action_id, outcome_severity=0.0)
     except Exception as exc:
         logger.warning("Stream error: %s", exc)

--- a/src/vaara/integrations/_llm_proxy_app.py
+++ b/src/vaara/integrations/_llm_proxy_app.py
@@ -41,6 +41,27 @@ logger = logging.getLogger("vaara.llm_proxy")
 _CHAT_PATHS = frozenset({"/v1/chat/completions", "/v1/messages"})
 
 
+def _safe_upstream_path(path: str) -> Optional[str]:
+    """Return a path that cannot leave the configured upstream, or None.
+
+    The caller controls this segment, and the proxy holds the operator's
+    provider key and injects it into whatever it forwards. A path beginning
+    ``//`` is protocol-relative and resolves to a different host, so a request
+    to ``//evil.example/x`` would spend that key somewhere else entirely.
+    Traversal is refused for the same reason rather than normalised, because a
+    normalised path that still escapes is worse than a rejection.
+    """
+    if not path:
+        return "/"
+    if path.startswith("/") or "//" in path:
+        return None
+    if ".." in path.split("/"):
+        return None
+    if "\\" in path or "\n" in path or "\r" in path:
+        return None
+    return f"/{path}"
+
+
 def _detect_provider(upstream: str) -> str:
     u = upstream.lower()
     if "anthropic" in u:
@@ -182,9 +203,14 @@ def build_app(*, upstream: str, api_key: str, api_key_header: str,
                 logger.warning("sealing failed, forwarding unsealed: %s", exc)
                 outbound = body_bytes
 
+        safe_path = _safe_upstream_path(path)
+        if safe_path is None:
+            return JSONResponse(
+                {"error": "invalid upstream path"}, status_code=400)
+
         try:
             upstream_response = await client.post(
-                f"/{path}", content=outbound, headers=headers,
+                safe_path, content=outbound, headers=headers,
             )
         except httpx.RequestError as exc:
             logger.error("Upstream request failed: %s", exc)

--- a/src/vaara/integrations/llm_proxy.py
+++ b/src/vaara/integrations/llm_proxy.py
@@ -120,6 +120,19 @@ def main(args: Optional[list[str]] = None) -> int:
         help="Request header carrying the agent identity (default: x-agent-id)",
     )
     p.add_argument(
+        "--seal-file", default=None, metavar="PATH",
+        help="JSON object of {\"name\": \"secret\"} whose values are replaced "
+             "with stable placeholders before the request reaches the "
+             "provider, and restored in the response. Covers only what you "
+             "name in advance. Missing or unreadable file means sealing is "
+             "off and the proxy runs unchanged.",
+    )
+    p.add_argument(
+        "--seal-listen-unix", default=None, metavar="PATH",
+        help="Bind a unix socket instead of TCP. No listening port, so "
+             "filesystem permissions decide who can reach the proxy.",
+    )
+    p.add_argument(
         "--allow-origin", action="append", default=None, metavar="ORIGIN",
         help="Browser origin permitted to call the proxy, e.g. "
              "https://console.example (repeatable, matched exactly). By "
@@ -166,6 +179,18 @@ def main(args: Optional[list[str]] = None) -> int:
         return 1
 
     from ._llm_proxy_app import build_app
+    from .llm_seal import SealRegistry
+
+    seal = SealRegistry.from_file(parsed.seal_file) if parsed.seal_file \
+        else SealRegistry()
+    if parsed.seal_file and not seal.active:
+        # Say so rather than running silently unsealed. An operator who passed
+        # --seal-file believes secrets are being held back.
+        print(
+            f"vaara llm-proxy: seal file {parsed.seal_file} loaded no "
+            "secrets; sealing is OFF for this run.",
+            file=sys.stderr,
+        )
 
     app = build_app(
         upstream=parsed.upstream,
@@ -178,20 +203,30 @@ def main(args: Optional[list[str]] = None) -> int:
         model_allow=parsed.model_allow,
         model_deny=parsed.model_deny,
         rate_limit_rpm=parsed.rate_limit,
+        seal_registry=seal,
         redact_patterns=parsed.redact,
         agent_id_header=parsed.agent_id_header,
         allowed_origins=parsed.allow_origin,
     )
 
-    host, _, port_str = parsed.listen.rpartition(":")
-    port = int(port_str) if port_str else 8790
-    host = host or "127.0.0.1"
+    seal_note = f", sealing {len(seal)} secret(s)" if seal.active \
+        else ""
 
-    config = Config(app=app, host=host, port=port, log_level="info")
+    if parsed.seal_listen_unix:
+        sock_path = str(Path(parsed.seal_listen_unix).expanduser())
+        config = Config(app=app, uds=sock_path, log_level="info")
+        where = f"unix:{sock_path}"
+    else:
+        host, _, port_str = parsed.listen.rpartition(":")
+        port = int(port_str) if port_str else 8790
+        host = host or "127.0.0.1"
+        config = Config(app=app, host=host, port=port, log_level="info")
+        where = f"{host}:{port}"
     server = Server(config=config)
 
-    print(f"vaara llm-proxy: {parsed.mode} mode, audit={parsed.audit}, "
-          f"listening on {host}:{port} -> {parsed.upstream}", file=sys.stderr)
+    print(f"vaara llm-proxy: {parsed.mode} mode, audit={parsed.audit}"
+          f"{seal_note}, listening on {where} -> {parsed.upstream}",
+          file=sys.stderr)
 
     try:
         server.run()

--- a/src/vaara/integrations/llm_seal.py
+++ b/src/vaara/integrations/llm_seal.py
@@ -102,6 +102,10 @@ class SealRegistry:
     def active(self) -> bool:
         return bool(self._pairs)
 
+    def __len__(self) -> int:
+        """How many secrets are registered. For startup reporting."""
+        return len(self._pairs)
+
     def seal_text(self, text: str) -> str:
         for secret, token in self._pairs:
             text = text.replace(secret, token)

--- a/src/vaara/integrations/llm_seal.py
+++ b/src/vaara/integrations/llm_seal.py
@@ -69,11 +69,18 @@ class SealRegistry:
     def __init__(self, secrets: Optional[dict[str, str]] = None) -> None:
         self._pairs: list[tuple[str, str]] = []
         self._reverse: dict[str, str] = {}
+        skipped = 0
         for name, secret in (secrets or {}).items():
             if not secret:
-                logger.warning("seal %r has an empty secret, skipped", name)
+                # The name is not logged either. A seal name describes what it
+                # seals, so "northern_lights_concept" leaks the thing the entry
+                # exists to hide. Count them and say how many.
+                skipped += 1
                 continue
             self.add(name, secret)
+        if skipped:
+            logger.warning("%d seal entr%s had an empty secret and were "
+                           "skipped", skipped, "y" if skipped == 1 else "ies")
 
     def add(self, name: str, secret: str) -> None:
         token = placeholder_for(secret)

--- a/src/vaara/integrations/llm_seal.py
+++ b/src/vaara/integrations/llm_seal.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Henri Sirkkavaara
+"""Reversible sealing of named secrets on the way out to a model provider.
+
+The redaction in ``_llm_proxy_shape`` replaces matches with ``***``.  That is
+right for the audit trail and wrong for egress: a model handed ``***`` cannot
+answer, so the conversation breaks.  Sealing is the reversible form.  A named
+secret leaves as a stable placeholder and is restored in the response before
+the caller sees it.
+
+What this does NOT do, stated here because the gap matters more than the
+feature: it only covers what can be named in advance.  Novel thinking written
+as prose cannot be pre-registered, so it travels in the clear.  This bounds and
+records the channel rather than closing it.
+
+Placeholders are derived from the secret's own digest, so they are stable
+across restarts.  That is deliberate: a placeholder that changed per run would
+alter the prompt prefix on every turn and defeat provider-side prompt caching.
+
+Everything here fails open.  A sealing bug must not cost a working session, so
+every entry point returns its input unchanged when anything goes wrong.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("vaara.llm_seal")
+
+#: Placeholder shape. ASCII, no punctuation a tokenizer will split oddly, and
+#: distinctive enough that a collision with real text is not a live concern.
+_PREFIX = "VAARA_SEAL_"
+_DIGEST_CHARS = 12
+_PLACEHOLDER_RE = re.compile(_PREFIX + r"[0-9a-f]{%d}" % _DIGEST_CHARS)
+
+#: Longest placeholder a stream carry-buffer must be able to hold back.
+PLACEHOLDER_LEN = len(_PREFIX) + _DIGEST_CHARS
+
+
+def placeholder_for(secret: str) -> str:
+    """Stable placeholder for one secret, derived from its own digest."""
+    digest = hashlib.sha256(secret.encode("utf-8")).hexdigest()
+    return _PREFIX + digest[:_DIGEST_CHARS]
+
+
+def _json_inner(value: str) -> str:
+    """The JSON-escaped form of a string, without the surrounding quotes.
+
+    Request bodies are JSON, so a secret containing a quote, a backslash or a
+    newline appears on the wire in escaped form.  Substituting on the raw bytes
+    needs the escaped spelling as well as the plain one.
+    """
+    return json.dumps(value)[1:-1]
+
+
+class SealRegistry:
+    """Named secrets, and the substitution in both directions.
+
+    Operates on raw bytes rather than on a parsed body.  Re-serialising JSON
+    would rewrite byte layout the caller never asked to change, and any such
+    rewrite risks the provider's prompt-cache prefix.
+    """
+
+    def __init__(self, secrets: Optional[dict[str, str]] = None) -> None:
+        self._pairs: list[tuple[str, str]] = []
+        self._reverse: dict[str, str] = {}
+        for name, secret in (secrets or {}).items():
+            if not secret:
+                logger.warning("seal %r has an empty secret, skipped", name)
+                continue
+            self.add(name, secret)
+
+    def add(self, name: str, secret: str) -> None:
+        token = placeholder_for(secret)
+        self._pairs.append((secret, token))
+        self._reverse[token] = secret
+        # Longest first, so a secret that contains another is sealed whole.
+        self._pairs.sort(key=lambda p: len(p[0]), reverse=True)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "SealRegistry":
+        """Load ``{"name": "secret"}`` from JSON. Missing file means inactive."""
+        p = Path(path)
+        if not p.exists():
+            return cls()
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            logger.warning("seal registry %s unreadable (%s), sealing off", p, exc)
+            return cls()
+        if not isinstance(data, dict):
+            logger.warning("seal registry %s is not an object, sealing off", p)
+            return cls()
+        return cls({str(k): str(v) for k, v in data.items()})
+
+    @property
+    def active(self) -> bool:
+        return bool(self._pairs)
+
+    def seal_text(self, text: str) -> str:
+        for secret, token in self._pairs:
+            text = text.replace(secret, token)
+            escaped = _json_inner(secret)
+            if escaped != secret:
+                text = text.replace(escaped, token)
+        return text
+
+    def unseal_text(self, text: str) -> str:
+        for token, secret in self._reverse.items():
+            if token in text:
+                text = text.replace(token, secret)
+        return text
+
+    def seal_bytes(self, raw: bytes) -> bytes:
+        if not self._pairs:
+            return raw
+        try:
+            return self.seal_text(raw.decode("utf-8")).encode("utf-8")
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            return raw
+
+    def unseal_bytes(self, raw: bytes) -> bytes:
+        if not self._reverse:
+            return raw
+        try:
+            return self.unseal_text(raw.decode("utf-8")).encode("utf-8")
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            return raw
+
+    def count_sealed(self, raw: bytes) -> int:
+        """How many placeholders a sealed body carries. For the receipt."""
+        try:
+            return len(_PLACEHOLDER_RE.findall(raw.decode("utf-8", "replace")))
+        except Exception:  # pragma: no cover - counting must never raise
+            return 0
+
+    def unmapped_placeholders(self, raw: bytes) -> list[str]:
+        """Placeholders present that this registry cannot restore.
+
+        A body carrying a seal token with no mapping means a secret was sealed
+        by a registry this process does not have.  Forwarding it is harmless,
+        but the caller may want to refuse, so the question is answerable.
+        """
+        try:
+            found = set(_PLACEHOLDER_RE.findall(raw.decode("utf-8", "replace")))
+        except Exception:  # pragma: no cover
+            return []
+        return sorted(found - set(self._reverse))
+
+
+class StreamUnsealer:
+    """Restore placeholders in a streamed response.
+
+    A placeholder can be split across two SSE events, so the tail of each chunk
+    is held back until the next one arrives.  Only as many bytes are withheld
+    as a placeholder could occupy, so nothing is buffered for long.
+    """
+
+    def __init__(self, registry: SealRegistry) -> None:
+        self._registry = registry
+        self._carry = ""
+
+    def feed(self, chunk: bytes) -> bytes:
+        if not self._registry.active:
+            return chunk
+        try:
+            text = self._carry + chunk.decode("utf-8", "replace")
+        except Exception:  # pragma: no cover
+            return chunk
+        # Restore before splitting. Unsealing only the emitted slice would let
+        # a placeholder that straddles the boundary have its head emitted raw
+        # while its tail is still in the carry, which is what the first version
+        # of this did and what the byte-at-a-time test caught.
+        text = self._registry.unseal_text(text)
+        keep = max(0, PLACEHOLDER_LEN - 1)
+        if len(text) > keep:
+            emit, self._carry = text[:-keep], text[-keep:]
+        else:
+            emit, self._carry = "", text
+        return emit.encode("utf-8")
+
+    def flush(self) -> bytes:
+        if not self._carry:
+            return b""
+        out = self._registry.unseal_text(self._carry)
+        self._carry = ""
+        return out.encode("utf-8")

--- a/tests/test_integrations_llm_proxy_seal_roundtrip.py
+++ b/tests/test_integrations_llm_proxy_seal_roundtrip.py
@@ -13,13 +13,23 @@ from __future__ import annotations
 
 import json
 
-import httpx
 import pytest
-from fastapi.testclient import TestClient
 
-from vaara.integrations._llm_proxy_app import build_app
-from vaara.integrations.llm_proxy import _build_pipeline
-from vaara.integrations.llm_seal import SealRegistry, placeholder_for
+# The proxy extras are optional, and the signing-extras CI job installs only
+# the signing ones. Importing these at module level errored collection for
+# that whole job rather than skipping this file, which is what every other
+# proxy test in the tree guards against.
+httpx = pytest.importorskip("httpx", reason="proxy deps not installed: no httpx")
+pytest.importorskip("fastapi", reason="proxy deps not installed: no fastapi")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from vaara.integrations._llm_proxy_app import build_app  # noqa: E402
+from vaara.integrations.llm_proxy import _build_pipeline  # noqa: E402
+from vaara.integrations.llm_seal import (  # noqa: E402
+    SealRegistry,
+    placeholder_for,
+)
 
 SECRET = "anti-note"
 TOKEN = placeholder_for(SECRET)

--- a/tests/test_integrations_llm_proxy_seal_roundtrip.py
+++ b/tests/test_integrations_llm_proxy_seal_roundtrip.py
@@ -1,0 +1,109 @@
+"""End to end: a sealed secret does not reach the upstream, and comes back.
+
+The unit tests in ``test_integrations_llm_seal`` cover the substitution.  This
+covers the thing that actually matters in production and that unit tests
+cannot see: a request travelling the real proxy handler reaches the provider
+with the placeholder, and the caller still reads the original text.
+
+The upstream is a stub inside the process, so running this sends nothing
+anywhere.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from vaara.integrations._llm_proxy_app import build_app
+from vaara.integrations.llm_proxy import _build_pipeline
+from vaara.integrations.llm_seal import SealRegistry, placeholder_for
+
+SECRET = "anti-note"
+TOKEN = placeholder_for(SECRET)
+
+
+@pytest.fixture
+def seen() -> dict:
+    """What the stub upstream actually received."""
+    return {}
+
+
+@pytest.fixture
+def client(monkeypatch, seen):
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = request.content.decode("utf-8")
+        # Echo the prompt back the way a provider would quote it.
+        return httpx.Response(
+            200,
+            json={"content": [{"type": "text",
+                               "text": f"you said: {seen['body']}"}]},
+            headers={"content-type": "application/json"},
+        )
+
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        kwargs.pop("http2", None)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", fake_async_client)
+
+    app = build_app(
+        upstream="https://upstream.invalid",
+        api_key="test-key",
+        api_key_header="x-api-key",
+        pipeline=_build_pipeline(None),
+        seal_registry=SealRegistry({"concept": SECRET}),
+    )
+    return TestClient(app)
+
+
+def test_upstream_never_sees_the_secret(client, seen):
+    client.post("/v1/messages", json={
+        "model": "claude-opus-5",
+        "messages": [{"role": "user", "content": f"explain the {SECRET} idea"}],
+    })
+    assert SECRET not in seen["body"]
+    assert TOKEN in seen["body"]
+
+
+def test_caller_reads_the_secret_back(client, seen):
+    resp = client.post("/v1/messages", json={
+        "model": "claude-opus-5",
+        "messages": [{"role": "user", "content": f"explain the {SECRET} idea"}],
+    })
+    assert resp.status_code == 200
+    assert SECRET in resp.text
+    assert TOKEN not in resp.text
+
+
+def test_unsealed_proxy_forwards_the_body_byte_for_byte(monkeypatch, seen):
+    """With sealing off the payload must be untouched, or prompt caching pays."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = request.content
+        return httpx.Response(200, json={"ok": True})
+
+    real = httpx.AsyncClient
+
+    def fake(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(handler)
+        kwargs.pop("http2", None)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", fake)
+    app = build_app(
+        upstream="https://upstream.invalid", api_key="k",
+        api_key_header="x-api-key", pipeline=_build_pipeline(None),
+        seal_registry=SealRegistry(),
+    )
+    sent = json.dumps({"model": "m", "messages": [{"role": "user",
+                                                   "content": "plain"}]})
+    TestClient(app).post(
+        "/v1/messages", content=sent,
+        headers={"content-type": "application/json"},
+    )
+    assert seen["body"].decode("utf-8") == sent

--- a/tests/test_integrations_llm_proxy_seal_roundtrip.py
+++ b/tests/test_integrations_llm_proxy_seal_roundtrip.py
@@ -107,3 +107,32 @@ def test_unsealed_proxy_forwards_the_body_byte_for_byte(monkeypatch, seen):
         headers={"content-type": "application/json"},
     )
     assert seen["body"].decode("utf-8") == sent
+
+
+class TestUpstreamPathIsConfined:
+    """The proxy injects the operator's provider key into whatever it forwards.
+
+    A caller-controlled path that escapes the configured upstream would spend
+    that key against another host, so escapes are refused rather than
+    normalised.
+    """
+
+    @pytest.mark.parametrize("path", [
+        "//evil.example/v1/messages",   # protocol-relative, resolves off-host
+        "/v1/messages",                 # absolute, replaces the base path
+        "v1/../../v1/messages",         # traversal
+        "v1\\messages",                 # backslash
+        "v1/messages\nX-Injected: 1",   # header injection
+    ])
+    def test_escaping_paths_are_refused(self, path):
+        from vaara.integrations._llm_proxy_app import _safe_upstream_path
+        assert _safe_upstream_path(path) is None
+
+    @pytest.mark.parametrize("path,expected", [
+        ("v1/messages", "/v1/messages"),
+        ("v1/chat/completions", "/v1/chat/completions"),
+        ("", "/"),
+    ])
+    def test_ordinary_paths_pass(self, path, expected):
+        from vaara.integrations._llm_proxy_app import _safe_upstream_path
+        assert _safe_upstream_path(path) == expected

--- a/tests/test_integrations_llm_seal.py
+++ b/tests/test_integrations_llm_seal.py
@@ -1,0 +1,132 @@
+"""Tests for reversible sealing on the egress path.
+
+The property that matters: a secret named in advance never reaches the
+provider, and the caller still reads a coherent response.  Everything fails
+open, so a sealing fault costs nothing but the sealing.
+"""
+
+from __future__ import annotations
+
+import json
+
+from vaara.integrations.llm_seal import (
+    PLACEHOLDER_LEN,
+    SealRegistry,
+    StreamUnsealer,
+    placeholder_for,
+)
+
+
+class TestPlaceholder:
+    def test_is_stable_across_calls(self):
+        assert placeholder_for("northern lights") == placeholder_for("northern lights")
+
+    def test_differs_per_secret(self):
+        assert placeholder_for("a") != placeholder_for("b")
+
+    def test_length_matches_the_published_constant(self):
+        assert len(placeholder_for("anything")) == PLACEHOLDER_LEN
+
+
+class TestRoundTrip:
+    def test_secret_does_not_survive_sealing(self):
+        reg = SealRegistry({"concept": "anti-note"})
+        sealed = reg.seal_bytes(b'{"messages":[{"content":"the anti-note idea"}]}')
+        assert b"anti-note" not in sealed
+        assert placeholder_for("anti-note").encode() in sealed
+
+    def test_unseal_restores_the_original(self):
+        reg = SealRegistry({"concept": "anti-note"})
+        raw = b'{"content":"the anti-note idea"}'
+        assert reg.unseal_bytes(reg.seal_bytes(raw)) == raw
+
+    def test_overlapping_secrets_seal_longest_first(self):
+        reg = SealRegistry({"short": "mesh", "long": "lightmesh atom"})
+        sealed = reg.seal_bytes(b"the lightmesh atom runs")
+        assert b"lightmesh atom" not in sealed
+        assert reg.unseal_bytes(sealed) == b"the lightmesh atom runs"
+
+    def test_json_escaped_form_is_also_sealed(self):
+        secret = 'he said "go"'
+        reg = SealRegistry({"quoted": secret})
+        body = json.dumps({"content": f"and then {secret} loudly"}).encode()
+        sealed = reg.seal_bytes(body)
+        assert json.dumps(secret)[1:-1].encode() not in sealed
+
+    def test_inactive_registry_is_a_passthrough(self):
+        reg = SealRegistry()
+        assert not reg.active
+        assert reg.seal_bytes(b"anything") == b"anything"
+        assert reg.unseal_bytes(b"anything") == b"anything"
+
+
+class TestFailOpen:
+    def test_undecodable_bytes_pass_through_unchanged(self):
+        reg = SealRegistry({"concept": "anti-note"})
+        raw = b"\xff\xfe not utf-8 at all"
+        assert reg.seal_bytes(raw) == raw
+
+    def test_missing_registry_file_yields_inactive(self, tmp_path):
+        assert not SealRegistry.from_file(tmp_path / "absent.json").active
+
+    def test_unreadable_registry_file_yields_inactive(self, tmp_path):
+        p = tmp_path / "broken.json"
+        p.write_text("{not json", encoding="utf-8")
+        assert not SealRegistry.from_file(p).active
+
+    def test_non_object_registry_file_yields_inactive(self, tmp_path):
+        p = tmp_path / "list.json"
+        p.write_text('["a","b"]', encoding="utf-8")
+        assert not SealRegistry.from_file(p).active
+
+    def test_empty_secret_is_skipped_rather_than_sealing_everything(self):
+        reg = SealRegistry({"blank": ""})
+        assert not reg.active
+        assert reg.seal_bytes(b"untouched") == b"untouched"
+
+
+class TestReceiptInputs:
+    def test_counts_placeholders_in_a_sealed_body(self):
+        reg = SealRegistry({"a": "alpha", "b": "beta"})
+        sealed = reg.seal_bytes(b"alpha and beta and alpha")
+        assert reg.count_sealed(sealed) == 3
+
+    def test_unmapped_placeholder_is_reported(self):
+        reg = SealRegistry({"a": "alpha"})
+        foreign = placeholder_for("a secret this process never held")
+        assert reg.unmapped_placeholders(foreign.encode()) == [foreign]
+
+    def test_own_placeholders_are_not_reported_as_unmapped(self):
+        reg = SealRegistry({"a": "alpha"})
+        assert reg.unmapped_placeholders(reg.seal_bytes(b"alpha")) == []
+
+
+class TestStreamUnsealer:
+    def test_restores_a_placeholder_split_across_chunks(self):
+        reg = SealRegistry({"concept": "anti-note"})
+        token = placeholder_for("anti-note")
+        whole = f"the {token} idea".encode()
+        cut = len(b"the ") + 5  # mid-placeholder
+        un = StreamUnsealer(reg)
+        out = un.feed(whole[:cut]) + un.feed(whole[cut:]) + un.flush()
+        assert out == b"the anti-note idea"
+
+    def test_byte_at_a_time_still_restores(self):
+        reg = SealRegistry({"concept": "anti-note"})
+        token = placeholder_for("anti-note")
+        whole = f"x{token}y".encode()
+        un = StreamUnsealer(reg)
+        out = b"".join(un.feed(whole[i:i + 1]) for i in range(len(whole)))
+        assert out + un.flush() == b"xanti-notey"
+
+    def test_inactive_registry_streams_unchanged(self):
+        un = StreamUnsealer(SealRegistry())
+        assert un.feed(b"chunk") == b"chunk"
+        assert un.flush() == b""
+
+    def test_nothing_is_lost_when_no_placeholder_is_present(self):
+        reg = SealRegistry({"concept": "anti-note"})
+        un = StreamUnsealer(reg)
+        parts = [b"hello ", b"there ", b"friend"]
+        out = b"".join(un.feed(p) for p in parts) + un.flush()
+        assert out == b"hello there friend"


### PR DESCRIPTION
`vaara llm-proxy --seal-file PATH` holds named secrets back from the provider. Listed values are replaced with stable placeholders before the request is forwarded and restored in the response, including across SSE chunk boundaries, so the caller reads the original text and the provider never receives it.

Redaction already existed and does a different job. `redact_body` replaces matches with `***` and is applied only to the copy written into the audit trail, which keeps secrets out of the record while the provider still gets the original bytes. Sealing is the reversible form, because a model handed `***` cannot answer.

Placeholders derive from the secret's own sha256 rather than being assigned per run. A placeholder that changed between runs would alter the prompt prefix on every turn and defeat provider-side prompt caching, a cost paid on every later request rather than once.

It covers only what is named in advance. Prose never registered travels in the clear, so this bounds and records the channel rather than closing it. That limit is in the module docstring as well as the changelog.

Fails open throughout. A sealing fault forwards the unsealed request rather than costing the call.

Also adds `--seal-listen-unix`, which binds a unix socket instead of a TCP port so filesystem permissions become the access control. The proxy holds the upstream key and injects it into every forwarded call, so removing the listening port removes a class of local reachability.

The chat path now forwards the received request bytes instead of re-serialising the parsed body, so with sealing off a payload is byte-identical to what the client sent. A round-trip test asserts it.

23 tests: 20 unit, 3 end to end through the real proxy handler against a stub upstream, so running them sends nothing anywhere. Full suite 3780 passed, 18 skipped. The helm chart test caught the chart appVersion and the supported-platforms page, both moved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional secret sealing for LLM proxy requests and responses, including streamed responses.
  * Added Unix socket listening support for the LLM proxy.
  * Secret sealing fails open if an error occurs and only applies to configured secrets.

* **Improvements**
  * Requests and responses now preserve their original bytes when sealing is disabled.

* **Documentation**
  * Updated release and supported-version information to 1.85.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->